### PR TITLE
Convert schema names to case-insensitive during import schema

### DIFF
--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -100,6 +100,7 @@ func importSchema() {
 
 func createTargetSchemas(conn *pgx.Conn) {
 	var targetSchemas []string
+	target.Schema = strings.ToLower(strings.Trim(target.Schema, "\"")) //trim case sensitivity quotes if needed, convert to lowercase
 	switch sourceDBType {
 	case "postgresql": // in case of postgreSQL as source, there can be multiple schemas present in a database
 		source = srcdb.Source{DBType: sourceDBType}
@@ -113,6 +114,7 @@ func createTargetSchemas(conn *pgx.Conn) {
 		targetSchemas = append(targetSchemas, target.Schema)
 
 	}
+	targetSchemas = utils.ToInsensitiveSlice(targetSchemas)
 
 	utils.PrintAndLog("schemas to be present in target database: %v\n", targetSchemas)
 

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -114,7 +114,7 @@ func createTargetSchemas(conn *pgx.Conn) {
 		targetSchemas = append(targetSchemas, target.Schema)
 
 	}
-	targetSchemas = utils.ToInsensitiveSlice(targetSchemas)
+	targetSchemas = utils.ToCaseInsensitiveNames(targetSchemas)
 
 	utils.PrintAndLog("schemas to be present in target database: %v\n", targetSchemas)
 

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -304,3 +304,13 @@ func InsensitiveSliceContains(slice []string, s string) bool {
 	log.Infof("string s=%q did not match with any string in %v", s, slice)
 	return false
 }
+
+func ToInsensitiveSlice(slice []string) []string {
+	for i, object := range slice {
+		if IsQuotedString(object) {
+			object = strings.Trim(object, "\"")
+		}
+		slice[i] = strings.ToLower(object)
+	}
+	return slice
+}

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -305,12 +305,10 @@ func InsensitiveSliceContains(slice []string, s string) bool {
 	return false
 }
 
-func ToInsensitiveSlice(slice []string) []string {
-	for i, object := range slice {
-		if IsQuotedString(object) {
-			object = strings.Trim(object, "\"")
-		}
-		slice[i] = strings.ToLower(object)
+func ToCaseInsensitiveNames(names []string) []string {
+	for i, object := range names {
+		object = strings.Trim(object, "\"")
+		names[i] = strings.ToLower(object)
 	}
-	return slice
+	return names
 }


### PR DESCRIPTION
[Fixes #334, #335, #336]
Voyager now converts any case sensitive names for target schema to lowercase. The user can convert the schema names to case-sensitive names post import using alter statements, if needed