### PR TITLE
Bug fix #195: Now comparing the target.Host IPs with the resolved IPs of the host provided by yb_servers() function

### DIFF
--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -261,5 +262,19 @@ func CsvStringToSlice(str string) []string {
 		result[i] = strings.TrimSpace(result[i])
 	}
 
+	return result
+}
+
+func LookupIP(name string) []string {
+	var result []string
+
+	ips, err := net.LookupIP(name)
+	if err != nil {
+		ErrExit("Error Resolving name=%s: %v", name, err)
+	}
+
+	for _, ip := range ips {
+		result = append(result, ip.String())
+	}
 	return result
 }


### PR DESCRIPTION
Fix the bug as mentioned in Issue #195 

Testing/Verification Details:
1. Testing with a local cluster of 3 nodes with localhost, localhost2, localhost3 DNSs defined in `/etc/hosts` file
2. `ns.LookUpIP("172.3.21.10")` function for some given IP Addr returns the same IP Addr i.e. "172.3.21.10"
3. Tested the behaviour with yb-managed cluster where load balancer is actually present.