### PR TITLE
Added code to run pg_dump and pg_restore version 14 and above

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -87,7 +87,9 @@ func getMappingForTableNameVsTableFileName(dataDirPath string) map[string]string
 		time.Sleep(time.Second * 1)
 	}
 
-	pgRestoreCmd := exec.Command("pg_restore", "-l", dataDirPath)
+	var pgRestorePath string
+	srcdb.FindCorrectPGCommandPath(&pgRestorePath, "pg_restore")
+	pgRestoreCmd := exec.Command(pgRestorePath, "-l", dataDirPath)
 	stdOut, err := pgRestoreCmd.Output()
 	log.Infof("cmd: %s", pgRestoreCmd.String())
 	log.Infof("output: %s", string(stdOut))

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -88,7 +88,10 @@ func getMappingForTableNameVsTableFileName(dataDirPath string) map[string]string
 	}
 
 	var pgRestorePath string
-	srcdb.FindCorrectPGCommandPath(&pgRestorePath, "pg_restore")
+	pgRestorePath, err := srcdb.GetAbsPathOfPGCommand("pg_restore")
+	if err != nil {
+		utils.ErrExit("could not get absolute path of pg_restore command: %v", pgRestorePath)
+	}
 	pgRestoreCmd := exec.Command(pgRestorePath, "-l", dataDirPath)
 	stdOut, err := pgRestoreCmd.Output()
 	log.Infof("cmd: %s", pgRestoreCmd.String())

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -87,7 +87,6 @@ func getMappingForTableNameVsTableFileName(dataDirPath string) map[string]string
 		time.Sleep(time.Second * 1)
 	}
 
-	var pgRestorePath string
 	pgRestorePath, err := srcdb.GetAbsPathOfPGCommand("pg_restore")
 	if err != nil {
 		utils.ErrExit("could not get absolute path of pg_restore command: %v", pgRestorePath)

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/godror/knownpb v0.1.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -236,6 +236,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -347,6 +349,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 h1:YocNLcTBdEdvY3iDK6jfWXvEaM5OCKkjxPKoJRdB3Gg=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2/go.mod h1:76rfSfYPWj01Z85hUf/ituArm797mNKcvINh1OlsZKo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -37,7 +37,7 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 	tableListPatterns := createTableListPatterns(tableList)
 
 	// Using pgdump for exporting data in directory format.
-	cmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`,
+	cmd := fmt.Sprintf(`%s "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`, PgDumpPath,
 		connectionUri, tableListPatterns, dataDirPath, source.NumConnections)
 
 	log.Infof("Running command: %s", cmd)

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -37,7 +37,11 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 	tableListPatterns := createTableListPatterns(tableList)
 
 	// Using pgdump for exporting data in directory format.
