### PR TITLE
Complete import progress bar even if fewer records are imported.

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -851,13 +851,11 @@ func doOneImport(task *SplitFileImportTask, targetChan chan *tgtdb.Target) {
 						rowsCount = task.OffsetEnd - task.OffsetStart
 						log.Infof("assuming affected rows count %v", rowsCount)
 					}
-				} else if rowsCount != task.OffsetEnd-task.OffsetStart {
-					// exceptional case, since all rows are not copied, so progress bar shouldn't complete
-					log.Infof("EXCEPTIONAL CASE: all rows are not copied")
-					setProgressAmount(task.SplitFilePath, rowsCount)
 				}
-
-				// update the import data status as soon as rows are copied
+				if rowsCount != task.OffsetEnd-task.OffsetStart {
+					log.Warnf("Expected to import %v records from %s. Imported %v.",
+						task.OffsetEnd-task.OffsetStart, inProgressFilePath, rowsCount)
+				}
 				incrementImportProgressBar(task.TableName, inProgressFilePath)
 			}
 			doneFilePath := getDoneFilePath(task)


### PR DESCRIPTION
Currently, progress bar value is computed based on the exact number of rows imported as a fraction of total number of rows in the table. Such a progress-bar can not be marked complete when fewer records got imported (either because of manual edits or some error in COPY command).

During import data, this results in repeatedly outputting progress-bar when yb-voyager is creating indexes.

This change ensures that all the progress bars are completed by contributing total number of records in a chunk towards the progress--irrespective of how many rows from the chunk were imported.