### PR TITLE
DMS-48: Fix exported row count mismatch issue.

### DIFF
--- a/yb_migrate/cmd/importData.go
+++ b/yb_migrate/cmd/importData.go
@@ -580,7 +580,7 @@ var reCopy = regexp.MustCompile(`(?i)COPY .* FROM STDIN;`)
 func isDataLine(line string) bool {
 	return !(len(line) == 0 ||
 		line == "\n" ||
-		line == `\.` ||
+		line == "\\." || line == "\\.\n" ||
 		reSetTo.MatchString(line) ||
 		reSetEq.MatchString(line) ||
 		reTruncate.MatchString(line) ||

--- a/yb_migrate/cmd/import_data_test.go
+++ b/yb_migrate/cmd/import_data_test.go
@@ -20,7 +20,8 @@ func TestIsDataLine(t *testing.T) {
 		{`COPY "Foo" ("v") FROM STDIN;`, false},
 		{"", false},
 		{"\n", false},
-		{`\.`, false},
+		{"\\.\n", false},
+		{"\\.", false},
 		{"SET MAX 530\n", true},
 		{"TRUNCATE FOO BAR", true},
 	}

--- a/yb_migrate/src/utils/commonVariables.go
+++ b/yb_migrate/src/utils/commonVariables.go
@@ -76,6 +76,13 @@ type Format interface {
 	PrintFormat(cnt int)
 }
 
+const (
+	TABLE_MIGRATION_NOT_STARTED = iota
+	TABLE_MIGRATION_IN_PROGRESS
+	TABLE_MIGRATION_DONE
+	TABLE_MIGRATION_COMPLETED
+)
+
 type TableProgressMetadata struct {
 	TableSchema          string
 	TableName            string


### PR DESCRIPTION
There was a bug in isDataLine() because of which the lines containing "\\.\n"
were also being considered as a data line. Fixed it.

Fixed a few more issues:
- Instead of magic numbers, use named constants for table export status.
- exportDataStatus() was busy looping--continuously looking for tmp data files.
  Added a second of sleep between each iterations. This halved CPU utilisation of
  yb_migrate from ~210% to ~107%.
- The above change surfaced another issue in the exportDataStatus():
  if exportDataStatus() misses a temp file (maybe because the table was very small and
  the temp file was quickly renamed to the final name), it would hang
  forever. Fixed the issue by also looking for final data file names.