### PR TITLE
Diagnostics env var+added yb-voyager version to callhome

### DIFF
--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -79,6 +79,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&callhome.SendDiagnostics, "send-diagnostics", true,
 		"enable or disable the 'send-diagnostics' feature that sends analytics data to Yugabyte.")
+	callhome.ReadEnvSendDiagnostics()
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/yb-voyager/cmd/version.go
+++ b/yb-voyager/cmd/version.go
@@ -5,11 +5,7 @@ import (
 	"runtime/debug"
 
 	"github.com/spf13/cobra"
-)
-
-const (
-	// This constant must be updated on every release.
-	YB_VOYAGER_VERSION = "1.0.0-beta"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 var versionCmd = &cobra.Command{
@@ -17,7 +13,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print yb-voyager version info.",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("VERSION=%s\n", YB_VOYAGER_VERSION)
+		fmt.Printf("VERSION=%s\n", utils.YB_VOYAGER_VERSION)
 
 		info, ok := debug.ReadBuildInfo()
 		if !ok {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 //call-home json formats
@@ -24,8 +25,6 @@ var (
 const (
 	CALL_HOME_SERVICE_HOST = "34.83.149.226"
 	CALL_HOME_SERVICE_PORT = 80
-	//This needs to be updated every time a new patch is released
-	YB_VOYAGER_VERSION = "1.0.0-beta"
 )
 
 type payload struct {
@@ -86,7 +85,7 @@ func initJSON(exportdir string) {
 	if Payload.MigrationUuid == uuid.Nil {
 		Payload.MigrationUuid, err = uuid.NewUUID()
 		Payload.StartTime = time.Now().Format("2006-01-02 15:04:05")
-		Payload.YBVoyagerVersion = YB_VOYAGER_VERSION
+		Payload.YBVoyagerVersion = utils.YB_VOYAGER_VERSION
 		if err != nil {
 			log.Errorf("Error while generating new UUID for diagnostics.json: %v", err)
 			return

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -24,11 +24,14 @@ var (
 const (
 	CALL_HOME_SERVICE_HOST = "34.83.149.226"
 	CALL_HOME_SERVICE_PORT = 80
+	//This needs to be updated every time a new patch is released
+	YB_VOYAGER_VERSION = "1.0.0-beta"
 )
 
 type payload struct {
 	MigrationUuid         uuid.UUID `json:"UUID"`
 	StartTime             string    `json:"start_time"`
+	YBVoyagerVersion      string    `json:"yb_voyager_version"`
 	LastUpdatedTime       string    `json:"last_updated_time"`
 	SourceDBType          string    `json:"source_db_type"`
 	SourceDBVersion       string    `json:"source_db_version"`
@@ -44,6 +47,16 @@ type payload struct {
 	TargetClusterLocation string    `json:"target_cluster_location"` //TODO
 	TargetDBCores         int       `json:"target_db_cores"`         //TODO
 	SourceCloudDBType     string    `json:"source_cloud_type"`       //TODO
+}
+
+//[For development] Read ENV VARS for value of SendDiagnostics
+func ReadEnvSendDiagnostics() {
+	rawSendDiag := os.Getenv("YB_VOYAGER_SEND_DIAGNOSTICS")
+	for _, val := range []string{"0", "no", "false"} {
+		if rawSendDiag == val {
+			SendDiagnostics = false
+		}
+	}
 }
 
 // Fill in primary-key based fields, if needed
@@ -73,6 +86,7 @@ func initJSON(exportdir string) {
 	if Payload.MigrationUuid == uuid.Nil {
 		Payload.MigrationUuid, err = uuid.NewUUID()
 		Payload.StartTime = time.Now().Format("2006-01-02 15:04:05")
+		Payload.YBVoyagerVersion = YB_VOYAGER_VERSION
 		if err != nil {
 			log.Errorf("Error while generating new UUID for diagnostics.json: %v", err)
 			return

--- a/yb-voyager/src/utils/version.go
+++ b/yb-voyager/src/utils/version.go
@@ -1,0 +1,6 @@
+package utils
+
+const (
+	// This constant must be updated on every release.
+	YB_VOYAGER_VERSION = "1.0.0-beta"
+)


### PR DESCRIPTION
-Can disable send-diagnostics flag using environment var `YB_VOYAGER_SEND_DIAGNOSTICS`
-Added yb-voyager version to call-home