### PR TITLE
Improving export data speed by initialzing progress bars with approx count instead of exact count

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -137,14 +137,9 @@ func getMappingForTableNameVsTableFileName(dataDirPath string) map[string]string
 
 func UpdateTableApproxRowCount(source *srcdb.Source, exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	var maxTableLines, totalTableLines int64
-
 	payload := callhome.GetPayload(exportDir)
 
 	utils.PrintAndLog("calculating approx num of rows to export for each table...")
-	if !source.VerboseMode {
-		go utils.Wait()
-	}
-
 	sortedKeys := utils.GetSortedKeys(tablesProgressMetadata)
 	for _, key := range sortedKeys {
 		approxRowCount := source.DB().GetTableApproxRowCount(tablesProgressMetadata[key])
@@ -156,10 +151,6 @@ func UpdateTableApproxRowCount(source *srcdb.Source, exportDir string, tablesPro
 		tablesProgressMetadata[key].CountTotalRows = approxRowCount
 	}
 
-	if !source.VerboseMode {
-		utils.WaitChannel <- 0
-		<-utils.WaitChannel
-	}
 	payload.LargestTableRows = maxTableLines
 	payload.TotalRows = totalTableLines
 	log.Tracef("After updating total approx row count, TablesProgressMetadata: %+v", tablesProgressMetadata)

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -135,53 +135,34 @@ func getMappingForTableNameVsTableFileName(dataDirPath string) map[string]string
 	return tableNameVsFileNameMap
 }
 
-func UpdateTableRowCount(source *srcdb.Source, exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
+func UpdateTableApproxRowCount(source *srcdb.Source, exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	var maxTableLines, totalTableLines int64
 
 	payload := callhome.GetPayload(exportDir)
 
-	fmt.Println("calculating num of rows to export for each table...")
+	utils.PrintAndLog("calculating approx num of rows to export for each table...")
 	if !source.VerboseMode {
 		go utils.Wait()
 	}
 
-	utils.PrintIfTrue(fmt.Sprintf("+%s+\n", strings.Repeat("-", 75)), source.VerboseMode)
-	utils.PrintIfTrue(fmt.Sprintf("| %50s | %20s |\n", "Table", "Row Count"), source.VerboseMode)
-
 	sortedKeys := utils.GetSortedKeys(tablesProgressMetadata)
 	for _, key := range sortedKeys {
-		utils.PrintIfTrue(fmt.Sprintf("|%s|\n", strings.Repeat("-", 75)), source.VerboseMode)
-
-		utils.PrintIfTrue(fmt.Sprintf("| %50s ", key), source.VerboseMode)
-
-		if source.VerboseMode {
-			go utils.Wait()
+		approxRowCount := source.DB().GetTableApproxRowCount(tablesProgressMetadata[key])
+		if approxRowCount > maxTableLines {
+			maxTableLines = approxRowCount
 		}
+		totalTableLines += approxRowCount
 
-		rowCount := source.DB().GetTableRowCount(tablesProgressMetadata[key].FullTableName)
-
-		if rowCount > maxTableLines {
-			maxTableLines = rowCount
-		}
-		totalTableLines += rowCount
-
-		if source.VerboseMode {
-			utils.WaitChannel <- 0
-			<-utils.WaitChannel
-		}
-
-		tablesProgressMetadata[key].CountTotalRows = rowCount
-		utils.PrintIfTrue(fmt.Sprintf("| %20d |\n", rowCount), source.VerboseMode)
+		tablesProgressMetadata[key].CountTotalRows = approxRowCount
 	}
-	utils.PrintIfTrue(fmt.Sprintf("+%s+\n", strings.Repeat("-", 75)), source.VerboseMode)
+
 	if !source.VerboseMode {
 		utils.WaitChannel <- 0
 		<-utils.WaitChannel
 	}
-
 	payload.LargestTableRows = maxTableLines
 	payload.TotalRows = totalTableLines
-	log.Tracef("After updating total row count, TablesProgressMetadata: %+v", tablesProgressMetadata)
+	log.Tracef("After updating total approx row count, TablesProgressMetadata: %+v", tablesProgressMetadata)
 }
 
 func GetTableRowCount(filePath string) map[string]int64 {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -138,7 +138,7 @@ func exportDataOffline() bool {
 	initializeExportTablePartitionMetadata(tableList)
 
 	log.Infof("Export table metadata: %s", spew.Sdump(tablesProgressMetadata))
-	UpdateTableRowCount(&source, exportDir, tablesProgressMetadata)
+	UpdateTableApproxRowCount(&source, exportDir, tablesProgressMetadata)
 
 	if source.DBType == POSTGRESQL {
 		//need to export setval() calls to resume sequence value generation

--- a/yb-voyager/src/srcdb/ora2pg_export_data.go
+++ b/yb-voyager/src/srcdb/ora2pg_export_data.go
@@ -89,8 +89,8 @@ func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir stri
 	exportDataStart <- true
 
 	err = exportDataCommand.Wait()
-	log.Infof("ora2pg STDOUT: %s", outbuf.String())
-	log.Errorf("ora2pg STDERR: %s", errbuf.String())
+	log.Infof("ora2pg STDOUT: %q", outbuf.String())
+	log.Errorf("ora2pg STDERR: %q", errbuf.String())
 	if err != nil {
 		utils.ErrExit("Data export failed: %v\n%s", err, errbuf.String())
 	}

--- a/yb-voyager/src/srcdb/ora2pg_export_data.go
+++ b/yb-voyager/src/srcdb/ora2pg_export_data.go
@@ -89,8 +89,8 @@ func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir stri
 	exportDataStart <- true
 
 	err = exportDataCommand.Wait()
-	log.Infof("ora2pg STDOUT: %q", outbuf.String())
-	log.Errorf("ora2pg STDERR: %q", errbuf.String())
+	log.Infof(`ora2pg STDOUT: "%s"`, outbuf.String())
+	log.Errorf(`ora2pg STDERR: "%s"`, errbuf.String())
 	if err != nil {
 		utils.ErrExit("Data export failed: %v\n%s", err, errbuf.String())
 	}

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -37,10 +37,31 @@ func (ora *Oracle) GetTableRowCount(tableName string) int64 {
 	log.Infof("Querying row count of table %q", tableName)
 	err := ora.db.QueryRow(query).Scan(&rowCount)
 	if err != nil {
-		utils.ErrExit("Failed to query row count of %q: %s", tableName, err)
+		utils.ErrExit("Failed to query %q for row count of %q: %s", query, tableName, err)
 	}
 	log.Infof("Table %q has %v rows.", tableName, rowCount)
 	return rowCount
+}
+
+func (ora *Oracle) GetTableApproxRowCount(tableProgressMetadata *utils.TableProgressMetadata) int64 {
+	var approxRowCount sql.NullInt64 // handles case: value of the row is null, default for int64 is 0
+	var query string
+	if !tableProgressMetadata.IsPartition {
+		query = fmt.Sprintf("SELECT NUM_ROWS FROM USER_TABLES "+
+			"WHERE TABLE_NAME='%s'", tableProgressMetadata.TableName) // TODO: approx row count query might be different for table partitions
+	} else {
+		query = fmt.Sprintf("SELECT NUM_ROWS FROM ALL_TAB_PARTITIONS "+
+			"WHERE TABLE_NAME='%s' AND PARTITION_NAME='%s'", tableProgressMetadata.ParentTable, tableProgressMetadata.TableName) // TODO: approx row count query might be different for table partitions
+	}
+
+	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)
+	err := ora.db.QueryRow(query).Scan(&approxRowCount)
+	if err != nil {
+		utils.ErrExit("Failed to query %q for approx row count of %q: %s", query, tableProgressMetadata.TableName, err)
+	}
+
+	log.Infof("Table %q has approx %v rows.", tableProgressMetadata.TableName, approxRowCount)
+	return approxRowCount.Int64
 }
 
 func (ora *Oracle) GetVersion() string {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -48,10 +48,10 @@ func (ora *Oracle) GetTableApproxRowCount(tableProgressMetadata *utils.TableProg
 	var query string
 	if !tableProgressMetadata.IsPartition {
 		query = fmt.Sprintf("SELECT NUM_ROWS FROM USER_TABLES "+
-			"WHERE TABLE_NAME='%s'", tableProgressMetadata.TableName) // TODO: approx row count query might be different for table partitions
+			"WHERE TABLE_NAME='%s'", tableProgressMetadata.TableName)
 	} else {
 		query = fmt.Sprintf("SELECT NUM_ROWS FROM ALL_TAB_PARTITIONS "+
-			"WHERE TABLE_NAME='%s' AND PARTITION_NAME='%s'", tableProgressMetadata.ParentTable, tableProgressMetadata.TableName) // TODO: approx row count query might be different for table partitions
+			"WHERE TABLE_NAME='%s' AND PARTITION_NAME='%s'", tableProgressMetadata.ParentTable, tableProgressMetadata.TableName)
 	}
 
 	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -33,7 +33,7 @@ func (pg *PostgreSQL) CheckRequiredToolsAreInstalled() {
 
 func (pg *PostgreSQL) GetTableRowCount(tableName string) int64 {
 	// new conn to avoid conn busy err as multiple parallel(and time-taking) queries possible
-	conn, err := pgx.Connect(context.Background(), pg.getConnectionString())
+	conn, err := pgx.Connect(context.Background(), pg.getConnectionUri())
 	if err != nil {
 		utils.ErrExit("Failed to connect to the source database for table row count: %s", err)
 	}

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -37,6 +37,7 @@ func (pg *PostgreSQL) GetTableRowCount(tableName string) int64 {
 	if err != nil {
 		utils.ErrExit("Failed to connect to the source database for table row count: %s", err)
 	}
+	defer conn.Close(context.Background())
 
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -53,7 +53,7 @@ func (pg *PostgreSQL) GetTableRowCount(tableName string) int64 {
 func (pg *PostgreSQL) GetTableApproxRowCount(tableProgressMetadata *utils.TableProgressMetadata) int64 {
 	var approxRowCount sql.NullInt64 // handles case: value of the row is null, default for int64 is 0
 	query := fmt.Sprintf("SELECT reltuples::bigint FROM pg_class "+
-		"where oid = '%s'::regclass", tableProgressMetadata.FullTableName) // TODO: approx row count query might be different for table partitions
+		"where oid = '%s'::regclass", tableProgressMetadata.FullTableName)
 
 	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)
 	err := pg.db.QueryRow(context.Background(), query).Scan(&approxRowCount)

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -10,6 +10,7 @@ import (
 type SourceDB interface {
 	Connect() error
 	GetTableRowCount(tableName string) int64
+	GetTableApproxRowCount(tableProgressMetadata *utils.TableProgressMetadata) int64
 	CheckRequiredToolsAreInstalled()
 	GetVersion() string
 	GetAllTableNames() []string


### PR DESCRIPTION
Now we will be using the approx count provided by stats/catalog tables of database to initialize the progress bars, later on replacing that with the actual row count.
With this change, there will almost no delay at the start of the data export and will be much faster as compared to the previous.

Test Plan followed:
        1. Stale/Old row count available in catalog tables, differing by 40-100% - **done**
        2. If table is truncated but stats contain old row count - **done** (truncate command blocked if data export is already y started by pg_dump)
        3. Big table with no info in stats table - **done**(it is in the behaviour of mpb i.e. if PB initialised with zero, doesn’t increment until something non-zero is present to compare)
        4. Each db type with table partitions present - **done** for Oracle and PostgreSQL
        5. Multiple Schemas migration in case of postgres - **done**

Fixing the issue #160 