### PR TITLE
Import data: use upsert mode as default if supported in tgt db else do transactional inserts 

### DIFF
--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -16,6 +16,8 @@ jobs:
     - name: Run installer script
       run: |
         yes | ./installer_scripts/install-yb-voyager local
+      env:
+        ON_INSTALLER_ERROR_OUTPUT_LOG: Y
 
     - name: Start MySQL
       run: |

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -32,6 +32,8 @@ jobs:
       run: |
         cd installer_scripts
         yes | ./install-yb-voyager local
+      env:
+        ON_INSTALLER_ERROR_OUTPUT_LOG: Y
 
     - name: Test PostgreSQL Connection
       run: |

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -45,6 +45,10 @@ on_exit() {
 		echo "Done!"
 	else
 		echo "Script failed. Check log file ${LOG_FILE} ."
+		if [[ ${ON_INSTALLER_ERROR_OUTPUT_LOG:-N} = "Y" ]]
+		then
+			sudo cat ${LOG_FILE}
+		fi
 	fi
 }
 
@@ -319,13 +323,8 @@ update_bashrc() {
 
 create_yb_session_vars_file() {
 	vars_file_name="/etc/yb-voyager/ybSessionVariables.sql"
-	if [ -f "$vars_file_name" ]
-	then
-		output "No need to create ybSessionVariables.sql again. Skipping."
-		return
-	fi
 	sudo mkdir -p /etc/yb-voyager
-	sudo wget -qO $vars_file_name https://github.com/yugabyte/yb-voyager/raw/main/yb-voyager/files/ybSessionVariables.sql
+	sudo touch $vars_file_name
 }
 
 create_base_ora2pg_conf_file() {

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -33,23 +33,27 @@ const (
 	LAST_SPLIT_NUM              = 0
 	SPLIT_INFO_PATTERN          = "[0-9]*.[0-9]*.[0-9]*.[0-9]*"
 	LAST_SPLIT_PATTERN          = "0.[0-9]*.[0-9]*.[0-9]*"
-	COPY_MAX_RETRY_COUNT        = 5
-	MAX_SLEEP_SECOND            = 10
+	COPY_MAX_RETRY_COUNT        = 10
+	MAX_SLEEP_SECOND            = 60
 )
 
-var IMPORT_SESSION_SETTERS = []string{
-	"SET client_encoding TO 'UTF8';",
-	// Disable transactions to improve ingestion throughput.
-	"SET yb_disable_transactional_writes to true;",
-	//Disable triggers or fkeys constraint checks.
-	"SET session_replication_role TO replica;",
-	// Enable UPSERT mode instead of normal inserts into a table.
-	"SET yb_enable_upsert_mode to true;",
-}
+// import session parameters
+const (
+	SET_CLIENT_ENCODING_TO_UTF8           = "SET client_encoding TO 'UTF8'"
+	SET_SESSION_REPLICATE_ROLE_TO_REPLICA = "SET session_replication_role TO replica" //Disable triggers or fkeys constraint checks.
+	SET_YB_ENABLE_UPSERT_MODE             = "SET yb_enable_upsert_mode to true"
+	SET_YB_DISABLE_TRANSACTIONAL_WRITES   = "SET yb_disable_transactional_writes to true" // Disable transactions to improve ingestion throughput.
+)
 
 var supportedSourceDBTypes = []string{ORACLE, MYSQL, POSTGRESQL}
 
 var validSSLModes = map[string][]string{
 	"mysql":      {"disable", "prefer", "require", "verify-ca", "verify-full"},
 	"postgresql": {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"},
+}
+
+var NonRetryCopyErrors = []string{
+	"Sending too long RPC message",
+	"invalid input syntax",
+	"violates unique constraint",
 }

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -147,8 +147,8 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 			"For example: \"host1:port1,host2:port2\" or \"host1,host2\"\n"+
 			"Note: use-public-ip flag will be ignored if this is used.")
 
-	cmd.Flags().BoolVar(&enableUpsert, "enable-upsert", false,
-		"true - to enable upsert for insert in target tables (default false)")
+	cmd.Flags().BoolVar(&enableUpsert, "enable-upsert", true,
+		"true - to enable upsert for insert in target tables")
 
 	// flag existence depends on fix of this gh issue: https://github.com/yugabyte/yugabyte-db/issues/12464
 	cmd.Flags().BoolVar(&disableTransactionalWrites, "disable-transactional-writes", false,

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -110,17 +110,18 @@ func prepareCopyCommands() {
 				if err != nil {
 					utils.ErrExit("opening datafile %q to prepare copy command: %v", err)
 				}
-				copyTableFromCommands[table] = fmt.Sprintf(`COPY %s(%s) FROM STDIN WITH (FORMAT %s, DELIMITER '%c', ESCAPE '%s', QUOTE '%s', HEADER)`,
+				copyTableFromCommands[table] = fmt.Sprintf(`COPY %s(%s) FROM STDIN WITH (FORMAT %s, DELIMITER '%c', ESCAPE '%s', QUOTE '%s', HEADER,`,
 					table, df.GetHeader(), fileFormat, []rune(delimiter)[0], fileOptsMap["escape_char"], fileOptsMap["quote_char"])
 			} else {
-				copyTableFromCommands[table] = fmt.Sprintf(`COPY %s FROM STDIN WITH (FORMAT %s, DELIMITER '%c', ESCAPE '%s', QUOTE '%s')`,
+				copyTableFromCommands[table] = fmt.Sprintf(`COPY %s FROM STDIN WITH (FORMAT %s, DELIMITER '%c', ESCAPE '%s', QUOTE '%s', `,
 					table, fileFormat, []rune(delimiter)[0], fileOptsMap["escape_char"], fileOptsMap["quote_char"])
 			}
 		} else if fileFormat == datafile.TEXT {
-			copyTableFromCommands[table] = fmt.Sprintf(`COPY %s FROM STDIN WITH (FORMAT %s, DELIMITER '%c')`, table, fileFormat, []rune(delimiter)[0])
+			copyTableFromCommands[table] = fmt.Sprintf(`COPY %s FROM STDIN WITH (FORMAT %s, DELIMITER '%c', `, table, fileFormat, []rune(delimiter)[0])
 		} else {
 			panic(fmt.Sprintf("File Type %q not implemented\n", fileFormat))
 		}
+		copyTableFromCommands[table] += ` ROWS_PER_TRANSACTION %v)`
 	}
 
 	log.Infof("copyTableFromCommands map: %+v", copyTableFromCommands)

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -72,11 +72,10 @@ func YugabyteDBImportSchema(target *tgtdb.Target, exportDir string) {
 				utils.ErrExit("Failed to run %q on target DB: %s", setSchemaQuery, err)
 			}
 
-			setClientEncQuery := IMPORT_SESSION_SETTERS[0]
-			log.Infof("Running query %q on the target DB", setClientEncQuery)
-			_, err = conn.Exec(context.Background(), setClientEncQuery)
+			log.Infof("Running query %q on the target DB", SET_CLIENT_ENCODING_TO_UTF8)
+			_, err = conn.Exec(context.Background(), SET_CLIENT_ENCODING_TO_UTF8)
 			if err != nil {
-				utils.ErrExit("Failed to run %q on target DB: %s", setClientEncQuery, err)
+				utils.ErrExit("Failed to run %q on target DB: %s", SET_CLIENT_ENCODING_TO_UTF8, err)
 			}
 		}
 

--- a/yb-voyager/files/ybSessionVariables.sql
+++ b/yb-voyager/files/ybSessionVariables.sql
@@ -1,2 +1,0 @@
-SET client_encoding TO 'UTF8';
-SET session_replication_role TO replica;

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -135,7 +135,7 @@ func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressM
 	renameDataFiles(tablesProgressMetadata)
 	exportedRowCount := getExportedRowCount(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileFormat:    datafile.CSV,
+		FileFormat:    datafile.TEXT,
 		TableRowCount: exportedRowCount,
 		Delimiter:     "\t",
 		HasHeader:     false,

--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -3,7 +3,6 @@ package tgtdb
 import (
 	"context"
 	"math/rand"
-	"strings"
 	"sync"
 
 	"github.com/jackc/pgx/v4"
@@ -121,7 +120,7 @@ func (pool *ConnectionPool) getNextUriIndex() int {
 func (pool *ConnectionPool) initSession(conn *pgx.Conn) error {
 	for _, v := range pool.params.SessionInitScript {
 		_, err := conn.Exec(context.Background(), v)
-		if err != nil && !strings.Contains(err.Error(), "unrecognized configuration parameter") {
+		if err != nil {
 			return err
 		}
 	}

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -278,3 +278,14 @@ func LookupIP(name string) []string {
 	}
 	return result
 }
+
+func InsensitiveSliceContains(slice []string, s string) bool {
+	for i := 0; i < len(slice); i++ {
+		if strings.Contains(strings.ToLower(s), strings.ToLower(slice[i])) {
+			log.Infof("string s=%q contains slice[i]=%q", s, slice[i])
+			return true
+		}
+	}
+	log.Infof("string s=%q did not match with any string in %v", s, slice)
+	return false
+}


### PR DESCRIPTION
- This change will fix the possibility of bugs in case rows are missing with the disabled transactions due to unique constraint violation

**Implementation Details:**
```
IF enable_upsert is supported by the YBDB:
   then only Disable transaction, if set as true
   Fire COPY command
   Retries in case: Any Failure (except invalid syntax error)
ELSE use transactional mode:
   Fire COPY command
   Retries in case: Any Failure (except unique constraint violation error and invalid syntax error)
```

--enable-upsert is set to true by default

-> Delay (10, 20, 30, 40, 50, 60 - max)
-> Max Retries: 10


**TEST PLAN **
1. Testing the behaviour with different yugabyte-db versions: `2.12`, `2.14`, `2.15` **->** **tested with current latest version of each i.e. 2.12.9, 2.15.2, 2.14.1**
2. With and without disable transactions flag
3. With and without disable upsert mode flag
3. Trying out Resume functionality with each of the above versions - combine with flags like `--batch-size` and `--parallel-jobs` 
5. Verify/Test flag: `--table-list` in combination with other flags like `--start-clean`
6. Verify import data status command throughout the testing
7. Verify import data file command