### PR TITLE
Update actual row counts for callhome

### DIFF
--- a/testscript.sh
+++ b/testscript.sh
@@ -1,0 +1,1 @@
+git rev-parse --show-toplevel

--- a/testscript.sh
+++ b/testscript.sh
@@ -1,1 +1,0 @@
-git rev-parse --show-toplevel

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -171,8 +171,6 @@ func GetTableRowCount(filePath string) map[string]int64 {
 }
 
 func printExportedRowCount(exportedRowCount map[string]int64) {
-	var maxTableLines, totalTableLines int64
-	payload := callhome.GetPayload(exportDir)
 
 	fmt.Println("exported num of rows for each table")
 	fmt.Printf("+%s+\n", strings.Repeat("-", 65))
@@ -184,17 +182,25 @@ func printExportedRowCount(exportedRowCount map[string]int64) {
 	}
 	sort.Strings(keys)
 
-	var rowCount int64
 	for _, key := range keys {
+		fmt.Printf("|%s|\n", strings.Repeat("-", 65))
+		fmt.Printf("| %30s | %30d |\n", key, exportedRowCount[key])
+	}
+	fmt.Printf("+%s+\n", strings.Repeat("-", 65))
+
+}
+
+func callhomeActualRowCounts(exportedRowCount map[string]int64) {
+	var maxTableLines, totalTableLines int64
+	payload := callhome.GetPayload(exportDir)
+	var rowCount int64
+	for key := range exportedRowCount {
 		rowCount = exportedRowCount[key]
 		if rowCount > maxTableLines {
 			maxTableLines = rowCount
 		}
 		totalTableLines += rowCount
-		fmt.Printf("|%s|\n", strings.Repeat("-", 65))
-		fmt.Printf("| %30s | %30d |\n", key, rowCount)
 	}
-	fmt.Printf("+%s+\n", strings.Repeat("-", 65))
 	payload.LargestTableRows = maxTableLines
 	payload.TotalRows = totalTableLines
 }

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -27,7 +27,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 
@@ -171,7 +170,6 @@ func GetTableRowCount(filePath string) map[string]int64 {
 }
 
 func printExportedRowCount(exportedRowCount map[string]int64) {
-
 	fmt.Println("exported num of rows for each table")
 	fmt.Printf("+%s+\n", strings.Repeat("-", 65))
 	fmt.Printf("| %30s | %30s |\n", "Table", "Row Count")
@@ -181,28 +179,11 @@ func printExportedRowCount(exportedRowCount map[string]int64) {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-
 	for _, key := range keys {
 		fmt.Printf("|%s|\n", strings.Repeat("-", 65))
 		fmt.Printf("| %30s | %30d |\n", key, exportedRowCount[key])
 	}
 	fmt.Printf("+%s+\n", strings.Repeat("-", 65))
-
-}
-
-func callhomeActualRowCounts(exportedRowCount map[string]int64) {
-	var maxTableLines, totalTableLines int64
-	payload := callhome.GetPayload(exportDir)
-	var rowCount int64
-	for key := range exportedRowCount {
-		rowCount = exportedRowCount[key]
-		if rowCount > maxTableLines {
-			maxTableLines = rowCount
-		}
-		totalTableLines += rowCount
-	}
-	payload.LargestTableRows = maxTableLines
-	payload.TotalRows = totalTableLines
 }
 
 //setup a project having subdirs for various database objects IF NOT EXISTS

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -166,9 +166,7 @@ func exportDataOffline() bool {
 
 	tableRowCount := datafile.OpenDescriptor(exportDir).TableRowCount
 	printExportedRowCount(tableRowCount)
-	callhomeActualRowCounts(tableRowCount)
-
-	callhome.UpdateDataSize(exportDir)
+	callhome.UpdateDataStats(exportDir, tableRowCount)
 	callhome.PackAndSendPayload(exportDir)
 	return true
 }

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -163,7 +163,10 @@ func exportDataOffline() bool {
 	}
 
 	source.DB().ExportDataPostProcessing(exportDir, tablesProgressMetadata)
-	printExportedRowCount(datafile.OpenDescriptor(exportDir).TableRowCount)
+
+	tableRowCount := datafile.OpenDescriptor(exportDir).TableRowCount
+	printExportedRowCount(tableRowCount)
+	callhomeActualRowCounts(tableRowCount)
 
 	callhome.UpdateDataSize(exportDir)
 	callhome.PackAndSendPayload(exportDir)

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -150,7 +150,8 @@ func PackAndSendPayload(exportdir string) {
 }
 
 // Find the largest and total data sizes, and upload to diagnostics json
-func UpdateDataSize(exportdir string) {
+func UpdateDataStats(exportdir string, exportedRowCount map[string]int64) {
+	//Table Size Stats
 	datadirfiles := filepath.Join(exportdir, "data", "*_data*")
 
 	files, err := filepath.Glob(datadirfiles)
@@ -172,6 +173,18 @@ func UpdateDataSize(exportdir string) {
 		totalSize += fileInfo.Size()
 	}
 
+	//Row Count Stats
+	var maxTableLines, totalTableLines int64
+	var rowCount int64
+	for key := range exportedRowCount {
+		rowCount = exportedRowCount[key]
+		if rowCount > maxTableLines {
+			maxTableLines = rowCount
+		}
+		totalTableLines += rowCount
+	}
+	Payload.LargestTableRows = maxTableLines
+	Payload.TotalRows = totalTableLines
 	Payload.TotalSize = totalSize
 	Payload.LargestTableSize = maxFileSize
 }


### PR DESCRIPTION
Correctly updates call-home stats, changed the location of where the relevant statistics (largest and max table rows) are recorded. Fixes #178 