### PR TITLE
TABLESPACE export not supported in yb-voyager (#170).

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Schema objects and data objects are both migrated as per the following compatibi
 
 |Source Database|Tables|Indexes|Constraints|Views|Procedures|Functions|Partition Tables|Sequences|Triggers|Types|Packages|Synonyms|Tablespaces|
 |-|-|-|-|-|-|-|-|-|-|-|-|-|-|
-|MySQL/MariaDB|Y|Y|Y|Y|Y|Y|N(https://github.com/yugabyte/yb-db-migration/issues/55)|N/A|Y|N/A|N/A|N/A|N(https://github.com/yugabyte/yb-db-migration/issues/47)|
-|PostgreSQL|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|N/A|N/A|N(https://github.com/yugabyte/yb-db-migration/issues/47)|
-|Oracle|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|N(https://github.com/yugabyte/yb-db-migration/issues/47)|
+|MySQL/MariaDB|Y|Y|Y|Y|Y|Y|N(https://github.com/yugabyte/yb-db-migration/issues/55)|N/A|Y|N/A|N/A|N/A|N(https://github.com/yugabyte/yb-db-migration/issues/170)|
+|PostgreSQL|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|N/A|N/A|N(https://github.com/yugabyte/yb-db-migration/issues/170)|
+|Oracle|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|N(https://github.com/yugabyte/yb-db-migration/issues/170)|
 
 
 *Note that the following versions have been tested with yb-voyager:*

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -37,7 +37,7 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 	tableListPatterns := createTableListPatterns(tableList)
 
 	// Using pgdump for exporting data in directory format.
-	cmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges`,
+	cmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`,
 		connectionUri, tableListPatterns, dataDirPath, source.NumConnections)
 
 	log.Infof("Running command: %s", cmd)

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -16,7 +16,7 @@ func pgdumpExtractSchema(schemaList string, connectionUri string, exportDir stri
 	fmt.Printf("exporting the schema %10s", "")
 	go utils.Wait("done\n", "error\n")
 
-	cmd := fmt.Sprintf(`pg_dump "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges`,
+	cmd := fmt.Sprintf(`pg_dump "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`,
 		connectionUri, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
 	log.Infof("Running command: %s", cmd)
 	preparedPgdumpCommand := exec.Command("/bin/bash", "-c", cmd)

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -43,18 +43,18 @@ type TableProgressMetadata struct {
 
 // the list elements order is same as the import objects order
 // TODO: Need to make each of the list comprehensive, not missing any database object category
-var oracleSchemaObjectList = []string{"TYPE", "SEQUENCE", "TABLE", "INDEX", "PACKAGE", "VIEW",
-	/*"GRANT",*/ "TRIGGER", "FUNCTION", "PROCEDURE", "PARTITION", /*"TABLESPACE",*/
+var oracleSchemaObjectList = []string{"TYPE", "SEQUENCE", "TABLE", "PARTITION", "INDEX", "PACKAGE", "VIEW",
+	/*"GRANT",*/ "TRIGGER", "FUNCTION", "PROCEDURE",
 	"MVIEW" /*"DBLINK",*/, "SYNONYM" /*, "DIRECTORY"*/}
 
 // In PG, PARTITION are exported along with TABLE
 var postgresSchemaObjectList = []string{"SCHEMA", "TYPE", "DOMAIN", "SEQUENCE",
 	"TABLE", "INDEX", "RULE", "FUNCTION", "AGGREGATE", "PROCEDURE", "VIEW", "TRIGGER",
-	"MVIEW", "EXTENSION", "COMMENT" /*TABLESPACES, GRANT, ROLE*/}
+	"MVIEW", "EXTENSION", "COMMENT" /* GRANT, ROLE*/}
 
 // In MYSQL, TYPE and SEQUENCE are not supported
-var mysqlSchemaObjectList = []string{"TABLE", "INDEX", "VIEW", /*"GRANT*/
-	"TRIGGER", "FUNCTION", "PROCEDURE" /* "TABLESPACE, PARTITION"*/}
+var mysqlSchemaObjectList = []string{"TABLE", "PARTITION", "INDEX", "VIEW", /*"GRANT*/
+	"TRIGGER", "FUNCTION", "PROCEDURE"}
 
 type ExportMetaInfo struct {
 	SourceDBType   string

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -53,7 +53,7 @@ var postgresSchemaObjectList = []string{"SCHEMA", "TYPE", "DOMAIN", "SEQUENCE",
 	"MVIEW", "EXTENSION", "COMMENT" /* GRANT, ROLE*/}
 
 // In MYSQL, TYPE and SEQUENCE are not supported
-var mysqlSchemaObjectList = []string{"TABLE", "PARTITION", "INDEX", "VIEW", /*"GRANT*/
+var mysqlSchemaObjectList = []string{"TABLE" /*, "PARTITION"*/, "INDEX", "VIEW", /*"GRANT*/
 	"TRIGGER", "FUNCTION", "PROCEDURE"}
 
 type ExportMetaInfo struct {


### PR DESCRIPTION
- Pg_dump for postgres export only schema/database level objects while TABLESPACE is global/shared across databases.
- Ora2pg for mysql does not even support TABLESPACE type for export, oracle it also it doesn't CREATE statements for tablespaces.


The way tablespaces are supported/used in databases like Oracle, MySQL, or PostgreSQL is by pointing them to some sta location on disk while YugabyteDB being a distributed cloud-native database uses tablespace them in a whole different way i.e. here you can define the geo-distribution(region, zone) of tables by defining them in a tablespace accordingly.
For more details about tablespaces in YugabyteDB, refer [this link](https://docs.yugabyte.com/preview/explore/ysql-language-features/going-beyond-sql/tablespaces/#overview)

This PR closes #170 ticket 