### PR TITLE
Added code to create metaInfo.json file and removed unnecessary flags…

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -94,10 +94,6 @@ analyze_schema() {
 		--output-format txt
 		--send-diagnostics=false
 	"
-        if [ "${SOURCE_DB_SCHEMA}" != "" ]
-        then
-                args="${args} --source-db-schema ${SOURCE_DB_SCHEMA}"
-        fi
         yb-voyager analyze-schema ${args} $*
 }
 

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -91,12 +91,6 @@ export_data() {
 
 analyze_schema() {
 	args="--export-dir ${EXPORT_DIR}
-		--source-db-type ${SOURCE_DB_TYPE}
-		--source-db-host ${SOURCE_DB_HOST}
-		--source-db-port ${SOURCE_DB_PORT}
-		--source-db-user ${SOURCE_DB_USER}
-		--source-db-password ${SOURCE_DB_PASSWORD}
-		--source-db-name ${SOURCE_DB_NAME}
 		--output-format txt
 		--send-diagnostics=false
 	"

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -739,7 +739,6 @@ func generateTxtReport(Report utils.Report) string {
 
 // add info to the 'reportStruct' variable and return
 func analyzeSchemaInternal() utils.Report {
-	//reading source db metainfo
 	miginfo, err := LoadMigInfo(exportDir)
 	if err != nil {
 		utils.ErrExit("unable to load migration info: %s", err)

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -97,7 +97,9 @@ func exportSchema() {
 		SourceDBName:    source.DBName,
 		SourceDBSchema:  source.Schema,
 		SourceDBVersion: source.DB().GetVersion(),
-		ExportDir:       exportDir,
+		SourceDBSid:     source.DBSid,
+		SourceTNSAlias:  source.TNSAlias,
+		exportDir:       exportDir,
 	}
 	err = SaveMigInfo(miginfo)
 	if err != nil {

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -16,10 +16,8 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -28,10 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 )
-
-type MetaInfo struct {
-	SourceDBType, SourceDBName, SourceDBSchema, SourceDBVersion string
-}
 
 var exportSchemaCmd = &cobra.Command{
 	Use:   "schema",
@@ -63,12 +57,10 @@ func exportSchema() {
 			if !proceed {
 				return
 			}
-			//clear directories
+
 			for _, dirName := range []string{"schema", "reports", "temp", "metainfo/schema"} {
 				utils.CleanDir(filepath.Join(exportDir, dirName))
 			}
-			//clear files
-			utils.ClearMatchingFiles(filepath.Join(exportDir, META_INFO_DIR_NAME, "metaInfo.json"))
 
 			clearSchemaIsExported(exportDir)
 		} else {
@@ -99,7 +91,18 @@ func exportSchema() {
 	callhome.PackAndSendPayload(exportDir)
 
 	setSchemaIsExported(exportDir)
-	createMetaInfoJsonFile()
+
+	miginfo := &MigInfo{
+		SourceDBType:    source.DBType,
+		SourceDBName:    source.DBName,
+		SourceDBSchema:  source.Schema,
+		SourceDBVersion: source.DB().GetVersion(),
+		ExportDir:       exportDir,
+	}
+	err = SaveMigInfo(miginfo)
+	if err != nil {
+		utils.ErrExit("unable to save migration info: %s", err)
+	}
 }
 
 func init() {
@@ -132,26 +135,4 @@ func setSchemaIsExported(exportDir string) {
 func clearSchemaIsExported(exportDir string) {
 	flagFilePath := filepath.Join(exportDir+"metainfo", "flags", "exportSchemaDone")
 	os.Remove(flagFilePath)
-}
-
-func createMetaInfoJsonFile() {
-	data := MetaInfo{
-		SourceDBType:    source.DBType,
-		SourceDBName:    source.DBName,
-		SourceDBSchema:  source.Schema,
-		SourceDBVersion: source.DB().GetVersion(),
-	}
-
-	file, err := json.MarshalIndent(data, "", " ")
-	if err != nil {
-		utils.ErrExit("unable to parse meta info data into json: %s", err)
-	}
-
-	metaInfoFilePath := filepath.Join(exportDir, META_INFO_DIR_NAME, "metaInfo.json")
-
-	err = ioutil.WriteFile(metaInfoFilePath, file, 0644)
-	if err != nil {
-		utils.ErrExit("unable to write meta info file: %s", err)
-	}
-
 }

--- a/yb-voyager/cmd/miginfo.go
+++ b/yb-voyager/cmd/miginfo.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type MigInfo struct {
+	SourceDBType    string
+	SourceDBName    string
+	SourceDBSchema  string
+	SourceDBVersion string
+	ExportDir       string
+}
+
+func SaveMigInfo(miginfo *MigInfo) error {
+
+	file, err := json.MarshalIndent(miginfo, "", " ")
+	if err != nil {
+		// unable to parse meta info data into json
+		return err
+	}
+
+	migInfoFilePath := filepath.Join(miginfo.ExportDir, META_INFO_DIR_NAME, "miginfo.json")
+
+	err = ioutil.WriteFile(migInfoFilePath, file, 0644)
+	if err != nil {
+		// unable to write miginfo.json file
+		return err
+	}
+
+	return nil
+}
+
+func LoadMigInfo(exportDir string) (*MigInfo, error) {
+
+	metaInfo := &MigInfo{}
+
+	migInfoFilePath := filepath.Join(exportDir, META_INFO_DIR_NAME, "miginfo.json")
+
+	log.Infof("loading db meta info from %q", migInfoFilePath)
+
+	metaInfoJson, err := ioutil.ReadFile(migInfoFilePath)
+	if err != nil {
+		// unable to load miginfo.json file
+		return nil, err
+	}
+
+	err = json.Unmarshal(metaInfoJson, &metaInfo)
+	if err != nil {
+		// unable to unmarshal miginfo json
+		return nil, err
+	}
+
+	log.Infof("parsed source db meta info: %+v", metaInfo)
+	return metaInfo, nil
+}


### PR DESCRIPTION
… from analyze-schema.
The metaInfo.json file is created during export schema phase and contains information about the source db like `sourceDBName`, `sourceDBType`, `sourceDBSchema`, `sourceDBVersion`.