### PR TITLE
Check to make sure two instances of yb-voyager dont use same export-dir simultaneously 

### DIFF
--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -60,10 +60,8 @@ var rootCmd = &cobra.Command{
 	},
 
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if exportDir != "" && utils.FileOrFolderExists(exportDir) {
-			if cmd.Use != "version" && cmd.Use != "status" {
-				unlockExportDir()
-			}
+		if exportDir != "" && utils.FileOrFolderExists(exportDir) && cmd.Use != "version" && cmd.Use != "status" {
+			unlockExportDir()
 		}
 	},
 }
@@ -139,13 +137,13 @@ func validateExportDirFlag() {
 func lockExportDir() {
 	lockfileName, err := filepath.Abs(filepath.Join(exportDir, ".lockfile.lck"))
 	if err != nil {
-		fmt.Printf("Failed to get the lockfile path: %v", err)
+		fmt.Fprintf(os.Stderr, "Failed to get the lockfile path: %v\n", err)
 		os.Exit(1)
 	}
 
 	lock, err = lockfile.New(lockfileName)
 	if err != nil {
-		fmt.Printf("Failed to create lockfile %q: %v", lockfileName, err)
+		fmt.Fprintf(os.Stderr, "Failed to create lockfile %q: %v\n", lockfileName, err)
 		os.Exit(1)
 	}
 
@@ -153,10 +151,10 @@ func lockExportDir() {
 	if err == nil {
 		return
 	} else if err == lockfile.ErrBusy {
-		fmt.Println("Another instance of yb-voyager is running in the export-dir.")
+		fmt.Fprintf(os.Stderr, "Another instance of yb-voyager is running in the export-dir = %s\n", exportDir)
 		os.Exit(1)
 	} else {
-		fmt.Printf("Unable to lock the export-dir: %v", err)
+		fmt.Fprintf(os.Stderr, "Unable to lock the export-dir: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -165,6 +163,7 @@ func lockExportDir() {
 func unlockExportDir() {
 	err := lock.Unlock()
 	if err != nil {
-		panic(fmt.Sprintf("Unable to unlock %q: %v", lock, err))
+		fmt.Fprintf(os.Stderr, "Unable to unlock %q: %v\n", lock, err)
+		os.Exit(1)
 	}
 }

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -151,7 +151,7 @@ func lockExportDir() {
 
 	err = lock.TryLock()
 	if err == nil {
-		fmt.Println("Locked the export directory")
+		return
 	} else if err == lockfile.ErrBusy {
 		fmt.Println("Another instance of yb-voyager is running in the export-dir.")
 		os.Exit(1)
@@ -167,5 +167,4 @@ func unlockExportDir() {
 	if err != nil {
 		panic(fmt.Sprintf("Unable to unlock %q: %v", lock, err))
 	}
-	fmt.Println("Unlocked the export directory")
 }

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -34,7 +34,7 @@ var (
 	migrationMode string
 	startClean    bool
 	logLevel      string
-	lock          lockfile.Lockfile
+	lockFile      lockfile.Lockfile
 )
 
 var rootCmd = &cobra.Command{
@@ -135,19 +135,19 @@ func validateExportDirFlag() {
 }
 
 func lockExportDir() {
-	lockfileName, err := filepath.Abs(filepath.Join(exportDir, ".lockfile.lck"))
+	lockFileName, err := filepath.Abs(filepath.Join(exportDir, ".lockfile.lck"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get the lockfile path: %v\n", err)
 		os.Exit(1)
 	}
 
-	lock, err = lockfile.New(lockfileName)
+	lockFile, err = lockfile.New(lockFileName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create lockfile %q: %v\n", lockfileName, err)
+		fmt.Fprintf(os.Stderr, "Failed to create lockfile %q: %v\n", lockFileName, err)
 		os.Exit(1)
 	}
 
-	err = lock.TryLock()
+	err = lockFile.TryLock()
 	if err == nil {
 		return
 	} else if err == lockfile.ErrBusy {
@@ -161,9 +161,9 @@ func lockExportDir() {
 }
 
 func unlockExportDir() {
-	err := lock.Unlock()
+	err := lockFile.Unlock()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to unlock %q: %v\n", lock, err)
+		fmt.Fprintf(os.Stderr, "Unable to unlock %q: %v\n", lockFile, err)
 		os.Exit(1)
 	}
 }

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -45,7 +45,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 
 		if exportDir != "" && utils.FileOrFolderExists(exportDir) {
-			if cmd.Use != "version" && cmd.Use != "status" && cmd.Use != "status" {
+			if cmd.Use != "version" && cmd.Use != "status" {
 				lockExportDir()
 			}
 			InitLogging(exportDir, cmd.Use == "status")
@@ -61,7 +61,7 @@ var rootCmd = &cobra.Command{
 
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		if exportDir != "" && utils.FileOrFolderExists(exportDir) {
-			if cmd.Use != "version" && cmd.Use != "status" && cmd.Use != "status" {
+			if cmd.Use != "version" && cmd.Use != "status" {
 				unlockExportDir()
 			}
 		}

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/xattr v0.4.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -364,6 +364,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
+github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/oklog/ulid/v2 v2.0.2 h1:r4fFzBm+bv0wNKNh5eXTwU7i85y5x+uwkxCUTNVQqLc=
 github.com/oklog/ulid/v2 v2.0.2/go.mod h1:mtBL0Qe/0HAx6/a4Z30qxVIAL1eQDweXq5lxOEiwQ68=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
Added code to lock the export-dir when a yb-voyager instance starts running and unlock the export-dir once it is finished.