### PR TITLE
[#305] Support resuming data import for tables not having any primary key

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -415,16 +415,6 @@ func generateSmallerSplits(taskQueue chan *SplitFileImportTask) {
 			utils.ClearMatchingFiles(filePattern)
 		}
 		importTables = allTables //since all tables needs to imported now
-	} else {
-		//truncate tables with no primary key
-		utils.PrintIfTrue("looking for tables without a Primary Key...\n", target.VerboseMode)
-		for _, tableName := range importTables {
-			if !checkPrimaryKey(tableName) {
-				fmt.Printf("truncate table '%s' with NO Primary Key for import of data to restart from beginning...\n", tableName)
-				utils.ClearMatchingFiles(exportDir + "/metainfo/data/" + tableName + ".[0-9]*.[0-9]*.[0-9]*.*") //correct and complete pattern to avoid matching cases with other table names
-				truncateTables([]string{tableName})
-			}
-		}
 	}
 
 	if target.VerboseMode {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -905,13 +905,8 @@ func doOneImport(task *SplitFileImportTask, connPool *tgtdb.ConnectionPool) {
 	err = connPool.WithConn(copyFn)
 	log.Infof("%q => %d rows affected", copyCommand, rowsAffected)
 	if err != nil {
-		if !disableTransactionalWrites && strings.Contains(err.Error(), "violates unique constraint") {
-			log.Infof("Ignoring encountered Error: %v, Assuming batch is already imported due to transactional mode", err)
-		} else {
-			utils.ErrExit("COPY %q FROM file %q: %s", task.TableName, inProgressFilePath, err)
-		}
+		utils.ErrExit("COPY %q FROM file %q: %s", task.TableName, inProgressFilePath, err)
 	}
-
 	incrementImportProgressBar(task.TableName, inProgressFilePath)
 	markTaskDone(task)
 }

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -511,6 +511,13 @@ func truncateTables(tables []string) {
 		if err != nil {
 			utils.ErrExit("error while truncating table %q: %s", table, err)
 		}
+
+		cmd := fmt.Sprintf(`DELETE FROM ybvoyager.batches WHERE file_name LIKE '%s\.%%'`, table)
+		res, err := conn.Exec(context.Background(), cmd)
+		if err != nil {
+			utils.ErrExit("remove %q related entries from ybvoyager.batches: %s", table, err)
+		}
+		log.Infof("query: [%s] => rows affected %v", cmd, res.RowsAffected())
 	}
 }
 


### PR DESCRIPTION
With this change, `import data` creates a new schema `ybvoyager` and a table `ybvoyager.batches` in the schema. After a split-file is imported, voyager atomically adds an entry to the `ybvoyager.batches` table. In other words, if a split file is imported, it must have an entry in the `batches` table. voyager does not initiate a COPY command if it finds that a split-file already has an entry in the `batches` table.

This change allows us to not truncate non-PK tables on resuming. A split-file is never inserted twice!