### PR TITLE
Import index, FK, and triggers in a separate phase after import data

### DIFF
--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -65,6 +65,11 @@ main() {
 
 	step "Import data."
 	import_data
+
+	step "Import remaining schema (FK, index, and trigger)."
+	import_schema --post-import-data
+	run_ysql ${TARGET_DB_NAME} "\di"
+	run_ysql ${TARGET_DB_NAME} "\dft"
 }
 
 main

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -114,10 +114,6 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&parallelImportJobs, "parallel-jobs", -1,
 		"Number of parallel copy command jobs. default: -1 means number of servers in the Yugabyte cluster")
 
-	cmd.Flags().BoolVar(&target.ImportIndexesAfterData, "import-indexes-after-data", true,
-		"false - import indexes before data\n"+
-			"true - create index after data i.e. index backfill")
-
 	cmd.Flags().BoolVar(&target.VerboseMode, "verbose", false,
 		"verbose mode for some extra details during execution of command")
 

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -163,6 +163,8 @@ func registerImportSchemaFlags(cmd *cobra.Command) {
 		"List of schema object types to include while importing schema. (Note: works only for import schema command)")
 	cmd.Flags().StringVar(&target.ExcludeImportObjects, "exclude-object-list", "",
 		"List of schema object types to exclude while importing schema (no-op if --object-list is used) (Note: works only for import schema command)")
+	cmd.Flags().BoolVar(&flagPostImportData, "post-import-data", false,
+		"If set, creates indexes, foreign-keys, and triggers in target db")
 }
 
 func validateTargetPortRange() {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -996,10 +996,11 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 			time.Sleep(time.Second * 5)
 			log.Infof("RETRYING DDL: %q", sqlInfo.stmt)
 			continue
-		} else if strings.Contains(err.Error(), "already exists") &&
-			(target.IgnoreIfExists || strings.EqualFold(sqlInfo.stmt, "CREATE SCHEMA public;")) {
-
-			err = nil
+		} else if strings.Contains(err.Error(), "already exists") {
+			fmt.Printf("XXX already exists error: %q\n", sqlInfo.stmt)
+			if target.IgnoreIfExists || strings.EqualFold(strings.Trim(sqlInfo.stmt, " \n"), "CREATE SCHEMA public;") {
+				err = nil
+			}
 		}
 		break // no more iteration in case of non retriable error
 	}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -446,19 +446,18 @@ func checkPrimaryKey(tableName string) bool {
 	}
 	originalTableName = table
 
