### PR TITLE
Fixed comment DDL export

### DIFF
--- a/yb-voyager/src/srcdb/data/sample-ora2pg.conf
+++ b/yb-voyager/src/srcdb/data/sample-ora2pg.conf
@@ -169,7 +169,7 @@ TYPE		TABLE
 
 # Set this to 1 if you don't want to export comments associated to tables and
 # column definitions. Default is enabled.
-DISABLE_COMMENT         0   #Important
+DISABLE_COMMENT         0
 
 # Set which object to export from. By default Ora2Pg export all objects.
 # Value must be a list of object name or regex separated by space. Note


### PR DESCRIPTION
[Fixes #246]
yb-voyager was unable to export comment DDLs from MySQL or Oracle as a source. This patch fixes this behaviour.

Oddly enough it was a comment that stopped us from exporting comments...