### PR TITLE
Added a check in --ignore-exist for some primary key cases

### DIFF
--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -91,17 +91,21 @@ func YugabyteDBImportSchema(target *tgtdb.Target, exportDir string) {
 			_, err := conn.Exec(context.Background(), sqlInfo.stmt)
 			if err != nil {
 				log.Errorf("Previous SQL statement failed with error: %s", err)
-				if strings.Contains(err.Error(), "already exists") && !target.IgnoreIfExists && !reCreateSchema.MatchString(sqlInfo.formattedStmtStr) {
-					fmt.Printf("\b \n    %s\n", err.Error())
-					fmt.Printf("    STATEMENT: %s\n", sqlInfo.formattedStmtStr)
-					if !target.ContinueOnError {
-						os.Exit(1)
+				if strings.Contains(err.Error(), "already exists") {
+					if !target.IgnoreIfExists && !reCreateSchema.MatchString(sqlInfo.formattedStmtStr) {
+						fmt.Printf("\b \n    %s\n", err.Error())
+						fmt.Printf("    STATEMENT: %s\n", sqlInfo.formattedStmtStr)
+						if !target.ContinueOnError {
+							os.Exit(1)
+						}
 					}
-				} else if strings.Contains(err.Error(), "multiple primary keys") && !target.IgnoreIfExists {
-					fmt.Printf("\b \n	%s\n", err.Error())
-					fmt.Printf("	STATEMENT: %s\n", sqlInfo.formattedStmtStr)
-					if !target.ContinueOnError {
-						os.Exit(1)
+				} else if strings.Contains(err.Error(), "multiple primary keys") {
+					if !target.IgnoreIfExists {
+						fmt.Printf("\b \n	%s\n", err.Error())
+						fmt.Printf("	STATEMENT: %s\n", sqlInfo.formattedStmtStr)
+						if !target.ContinueOnError {
+							os.Exit(1)
+						}
 					}
 				} else {
 					errOccured = 1

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -91,13 +91,17 @@ func YugabyteDBImportSchema(target *tgtdb.Target, exportDir string) {
 			_, err := conn.Exec(context.Background(), sqlInfo.stmt)
 			if err != nil {
 				log.Errorf("Previous SQL statement failed with error: %s", err)
-				if strings.Contains(err.Error(), "already exists") {
-					if !target.IgnoreIfExists && !reCreateSchema.MatchString(sqlInfo.formattedStmtStr) {
-						fmt.Printf("\b \n    %s\n", err.Error())
-						fmt.Printf("    STATEMENT: %s\n", sqlInfo.formattedStmtStr)
-						if !target.ContinueOnError {
-							os.Exit(1)
-						}
+				if strings.Contains(err.Error(), "already exists") && !target.IgnoreIfExists && !reCreateSchema.MatchString(sqlInfo.formattedStmtStr) {
+					fmt.Printf("\b \n    %s\n", err.Error())
+					fmt.Printf("    STATEMENT: %s\n", sqlInfo.formattedStmtStr)
+					if !target.ContinueOnError {
+						os.Exit(1)
+					}
+				} else if strings.Contains(err.Error(), "multiple primary keys") && !target.IgnoreIfExists {
+					fmt.Printf("\b \n	%s\n", err.Error())
+					fmt.Printf("	STATEMENT: %s\n", sqlInfo.formattedStmtStr)
+					if !target.ContinueOnError {
+						os.Exit(1)
 					}
 				} else {
 					errOccured = 1


### PR DESCRIPTION
[Fixes #293]
If a primary key DDL is provided as an alter table statement rather than a direct declaration in the schema DDL (eg. `ALTER TABLE ONLY public.actor ADD CONSTRAINT actor_pkey PRIMARY KEY (actor_id);`), --ignore-exist flag will incorrectly flag an error stating `multiple primary keys are not allowed`. This patch adds a check for this statement, and fixes said issue.