### PR TITLE
Fix import data copy error

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -982,14 +982,14 @@ func extractCopyStmtForTable(table string, fileToSearchIn string) {
 		return
 	}
 	// pg_dump and ora2pg always have columns - "COPY table (col1, col2) FROM STDIN"
-	copyCommandRegex := regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]*(.*) FROM STDIN`, table))
+	copyCommandRegex := regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]+\(.*\) FROM STDIN`, table))
 	if sourceDBType == "postgresql" {
 		// find the line from toc.txt file
 		fileToSearchIn = exportDir + "/data/toc.txt"
 
 		// if no schema then add public in tableName as it is there in postgres' toc file
 		if len(strings.Split(table, ".")) == 1 {
-			copyCommandRegex = regexp.MustCompile(fmt.Sprintf(`(?i)COPY public.%s[\s]*(.*) FROM STDIN`, table))
+			copyCommandRegex = regexp.MustCompile(fmt.Sprintf(`(?i)COPY public.%s[\s]+\(.*\) FROM STDIN`, table))
 		}
 	}
 


### PR DESCRIPTION
[Fixes #263]
During a PostgreSQL migration , if multiple tables existed with the same prefix set of characters (For eg. `abc` and `abcd` have `abc` in common as a prefix), the copy regex being used would pick up the first instance of a copy statement to be used, considering its table name as a prefix, rather than taking the particular copy command to be used for that table:

```
COPY abcd (a, b, c, d) FROM STDIN;
COPY abc(a, b, c) FROM STDIN;
```

As the copy statement for table `abcd` comes first, the copy statement corresponding to the table `abc` that would be picked up is that of table `abcd`. 

This behaviour is now rectified to its expected behaviour in this patch, each table picks up their respective copy statements