### PR TITLE
Removed logging from status type commands

### DIFF
--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
@@ -21,7 +20,6 @@ var exportDataStatusCmd = &cobra.Command{
 		validateExportDirFlag()
 		err := runExportDataStatusCmd()
 		if err != nil {
-			log.Errorf("Get export data status failed: %s", err)
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 			os.Exit(1)
 		}

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 )
@@ -21,7 +20,6 @@ var importDataStatusCmd = &cobra.Command{
 		validateExportDirFlag()
 		err := runImportDataStatusCmd()
 		if err != nil {
-			log.Errorf("Get import data status failed: %s", err)
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 			os.Exit(1)
 		}

--- a/yb-voyager/cmd/logging.go
+++ b/yb-voyager/cmd/logging.go
@@ -47,9 +47,9 @@ func (mf *MyFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return []byte(msg), nil
 }
 
-func InitLogging(logDir string, statusCommand bool) {
+func InitLogging(logDir string, disableLogging bool) {
 	// Redirect log messages to ${logDir}/yb-voyager.log if not a status command.
-	if statusCommand {
+	if disableLogging {
 		log.SetOutput(ioutil.Discard)
 		return
 	}

--- a/yb-voyager/cmd/logging.go
+++ b/yb-voyager/cmd/logging.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -46,8 +47,12 @@ func (mf *MyFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return []byte(msg), nil
 }
 
-func InitLogging(logDir string) {
-	// Redirect log messages to ${logDir}/yb-voyager.log .
+func InitLogging(logDir string, statusCommand bool) {
+	// Redirect log messages to ${logDir}/yb-voyager.log if not a status command.
+	if statusCommand {
+		log.SetOutput(ioutil.Discard)
+		return
+	}
 	logFileName := filepath.Join(logDir, "yb-voyager.log")
 	f, err := os.OpenFile(logFileName, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {
@@ -57,7 +62,6 @@ func InitLogging(logDir string) {
 
 	log.SetReportCaller(true)
 	log.SetFormatter(&MyFormatter{})
-
 	log.Info("Logging initialised.")
 	log.Infof("Args: %v", os.Args)
 }

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -41,7 +41,7 @@ var rootCmd = &cobra.Command{
 
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if exportDir != "" && utils.FileOrFolderExists(exportDir) {
-			InitLogging(exportDir)
+			InitLogging(exportDir, cmd.Use == "status")
 		}
 	},
 


### PR DESCRIPTION
[Fixes #217]
This PR disables logging for export/import data status, as when used with `watch`, populates the log file until the command is stopped. Note that any errors, if raised will still print to the terminal screen