### PR TITLE
Reduce CPU usage while exporting data.

### DIFF
--- a/yb_migrate/cmd/exportDataStatus.go
+++ b/yb_migrate/cmd/exportDataStatus.go
@@ -163,6 +163,7 @@ func startExportPB(progressContainer *mpb.Progress, tableMetadata *utils.TablePr
 				tableMetadata.CountLiveRows += 1
 			}
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	/*


### PR DESCRIPTION
With this one line change CPU utilisation of `export data` command
dropped by 60%.

startExportPB() was busy looping until the file has new contents appended by
the ora2pg/pg_dump. Added a sleep of 100 msec to ease a bit.