### PR TITLE
Double quote reserved words in PG

### DIFF
--- a/yb-voyager/src/srcdb/data/sample-ora2pg.conf
+++ b/yb-voyager/src/srcdb/data/sample-ora2pg.conf
@@ -565,7 +565,7 @@ ORA_RESERVED_WORDS	audit,comment,references
 
 # Enable this directive if you have tables or column names that are a reserved
 # word for PostgreSQL. Ora2Pg will double quote the name of the object. 
-USE_RESERVED_WORDS	0
+USE_RESERVED_WORDS	1
 
 # By default Ora2Pg export Oracle tables with the NOLOGGING attribute as
 # UNLOGGED tables. You may want to fully disable this feature because


### PR DESCRIPTION
[Fixes #248]
yb-voyager now exports reserved words from MySQL and Oracle surrounded by double quotation marks.