### PR TITLE
Added export data status command

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -41,7 +41,7 @@ func updateFilePaths(source *srcdb.Source, exportDir string, tablesProgressMetad
 
 	sortedKeys := utils.GetSortedKeys(tablesProgressMetadata)
 	if source.DBType == "postgresql" {
-		requiredMap = GetMappingForTableNameVsTableFileName(filepath.Join(exportDir, "data"))
+		requiredMap = getMappingForTableNameVsTableFileName(filepath.Join(exportDir, "data"))
 		for _, key := range sortedKeys {
 			tableName := tablesProgressMetadata[key].TableName
 			fullTableName := tablesProgressMetadata[key].FullTableName
@@ -77,7 +77,7 @@ func updateFilePaths(source *srcdb.Source, exportDir string, tablesProgressMetad
 	log.Infof(logMsg)
 }
 
-func GetMappingForTableNameVsTableFileName(dataDirPath string) map[string]string {
+func getMappingForTableNameVsTableFileName(dataDirPath string) map[string]string {
 	tocTextFilePath := filepath.Join(dataDirPath, "toc.txt")
 	// waitingFlag := 0
 	for !utils.FileOrFolderExists(tocTextFilePath) {

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -41,7 +41,7 @@ func updateFilePaths(source *srcdb.Source, exportDir string, tablesProgressMetad
 
 	sortedKeys := utils.GetSortedKeys(tablesProgressMetadata)
 	if source.DBType == "postgresql" {
-		requiredMap = getMappingForTableNameVsTableFileName(filepath.Join(exportDir, "data"))
+		requiredMap = GetMappingForTableNameVsTableFileName(filepath.Join(exportDir, "data"))
 		for _, key := range sortedKeys {
 			tableName := tablesProgressMetadata[key].TableName
 			fullTableName := tablesProgressMetadata[key].FullTableName
@@ -77,7 +77,7 @@ func updateFilePaths(source *srcdb.Source, exportDir string, tablesProgressMetad
 	log.Infof(logMsg)
 }
 
-func getMappingForTableNameVsTableFileName(dataDirPath string) map[string]string {
+func GetMappingForTableNameVsTableFileName(dataDirPath string) map[string]string {
 	tocTextFilePath := filepath.Join(dataDirPath, "toc.txt")
 	// waitingFlag := 0
 	for !utils.FileOrFolderExists(tocTextFilePath) {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -38,8 +38,7 @@ var exportCmd = &cobra.Command{
 	Long: `Export has various sub-commands to extract schema, data and generate migration report.
 `,
 
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+	PreRun: func(cmd *cobra.Command, args []string) {
 		setExportFlagsDefaults()
 		validateExportFlags()
 		markFlagsRequired(cmd)
@@ -58,13 +57,13 @@ func init() {
 
 	registerCommonExportFlags(exportCmd)
 
-	exportCmd.PersistentFlags().StringVar(&source.TableList, "table-list", "",
+	exportCmd.Flags().StringVar(&source.TableList, "table-list", "",
 		"list of the tables to export data(Note: works only for export data command)")
 
-	exportCmd.PersistentFlags().StringVar(&migrationMode, "migration-mode", "offline",
+	exportCmd.Flags().StringVar(&migrationMode, "migration-mode", "offline",
 		"mode can be offline | online(applicable only for data migration)")
 
-	exportCmd.PersistentFlags().IntVar(&source.NumConnections, "parallel-jobs", 1,
+	exportCmd.Flags().IntVar(&source.NumConnections, "parallel-jobs", 1,
 		"number of Parallel Jobs to extract data from source database")
 
 	exportCmd.Flags().BoolVar(&disablePb, "disable-pb", false,
@@ -72,57 +71,57 @@ func init() {
 }
 
 func registerCommonExportFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&source.DBType, "source-db-type", "",
+	cmd.Flags().StringVar(&source.DBType, "source-db-type", "",
 		fmt.Sprintf("source database type: %s\n", supportedSourceDBTypes))
 
-	cmd.PersistentFlags().StringVar(&source.Host, "source-db-host", "localhost",
+	cmd.Flags().StringVar(&source.Host, "source-db-host", "localhost",
 		"source database server host")
 
-	cmd.PersistentFlags().IntVar(&source.Port, "source-db-port", -1,
+	cmd.Flags().IntVar(&source.Port, "source-db-port", -1,
 		"source database server port number")
 
-	cmd.PersistentFlags().StringVar(&source.User, "source-db-user", "",
+	cmd.Flags().StringVar(&source.User, "source-db-user", "",
 		"connect to source database as specified user")
 
 	// TODO: All sensitive parameters can be taken from the environment variable
-	cmd.PersistentFlags().StringVar(&source.Password, "source-db-password", "",
+	cmd.Flags().StringVar(&source.Password, "source-db-password", "",
 		"connect to source as specified user")
 
-	cmd.PersistentFlags().StringVar(&source.DBName, "source-db-name", "",
+	cmd.Flags().StringVar(&source.DBName, "source-db-name", "",
 		"source database name to be migrated to YugabyteDB")
 
-	cmd.PersistentFlags().StringVar(&source.DBSid, "oracle-db-sid", "",
+	cmd.Flags().StringVar(&source.DBSid, "oracle-db-sid", "",
 		"[For Oracle Only] Oracle System Identifier (SID) that you wish to use while exporting data from Oracle instances")
 
-	cmd.PersistentFlags().StringVar(&source.OracleHome, "oracle-home", "",
+	cmd.Flags().StringVar(&source.OracleHome, "oracle-home", "",
 		"[For Oracle Only] Path to set $ORACLE_HOME environment variable. tnsnames.ora is found in $ORACLE_HOME/network/admin")
 
-	cmd.PersistentFlags().StringVar(&source.TNSAlias, "oracle-tns-alias", "",
+	cmd.Flags().StringVar(&source.TNSAlias, "oracle-tns-alias", "",
 		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle instance. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
 
 	//out of schema and db-name one should be mandatory(oracle vs others)
 
-	cmd.PersistentFlags().StringVar(&source.Schema, "source-db-schema", "",
+	cmd.Flags().StringVar(&source.Schema, "source-db-schema", "",
 		"source schema name which needs to be migrated to YugabyteDB (valid for Oracle, PostgreSQL)\n"+
 			"Note: in case of PostgreSQL, it can be a single or comma separated list of schemas")
 
 	// TODO SSL related more args will come. Explore them later.
-	cmd.PersistentFlags().StringVar(&source.SSLCertPath, "source-ssl-cert", "",
+	cmd.Flags().StringVar(&source.SSLCertPath, "source-ssl-cert", "",
 		"provide Source SSL Certificate Path")
 
-	cmd.PersistentFlags().StringVar(&source.SSLMode, "source-ssl-mode", "prefer",
+	cmd.Flags().StringVar(&source.SSLMode, "source-ssl-mode", "prefer",
 		"specify the source SSL mode out of - disable, allow, prefer, require, verify-ca, verify-full. \nMySQL does not support 'allow' sslmode, and Oracle does not use explicit sslmode paramters.")
 
-	cmd.PersistentFlags().StringVar(&source.SSLKey, "source-ssl-key", "",
+	cmd.Flags().StringVar(&source.SSLKey, "source-ssl-key", "",
 		"provide SSL Key Path")
 
-	cmd.PersistentFlags().StringVar(&source.SSLRootCert, "source-ssl-root-cert", "",
+	cmd.Flags().StringVar(&source.SSLRootCert, "source-ssl-root-cert", "",
 		"provide SSL Root Certificate Path")
 
-	cmd.PersistentFlags().StringVar(&source.SSLCRL, "source-ssl-crl", "",
+	cmd.Flags().StringVar(&source.SSLCRL, "source-ssl-crl", "",
 		"provide SSL Root Certificate Revocation List (CRL)")
 
-	cmd.PersistentFlags().BoolVar(&startClean, "start-clean", false,
+	cmd.Flags().BoolVar(&startClean, "start-clean", false,
 		"clean the project's data directory for already existing files before start(Note: works only for export data command)")
 }
 
@@ -249,15 +248,15 @@ func validateOracleParams() {
 
 func markFlagsRequired(cmd *cobra.Command) {
 	// mandatory for all
-	cmd.MarkPersistentFlagRequired("source-db-type")
-	cmd.MarkPersistentFlagRequired("source-db-user")
-	cmd.MarkPersistentFlagRequired("source-db-password")
+	cmd.MarkFlagRequired("source-db-type")
+	cmd.MarkFlagRequired("source-db-user")
+	cmd.MarkFlagRequired("source-db-password")
 
 	switch source.DBType {
 	case POSTGRESQL, ORACLE: // schema and database names are mandatory
-		cmd.MarkPersistentFlagRequired("source-db-name")
-		cmd.MarkPersistentFlagRequired("source-db-schema")
+		cmd.MarkFlagRequired("source-db-name")
+		cmd.MarkFlagRequired("source-db-schema")
 	case MYSQL:
-		cmd.MarkPersistentFlagRequired("source-db-name")
+		cmd.MarkFlagRequired("source-db-name")
 	}
 }

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -40,8 +40,10 @@ var exportDataCmd = &cobra.Command{
 	Short: "This command is used to export table's data from source database to *.sql files",
 	Long:  ``,
 
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+	PreRun: func(cmd *cobra.Command, args []string) {
+		setExportFlagsDefaults()
+		validateExportFlags()
+		markFlagsRequired(cmd)
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {
@@ -52,8 +54,18 @@ var exportDataCmd = &cobra.Command{
 
 func init() {
 	exportCmd.AddCommand(exportDataCmd)
+	registerCommonExportFlags(exportDataCmd)
 	exportDataCmd.Flags().BoolVar(&disablePb, "disable-pb", false,
 		"true - to disable progress bar during data export(default false)")
+
+	exportDataCmd.Flags().StringVar(&source.TableList, "table-list", "",
+		"list of the tables to export data")
+
+	exportDataCmd.Flags().StringVar(&migrationMode, "migration-mode", "offline",
+		"mode can be offline | online")
+
+	exportDataCmd.Flags().IntVar(&source.NumConnections, "parallel-jobs", 1,
+		"number of Parallel Jobs to extract data from source database")
 }
 
 func exportData() {

--- a/yb-voyager/cmd/exportDataStatus.go
+++ b/yb-voyager/cmd/exportDataStatus.go
@@ -164,12 +164,11 @@ func startExportPB(progressContainer *mpb.Progress, mapKey string, quitChan chan
 	total := int64(0) // mandatory to set total with 0 while AddBar to achieve dynamic total behaviour
 	bar := progressContainer.AddBar(total,
 		mpb.BarFillerClearOnComplete(),
-		// mpb.BarRemoveOnComplete(),
+		mpb.BarRemoveOnComplete(),
 		mpb.PrependDecorators(
 			decor.Name(tableName),
 		),
 		mpb.AppendDecorators(
-			// decor.Percentage(decor.WCSyncSpaceR),
 			decor.OnComplete(
 				decor.NewPercentage("%.2f", decor.WCSyncSpaceR), "completed",
 			),

--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -93,12 +93,12 @@ func runExportDataStatusCmd() error {
 		if (source.DBType == POSTGRESQL && utils.FileOrFolderExists(filepath.Join(dataDir, finalFullTableName)+"_data.sql")) || utils.FileOrFolderExists(filepath.Join(dataDir, finalFullTableName)) {
 			status = "DONE"
 		} else if utils.FileOrFolderExists(filepath.Join(dataDir, tableMap[tableName])) {
-			status = "MIGRATING"
+			status = "EXPORTING"
 		} else {
 			status = "NOT_STARTED"
 		}
 		if source.DBType == ORACLE || source.DBType == MYSQL {
-			finalFullTableName = tableName[:len(tableName)-9]
+			finalFullTableName = tableName[:len(tableName)-len("_data.sql")]
 		}
 		row := &exportTableMigStatusOutputRow{
 			tableName: finalFullTableName,
@@ -109,7 +109,7 @@ func runExportDataStatusCmd() error {
 
 	// First sort by status and then by table-name.
 	sort.Slice(outputRows, func(i, j int) bool {
-		ordStates := map[string]int{"MIGRATING": 1, "DONE": 2, "NOT_STARTED": 3}
+		ordStates := map[string]int{"EXPORTING": 1, "DONE": 2, "NOT_STARTED": 3}
 		row1 := outputRows[i]
 		row2 := outputRows[j]
 		if row1.status == row2.status {

--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -57,7 +57,7 @@ func runExportDataStatusCmd() error {
 	} else if utils.FileOrFolderExists(dbTypeFlag+"mysql") || utils.FileOrFolderExists(dbTypeFlag+"oracle") {
 		files, err := filepath.Glob(filepath.Join(dataDir, "*_data.sql"))
 		if err != nil {
-			return fmt.Errorf("Error while checking data directory for export data status: %v", err)
+			return fmt.Errorf("error while checking data directory for export data status: %v", err)
 		}
 		var fileName string
 		for _, file := range files {
@@ -70,7 +70,7 @@ func runExportDataStatusCmd() error {
 			}
 		}
 	} else {
-		return fmt.Errorf("Unable to identify source-db-type.")
+		return fmt.Errorf("unable to identify source-db-type")
 	}
 
 	if len(tableMap) > 0 {

--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -54,7 +54,7 @@ func runExportDataStatusCmd() error {
 	dbTypeFlag := ExtractMetaInfo(exportDir).SourceDBType
 	source.DBType = dbTypeFlag
 	if dbTypeFlag == "postgresql" {
-		tableMap = GetMappingForTableNameVsTableFileName(dataDir)
+		tableMap = getMappingForTableNameVsTableFileName(dataDir)
 	} else if dbTypeFlag == "mysql" || dbTypeFlag == "oracle" {
 		files, err := filepath.Glob(filepath.Join(dataDir, "*_data.sql"))
 		if err != nil {

--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+)
+
+var exportDataStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print status of an ongoing/completed export.",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		validateExportDirFlag()
+		err := runExportDataStatusCmd()
+		if err != nil {
+			log.Errorf("Get export data status failed: %s", err)
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	exportDataCmd.AddCommand(exportDataStatusCmd)
+}
+
+type exportTableMigStatusOutputRow struct {
+	tableName string
+	status    string
+}
+
+// Note that the `export data status` is running in a separate process. It won't have access to the in-memory state
+// held in the main `export data` process.
+func runExportDataStatusCmd() error {
+	exportSchemaDoneFlagFilePath := filepath.Join(exportDir, "metainfo/flags/exportSchemaDone")
+	_, err := os.Stat(exportSchemaDoneFlagFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("cannot run `export data status` before schema export is done")
+		}
+		return fmt.Errorf("check if schema export is done: %w", err)
+	}
+
+	tableMap := make(map[string]string)
+	dataDir := filepath.Join(exportDir, "data")
+	dbTypeFlag := filepath.Join(exportDir, "metainfo", "schema", "source-db-")
+	if utils.FileOrFolderExists(dbTypeFlag + "postgresql") {
+		tableMap = GetMappingForTableNameVsTableFileName(dataDir)
+	} else if utils.FileOrFolderExists(dbTypeFlag+"mysql") || utils.FileOrFolderExists(dbTypeFlag+"oracle") {
+		files, err := filepath.Glob(filepath.Join(dataDir, "*_data.sql"))
+		if err != nil {
+			return fmt.Errorf("Error while checking data directory for export data status: %v", err)
+		}
+		var fileName string
+		for _, file := range files {
+			fileName = filepath.Base(file)
+			//Sample file name: [tmp_]YB_VOYAGER_TEST_data.sql
+			if strings.HasPrefix(fileName, "tmp_") {
+				tableMap[fileName[4:len(fileName)-9]] = fileName[:len(fileName)-9]
+			} else {
+				tableMap[fileName[:len(fileName)-9]] = "tmp_" + fileName[:len(fileName)-9]
+			}
+		}
+	} else {
+		return fmt.Errorf("Unable to identify source-db-type.")
+	}
+
+	if len(tableMap) > 0 {
+		fmt.Printf("%-30s %-12s\n", "TABLE", "STATUS")
+	}
+	var outputRows []*exportTableMigStatusOutputRow
+	var fullTableName string
+	for tableName := range tableMap {
+		//"_" is treated as a wildcard character in regex query for Glob
+		if tableName == "postdata" {
+			continue
+		}
+		if strings.HasPrefix(tableName, "public.") {
+			fullTableName = tableName[7:]
+		} else {
+			fullTableName = tableName
+		}
+		var status string
+		if utils.FileOrFolderExists(filepath.Join(dataDir, fullTableName) + "_data.sql") {
+			status = "DONE"
+		} else if utils.FileOrFolderExists(filepath.Join(dataDir, tableMap[tableName])+"_data.sql") || utils.FileOrFolderExists(filepath.Join(dataDir, tableMap[tableName])) {
+			status = "MIGRATING"
+		} else {
+			status = "NOT_STARTED"
+		}
+
+		row := &exportTableMigStatusOutputRow{
+			tableName: tableName,
+			status:    status,
+		}
+		outputRows = append(outputRows, row)
+	}
+
+	// First sort by status and then by table-name.
+	sort.Slice(outputRows, func(i, j int) bool {
+		ordStates := map[string]int{"MIGRATING": 1, "DONE": 2, "NOT_STARTED": 3}
+		row1 := outputRows[i]
+		row2 := outputRows[j]
+		if row1.status == row2.status {
+			return strings.Compare(row1.tableName, row2.tableName) < 0
+		} else {
+			return ordStates[row1.status] < ordStates[row2.status]
+		}
+	})
+	for _, row := range outputRows {
+		fmt.Printf("%-30s %-12s\n",
+			row.tableName, row.status)
+	}
+	return nil
+}

--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -98,7 +98,7 @@ func runExportDataStatusCmd() error {
 			status = "NOT_STARTED"
 		}
 		if source.DBType == ORACLE || source.DBType == MYSQL {
-			tableName = tableName[:len(tableName)-9]
+			finalFullTableName = tableName[:len(tableName)-9]
 		}
 		row := &exportTableMigStatusOutputRow{
 			tableName: finalFullTableName,

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -37,8 +37,10 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+	PreRun: func(cmd *cobra.Command, args []string) {
+		setExportFlagsDefaults()
+		validateExportFlags()
+		markFlagsRequired(cmd)
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {
@@ -92,11 +94,12 @@ func exportSchema() {
 func init() {
 	exportCmd.AddCommand(exportSchemaCmd)
 
+	registerCommonExportFlags(exportSchemaCmd)
 	// Hide num-connections flag from help description from Export Schema command
-	exportSchemaCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		command.Flags().MarkHidden("parallel-jobs")
-		command.Parent().HelpFunc()(command, strings)
-	})
+	// exportSchemaCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+	// 	command.Flags().MarkHidden("parallel-jobs")
+	// 	command.Parent().HelpFunc()(command, strings)
+	// })
 
 }
 

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -95,12 +95,6 @@ func init() {
 	exportCmd.AddCommand(exportSchemaCmd)
 
 	registerCommonExportFlags(exportSchemaCmd)
-	// Hide num-connections flag from help description from Export Schema command
-	// exportSchemaCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-	// 	command.Flags().MarkHidden("parallel-jobs")
-	// 	command.Parent().HelpFunc()(command, strings)
-	// })
-
 }
 
 func schemaIsExported(exportDir string) bool {

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -15,7 +15,7 @@ import (
 
 var importDataStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Print status of an ongoing/completed migration.",
+	Short: "Print status of an ongoing/completed import.",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		validateExportDirFlag()

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -15,7 +15,7 @@ import (
 
 var importDataStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Print status of an ongoing/completed import.",
+	Short: "Print status of an ongoing/completed data import.",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		validateExportDirFlag()


### PR DESCRIPTION
Resolves #119 
-Added export data status command
-Export data now uses mpb.RemoveOnComplete()
-Made some changes to flags(PersistentPreRun->PreRun, similar with flags)in commands, help messages should be more accurate now

Implementation Details:
Due to the lack of data present at this stage of migration, we have opted to only go for table name and its status (MIGRATING, DONE, NOT_STARTED). For postgres, we make use of the toc.txt file, while for oracle and mysql we create the map between in-progress and completed file names at runtime, making use of the "tmp_" prefix. This way, we can find all three statuses for postgres, but only within [MIGRATING, DONE] statuses in the case of oracle and mysql