### PR TITLE
Create new log file when size limit is reached for current log file

### DIFF
--- a/yb-voyager/cmd/logging.go
+++ b/yb-voyager/cmd/logging.go
@@ -73,6 +73,9 @@ func replaceLogFileIfNeeded(logDir string) {
 	oldLogFilePath := filepath.Join(logDir, "yb-voyager-old.log")
 	fileInfo, err := os.Stat(logFilePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
 		panic(fmt.Sprintf("Failed to read log file %q: %s", logFilePath, err))
 	}
 	if fileInfo.Size() < FOUR_MB {


### PR DESCRIPTION
[Fixes #378]
When the current log file reaches 4MB in size, we now create a new log file and move the older log file to a different file.