### PR TITLE
Restrict split size to 200MB.

### DIFF
--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -35,6 +35,7 @@ const (
 	LAST_SPLIT_PATTERN          = "0.[0-9]*.[0-9]*.[0-9]*"
 	COPY_MAX_RETRY_COUNT        = 10
 	MAX_SLEEP_SECOND            = 60
+	MAX_SPLIT_SIZE_BYTES        = 200 * 1024 * 1024
 )
 
 // import session parameters

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -628,7 +628,10 @@ func splitFilesForTable(filePath string, t string, taskQueue chan *SplitFileImpo
 			sz = 0
 		}
 
-		if numLinesInThisSplit == numLinesInASplit || readLineErr != nil {
+		if numLinesInThisSplit == numLinesInASplit ||
+			dataFile.GetBytesRead() >= MAX_SPLIT_SIZE_BYTES ||
+			readLineErr != nil {
+
 			err = bufferedWriter.Flush()
 			if err != nil {
 				utils.ErrExit("flush data in file %q: %s", outfile.Name(), err)


### PR DESCRIPTION
This should take care of the `Sending too long RPC message` error coming from DB.