### PR TITLE
Support for MySQL Table Partitions

### DIFF
--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -280,9 +280,11 @@ install_ora2pg() {
 	sudo cpanm DBD::mysql Test::NoWarnings DBD::Oracle 1>&2
 
 	output "Installing ora2pg."
-	wget --no-verbose https://github.com/darold/ora2pg/archive/refs/tags/v${ORA2PG_VERSION}.tar.gz 1>&2
-	tar -xf v${ORA2PG_VERSION}.tar.gz 1>&2
-	cd ora2pg-${ORA2PG_VERSION}/
+	# wget --no-verbose https://github.com/darold/ora2pg/archive/refs/tags/v${ORA2PG_VERSION}.tar.gz 1>&2
+	# tar -xf v${ORA2PG_VERSION}.tar.gz 1>&2
+	# cd ora2pg-${ORA2PG_VERSION}/
+	git clone https://github.com/darold/ora2pg.git # master branch
+	cd ora2pg
 	perl Makefile.PL 1>&2
 	make 1>&2
 	sudo make install 1>&2

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -143,7 +143,6 @@ func UpdateTableApproxRowCount(source *srcdb.Source, exportDir string, tablesPro
 		approxRowCount := source.DB().GetTableApproxRowCount(tablesProgressMetadata[key])
 		tablesProgressMetadata[key].CountTotalRows = approxRowCount
 	}
-
 	log.Tracef("After updating total approx row count, TablesProgressMetadata: %+v", tablesProgressMetadata)
 }
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -144,28 +143,6 @@ func UpdateTableApproxRowCount(source *srcdb.Source, exportDir string, tablesPro
 		tablesProgressMetadata[key].CountTotalRows = approxRowCount
 	}
 	log.Tracef("After updating total approx row count, TablesProgressMetadata: %+v", tablesProgressMetadata)
