### PR TITLE
Fixed number type casting from oracle

### DIFF
--- a/yb-voyager/src/srcdb/data/sample-ora2pg.conf
+++ b/yb-voyager/src/srcdb/data/sample-ora2pg.conf
@@ -705,7 +705,7 @@ PG_NUMERIC_TYPE	1
 # Oracle data type NUMBER(p) or NUMBER are converted to smallint, integer
 # or bigint PostgreSQL data type following the length of the precision. If
 # NUMBER without precision are set to DEFAULT_NUMERIC (see bellow).
-PG_INTEGER_TYPE	1
+PG_INTEGER_TYPE	0
 
 # NUMBER() without precision are converted by default to bigint only if
 # PG_INTEGER_TYPE is true. You can overwrite this value to any PG type,


### PR DESCRIPTION
[Fixes #215]

This patch changes a directive which now correctly maps numeric data types specified without precision or scale to the equivalent in PG.

Old behaviour:
`number`->`bigint`

New behaviour:
`number`->`numeric`