### PR TITLE
Cherry-pick: Added yb-voyager version info in logs for every run (#317)

### DIFF
--- a/yb-voyager/cmd/logging.go
+++ b/yb-voyager/cmd/logging.go
@@ -64,4 +64,5 @@ func InitLogging(logDir string) {
 
 	log.Info("Logging initialised.")
 	log.Infof("Args: %v", os.Args)
+	log.Infof("\n%s", getVersionInfo())
 }

--- a/yb-voyager/cmd/version.go
+++ b/yb-voyager/cmd/version.go
@@ -13,24 +13,31 @@ var versionCmd = &cobra.Command{
 	Short: "Print yb-voyager version info.",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("VERSION=%s\n", utils.YB_VOYAGER_VERSION)
-		h := utils.GitCommitHash()
-		if h != "" {
-			fmt.Printf("GIT_COMMIT_HASH=%s\n", h)
-		}
-		info, ok := debug.ReadBuildInfo()
-		if !ok {
-			return
-		}
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				fmt.Printf("GIT_COMMIT_HASH=%s\n", setting.Value)
-			}
-			if setting.Key == "vcs.time" {
-				fmt.Printf("LAST_COMMIT_DATE=%s\n", setting.Value)
-			}
-		}
+		info := getVersionInfo()
+		fmt.Print(info)
 	},
+}
+
+func getVersionInfo() string {
+	versionInfo := fmt.Sprintf("VERSION=%s\n", utils.YB_VOYAGER_VERSION)
+	h := utils.GitCommitHash()
+	if h != "" {
+		fmt.Printf("GIT_COMMIT_HASH=%s\n", h)
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return versionInfo
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			versionInfo += fmt.Sprintf("GIT_COMMIT_HASH=%s\n", setting.Value)
+		}
+		if setting.Key == "vcs.time" {
+			versionInfo += fmt.Sprintf("LAST_COMMIT_DATE=%s\n", setting.Value)
+		}
+	}
+
+	return versionInfo
 }
 
 func init() {


### PR DESCRIPTION
- Will help to identify which version is used for the run