### PR TITLE
Added --exclude-import-objects and --import-objects flags

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -110,7 +110,7 @@ func exportDataOffline() bool {
 		finalTableList = extractTableListFromString(source.TableList)
 	} else {
 		tableList = source.DB().GetAllTableNames()
-		finalTableList = utils.RemoveExcludeList(tableList, excludeTableList)
+		finalTableList = utils.SetDifference(tableList, excludeTableList)
 		fmt.Printf("Num tables to export: %d\n", len(finalTableList))
 		utils.PrintAndLog("table list for data export: %v", finalTableList)
 	}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -110,7 +110,7 @@ func exportDataOffline() bool {
 		finalTableList = extractTableListFromString(source.TableList)
 	} else {
 		tableList = source.DB().GetAllTableNames()
-		finalTableList = removeExcludeTables(tableList, excludeTableList)
+		finalTableList = utils.RemoveExcludeList(tableList, excludeTableList)
 		fmt.Printf("Num tables to export: %d\n", len(finalTableList))
 		utils.PrintAndLog("table list for data export: %v", finalTableList)
 	}

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -167,7 +167,7 @@ func registerImportDataFlags(cmd *cobra.Command) {
 
 func registerImportSchemaFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&target.ImportObjects, "object-list", "",
-		"List of schema object types to include while importing schema (Note: works only for import schema command)")
+		"List of schema object types to include while importing schema. (Note: works only for import schema command)")
 	cmd.Flags().StringVar(&target.ExcludeImportObjects, "exclude-object-list", "",
 		"List of schema object types to exclude while importing schema (no-op if --object-list is used) (Note: works only for import schema command)")
 }
@@ -196,7 +196,7 @@ func validateImportObjectsFlag(importObjectsString string, flagName string) {
 	objectList := utils.CsvStringToSlice(importObjectsString)
 	for _, object := range objectList {
 		if !slices.Contains(availableObjects, strings.ToUpper(object)) {
-			utils.ErrExit("Error: Invalid object type '%v' specified wtih --%s flag", object, flagName)
+			utils.ErrExit("Error: Invalid object type '%v' specified wtih --%s flag. Supported object types are: %v", object, flagName, availableObjects)
 		}
 	}
 }

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -60,12 +60,14 @@ func validateImportFlags() {
 	validateExportDirFlag()
 	checkOrSetDefaultTargetSSLMode()
 	validateTargetPortRange()
-
 	if target.TableList != "" && target.ExcludeTableList != "" {
 		utils.ErrExit("Error: Only one of --table-list and --exclude-table-list are allowed")
 	}
 	validateTableListFlag(target.TableList, "table-list")
 	validateTableListFlag(target.ExcludeTableList, "exclude-table-list")
+	if target.ImportObjects != "" && target.ExcludeImportObjects != "" {
+		utils.ErrExit("Error: Only one of --object-list and --exclude-object-list are allowed")
+	}
 	validateImportObjectsFlag(target.ImportObjects, "object-list")
 	validateImportObjectsFlag(target.ExcludeImportObjects, "exclude-object-list")
 	validateTargetSchemaFlag()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -371,8 +371,8 @@ func generateSmallerSplits(taskQueue chan *SplitFileImportTask) {
 	}
 
 	excludeTableList := utils.CsvStringToSlice(target.ExcludeTableList)
-	importTables = utils.RemoveExcludeList(importTables, excludeTableList)
-	allTables = utils.RemoveExcludeList(allTables, excludeTableList)
+	importTables = utils.SetDifference(importTables, excludeTableList)
+	allTables = utils.SetDifference(allTables, excludeTableList)
 	sort.Strings(allTables)
 	sort.Strings(importTables)
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -371,8 +371,8 @@ func generateSmallerSplits(taskQueue chan *SplitFileImportTask) {
 	}
 
 	excludeTableList := utils.CsvStringToSlice(target.ExcludeTableList)
-	importTables = removeExcludeTables(importTables, excludeTableList)
-	allTables = removeExcludeTables(allTables, excludeTableList)
+	importTables = utils.RemoveExcludeList(importTables, excludeTableList)
+	allTables = utils.RemoveExcludeList(allTables, excludeTableList)
 	sort.Strings(allTables)
 	sort.Strings(importTables)
 
@@ -1117,25 +1117,8 @@ func checkSessionVariableSupport(sqlStmt string) bool {
 	return err == nil
 }
 
-func removeExcludeTables(tableList []string, excludeTableList []string) []string {
-	if len(tableList) == 0 || len(excludeTableList) == 0 {
-		return tableList
-	}
-	var finalTableList []string
-	for _, table := range tableList {
-		if slices.Contains(excludeTableList, table) {
-			continue
-		}
-		finalTableList = append(finalTableList, table)
-	}
-	return finalTableList
-}
-
 func init() {
 	importCmd.AddCommand(importDataCmd)
 	registerCommonImportFlags(importDataCmd)
-	importDataCmd.Flags().BoolVar(&disablePb, "disable-pb", false,
-		"true - to disable progress bar during data export (default false)")
-	importDataCmd.Flags().StringVar(&target.ExcludeTableList, "exclude-table-list", "",
-		"List of tables to exclude while importing data (no-op if --table-list is used)")
+	registerImportDataFlags(importDataCmd)
 }

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -48,6 +48,7 @@ var importSchemaCmd = &cobra.Command{
 func init() {
 	importCmd.AddCommand(importSchemaCmd)
 	registerCommonImportFlags(importSchemaCmd)
+	registerImportSchemaFlags(importSchemaCmd)
 }
 
 func importSchema() {

--- a/yb-voyager/src/tgtdb/target.go
+++ b/yb-voyager/src/tgtdb/target.go
@@ -23,6 +23,8 @@ type Target struct {
 	TableList              string
 	ExcludeTableList       string
 	ImportMode             bool
+	ImportObjects          string
+	ExcludeImportObjects   string
 	dbVersion              string
 
 	db *TargetDB

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -29,6 +29,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/yosssi/gohtml"
+	"golang.org/x/exp/slices"
 )
 
 var DoNotPrompt bool
@@ -254,6 +255,20 @@ func GetSortedKeys(tablesProgressMetadata map[string]*TableProgressMetadata) []s
 
 	sort.Strings(keys)
 	return keys
+}
+
+func RemoveExcludeList(includeList []string, excludeList []string) []string {
+	if len(includeList) == 0 || len(excludeList) == 0 {
+		return includeList
+	}
+	var finalList []string
+	for _, object := range includeList {
+		if slices.Contains(excludeList, object) {
+			continue
+		}
+		finalList = append(finalList, object)
+	}
+	return finalList
 }
 
 func CsvStringToSlice(str string) []string {

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -257,7 +257,7 @@ func GetSortedKeys(tablesProgressMetadata map[string]*TableProgressMetadata) []s
 	return keys
 }
 
-func RemoveExcludeList(includeList []string, excludeList []string) []string {
+func SetDifference(includeList []string, excludeList []string) []string {
 	if len(includeList) == 0 || len(excludeList) == 0 {
 		return includeList
 	}


### PR DESCRIPTION
[Fixes #203]
We can now exclude/ import certain object types during the import schema phase with the help of these new flags. The implementation logic is similar to that of `--table-list` and `--exclude-table-list` flags.