### PR TITLE
Bug fix: conn busy error from database during import data commands

### DIFF
--- a/yb_migrate/src/tgtdb/target.go
+++ b/yb_migrate/src/tgtdb/target.go
@@ -22,6 +22,7 @@ type Target struct {
 	VerboseMode            bool
 	TableList              string
 	ImportMode             bool
+	dbVersion              string
 
 	db *TargetDB
 }


### PR DESCRIPTION
Reason/Fix: For each server clone we were calling `select version()` query concurrently using the same db connection, with this fix we will just copy the dbVersion while cloning the target struct

Testing: I have tested it with a usecase where i was consistently getting the error.