### PR TITLE
Use a tagged release version for add-to-project

### DIFF
--- a/.github/workflows/organize_issues.yml
+++ b/.github/workflows/organize_issues.yml
@@ -25,7 +25,7 @@ jobs:
           add-labels: "triage"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Add issue to project
-        uses: actions/add-to-project@RELEASE_VERSION
+        uses: actions/add-to-project@v0.3.0
         with:
           project-url: https://github.com/orgs/yugabyte/projects/10
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
A minor change, where we now use a tagged release version(v0.3.0) as "RELEASE_VERSION" does not resolve to a meaningful commit for the add-to-project action