### PR TITLE
Added exclude-table-list flag

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -165,7 +165,12 @@ func validateExportFlags() {
 	validatePortRange()
 	validateSSLMode()
 	validateOracleParams()
-	validateTableListFlag(source.TableList)
+
+	if source.TableList != "" && source.ExcludeTableList != "" {
+		utils.ErrExit("Error: Only one of --table-list and --exclude-table-list are allowed")
+	}
+	validateTableListFlag(source.TableList, false)
+	validateTableListFlag(source.ExcludeTableList, true)
 
 	// checking if wrong flag is given used for a db type
 	if source.DBType != ORACLE {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -69,6 +69,9 @@ func init() {
 
 	exportCmd.Flags().BoolVar(&disablePb, "disable-pb", false,
 		"true - to disable progress bar during data export (default false)")
+
+	exportCmd.Flags().StringVar(&source.ExcludeTableList, "exclude-table-list", "",
+		"List of tables to exclude while exporting data (no-op if --table-list is used) (Note: works only for export data command)")
 }
 
 func registerCommonExportFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -169,8 +169,8 @@ func validateExportFlags() {
 	if source.TableList != "" && source.ExcludeTableList != "" {
 		utils.ErrExit("Error: Only one of --table-list and --exclude-table-list are allowed")
 	}
-	validateTableListFlag(source.TableList, false)
-	validateTableListFlag(source.ExcludeTableList, true)
+	validateTableListFlag(source.TableList, "table-list")
+	validateTableListFlag(source.ExcludeTableList, "exclude-table-list")
 
 	// checking if wrong flag is given used for a db type
 	if source.DBType != ORACLE {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -63,8 +63,8 @@ func validateImportFlags() {
 	if target.TableList != "" && target.ExcludeTableList != "" {
 		utils.ErrExit("Error: Only one of --table-list and --exclude-table-list are allowed")
 	}
-	validateTableListFlag(target.TableList, false)
-	validateTableListFlag(target.ExcludeTableList, true)
+	validateTableListFlag(target.TableList, "table-list")
+	validateTableListFlag(target.ExcludeTableList, "exclude-table-list")
 	validateTargetSchemaFlag()
 }
 

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -51,6 +51,8 @@ func init() {
 	registerCommonImportFlags(importCmd)
 	importCmd.Flags().BoolVar(&disablePb, "disable-pb", false,
 		"true - to disable progress bar during data import (default false)")
+	importCmd.Flags().StringVar(&target.ExcludeTableList, "exclude-table-list", "",
+		"List of tables to exclude while importing data (no-op if --table-list is used) (Note: works only for import data command)")
 }
 
 func validateImportFlags() {
@@ -58,7 +60,11 @@ func validateImportFlags() {
 	checkOrSetDefaultTargetSSLMode()
 	validateTargetPortRange()
 
-	validateTableListFlag(target.TableList)
+	if target.TableList != "" && target.ExcludeTableList != "" {
+		utils.ErrExit("Error: Only one of --table-list and --exclude-table-list are allowed")
+	}
+	validateTableListFlag(target.TableList, false)
+	validateTableListFlag(target.ExcludeTableList, true)
 	validateTargetSchemaFlag()
 }
 

--- a/yb-voyager/src/srcdb/source.go
+++ b/yb-voyager/src/srcdb/source.go
@@ -15,26 +15,27 @@ import (
 )
 
 type Source struct {
-	DBType         string
-	Host           string
-	Port           int
-	User           string
-	Password       string
-	DBName         string
-	DBSid          string
-	OracleHome     string
-	TNSAlias       string
-	Schema         string
-	SSLMode        string
-	SSLCertPath    string
-	SSLKey         string
-	SSLRootCert    string
-	SSLCRL         string
-	SSLQueryString string
-	Uri            string
-	NumConnections int
-	VerboseMode    bool
-	TableList      string
+	DBType           string
+	Host             string
+	Port             int
+	User             string
+	Password         string
+	DBName           string
+	DBSid            string
+	OracleHome       string
+	TNSAlias         string
+	Schema           string
+	SSLMode          string
+	SSLCertPath      string
+	SSLKey           string
+	SSLRootCert      string
+	SSLCRL           string
+	SSLQueryString   string
+	Uri              string
+	NumConnections   int
+	VerboseMode      bool
+	TableList        string
+	ExcludeTableList string
 
 	sourceDB SourceDB
 }

--- a/yb-voyager/src/tgtdb/target.go
+++ b/yb-voyager/src/tgtdb/target.go
@@ -21,6 +21,7 @@ type Target struct {
 	IgnoreIfExists         bool
 	VerboseMode            bool
 	TableList              string
+	ExcludeTableList       string
 	ImportMode             bool
 	dbVersion              string
 


### PR DESCRIPTION
Added the --exclude-table-list flag (#138) to exclude certain tables during the export data phase
- Works only with export data command
- No-op if `--table-list` is provided
- Removes tables as per the set notation A-B, where A is the set of tables available, and B is the set of tables to be excluded from export

It should be noted that I opted to not use the switches provided by the internal tools for excluding certain tables, but rather removed the tables at the time of populating the table-list. This was mainly done as we populate a table-list to print when export data is initialised, which needs to be updated before printing in the case of excluding tables