-}
-
-func GetTableRowCount(filePath string) map[string]int64 {
-	tableRowCountMap := make(map[string]int64)
-
-	fileBytes, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		utils.ErrExit("read file %q: %s", filePath, err)
-	}
-
-	lines := strings.Split(strings.Trim(string(fileBytes), "\n"), "\n")
-
-	for _, line := range lines {
-		tableName := strings.Split(line, ",")[0]
-		rowCount := strings.Split(line, ",")[1]
-		rowCountInt64, _ := strconv.ParseInt(rowCount, 10, 64)
-
-		tableRowCountMap[tableName] = rowCountInt64
-	}
-
-	log.Infof("tableRowCountMap: %v", tableRowCountMap)
-	return tableRowCountMap
 }
 
 func printExportedRowCount(exportedRowCount map[string]int64) {

--- a/yb-voyager/cmd/exportDataStatus.go
+++ b/yb-voyager/cmd/exportDataStatus.go
@@ -72,7 +72,7 @@ func initializeExportTableMetadata(tableList []string) {
 
 func initializeExportTablePartitionMetadata(tableList []string) {
 	for _, parentTable := range tableList {
-		if source.DBType == ORACLE {
+		if source.DBType == ORACLE || source.DBType == MYSQL {
 			partitionList := source.DB().GetAllPartitionNames(parentTable)
 			if len(partitionList) > 0 {
 				utils.PrintAndLog("Table %q has partitions: %v", parentTable, partitionList)
@@ -82,6 +82,9 @@ func initializeExportTablePartitionMetadata(tableList []string) {
 					fullTableName := fmt.Sprintf("%s PARTITION(%s)", tablesProgressMetadata[parentTable].FullTableName, partitionName)
 					tablesProgressMetadata[key] = &utils.TableProgressMetadata{}
 					tablesProgressMetadata[key].TableSchema = source.Schema
+					if source.DBType == MYSQL { // for a table in MySQL: database and schema is same
+						tablesProgressMetadata[key].TableSchema = source.DBName
+					}
 					tablesProgressMetadata[key].TableName = partitionName
 
 					// partition are unique under a table in oracle

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -952,11 +952,10 @@ func executeSqlFile(filePath string, objectType string) int {
 			return 1
 		}
 
-		setClientEncQuery := IMPORT_SESSION_SETTERS[0]
-		log.Infof("Running query %q on the target DB", setClientEncQuery)
-		_, err = conn.Exec(context.Background(), setClientEncQuery)
+		log.Infof("Running query %q on the target DB", SET_CLIENT_ENCODING_TO_UTF8)
+		_, err = conn.Exec(context.Background(), SET_CLIENT_ENCODING_TO_UTF8)
 		if err != nil {
-			utils.PrintAndLog("Failed to run %q on target DB: %s", setClientEncQuery, err)
+			utils.PrintAndLog("Failed to run %q on target DB: %s", SET_CLIENT_ENCODING_TO_UTF8, err)
 			return 1
 		}
 	}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -961,6 +961,7 @@ func executeSqlFile(filePath string, objectType string) int {
 		}
 	}
 
+	reCreateSchema := regexp.MustCompile(`(?i)CREATE SCHEMA public`)
 	sqlStrArray := createSqlStrArray(filePath, objectType)
 	for _, sqlStr := range sqlStrArray {
 		log.Infof("Execute STATEMENT:\n%s", sqlStr[1])
@@ -968,7 +969,7 @@ func executeSqlFile(filePath string, objectType string) int {
 		if err != nil {
 			log.Errorf("Previous SQL statement failed with error: %s", err)
 			if strings.Contains(err.Error(), "already exists") {
-				if !target.IgnoreIfExists {
+				if !target.IgnoreIfExists && !reCreateSchema.MatchString(sqlStr[1]) {
 					fmt.Printf("\b \n    %s\n", err.Error())
 					fmt.Printf("    STATEMENT: %s\n", sqlStr[1])
 					if !target.ContinueOnError {

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -112,12 +112,14 @@ func (ms *MySQL) GetAllPartitionNames(tableName string) []string {
 
 	var partitionNames []string
 	for rows.Next() {
-		var partitionName string
+		var partitionName sql.NullString
 		err = rows.Scan(&partitionName)
 		if err != nil {
 			utils.ErrExit("error in scanning query rows: %v", err)
 		}
-		partitionNames = append(partitionNames, partitionName)
+		if partitionName.Valid {
+			partitionNames = append(partitionNames, partitionName.String)
+		}
 	}
 	log.Infof("Partition Names for parent table %q: %q", tableName, partitionNames)
 	return partitionNames

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -46,8 +46,15 @@ func (ms *MySQL) GetTableRowCount(tableName string) int64 {
 
 func (ms *MySQL) GetTableApproxRowCount(tableProgressMetadata *utils.TableProgressMetadata) int64 {
 	var approxRowCount sql.NullInt64 // handles case: value of the row is null, default for int64 is 0
-	query := fmt.Sprintf("SELECT table_rows from information_schema.tables "+
-		"where table_name = '%s'", tableProgressMetadata.TableName) // TODO: approx row count query might be different for table partitions
+	var query string
+	if !tableProgressMetadata.IsPartition {
+		query = fmt.Sprintf("SELECT table_rows from information_schema.tables "+
+			"where table_name = '%s'", tableProgressMetadata.TableName)
+	} else {
+		query = fmt.Sprintf("SELECT table_rows from information_schema.partitions "+
+			"where table_name='%s' and partition_name='%s' and table_schema='%s'",
+			tableProgressMetadata.ParentTable, tableProgressMetadata.TableName, tableProgressMetadata.TableSchema)
+	}
 
 	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)
 	err := ms.db.QueryRow(query).Scan(&approxRowCount)
@@ -88,11 +95,32 @@ func (ms *MySQL) GetAllTableNames() []string {
 		}
 		tableNames = append(tableNames, tableName)
 	}
+	log.Infof("GetAllTableNames(): %s", tableNames)
 	return tableNames
 }
 
 func (ms *MySQL) GetAllPartitionNames(tableName string) []string {
-	panic("Not Implemented")
+	query := fmt.Sprintf(`SELECT partition_name  from information_schema.partitions
+	WHERE table_name='%s' and table_schema='%s' ORDER BY partition_name ASC`,
+		tableName, ms.source.DBName)
+
+	rows, err := ms.db.Query(query)
+	if err != nil {
+		utils.ErrExit("failed to list partitions of table %q: %v", tableName, err)
+	}
+	defer rows.Close()
+
+	var partitionNames []string
+	for rows.Next() {
+		var partitionName string
+		err = rows.Scan(&partitionName)
+		if err != nil {
+			utils.ErrExit("error in scanning query rows: %v", err)
+		}
+		partitionNames = append(partitionNames, partitionName)
+	}
+	log.Infof("Partition Names for parent table %q: %q", tableName, partitionNames)
+	return partitionNames
 }
 
 func (ms *MySQL) getConnectionUri() string {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -55,6 +55,7 @@ func (pg *PostgreSQL) GetTableApproxRowCount(tableProgressMetadata *utils.TableP
 	var approxRowCount sql.NullInt64 // handles case: value of the row is null, default for int64 is 0
 	query := fmt.Sprintf("SELECT reltuples::bigint FROM pg_class "+
 		"where oid = '%s'::regclass", tableProgressMetadata.FullTableName)
+	// table partition names are under schema as a namespace
 
 	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)
 	if err != nil {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -58,7 +58,11 @@ func (pg *PostgreSQL) GetTableApproxRowCount(tableProgressMetadata *utils.TableP
 	// table partition names are under schema as a namespace
 
 	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)
+	err := pg.db.QueryRow(context.Background(), query).Scan(&approxRowCount)
 	if err != nil {
+		utils.ErrExit("Failed to query %q for approx row count of %q: %s", query, tableProgressMetadata.FullTableName, err)
+	}
+
 	log.Infof("Table %q has approx %v rows.", tableProgressMetadata.FullTableName, approxRowCount)
 	return approxRowCount.Int64
 }

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -57,11 +57,7 @@ func (pg *PostgreSQL) GetTableApproxRowCount(tableProgressMetadata *utils.TableP
 		"where oid = '%s'::regclass", tableProgressMetadata.FullTableName)
 
 	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)
-	err := pg.db.QueryRow(context.Background(), query).Scan(&approxRowCount)
 	if err != nil {
-		utils.ErrExit("Failed to query %q for approx row count of %q: %s", query, tableProgressMetadata.FullTableName, err)
-	}
-
 	log.Infof("Table %q has approx %v rows.", tableProgressMetadata.FullTableName, approxRowCount)
 	return approxRowCount.Int64
 }

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -53,7 +53,7 @@ var postgresSchemaObjectList = []string{"SCHEMA", "TYPE", "DOMAIN", "SEQUENCE",
 	"MVIEW", "EXTENSION", "COMMENT" /* GRANT, ROLE*/}
 
 // In MYSQL, TYPE and SEQUENCE are not supported
-var mysqlSchemaObjectList = []string{"TABLE" /*, "PARTITION"*/, "INDEX", "VIEW", /*"GRANT*/
+var mysqlSchemaObjectList = []string{"TABLE", "PARTITION", "INDEX", "VIEW", /*"GRANT*/
 	"TRIGGER", "FUNCTION", "PROCEDURE"}
 
 type ExportMetaInfo struct {


### PR DESCRIPTION
This PR adds support for migrating tables partitions from MySQL to YugabyteDB and will close #55 
Note: the ora2pg used should be from the current master branch since the `v.23.1` release doesn't have the required changes.

For table partition indexes in case of MySQL and Oracle, there is a new file `exportDir/schema/partitions/PARTITION_INDEXES_partition.sql` containing that. which also need to be imported during index creation

TODO:
1. Update the analyze-schema part wrt to report PARTITION indexes 