-	cmd := fmt.Sprintf(`%s "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`, PgDumpPath,
+	pgDumpPath, err := GetAbsPathOfPGCommand("pg_dump")
+	if err != nil {
+		utils.ErrExit("could not get absolute path of pg_dump command: %v", err)
+	}
+	cmd := fmt.Sprintf(`%s "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`, pgDumpPath,
 		connectionUri, tableListPatterns, dataDirPath, source.NumConnections)
 
 	log.Infof("Running command: %s", cmd)
@@ -46,7 +50,7 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 	proc := exec.CommandContext(ctx, "/bin/bash", "-c", cmd)
 	proc.Stderr = &outbuf
 	proc.Stdout = &errbuf
-	err := proc.Start()
+	err = proc.Start()
 	if outbuf.String() != "" {
 		log.Infof("%s", outbuf.String())
 	}

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -16,7 +16,7 @@ func pgdumpExtractSchema(schemaList string, connectionUri string, exportDir stri
 	fmt.Printf("exporting the schema %10s", "")
 	go utils.Wait("done\n", "error\n")
 
-	cmd := fmt.Sprintf(`pg_dump "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`,
+	cmd := fmt.Sprintf(`%s "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`, PgDumpPath,
 		connectionUri, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
 	log.Infof("Running command: %s", cmd)
 	preparedPgdumpCommand := exec.Command("/bin/bash", "-c", cmd)

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -16,7 +16,11 @@ func pgdumpExtractSchema(schemaList string, connectionUri string, exportDir stri
 	fmt.Printf("exporting the schema %10s", "")
 	go utils.Wait("done\n", "error\n")
 
-	cmd := fmt.Sprintf(`%s "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`, PgDumpPath,
+	pgDumpPath, err := GetAbsPathOfPGCommand("pg_dump")
+	if err != nil {
+		utils.ErrExit("could not get absolute path of pg_dump command: %v", err)
+	}
+	cmd := fmt.Sprintf(`%s "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`, pgDumpPath,
 		connectionUri, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
 	log.Infof("Running command: %s", cmd)
 	preparedPgdumpCommand := exec.Command("/bin/bash", "-c", cmd)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -35,8 +35,6 @@ func (pg *PostgreSQL) Connect() error {
 
 func (pg *PostgreSQL) CheckRequiredToolsAreInstalled() {
 	checkTools("strings")
-	// pgDumpPath, _ := GetAbsPathOfPGCommand("pg_dump")
-	// pgRestorePath, _ := GetAbsPathOfPGCommand("pg_restore")
 }
 
 func (pg *PostgreSQL) GetTableRowCount(tableName string) int64 {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -190,7 +190,7 @@ func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressM
 func GetAbsPathOfPGCommand(cmd string) (string, error) {
 	paths, err := findAllExecutablesInPath(cmd)
 	if err != nil {
-		err = fmt.Errorf("error in finding executables: %v", err)
+		err = fmt.Errorf("error in finding executables: %w", err)
 		return "", err
 	}
 	if len(paths) == 0 {
@@ -202,19 +202,15 @@ func GetAbsPathOfPGCommand(cmd string) (string, error) {
 		cmd := exec.Command(path, "--version")
 		stdout, err := cmd.Output()
 		if err != nil {
-			err = fmt.Errorf("error in finding version of %v from path %v: %v", cmd, path, err)
+			err = fmt.Errorf("error in finding version of %v from path %v: %w", cmd, path, err)
 			return "", err
 		}
 
 		// example output centos: pg_restore (PostgreSQL) 14.5
 		// example output Ubuntu: pg_dump (PostgreSQL) 14.5 (Ubuntu 14.5-1.pgdg22.04+1)
 		currVersion := strings.Fields(string(stdout))[2]
-		if err != nil {
-			err = fmt.Errorf("error in converting version found from string to float: %v", err)
-			return "", err
-		}
 
-		if version.CompareSimple(currVersion, PG_COMMAND_VERSION) > 0 {
+		if version.CompareSimple(currVersion, PG_COMMAND_VERSION) >= 0 {
 			return path, nil
 		}
 	}

--- a/yb-voyager/src/srcdb/utils.go
+++ b/yb-voyager/src/srcdb/utils.go
@@ -36,7 +36,7 @@ func findAllExecutablesInPath(executableName string) ([]string, error) {
 	if pathString == "" {
 		return nil, fmt.Errorf("PATH environment variable is not set")
 	}
-	paths := strings.Split(pathString, ":")
+	paths := strings.Split(pathString, string(os.PathListSeparator))
 	var result []string
 	for _, dir := range paths {
 		fullPath := path.Join(dir, executableName)

--- a/yb-voyager/src/srcdb/utils.go
+++ b/yb-voyager/src/srcdb/utils.go
@@ -1,7 +1,11 @@
 package srcdb
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"path"
+	"strings"
 	"unicode"
 
 	log "github.com/sirupsen/logrus"
@@ -25,4 +29,20 @@ func nameContainsCapitalLetter(name string) bool {
 		}
 	}
 	return false
+}
+
+func findAllExecutablesInPath(executableName string) ([]string, error) {
+	pathString := os.Getenv("PATH")
+	if pathString == "" {
+		return nil, fmt.Errorf("PATH environment variable is not set")
+	}
+	paths := strings.Split(pathString, ":")
+	var result []string
+	for _, dir := range paths {
+		fullPath := path.Join(dir, executableName)
+		if _, err := os.Stat(fullPath); err == nil {
+			result = append(result, fullPath)
+		}
+	}
+	return result, nil
 }


### PR DESCRIPTION
I have searched and replaced all the occurrences of running the pg_dump and pg_restore command in the go project with the path to the version 14 and higher of either.