### PR TITLE
Fixed help message for source-db-schema

### DIFF
--- a/yb_migrate/cmd/export.go
+++ b/yb_migrate/cmd/export.go
@@ -107,7 +107,7 @@ func init() {
 	//out of schema and db-name one should be mandatory(oracle vs others)
 
 	exportCmd.PersistentFlags().StringVar(&source.Schema, "source-db-schema", "",
-		"source schema name which needs to be migrated to YugabyteDB")
+		"[For Oracle Only] source schema name which needs to be migrated to YugabyteDB")
 
 	// TODO SSL related more args will come. Explore them later.
 	exportCmd.PersistentFlags().StringVar(&source.SSLCertPath, "source-ssl-cert", "",

--- a/yb_migrate/cmd/generateReport.go
+++ b/yb_migrate/cmd/generateReport.go
@@ -854,7 +854,7 @@ func init() {
 	//out of schema and db-name one should be mandatory(oracle vs others)
 
 	generateReportCmd.PersistentFlags().StringVar(&source.Schema, "source-db-schema", "public",
-		"source schema name which needs to be migrated to YugabyteDB")
+		"[For Oracle Only] source schema name which needs to be migrated to YugabyteDB")
 
 	// TODO SSL related more args will come. Explore them later.
 	generateReportCmd.PersistentFlags().StringVar(&source.SSLCertPath, "source-ssl-cert", "",


### PR DESCRIPTION
Minor PR-
The help message for source-db-schema now mentions it is for Oracle DB Type only