### PR TITLE
Import Data Resume-ability bug fix #208 and start clean behaviour change #209

### DIFF
--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -32,6 +32,7 @@ const (
 	POSTGRESQL                  = "postgresql"
 	LAST_SPLIT_NUM              = 0
 	SPLIT_INFO_PATTERN          = "[0-9]*.[0-9]*.[0-9]*.[0-9]*"
+	LAST_SPLIT_PATTERN          = "0.[0-9]*.[0-9]*.[0-9]*"
 	COPY_MAX_RETRY_COUNT        = 5
 	MAX_SLEEP_SECOND            = 10
 )

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -375,8 +375,13 @@ func generateSmallerSplits(taskQueue chan *SplitFileImportTask) {
 	if startClean { //start data migraiton from beginning
 		fmt.Printf("Truncating all tables: %v\n", allTables)
 		truncateTables(allTables)
-		log.Infof("cleaning the database and %s/metadata/data directory", exportDir)
-		utils.CleanDir(exportDir + "/metainfo/data")
+
+		for _, table := range allTables {
+			tableSplitsPatternStr := fmt.Sprintf("%s.%s", table, SPLIT_INFO_PATTERN)
+			filePattern := filepath.Join(exportDir, "metainfo/data", tableSplitsPatternStr)
+			utils.ClearMatchingFiles(filePattern)
+			log.Infof("clearing the generated splits for table %q matching %q pattern", table, filePattern)
+		}
 		importTables = allTables //since all tables needs to imported now
 	} else {
 		//truncate tables with no primary key


### PR DESCRIPTION
Fix/changes are done as mentioned in corresponding tickets #208 and #209.

Test Plan:
Tested by simulating a similar scenario where only *.D splits are present on disruption/exit of yb-voyager import data command and on retry it is generating the remaining splits and continue
Also confirmed that the already Done splits are not regenerated-and-retried(which was happening previously)
For startClean behaviour testing, i just tested  it in combination with --table-list flag, it works fine now as expected.