### PR TITLE
Disable the use of source and target uri related flags

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"path/filepath"
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
@@ -710,16 +711,16 @@ func generateTxtReport(Report utils.Report) string {
 // add info to the 'reportStruct' variable and return
 func analyzeSchemaInternal() utils.Report {
 	reportStruct = utils.Report{}
-	schemaDir := exportDir + "/schema"
+	schemaDir := filepath.Join(exportDir, "schema")
 	sourceObjList = utils.GetSchemaObjectList(source.DBType)
 	initializeSummaryMap()
 	for _, objType := range sourceObjList {
 		var filePath string
 		if objType == "INDEX" {
-			filePath = schemaDir + "/tables/INDEXES_table.sql"
+			filePath = filepath.Join(schemaDir, "tables", "INDEXES_table.sql")
 		} else {
-			filePath = schemaDir + "/" + strings.ToLower(objType) + "s"
-			filePath += "/" + strings.ToLower(objType) + ".sql"
+			filePath = filepath.Join(schemaDir, strings.ToLower(objType)+"s")
+			filePath = filepath.Join(filePath, strings.ToLower(objType)+".sql")
 		}
 
 		if !utils.FileOrFolderExists(filePath) {
@@ -737,7 +738,7 @@ func analyzeSchemaInternal() utils.Report {
 
 func analyzeSchema() {
 	reportFile := "report." + outputFormat
-	reportPath := exportDir + "/reports/" + reportFile
+	reportPath := filepath.Join(exportDir, "reports", reportFile)
 
 	if !schemaIsExported(exportDir) {
 		utils.ErrExit("run export schema before running analyze-schema")

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -817,18 +817,13 @@ var analyzeSchemaCmd = &cobra.Command{
 
 		//marking flags as required based on conditions
 		cmd.MarkPersistentFlagRequired("source-db-type")
-		if source.Uri == "" { //if uri is not given
-			cmd.MarkPersistentFlagRequired("source-db-user")
-			cmd.MarkPersistentFlagRequired("source-db-password")
-			if source.DBType != ORACLE {
-				cmd.MarkPersistentFlagRequired("source-db-name")
-			} else if source.DBType == ORACLE {
-				cmd.MarkPersistentFlagRequired("source-db-schema")
-				validateOracleParams()
-			}
-		} else {
-			//check and parse the source
-			source.ParseURI()
+		cmd.MarkPersistentFlagRequired("source-db-user")
+		cmd.MarkPersistentFlagRequired("source-db-password")
+		if source.DBType != ORACLE {
+			cmd.MarkPersistentFlagRequired("source-db-name")
+		} else if source.DBType == ORACLE {
+			cmd.MarkPersistentFlagRequired("source-db-schema")
+			validateOracleParams()
 		}
 
 		if source.TableList != "" {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -48,18 +48,13 @@ var exportCmd = &cobra.Command{
 
 		//marking flags as required based on conditions
 		cmd.MarkPersistentFlagRequired("source-db-type")
-		if source.Uri == "" { //if uri is not given
-			cmd.MarkPersistentFlagRequired("source-db-user")
-			cmd.MarkPersistentFlagRequired("source-db-password")
-			if source.DBType != ORACLE {
-				cmd.MarkPersistentFlagRequired("source-db-name")
-			} else if source.DBType == ORACLE {
-				cmd.MarkPersistentFlagRequired("source-db-schema")
-				validateOracleParams()
-			}
-		} else {
-			//check and parse the source
-			source.ParseURI()
+		cmd.MarkPersistentFlagRequired("source-db-user")
+		cmd.MarkPersistentFlagRequired("source-db-password")
+		if source.DBType != ORACLE {
+			cmd.MarkPersistentFlagRequired("source-db-name")
+		} else if source.DBType == ORACLE {
+			cmd.MarkPersistentFlagRequired("source-db-schema")
+			validateOracleParams()
 		}
 
 		if source.TableList != "" {
@@ -139,17 +134,6 @@ func registerCommonExportFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringVar(&source.SSLCRL, "source-ssl-crl", "",
 		"provide SSL Root Certificate Revocation List (CRL)")
-
-	cmd.PersistentFlags().StringVar(&source.Uri, "source-db-uri", "",
-		`URI for connecting to the source database
-	format:
-		1. Oracle:	user/password@//host:port:SID	OR
-				user/password@//host:port/service_name	OR
-				user/password@TNS_alias
-		2. MySQL:	mysql://[user[:[password]]@]host[:port][/dbname][?sslmode=mode&sslcert=cert_path...]
-		3. PostgreSQL:	postgresql://[user[:[password]]@]host[:port][/dbname][?sslmode=mode&sslcert=cert_path...]
-		
-	`)
 
 	cmd.PersistentFlags().BoolVar(&startClean, "start-clean", false,
 		"clean the project's data directory for already existing files before start(Note: works only for export data command)")

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -190,8 +190,8 @@ func checkTableListFlag(tableListString string) {
 }
 
 func checkDataDirs() {
-	exportDataDir := exportDir + "/data"
-	flagFilePath := exportDir + "/metainfo/flags/exportDataDone"
+	exportDataDir := filepath.Join(exportDir, "data")
+	flagFilePath := filepath.Join(exportDir, "metainfo", "flags", "exportDataDone")
 	dfdFilePath := exportDir + datafile.DESCRIPTOR_PATH
 	if startClean {
 		utils.CleanDir(exportDataDir)
@@ -205,7 +205,7 @@ func checkDataDirs() {
 }
 
 func createExportDataDoneFlag() {
-	exportDoneFlagPath := filepath.Join(exportDir, "/metainfo/flags/exportDataDone")
+	exportDoneFlagPath := filepath.Join(exportDir, "metainfo", "flags", "exportDataDone")
 	_, err := os.Create(exportDoneFlagPath)
 	if err != nil {
 		utils.ErrExit("creating exportDataDone flag: %v", err)

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -79,7 +79,7 @@ func exportSchema() {
 
 	CreateMigrationProjectIfNotExists(source.DBType, exportDir)
 	source.DB().ExportSchema(exportDir)
-	utils.PrintAndLog("\nExported schema files created under directory: %s\n", exportDir+"/schema")
+	utils.PrintAndLog("\nExported schema files created under directory: %s\n", filepath.Join(exportDir, "schema"))
 
 	payload := callhome.GetPayload(exportDir)
 	payload.SourceDBType = source.DBType
@@ -101,7 +101,7 @@ func init() {
 }
 
 func schemaIsExported(exportDir string) bool {
-	flagFilePath := exportDir + "/metainfo/flags/exportSchemaDone"
+	flagFilePath := filepath.Join(exportDir, "metainfo", "flags", "exportSchemaDone")
 	_, err := os.Stat(flagFilePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -113,7 +113,7 @@ func schemaIsExported(exportDir string) bool {
 }
 
 func setSchemaIsExported(exportDir string) {
-	flagFilePath := exportDir + "/metainfo/flags/exportSchemaDone"
+	flagFilePath := filepath.Join(exportDir, "metainfo", "flags", "exportSchemaDone")
 	fh, err := os.Create(flagFilePath)
 	if err != nil {
 		utils.ErrExit("create %q: %s", flagFilePath, err)
@@ -122,6 +122,6 @@ func setSchemaIsExported(exportDir string) {
 }
 
 func clearSchemaIsExported(exportDir string) {
-	flagFilePath := exportDir + "/metainfo/flags/exportSchemaDone"
+	flagFilePath := filepath.Join(exportDir+"metainfo", "flags", "exportSchemaDone")
 	os.Remove(flagFilePath)
 }

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -54,10 +54,7 @@ func validateImportFlags(cmd *cobra.Command) {
 	checkExportDirFlag()
 	checkOrSetDefaultTargetSSLMode()
 	validateTargetPortRange()
-	if target.Uri == "" {
-		cmd.MarkFlagRequired("target-db-user")
-		cmd.MarkFlagRequired("target-db-password")
-	}
+
 	if target.TableList != "" {
 		checkTableListFlag(target.TableList)
 	}
@@ -75,15 +72,14 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&target.User, "target-db-user", "",
 		"Username with which to connect to the target YugabyteDB server")
+	cmd.MarkFlagRequired("target-db-user")
 
 	cmd.Flags().StringVar(&target.Password, "target-db-password", "",
 		"Password with which to connect to the target YugabyteDB server")
+	cmd.MarkFlagRequired("target-db-password")
 
 	cmd.Flags().StringVar(&target.DBName, "target-db-name", YUGABYTEDB_DEFAULT_DATABASE,
 		"Name of the database on the target YugabyteDB server on which import needs to be done")
-
-	cmd.Flags().StringVar(&target.Uri, "target-db-uri", "",
-		"Complete connection uri to the target YugabyteDB server")
 
 	cmd.Flags().StringVar(&target.Schema, "target-db-schema", YUGABYTEDB_DEFAULT_SCHEMA,
 		"target schema name in YugabyteDB (Note: works only for source as Oracle and MySQL, in case of PostgreSQL you can ALTER schema name post import)")
@@ -165,11 +161,9 @@ func validateTargetPortRange() {
 }
 
 func checkOrSetDefaultTargetSSLMode() {
-	if target.Uri == "" {
-		if target.SSLMode == "" {
-			target.SSLMode = "prefer"
-		} else if target.SSLMode != "disable" && target.SSLMode != "prefer" && target.SSLMode != "require" && target.SSLMode != "verify-ca" && target.SSLMode != "verify-full" {
-			utils.ErrExit("Invalid sslmode %q. Required one of [disable, allow, prefer, require, verify-ca, verify-full]", target.SSLMode)
-		}
+	if target.SSLMode == "" {
+		target.SSLMode = "prefer"
+	} else if target.SSLMode != "disable" && target.SSLMode != "prefer" && target.SSLMode != "require" && target.SSLMode != "verify-ca" && target.SSLMode != "verify-full" {
+		utils.ErrExit("Invalid sslmode %q. Required one of [disable, allow, prefer, require, verify-ca, verify-full]", target.SSLMode)
 	}
 }

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -25,7 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
@@ -138,37 +137,4 @@ func checkIfTargetSchemaExists(conn *pgx.Conn, targetSchema string) bool {
 	}
 
 	return fetchedSchema == targetSchema
-}
-
-func generateSSLQueryStringIfNotExists(t *tgtdb.Target) string {
-	SSLQueryString := ""
-	if t.SSLMode == "" {
-		t.SSLMode = "prefer"
-	}
-	if t.SSLQueryString == "" {
-
-		if t.SSLMode == "disable" || t.SSLMode == "allow" || t.SSLMode == "prefer" || t.SSLMode == "require" || t.SSLMode == "verify-ca" || t.SSLMode == "verify-full" {
-			SSLQueryString = "sslmode=" + t.SSLMode
-			if t.SSLMode == "require" || t.SSLMode == "verify-ca" || t.SSLMode == "verify-full" {
-				SSLQueryString = fmt.Sprintf("sslmode=%s", t.SSLMode)
-				if t.SSLCertPath != "" {
-					SSLQueryString += "&sslcert=" + t.SSLCertPath
-				}
-				if t.SSLKey != "" {
-					SSLQueryString += "&sslkey=" + t.SSLKey
-				}
-				if t.SSLRootCert != "" {
-					SSLQueryString += "&sslrootcert=" + t.SSLRootCert
-				}
-				if t.SSLCRL != "" {
-					SSLQueryString += "&sslcrl=" + t.SSLCRL
-				}
-			}
-		} else {
-			fmt.Println("Invalid sslmode entered")
-		}
-	} else {
-		SSLQueryString = t.SSLQueryString
-	}
-	return SSLQueryString
 }

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -31,17 +31,8 @@ import (
 func YugabyteDBImportSchema(target *tgtdb.Target, exportDir string) {
 	projectDirPath := exportDir
 
-	targetConnectionURI := ""
-	if target.Uri == "" {
-		targetConnectionURI = fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?%s",
-			target.User, target.Password, target.Host, target.Port, target.DBName, generateSSLQueryStringIfNotExists(target))
-	} else {
-		targetConnectionURI = target.Uri
-	}
-
 	//this list also has defined the order to create object type in target YugabyteDB
 	importObjectOrderList := utils.GetSchemaObjectList(sourceDBType)
-
 	for _, importObjectType := range importObjectOrderList {
 		var importObjectDirPath, importObjectFilePath string
 
@@ -65,7 +56,7 @@ func YugabyteDBImportSchema(target *tgtdb.Target, exportDir string) {
 
 		log.Infof("Importing %q", importObjectFilePath)
 
-		conn, err := pgx.Connect(context.Background(), targetConnectionURI)
+		conn, err := pgx.Connect(context.Background(), target.GetConnectionUri())
 		if err != nil {
 			utils.WaitChannel <- 1
 			<-utils.WaitChannel

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -29,22 +30,20 @@ import (
 )
 
 func YugabyteDBImportSchema(target *tgtdb.Target, exportDir string) {
-	projectDirPath := exportDir
-
 	//this list also has defined the order to create object type in target YugabyteDB
 	importObjectOrderList := utils.GetSchemaObjectList(sourceDBType)
 	for _, importObjectType := range importObjectOrderList {
 		var importObjectDirPath, importObjectFilePath string
 
 		if importObjectType != "INDEX" {
-			importObjectDirPath = projectDirPath + "/schema/" + strings.ToLower(importObjectType) + "s"
-			importObjectFilePath = importObjectDirPath + "/" + strings.ToLower(importObjectType) + ".sql"
+			importObjectDirPath = filepath.Join(exportDir, "schema", strings.ToLower(importObjectType)+"s")
+			importObjectFilePath = filepath.Join(importObjectDirPath, strings.ToLower(importObjectType)+".sql")
 		} else {
 			if target.ImportIndexesAfterData {
 				continue
 			}
-			importObjectDirPath = projectDirPath + "/schema/" + "tables"
-			importObjectFilePath = importObjectDirPath + "/" + "INDEXES_table.sql"
+			importObjectDirPath = filepath.Join(exportDir, "schema", "tables")
+			importObjectFilePath = filepath.Join(importObjectDirPath, "INDEXES_table.sql")
 		}
 
 		if !utils.FileOrFolderExists(importObjectFilePath) {

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -22,7 +22,7 @@ func newMySQL(s *Source) *MySQL {
 }
 
 func (ms *MySQL) Connect() error {
-	db, err := sql.Open("mysql", ms.getConnectionString())
+	db, err := sql.Open("mysql", ms.GetConnectionUri())
 	ms.db = db
 	return err
 }
@@ -78,8 +78,12 @@ func (ms *MySQL) GetAllPartitionNames(tableName string) []string {
 	panic("Not Implemented")
 }
 
-func (ms *MySQL) getConnectionString() string {
+func (ms *MySQL) GetConnectionUri() string {
 	source := ms.source
+	if source.Uri != "" {
+		return source.Uri
+	}
+
 	parseSSLString(source)
 	var tlsString string
 	switch source.SSLMode {
@@ -100,9 +104,10 @@ func (ms *MySQL) getConnectionString() string {
 		errMsg := "Incorrect SSL Mode Provided. Please enter a valid sslmode."
 		panic(errMsg)
 	}
-	connStr := fmt.Sprintf("%s:%s@(%s:%d)/%s?%s", source.User, source.Password,
+
+	ms.source.Uri = fmt.Sprintf("%s:%s@(%s:%d)/%s?%s", source.User, source.Password,
 		source.Host, source.Port, source.DBName, tlsString)
-	return connStr
+	return ms.source.Uri
 }
 
 func (ms *MySQL) ExportSchema(exportDir string) {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -21,7 +21,7 @@ func newOracle(s *Source) *Oracle {
 }
 
 func (ora *Oracle) Connect() error {
-	db, err := sql.Open("godror", ora.getConnectionString())
+	db, err := sql.Open("godror", ora.GetConnectionUri())
 	ora.db = db
 	return err
 }
@@ -112,10 +112,13 @@ func (ora *Oracle) GetAllPartitionNames(tableName string) []string {
 	return partitionNames
 }
 
-func (ora *Oracle) getConnectionString() string {
+func (ora *Oracle) GetConnectionUri() string {
 	source := ora.source
-	var connStr string
+	if source.Uri != "" {
+		return source.Uri
+	}
 
+	var connStr string
 	switch true {
 	case source.DBSid != "":
 		connStr = fmt.Sprintf("%s/%s@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SID=%s)))",
@@ -129,7 +132,8 @@ func (ora *Oracle) getConnectionString() string {
 			source.User, source.Password, source.Host, source.Port, source.DBName)
 	}
 
-	return connStr
+	ora.source.Uri = connStr
+	return ora.source.Uri
 }
 
 func (ora *Oracle) ExportSchema(exportDir string) {

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -36,16 +36,10 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, exportDir stri
 
 	tableListPatterns := createTableListPatterns(tableList)
 
-	SSLQueryString := generateSSLQueryStringIfNotExists(source)
-
 	// Using pgdump for exporting data in directory format.
-	cmd := ""
-	if source.Uri != "" {
-		cmd = fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --compress=0 %s -Fd --file %s --jobs %d`, source.Uri, tableListPatterns, dataDirPath, source.NumConnections)
-	} else {
-		cmd = fmt.Sprintf(`pg_dump "postgresql://%s:%s@%s:%d/%s?%s" --no-blobs --data-only --compress=0 %s -Fd --file %s --jobs %d`, source.User, source.Password,
-			source.Host, source.Port, source.DBName, SSLQueryString, tableListPatterns, dataDirPath, source.NumConnections)
-	}
+	cmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --compress=0 %s -Fd --file %s --jobs %d`,
+		source.sourceDB.GetConnectionUri(), tableListPatterns, dataDirPath, source.NumConnections)
+
 	log.Infof("Running command: %s", cmd)
 	var outbuf bytes.Buffer
 	var errbuf bytes.Buffer

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -18,10 +19,10 @@ func pgdumpExtractSchema(source *Source, exportDir string) {
 	preparePgdumpCommandString := ""
 
 	if source.Uri != "" {
-		preparePgdumpCommandString = fmt.Sprintf(`pg_dump "%s" --schema-only --no-owner -f %s/temp/schema.sql`, source.Uri, exportDir)
+		preparePgdumpCommandString = fmt.Sprintf(`pg_dump "%s" --schema-only --no-owner -f %s`, source.Uri, filepath.Join(exportDir, "temp", "schema.sql"))
 	} else {
-		preparePgdumpCommandString = fmt.Sprintf(`pg_dump "postgresql://%s:%s@%s:%d/%s?%s" --schema-only --no-owner -f %s/temp/schema.sql`, source.User, source.Password, source.Host,
-			source.Port, source.DBName, SSLQueryString, exportDir)
+		preparePgdumpCommandString = fmt.Sprintf(`pg_dump "postgresql://%s:%s@%s:%d/%s?%s" --schema-only --no-owner -f %s`, source.User, source.Password, source.Host,
+			source.Port, source.DBName, SSLQueryString, filepath.Join(exportDir, "temp", "schema.sql"))
 	}
 
 	log.Infof("Running command: %s", preparePgdumpCommandString)
@@ -49,8 +50,8 @@ func pgdumpExtractSchema(source *Source, exportDir string) {
 //NOTE: This is for case when --schema-only option is provided with pg_dump[Data shouldn't be there]
 func parseSchemaFile(source *Source, exportDir string) {
 	log.Info("Begun parsing the schema file.")
-	schemaFilePath := exportDir + "/temp" + "/schema.sql"
-	schemaDirPath := exportDir + "/schema"
+	schemaFilePath := filepath.Join(exportDir, "temp", "schema.sql")
+	schemaDirPath := filepath.Join(exportDir, "schema")
 	schemaFileData, err := ioutil.ReadFile(schemaFilePath)
 	if err != nil {
 		utils.ErrExit("Failed to read file %q: %v", schemaFilePath, err)
@@ -129,27 +130,27 @@ func parseSchemaFile(source *Source, exportDir string) {
 	//TODO: convert below code into a for-loop
 
 	//writing to .sql files in project
-	ioutil.WriteFile(schemaDirPath+"/tables/table.sql", []byte(setSessionVariables.String()+createTableSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/tables/INDEXES_table.sql", []byte(setSessionVariables.String()+createIndexSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/functions/function.sql", []byte(setSessionVariables.String()+createFunctionSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/procedures/procedure.sql", []byte(setSessionVariables.String()+createProcedureSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/triggers/trigger.sql", []byte(setSessionVariables.String()+createTriggerSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "tables", "table.sql"), []byte(setSessionVariables.String()+createTableSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "tables", "INDEXES_table.sql"), []byte(setSessionVariables.String()+createIndexSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "functions", "function.sql"), []byte(setSessionVariables.String()+createFunctionSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "procedures", "procedure.sql"), []byte(setSessionVariables.String()+createProcedureSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "triggers", "trigger.sql"), []byte(setSessionVariables.String()+createTriggerSqls.String()), 0644)
 
-	ioutil.WriteFile(schemaDirPath+"/types/type.sql", []byte(setSessionVariables.String()+createTypeSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/domains/domain.sql", []byte(setSessionVariables.String()+createDomainSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "types", "type.sql"), []byte(setSessionVariables.String()+createTypeSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "domains", "domain.sql"), []byte(setSessionVariables.String()+createDomainSqls.String()), 0644)
 
-	ioutil.WriteFile(schemaDirPath+"/aggregates/aggregate.sql", []byte(setSessionVariables.String()+createAggregateSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/rules/rule.sql", []byte(setSessionVariables.String()+createRuleSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/sequences/sequence.sql", []byte(setSessionVariables.String()+createSequenceSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/views/view.sql", []byte(setSessionVariables.String()+createViewSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/mviews/mview.sql", []byte(setSessionVariables.String()+createMatViewSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "aggregates", "aggregate.sql"), []byte(setSessionVariables.String()+createAggregateSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "rules", "rule.sql"), []byte(setSessionVariables.String()+createRuleSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "sequences", "sequence.sql"), []byte(setSessionVariables.String()+createSequenceSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "views", "view.sql"), []byte(setSessionVariables.String()+createViewSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "mviews", "mview.sql"), []byte(setSessionVariables.String()+createMatViewSqls.String()), 0644)
 
 	if uncategorizedSqls.Len() > 0 {
-		ioutil.WriteFile(schemaDirPath+"/uncategorized.sql", []byte(setSessionVariables.String()+uncategorizedSqls.String()), 0644)
+		ioutil.WriteFile(filepath.Join(schemaDirPath, "uncategorized.sql"), []byte(setSessionVariables.String()+uncategorizedSqls.String()), 0644)
 	}
 
-	ioutil.WriteFile(schemaDirPath+"/schemas/schema.sql", []byte(setSessionVariables.String()+createSchemaSqls.String()), 0644)
-	ioutil.WriteFile(schemaDirPath+"/extensions/extension.sql", []byte(setSessionVariables.String()+createExtensionSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "schemas", "schema.sql"), []byte(setSessionVariables.String()+createSchemaSqls.String()), 0644)
+	ioutil.WriteFile(filepath.Join(schemaDirPath, "extensions", "extension.sql"), []byte(setSessionVariables.String()+createExtensionSqls.String()), 0644)
 
 }
 

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -15,18 +15,11 @@ import (
 func pgdumpExtractSchema(source *Source, exportDir string) {
 	fmt.Printf("exporting the schema %10s", "")
 	go utils.Wait("done\n", "error\n")
-	SSLQueryString := generateSSLQueryStringIfNotExists(source)
-	preparePgdumpCommandString := ""
 
-	if source.Uri != "" {
-		preparePgdumpCommandString = fmt.Sprintf(`pg_dump "%s" --schema-only --no-owner -f %s`, source.Uri, filepath.Join(exportDir, "temp", "schema.sql"))
-	} else {
-		preparePgdumpCommandString = fmt.Sprintf(`pg_dump "postgresql://%s:%s@%s:%d/%s?%s" --schema-only --no-owner -f %s`, source.User, source.Password, source.Host,
-			source.Port, source.DBName, SSLQueryString, filepath.Join(exportDir, "temp", "schema.sql"))
-	}
-
-	log.Infof("Running command: %s", preparePgdumpCommandString)
-	preparedYsqldumpCommand := exec.Command("/bin/bash", "-c", preparePgdumpCommandString)
+	cmd := fmt.Sprintf(`pg_dump "%s" --schema-only --no-owner -f %s`,
+		source.sourceDB.GetConnectionUri(), filepath.Join(exportDir, "temp", "schema.sql"))
+	log.Infof("Running command: %s", cmd)
+	preparedYsqldumpCommand := exec.Command("/bin/bash", "-c", cmd)
 
 	stdout, err := preparedYsqldumpCommand.CombinedOutput()
 	//pg_dump formats its stdout messages, %s is sufficient.

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -21,7 +21,7 @@ func newPostgreSQL(s *Source) *PostgreSQL {
 }
 
 func (pg *PostgreSQL) Connect() error {
-	db, err := pgx.Connect(context.Background(), pg.getConnectionString())
+	db, err := pgx.Connect(context.Background(), pg.GetConnectionUri())
 	pg.db = db
 	return err
 }
@@ -87,15 +87,15 @@ func (pg *PostgreSQL) GetAllPartitionNames(tableName string) []string {
 	panic("Not Implemented")
 }
 
-func (pg *PostgreSQL) getConnectionString() string {
+func (pg *PostgreSQL) GetConnectionUri() string {
 	source := pg.source
-
 	if source.Uri != "" {
 		return source.Uri
 	}
 
-	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?%s", source.User, source.Password,
+	pg.source.Uri = fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?%s", source.User, source.Password,
 		source.Host, source.Port, source.DBName, generateSSLQueryStringIfNotExists(source))
+	return pg.source.Uri
 }
 
 func (pg *PostgreSQL) ExportSchema(exportDir string) {

--- a/yb-voyager/src/srcdb/source.go
+++ b/yb-voyager/src/srcdb/source.go
@@ -6,9 +6,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io/ioutil"
-	"net/url"
-	"os"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -46,78 +43,6 @@ func (s *Source) DB() SourceDB {
 		s.sourceDB = newSourceDB(s)
 	}
 	return s.sourceDB
-}
-
-func (s *Source) ParseURI() {
-	var err error
-	switch s.DBType {
-	case "oracle":
-		//TODO: figure out correct uri format for oracle and implement
-		oracleUriRegexpTNS := regexp.MustCompile(`([a-zA-Z0-9_.-]+)/([^@ ]+)@([a-zA-Z0-9_.-]+)`)
-		oracleUriRegexpSID := regexp.MustCompile(`([a-zA-Z0-9_.-]+)/([^@ ]+)@//([a-zA-Z0-9_.-]+):([0-9]+):([a-zA-Z0-9_.-]+)`)
-		oracleUriRegexpServiceName := regexp.MustCompile(`([a-zA-Z0-9_.-]+)/([^@ ]+)@//([a-zA-Z0-9_.-]+):([0-9]+)/([a-zA-Z0-9_.-]+)`)
-		if uriParts := oracleUriRegexpTNS.FindStringSubmatch(s.Uri); uriParts != nil {
-			s.User = uriParts[1]
-			s.Password = uriParts[2]
-			s.TNSAlias = uriParts[3]
-			s.Schema = s.User
-		} else if uriParts := oracleUriRegexpSID.FindStringSubmatch(s.Uri); uriParts != nil {
-			s.User = uriParts[1]
-			s.Password = uriParts[2]
-			s.Host = uriParts[3]
-			s.Port, err = strconv.Atoi(uriParts[4])
-			if err != nil {
-				panic(err)
-			}
-			s.DBSid = uriParts[5]
-			s.Schema = s.User
-		} else if uriParts := oracleUriRegexpServiceName.FindStringSubmatch(s.Uri); uriParts != nil {
-			s.User = uriParts[1]
-			s.Password = uriParts[2]
-			s.Host = uriParts[3]
-			s.Port, err = strconv.Atoi(uriParts[4])
-			if err != nil {
-				panic(err)
-			}
-			s.DBName = uriParts[5]
-			s.Schema = s.User
-		} else {
-			fmt.Printf("invalid connection uri for source db uri\n")
-			os.Exit(1)
-		}
-	case "mysql":
-		uriParts, err := url.Parse(s.Uri)
-		if err != nil {
-			panic(err)
-		}
-
-		s.User = uriParts.User.Username()
-		if s.User == "" {
-			fmt.Println("Username is mandatory!")
-			os.Exit(1)
-		}
-		s.Password, _ = uriParts.User.Password()
-		if s.Password == "" {
-			fmt.Println("Password is mandatory!")
-			os.Exit(1)
-		}
-		host_port := strings.Split(uriParts.Host, ":")
-		if len(host_port) > 1 {
-			s.Host = host_port[0]
-			s.Port, err = strconv.Atoi(host_port[1])
-			if err != nil {
-				panic(err)
-			}
-		} else {
-			s.Host = host_port[0]
-			s.Port = 3306
-		}
-		if uriParts.Path != "" {
-			s.DBName = uriParts.Path[1:]
-		}
-		s.SSLQueryString = uriParts.RawQuery
-
-	}
 }
 
 func parseSSLString(source *Source) {

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -9,6 +9,7 @@ import (
 
 type SourceDB interface {
 	Connect() error
+	GetConnectionUri() string
 	GetTableRowCount(tableName string) int64
 	CheckRequiredToolsAreInstalled()
 	GetVersion() string

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -215,9 +215,9 @@ func PrettifyJsonString(jsonStr string) string {
 func GetObjectDirPath(schemaDirPath string, objType string) string {
 	var requiredPath string
 	if objType == "INDEX" {
-		requiredPath = schemaDirPath + "/tables"
+		requiredPath = filepath.Join(schemaDirPath, "tables")
 	} else {
-		requiredPath = schemaDirPath + "/" + strings.ToLower(objType) + "s"
+		requiredPath = filepath.Join(schemaDirPath, strings.ToLower(objType)+"s")
 	}
 	return requiredPath
 }
@@ -225,10 +225,10 @@ func GetObjectDirPath(schemaDirPath string, objType string) string {
 func GetObjectFilePath(schemaDirPath string, objType string) string {
 	var requiredPath string
 	if objType == "INDEX" {
-		requiredPath = schemaDirPath + "/tables/INDEXES_table.sql"
+		requiredPath = filepath.Join(schemaDirPath, "tables", "INDEXES_table.sql")
 	} else {
-		requiredPath = schemaDirPath + "/" + strings.ToLower(objType) + "s/" +
-			strings.ToLower(objType) + ".sql"
+		requiredPath = filepath.Join(schemaDirPath, strings.ToLower(objType)+"s",
+			strings.ToLower(objType)+".sql")
 	}
 	return requiredPath
 }


### PR DESCRIPTION
This PR removed the use of `--soruce-db-uri` and `--target-db-uri` flags so that to use the separate flags to provide the information.

The reason for moving away from the use of these flags is to avoid ambiguity as for each database type there are many cases where the connection string format followed for corresponding drivers and underlying tools is different.