### PR TITLE
Added support for text format  --file-opts flag in import data file command

### DIFF
--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
+	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/net v0.0.0-20220111093109-d55c255bac03 // indirect
 	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -188,6 +188,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -500,6 +501,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d h1:vtUKgx8dahOomfFzLREU8nSv25YHnTgLBn4rDnWZdU0=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/yb-voyager/src/datafile/datafile.go
+++ b/yb-voyager/src/datafile/datafile.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	CSV = "csv"
-	SQL = "sql"
+	CSV  = "csv"
+	SQL  = "sql"
+	TEXT = "text"
 )
 
 type DataFile interface {
@@ -23,13 +24,13 @@ type DataFile interface {
 var reCopy = regexp.MustCompile(`(?i)COPY .* FROM STDIN;`)
 
 func OpenDataFile(filePath string, descriptor *Descriptor) (DataFile, error) {
-	switch descriptor.FileType {
-	case CSV:
+	switch descriptor.FileFormat {
+	case CSV, TEXT:
 		return openCsvDataFile(filePath, descriptor)
 	case SQL:
 		return openSqlDataFile(filePath, descriptor)
 	default:
-		panic(fmt.Sprintf("Unknown file type %q", descriptor.FileType))
+		panic(fmt.Sprintf("Unknown file type %q", descriptor.FileFormat))
 
 	}
 }

--- a/yb-voyager/src/datafile/descriptor.go
+++ b/yb-voyager/src/datafile/descriptor.go
@@ -14,7 +14,7 @@ const (
 )
 
 type Descriptor struct {
-	FileType      string           `json:"FileType"`
+	FileFormat    string           `json:"FileFormat"`
 	TableRowCount map[string]int64 `json:"TableRowCount"`
 	TableFileSize map[string]int64 `json:"TableFileSize"`
 	Delimiter     string           `json:"Delimiter"`

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -116,7 +116,7 @@ func (ms *MySQL) ExportData(ctx context.Context, exportDir string, tableList []s
 func (ms *MySQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	exportedRowCount := getExportedRowCount(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileType:      datafile.SQL,
+		FileFormat:    datafile.SQL,
 		TableRowCount: exportedRowCount,
 		Delimiter:     "\t",
 		HasHeader:     false,

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -143,7 +143,7 @@ func (ora *Oracle) ExportData(ctx context.Context, exportDir string, tableList [
 func (ora *Oracle) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	exportedRowCount := getExportedRowCount(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileType:      datafile.SQL,
+		FileFormat:    datafile.SQL,
 		TableRowCount: exportedRowCount,
 		Delimiter:     "\t",
 		HasHeader:     false,

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -110,7 +110,7 @@ func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressM
 	renameDataFiles(tablesProgressMetadata)
 	exportedRowCount := getExportedRowCount(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileType:      datafile.CSV,
+		FileFormat:    datafile.CSV,
 		TableRowCount: exportedRowCount,
 		Delimiter:     "\t",
 		HasHeader:     false,


### PR DESCRIPTION
This PR implement the following:
1. Added support for text file format
2. Added --file-opts flag to provide additional file options like escape_char and quote_char

Sample commands:
```
 yb_migrate import data file --otherFlags... --format csv --file-opts "escape_char=\",quote_char=\""
 yb_migrate import data file --otherFlags... --format text
```

Test Plan:
1. with text format with different delimiters
2. with csv format: different delimiters and `--file-opts` variation
3. Perf test stats for 120M rows data, same as expected.