-
 	if utils.IsQuotedString(table) {
 		table = strings.Trim(table, `"`)
-	  } else {
+	} else {
 		table = strings.ToLower(table)
-	  }
+	}
 
 	checkTableSql := fmt.Sprintf(`SELECT '%s.%s'::regclass;`, schema, originalTableName)
 	log.Infof("Running query on target DB: %s", checkTableSql)
 
 	rows, err := conn.Query(context.Background(), checkTableSql)
 	if err != nil {
-		if strings.Contains(err.Error(), "does not exist"){
+		if strings.Contains(err.Error(), "does not exist") {
 			utils.ErrExit("table %q doesn't exist in target DB", table)
 		} else {
 			utils.ErrExit("error in querying to check table %q is present: %v", table, err)
@@ -466,9 +465,9 @@ func checkPrimaryKey(tableName string) bool {
 	} else {
 		log.Infof("table %s is present in DB", table)
 	}
-		
-    rows.Close()
-	
+
+	rows.Close()
+
 	/* currently object names for yugabytedb is implemented as case-sensitive i.e. lower-case
 	but in case of oracle exported data files(which we use for to extract tablename)
 	so eg. file EMPLOYEE_data.sql -> table EMPLOYEE which needs to converted for using further */
@@ -997,7 +996,8 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 			time.Sleep(time.Second * 5)
 			log.Infof("RETRYING DDL: %q", sqlInfo.stmt)
 			continue
-		} else if strings.Contains(err.Error(), "already exists") {
+		} else if strings.Contains(err.Error(), "already exists") ||
+			strings.Contains(err.Error(), "multiple primary keys") {
 			// pg_dump generates `CREATE SCHEMA public;` in the schemas.sql. Because the `public`
 			// schema already exists on the target YB db, the create schema statement fails with
 			// "already exists" error. Ignore the error.

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -503,7 +503,7 @@ func truncateTables(tables []string) {
 		if target.VerboseMode {
 			fmt.Printf("Truncating table %s...\n", table)
 		}
-		truncateStmt := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", table)
+		truncateStmt := fmt.Sprintf("TRUNCATE TABLE %s", table)
 		_, err := conn.Exec(context.Background(), truncateStmt)
 		if err != nil {
 			utils.ErrExit("error while truncating table %q: %s", table, err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -704,7 +704,7 @@ func executePostImportDataSqls() {
 		executeSqlFile(sequenceFilePath, "SEQUENCE")
 	}
 
-	if utils.FileOrFolderExists(indexesFilePath) && target.ImportIndexesAfterData {
+	if utils.FileOrFolderExists(indexesFilePath) {
 		fmt.Printf("creating indexes %10s", "")
 		go utils.Wait("done\n", "")
 		executeSqlFile(indexesFilePath, "INDEX")

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -996,7 +996,9 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 			time.Sleep(time.Second * 5)
 			log.Infof("RETRYING DDL: %q", sqlInfo.stmt)
 			continue
-		} else if strings.Contains(err.Error(), "already exists") && target.IgnoreIfExists {
+		} else if strings.Contains(err.Error(), "already exists") &&
+			(target.IgnoreIfExists || strings.EqualFold(sqlInfo.stmt, "CREATE SCHEMA public;")) {
+
 			err = nil
 		}
 		break // no more iteration in case of non retriable error

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -51,15 +51,13 @@ func init() {
 	registerImportSchemaFlags(importSchemaCmd)
 }
 
-func importSchema() {
-	utils.PrintAndLog("import of schema in %q database started", target.DBName)
-	bgCtx := context.Background()
+var flagPostImportData bool
 
+func importSchema() {
 	err := target.DB().Connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to target YB cluster: %s", err)
 	}
-
 	conn := target.DB().Conn()
 	targetDBVersion := target.DB().GetVersion()
 	fmt.Printf("Target YugabyteDB version: %s\n", targetDBVersion)
@@ -67,6 +65,35 @@ func importSchema() {
 	payload := callhome.GetPayload(exportDir)
 	payload.TargetDBVersion = targetDBVersion
 
+	if !flagPostImportData {
+		createTargetSchemas(conn)
+	}
+	var importObjectList []string
+	var skipFn func(objType, stmt string) bool
+	isCreateFKStmt := func(objType, stmt string) bool {
+		return objType == "TABLE" && strings.HasPrefix(stmt, "ALTER TABLE") &&
+			strings.Contains(stmt, "ADD CONSTRAINT") &&
+			strings.Contains(stmt, "FOREIGN KEY")
+	}
+	if !flagPostImportData { // Pre data load.
+		importObjectList = getImportObjectList()
+		importObjectList = utils.SetDifference(importObjectList, []string{"TRIGGER", "INDEX"})
+		if len(importObjectList) == 0 {
+			utils.ErrExit("No schema objects to import! Must import at least 1 of the supported schema object types: %v", utils.GetSchemaObjectList(sourceDBType))
+		}
+		// Do not create FK before loading data.
+		skipFn = isCreateFKStmt
+	} else { // Post data load.
+		importObjectList = []string{"TABLE", "INDEX", "TRIGGER"}
+		skipFn = func(objType, stmt string) bool {
+			return objType == "TABLE" && !isCreateFKStmt(objType, stmt)
+		}
+	}
+	importSchemaInternal(&target, exportDir, importObjectList, skipFn)
+	callhome.PackAndSendPayload(exportDir)
+}
+
+func createTargetSchemas(conn *pgx.Conn) {
 	var targetSchemas []string
 	switch sourceDBType {
 	case "postgresql": // in case of postgreSQL as source, there can be multiple schemas present in a database
@@ -97,7 +124,7 @@ func importSchema() {
 				}
 
 				utils.PrintAndLog("dropping schema '%s' in target database", targetSchema)
-				_, err := conn.Exec(bgCtx, dropSchemaQuery)
+				_, err := conn.Exec(context.Background(), dropSchemaQuery)
 				if err != nil {
 					utils.ErrExit("Failed to drop schema %q: %s", targetSchema, err)
 				}
@@ -114,7 +141,7 @@ func importSchema() {
 		only create target.Schema, other required schemas are created via .sql files */
 		if !schemaExists {
 			utils.PrintAndLog("creating schema '%s' in target database...", target.Schema)
-			_, err := conn.Exec(bgCtx, createSchemaQuery)
+			_, err := conn.Exec(context.Background(), createSchemaQuery)
 			if err != nil {
 				utils.ErrExit("Failed to create %q schema in the target DB: %s", target.Schema, err)
 			}
@@ -125,9 +152,6 @@ func importSchema() {
 			utils.ErrExit("User selected not to import in the `public` schema. Exiting.")
 		}
 	}
-
-	YugabyteDBImportSchema(&target, exportDir)
-	callhome.PackAndSendPayload(exportDir)
 }
 
 func checkIfTargetSchemaExists(conn *pgx.Conn, targetSchema string) bool {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -71,6 +71,7 @@ func importSchema() {
 	var objectList []string
 	var skipFn func(objType, stmt string) bool
 	isCreateFKStmt := func(objType, stmt string) bool {
+		stmt = strings.ToUpper(stmt)
 		return objType == "TABLE" && strings.HasPrefix(stmt, "ALTER TABLE") &&
 			strings.Contains(stmt, "ADD CONSTRAINT") &&
 			strings.Contains(stmt, "FOREIGN KEY")

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -153,14 +153,12 @@ func ExtractMetaInfo(exportDir string) utils.ExportMetaInfo {
 	return metaInfo
 }
 
-func getImportObjectList() []string {
+func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	var finalImportObjectList []string
 	excludeObjectList := utils.CsvStringToSlice(target.ExcludeImportObjects)
 	for i, item := range excludeObjectList {
 		excludeObjectList[i] = strings.ToUpper(item)
 	}
-	// This list also has defined the order to create object type in target YugabyteDB.
-	importObjectOrderList := utils.GetSchemaObjectList(sourceDBType)
 	if target.ImportObjects != "" {
 		includeObjectList := utils.CsvStringToSlice(target.ImportObjects)
 		for i, item := range includeObjectList {

--- a/yb-voyager/src/tgtdb/target.go
+++ b/yb-voyager/src/tgtdb/target.go
@@ -3,29 +3,28 @@ package tgtdb
 import "fmt"
 
 type Target struct {
-	Host                   string
-	Port                   int
-	User                   string
-	Password               string
-	DBName                 string
-	Schema                 string
-	SSLMode                string
-	SSLCertPath            string
-	SSLKey                 string
-	SSLRootCert            string
-	SSLCRL                 string
-	SSLQueryString         string
-	Uri                    string
-	ImportIndexesAfterData bool
-	ContinueOnError        bool
-	IgnoreIfExists         bool
-	VerboseMode            bool
-	TableList              string
-	ExcludeTableList       string
-	ImportMode             bool
-	ImportObjects          string
-	ExcludeImportObjects   string
-	dbVersion              string
+	Host                 string
+	Port                 int
+	User                 string
+	Password             string
+	DBName               string
+	Schema               string
+	SSLMode              string
+	SSLCertPath          string
+	SSLKey               string
+	SSLRootCert          string
+	SSLCRL               string
+	SSLQueryString       string
+	Uri                  string
+	ContinueOnError      bool
+	IgnoreIfExists       bool
+	VerboseMode          bool
+	TableList            string
+	ExcludeTableList     string
+	ImportMode           bool
+	ImportObjects        string
+	ExcludeImportObjects string
+	dbVersion            string
 
 	db *TargetDB
 }


### PR DESCRIPTION
This PR introduces `--post-import-data` flag to the `import schema` command. The user is expected, to run `import schema` with the flag, AFTER data import is complete.
With this change, we assume that no FK, index, or triggers are present when `import data` is running. That allows us to get rid of the `CASCADE` clause from the `TRUNCATE TABLE`.