### PR TITLE
Fix a panic in the `import data status` command.

### DIFF
--- a/yb_migrate/cmd/importDataStatusCommand.go
+++ b/yb_migrate/cmd/importDataStatusCommand.go
@@ -17,10 +17,6 @@ var importDataStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Print status of an ongoing/completed migration.",
 
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
-	},
-
 	Run: func(cmd *cobra.Command, args []string) {
 		err := runImportDataStatusCmd()
 		if err != nil {


### PR DESCRIPTION
The cobra command definition was calling parent command's
PersistentPreRun() method. With the recent changes, parent commands
were changed to use PreRun() instead of PersistentPreRun. That
caused the `import data status` command to panic with a nil pointer
dereference error.