### PR TITLE
Add a test case for oracle.

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -16,6 +16,7 @@ print_env() {
 	echo "SOURCE_DB_USER=${SOURCE_DB_USER}"
 	echo "SOURCE_DB_PASSWORD=${SOURCE_DB_PASSWORD}"
 	echo "SOURCE_DB_NAME=${SOURCE_DB_NAME}"
+	echo "SOURCE_DB_SCHEMA=${SOURCE_DB_SCHEMA}"
 	echo ""
 	echo "TARGET_DB_HOST=${TARGET_DB_HOST}"
 	echo "TARGET_DB_PORT=${TARGET_DB_PORT}"
@@ -54,55 +55,72 @@ run_mysql() {
 }
 
 export_schema() {
-	yb_migrate export schema --export-dir ${EXPORT_DIR} \
-		--source-db-type ${SOURCE_DB_TYPE} \
-		--source-db-host ${SOURCE_DB_HOST} \
-		--source-db-port ${SOURCE_DB_PORT} \
-		--source-db-user ${SOURCE_DB_USER} \
-		--source-db-password ${SOURCE_DB_PASSWORD} \
-		--source-db-name ${SOURCE_DB_NAME} \
-		$*
+	args="--export-dir ${EXPORT_DIR}
+		--source-db-type ${SOURCE_DB_TYPE}
+		--source-db-host ${SOURCE_DB_HOST}
+		--source-db-port ${SOURCE_DB_PORT}
+		--source-db-user ${SOURCE_DB_USER}
+		--source-db-password ${SOURCE_DB_PASSWORD}
+		--source-db-name ${SOURCE_DB_NAME}
+	"
+	if [ "${SOURCE_DB_SCHEMA}" != "" ]
+	then
+		args="${args} --source-db-schema ${SOURCE_DB_SCHEMA}"
+	fi
+	yb_migrate export schema ${args} $*
 }
 
 export_data() {
-	yb_migrate export data --export-dir ${EXPORT_DIR} \
-		--source-db-type ${SOURCE_DB_TYPE} \
-		--source-db-host ${SOURCE_DB_HOST} \
-		--source-db-port ${SOURCE_DB_PORT} \
-		--source-db-user ${SOURCE_DB_USER} \
-		--source-db-password ${SOURCE_DB_PASSWORD} \
-		--source-db-name ${SOURCE_DB_NAME} \
-		$*
+	args="--export-dir ${EXPORT_DIR}
+		--source-db-type ${SOURCE_DB_TYPE}
+		--source-db-host ${SOURCE_DB_HOST}
+		--source-db-port ${SOURCE_DB_PORT}
+		--source-db-user ${SOURCE_DB_USER}
+		--source-db-password ${SOURCE_DB_PASSWORD}
+		--source-db-name ${SOURCE_DB_NAME}
+	"
+	if [ "${SOURCE_DB_SCHEMA}" != "" ]
+	then
+		args="${args} --source-db-schema ${SOURCE_DB_SCHEMA}"
+	fi
+	yb_migrate export data ${args} $*
 }
 
 analyze_schema() {
-	yb_migrate analyze-schema --export-dir ${EXPORT_DIR} \
-		--source-db-type ${SOURCE_DB_TYPE} \
-		--source-db-host ${SOURCE_DB_HOST} \
-		--source-db-port ${SOURCE_DB_PORT} \
-		--source-db-user ${SOURCE_DB_USER} \
-		--source-db-password ${SOURCE_DB_PASSWORD} \
-		--source-db-name ${SOURCE_DB_NAME} \
-		--output-format txt \
-		$*
+	args="--export-dir ${EXPORT_DIR}
+		--source-db-type ${SOURCE_DB_TYPE}
+		--source-db-host ${SOURCE_DB_HOST}
+		--source-db-port ${SOURCE_DB_PORT}
+		--source-db-user ${SOURCE_DB_USER}
+		--source-db-password ${SOURCE_DB_PASSWORD}
+		--source-db-name ${SOURCE_DB_NAME}
+		--output-format txt
+	"
+        if [ "${SOURCE_DB_SCHEMA}" != "" ]
+        then
+                args="${args} --source-db-schema ${SOURCE_DB_SCHEMA}"
+        fi
+        yb_migrate analyze-schema ${args} $*
 }
 
 import_schema() {
-	yes | yb_migrate import schema --export-dir ${EXPORT_DIR} \
+	yb_migrate import schema --export-dir ${EXPORT_DIR} \
 		--target-db-host ${TARGET_DB_HOST} \
 		--target-db-port ${TARGET_DB_PORT} \
 		--target-db-user ${TARGET_DB_USER} \
 		--target-db-password ${TARGET_DB_PASSWORD:-''} \
 		--target-db-name ${TARGET_DB_NAME} \
+		--yes \
 		$*
 }
 
 import_data() {
-	yes | yb_migrate import data --export-dir ${EXPORT_DIR} \
+	yb_migrate import data --export-dir ${EXPORT_DIR} \
 		--target-db-host ${TARGET_DB_HOST} \
 		--target-db-port ${TARGET_DB_PORT} \
 		--target-db-user ${TARGET_DB_USER} \
 		--target-db-password ${TARGET_DB_PASSWORD:-''} \
 		--target-db-name ${TARGET_DB_NAME} \
+		--disable-pb \
 		$*
 }

--- a/migtests/scripts/oracle/env.sh
+++ b/migtests/scripts/oracle/env.sh
@@ -1,0 +1,7 @@
+# We use an already deployed RDS Oracle instance for testing.
+# ssinghal-dms-oracle: https://us-west-2.console.aws.amazon.com/rds/home?region=us-west-2#database:id=ssinghal-dms-oracle;is-cluster=false
+export SOURCE_DB_HOST=${SOURCE_DB_HOST:-"35.165.118.74"}
+export SOURCE_DB_PORT=${SOURCE_DB_PORT:-1521}
+export SOURCE_DB_USER=${SOURCE_DB_USER:-"sakila_demo"}
+export SOURCE_DB_PASSWORD=${SOURCE_DB_PASSWORD:-"password"}
+export SOURCE_DB_SCHEMA=${SOURCE_DB_SCHEMA:-"sakila_demo"}

--- a/migtests/scripts/yugabytedb/env.sh
+++ b/migtests/scripts/yugabytedb/env.sh
@@ -2,4 +2,8 @@ export TARGET_DB_HOST=${TARGET_DB_HOST:-"127.0.0.1"}
 export TARGET_DB_PORT=${TARGET_DB_PORT:-5433}
 export TARGET_DB_USER=${TARGET_DB_USER:-"yugabyte"}
 export TARGET_DB_PASSWORD=${TARGET_DB_PASSWORD:-''}
-export TARGET_DB_NAME=${TARGET_DB_NAME:-${SOURCE_DB_NAME}}
+# The PG driver, used to connect to YB, is case-sensitive about database name.
+if [ "${TARGET_DB_NAME}" == "" ]
+then
+	export TARGET_DB_NAME=`echo ${SOURCE_DB_NAME} | tr [A-Z] [a-z]`
+fi

--- a/migtests/tests/ora-sakila-demo/env.sh
+++ b/migtests/tests/ora-sakila-demo/env.sh
@@ -1,0 +1,2 @@
+export SOURCE_DB_TYPE="oracle"
+export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"DMS"}

--- a/migtests/tests/ora-sakila-demo/fix-schema
+++ b/migtests/tests/ora-sakila-demo/fix-schema
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+pushd ${EXPORT_DIR}/schema
+
+echo "Truncate the synonym.sql"
+echo "" > synonyms/synonym.sql

--- a/migtests/tests/ora-sakila-demo/init-db
+++ b/migtests/tests/ora-sakila-demo/init-db
@@ -1,0 +1,2 @@
+# We use the prepopulated sakila_demo instance on the RDS Oracle instance.
+# So this script is a no-op.


### PR DESCRIPTION
We use a pre-populated RDS Oracle instance (https://us-west-2.console.aws.amazon.com/rds/home?region=us-west-2#database:id=ssinghal-dms-oracle;is-cluster=false)
for migration testing with Oracle.