### PR TITLE
Implemented --enable-upsert mode in import commands

### DIFF
--- a/yb_migrate/cmd/constants.go
+++ b/yb_migrate/cmd/constants.go
@@ -39,6 +39,8 @@ var IMPORT_SESSION_SETTERS = []string{
 	"SET yb_disable_transactional_writes to true;",
 	//Disable triggers or fkeys constraint checks.
 	"SET session_replication_role TO replica;",
+	// Enable UPSERT mode instead of normal inserts into a table.
+	"SET yb_enable_upsert_mode to true;",
 }
 
 var supportedSourceDBTypes = []string{ORACLE, MYSQL, POSTGRESQL}

--- a/yb_migrate/cmd/import.go
+++ b/yb_migrate/cmd/import.go
@@ -144,8 +144,11 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&loadBalancerUsed, "load-balancer", false,
 		"true - if given --target-db-host is a load balancer ip (default false)")
 
-	cmd.PersistentFlags().BoolVar(&disablePb, "disable-pb", false,
+	cmd.Flags().BoolVar(&disablePb, "disable-pb", false,
 		"true - to disable progress bar during data import (default false)")
+
+	cmd.Flags().BoolVar(&enableUpsert, "enable-upsert", false,
+		"true - to enable upsert for insert in target tables (default false)")
 }
 
 func validateTargetPortRange() {

--- a/yb_migrate/cmd/importData.go
+++ b/yb_migrate/cmd/importData.go
@@ -69,6 +69,7 @@ var usePublicIp bool
 var targetEndpoints string
 var copyTableFromCommands = make(map[string]string)
 var loadBalancerUsed bool // specifies whether load balancer is used in front of yb servers
+var enableUpsert bool     // upsert instead of insert for import data
 
 type SplitFileImportTask struct {
 	TableName           string
@@ -885,9 +886,11 @@ func checkSessionVariableSupported(idx int, dbVersion string) bool {
 	splits := strings.Split(dbVersion, "YB-")
 	dbVersion = splits[len(splits)-1]
 
-	if idx == 1 { //yb_disable_transactional_writes
-		//only supported for these versions
+	if idx == 1 { // yb_disable_transactional_writes
+		// only supported for these versions
 		return strings.Compare(dbVersion, "2.8.1") == 0 || strings.Compare(dbVersion, "2.11.2") >= 0
+	} else if idx == 3 { // yb_enable_upsert_mode
+		return enableUpsert
 	}
 	return true
 }


### PR DESCRIPTION
This flag can be useful in scenarios like an incremental load of data having new inserts + updates.(deletes can't be captured with this).