### PR TITLE
Modified extracting the table name from the table-list flag according to the default cases of Source DBs if not quoted

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -213,16 +213,32 @@ func extractTableListFromString(flagTableList string) []string {
 		return []string{}
 	}
 	tableList := utils.CsvStringToSlice(flagTableList)
-	if source.DBType != POSTGRESQL {
+	if source.DBType == MYSQL {
 		return tableList
 	}
 	// in postgres format should be schema.table, public is default and other parts of code assume schema.table format
 	for _, table := range tableList {
 		parts := strings.Split(table, ".")
 		if len(parts) == 1 {
-			finalTableList = append(finalTableList, "public."+table)
+			if source.DBType == ORACLE {
+				if utils.IsQuotedString(parts[0]) {
+					parts[0] = strings.Trim(parts[0],`"`)
+				} else {
+					parts[0] = strings.ToUpper(parts[0])
+				}
+			} else if  source.DBType == POSTGRESQL {
+				finalTableList = append(finalTableList, "public."+table)
+			}
 		} else if len(parts) == 2 {
-			finalTableList = append(finalTableList, table)
+			if source.DBType == ORACLE {
+				if utils.IsQuotedString(parts[1]) {
+					parts[1] = strings.Trim(parts[1],`"`)
+				} else {
+					parts[1] = strings.ToUpper(parts[1])
+				}
+			} else if  source.DBType == POSTGRESQL {
+				finalTableList = append(finalTableList, table)
+			}
 		} else {
 			utils.ErrExit("invalid table name %q in the --table-list flag.", table)
 		}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -229,6 +229,10 @@ func extractTableListFromString(flagTableList string) []string {
 				table = strings.Join(parts, ".")
 				finalTableList = append(finalTableList, table)
 			} else if  source.DBType == POSTGRESQL {
+				if !utils.IsQuotedString(parts[0]) {
+					parts[0] = strings.ToLower(parts[0])
+				}
+				table = strings.Join(parts, ".")
 				finalTableList = append(finalTableList, "public."+table)
 			}
 		} else if len(parts) == 2 {
@@ -241,6 +245,10 @@ func extractTableListFromString(flagTableList string) []string {
 				table = strings.Join(parts, ".")
 				finalTableList = append(finalTableList, table)
 			} else if  source.DBType == POSTGRESQL {
+				if !utils.IsQuotedString(parts[0]) {
+					parts[0] = strings.ToLower(parts[0])
+				}
+				table = strings.Join(parts, ".")
 				finalTableList = append(finalTableList, table)
 			}
 		} else {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -226,6 +226,8 @@ func extractTableListFromString(flagTableList string) []string {
 				} else {
 					parts[0] = strings.ToUpper(parts[0])
 				}
+				table = strings.Join(parts, ".")
+				finalTableList = append(finalTableList, table)
 			} else if  source.DBType == POSTGRESQL {
 				finalTableList = append(finalTableList, "public."+table)
 			}
@@ -236,6 +238,8 @@ func extractTableListFromString(flagTableList string) []string {
 				} else {
 					parts[1] = strings.ToUpper(parts[1])
 				}
+				table = strings.Join(parts, ".")
+				finalTableList = append(finalTableList, table)
 			} else if  source.DBType == POSTGRESQL {
 				finalTableList = append(finalTableList, table)
 			}


### PR DESCRIPTION
This PR includes modifying the table-names from the `--table-list` flag into default cases of the Source DBs if not quoted -
1. For Oracle, convert the name to Upper if not quoted else pass as is without quotes.
2. For PostgreSQL, convert the name to Lower if not quoted else pass as is with quotes.
3. For MySQL, pass the table list as is because names are case Sensitive in MySQL.