### PR TITLE
Redact visible passwords in yb-voyager.log

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -131,7 +131,8 @@ func getYBServers() []*tgtdb.Target {
 			}
 
 			clone.Uri = getCloneConnectionUri(clone)
-			log.Infof("using yb server for import data: %+v", clone)
+			redactedClone := tgtdb.GetRedactedTarget(clone)
+			log.Infof("using yb server for import data: %+v", redactedClone)
 			targets = append(targets, clone)
 		}
 	} else {
@@ -211,7 +212,7 @@ func testYbServers(targets []*tgtdb.Target) {
 		utils.ErrExit("no yb servers available/given for data import")
 	}
 	for _, target := range targets {
-		log.Debugf("testing server: %s\n", spew.Sdump(target))
+		log.Debugf("testing server: %s\n", spew.Sdump(tgtdb.GetRedactedTarget(target)))
 		conn, err := pgx.Connect(context.Background(), target.GetConnectionUri())
 		if err != nil {
 			utils.ErrExit("error while testing yb servers: %v", err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -131,8 +131,7 @@ func getYBServers() []*tgtdb.Target {
 			}
 
 			clone.Uri = getCloneConnectionUri(clone)
-			redactedClone := tgtdb.GetRedactedTarget(clone)
-			log.Infof("using yb server for import data: %+v", redactedClone)
+			log.Infof("using yb server for import data: %+v", tgtdb.GetRedactedTarget(clone))
 			targets = append(targets, clone)
 		}
 	} else {
@@ -212,7 +211,7 @@ func testYbServers(targets []*tgtdb.Target) {
 		utils.ErrExit("no yb servers available/given for data import")
 	}
 	for _, target := range targets {
-		log.Debugf("testing server: %s\n", spew.Sdump(tgtdb.GetRedactedTarget(target)))
+		log.Infof("testing server: %s\n", spew.Sdump(tgtdb.GetRedactedTarget(target)))
 		conn, err := pgx.Connect(context.Background(), target.GetConnectionUri())
 		if err != nil {
 			utils.ErrExit("error while testing yb servers: %v", err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -211,7 +211,7 @@ func testYbServers(targets []*tgtdb.Target) {
 		utils.ErrExit("no yb servers available/given for data import")
 	}
 	for _, target := range targets {
-		log.Infof("testing server: %s\n", spew.Sdump(target))
+		log.Debugf("testing server: %s\n", spew.Sdump(target))
 		conn, err := pgx.Connect(context.Background(), target.GetConnectionUri())
 		if err != nil {
 			utils.ErrExit("error while testing yb servers: %v", err)
@@ -275,7 +275,7 @@ func importData() {
 	for _, t := range targets {
 		targetUriList = append(targetUriList, t.Uri)
 	}
-	log.Infof("targetUriList: %s", targetUriList)
+	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
 	params := &tgtdb.ConnectionParams{
 		NumConnections:    parallelImportJobs + 1,
 		ConnUriList:       targetUriList,

--- a/yb-voyager/cmd/logging.go
+++ b/yb-voyager/cmd/logging.go
@@ -63,6 +63,16 @@ func InitLogging(logDir string, disableLogging bool) {
 	log.SetReportCaller(true)
 	log.SetFormatter(&MyFormatter{})
 	log.Info("Logging initialised.")
+	redactPasswordFromArgs()
 	log.Infof("Args: %v", os.Args)
 	log.Infof("\n%s", getVersionInfo())
+}
+
+func redactPasswordFromArgs() {
+	for i := 0; i < len(os.Args); i++ {
+		opt := os.Args[i]
+		if opt == "--source-db-password" || opt == "--target-db-password" {
+			os.Args[i+1] = "XXX"
+		}
+	}
 }

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/godror/godror v0.30.2
 	github.com/google/uuid v1.1.2
 	github.com/jackc/pgx/v4 v4.14.1
+	github.com/nightlyone/lockfile v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
@@ -16,6 +17,7 @@ require (
 	github.com/tevino/abool/v2 v2.0.1
 	github.com/vbauerster/mpb/v7 v7.3.0
 	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4
+	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 )
 
 require (
@@ -38,9 +40,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
-	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/pkg/xattr v0.4.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
@@ -48,9 +48,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	github.com/ucarion/redact v0.0.0-20190527210305-5ee85e474909 // indirect
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
-	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/net v0.0.0-20220111093109-d55c255bac03 // indirect
 	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/ucarion/redact v0.0.0-20190527210305-5ee85e474909 // indirect
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/net v0.0.0-20220111093109-d55c255bac03 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -186,7 +186,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -252,7 +251,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -273,7 +271,6 @@ github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 h1:DadwsjnMwFjfWc9y5W
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -377,8 +374,6 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/pkg/xattr v0.4.7 h1:XoA3KzmFvyPlH4RwX5eMcgtzcaGBaSvgt3IoFQfbrmQ=
-github.com/pkg/xattr v0.4.7/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -445,8 +440,6 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tevino/abool/v2 v2.0.1 h1:OF7FC5V5z3yAWyixbc32ecEzrgAJCsPkVOsPM2qoZPI=
 github.com/tevino/abool/v2 v2.0.1/go.mod h1:+Lmlqk6bHDWHqN1cbxqhwEAwMPXgc8I1SDEamtseuXY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/ucarion/redact v0.0.0-20190527210305-5ee85e474909 h1:14FEA22rdU7tiZrrU+ktRb7tEVMmZopVtu9SCy8Wi3A=
-github.com/ucarion/redact v0.0.0-20190527210305-5ee85e474909/go.mod h1:caJCIpIXxCxz3yovet6uYzGkG4MuBHlDnjZP9IGGGJc=
 github.com/vbauerster/mpb/v7 v7.3.0 h1:WwRtHHT26gjVln0yJypDEEpTWyX9sk4QcUxM6tQjdEc=
 github.com/vbauerster/mpb/v7 v7.3.0/go.mod h1:KERDXx9bfuStUwTH2FbsrJhJhVu1q+xmjjoCZMZrin4=
 github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4 h1:0sw0nJM544SpsihWx1bkXdYLQDlzRflMgFJQ4Yih9ts=
@@ -578,7 +571,6 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220111093109-d55c255bac03 h1:0FB83qp0AzVJm+0wcIlauAjJ+tNdh7jLuacRYCIVv7s=
 golang.org/x/net v0.0.0-20220111093109-d55c255bac03/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -678,8 +670,6 @@ golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211214234402-4825e8c3871d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320 h1:0jf+tOCoZ3LyutmCOWpVni1chK4VfFLhRsDK7MhqGRY=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f h1:8w7RhxzTVgUzw/AH/9mUV5q0vMgy40SQRursCcfmkCw=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -761,7 +751,6 @@ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -445,6 +445,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tevino/abool/v2 v2.0.1 h1:OF7FC5V5z3yAWyixbc32ecEzrgAJCsPkVOsPM2qoZPI=
 github.com/tevino/abool/v2 v2.0.1/go.mod h1:+Lmlqk6bHDWHqN1cbxqhwEAwMPXgc8I1SDEamtseuXY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/ucarion/redact v0.0.0-20190527210305-5ee85e474909 h1:14FEA22rdU7tiZrrU+ktRb7tEVMmZopVtu9SCy8Wi3A=
+github.com/ucarion/redact v0.0.0-20190527210305-5ee85e474909/go.mod h1:caJCIpIXxCxz3yovet6uYzGkG4MuBHlDnjZP9IGGGJc=
 github.com/vbauerster/mpb/v7 v7.3.0 h1:WwRtHHT26gjVln0yJypDEEpTWyX9sk4QcUxM6tQjdEc=
 github.com/vbauerster/mpb/v7 v7.3.0/go.mod h1:KERDXx9bfuStUwTH2FbsrJhJhVu1q+xmjjoCZMZrin4=
 github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4 h1:0sw0nJM544SpsihWx1bkXdYLQDlzRflMgFJQ4Yih9ts=

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -37,11 +37,11 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 	tableListPatterns := createTableListPatterns(tableList)
 
 	// Using pgdump for exporting data in directory format.
-	cmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`,
-		connectionUri, tableListPatterns, dataDirPath, source.NumConnections)
+	pgDumpArgs := fmt.Sprintf(`--no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`,
+		tableListPatterns, dataDirPath, source.NumConnections)
+	cmd := fmt.Sprintf(`pg_dump "%s" %s`, connectionUri, pgDumpArgs)
 	redactedUri := utils.GetRedactedURLs([]string{connectionUri})[0]
-	redactedCmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`,
-		redactedUri, tableListPatterns, dataDirPath, source.NumConnections)
+	redactedCmd := fmt.Sprintf(`pg_dump "%s" %s`, redactedUri, pgDumpArgs)
 	log.Infof("Running command: %s", redactedCmd)
 	var outbuf bytes.Buffer
 	var errbuf bytes.Buffer

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -39,8 +39,10 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 	// Using pgdump for exporting data in directory format.
 	cmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`,
 		connectionUri, tableListPatterns, dataDirPath, source.NumConnections)
-
-	log.Infof("Running command: %s", cmd)
+	redactedUri := utils.GetRedactedURLs([]string{connectionUri})[0]
+	redactedCmd := fmt.Sprintf(`pg_dump "%s" --no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces`,
+		redactedUri, tableListPatterns, dataDirPath, source.NumConnections)
+	log.Infof("Running command: %s", redactedCmd)
 	var outbuf bytes.Buffer
 	var errbuf bytes.Buffer
 	proc := exec.CommandContext(ctx, "/bin/bash", "-c", cmd)

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -16,11 +16,10 @@ func pgdumpExtractSchema(schemaList string, connectionUri string, exportDir stri
 	fmt.Printf("exporting the schema %10s", "")
 	go utils.Wait("done\n", "error\n")
 
-	cmd := fmt.Sprintf(`pg_dump "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`,
-		connectionUri, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
+	pgDumpArgs := fmt.Sprintf(`--schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
+	cmd := fmt.Sprintf(`pg_dump "%s" %s`, connectionUri, pgDumpArgs)
 	redactedUri := utils.GetRedactedURLs([]string{connectionUri})[0]
-	redactedCmd := fmt.Sprintf(`pg_dump "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`,
-		redactedUri, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
+	redactedCmd := fmt.Sprintf(`pg_dump "%s" %s`, redactedUri, pgDumpArgs)
 	log.Infof("Running command: %s", redactedCmd)
 	preparedPgdumpCommand := exec.Command("/bin/bash", "-c", cmd)
 

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -18,7 +18,10 @@ func pgdumpExtractSchema(schemaList string, connectionUri string, exportDir stri
 
 	cmd := fmt.Sprintf(`pg_dump "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`,
 		connectionUri, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
-	log.Infof("Running command: %s", cmd)
+	redactedUri := utils.GetRedactedURLs([]string{connectionUri})[0]
+	redactedCmd := fmt.Sprintf(`pg_dump "%s" --schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces`,
+		redactedUri, schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
+	log.Infof("Running command: %s", redactedCmd)
 	preparedPgdumpCommand := exec.Command("/bin/bash", "-c", cmd)
 
 	stdout, err := preparedPgdumpCommand.CombinedOutput()

--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -85,11 +85,11 @@ func (pool *ConnectionPool) createNewConnection() (*pgx.Conn, error) {
 
 func (pool *ConnectionPool) connect(uri string) (*pgx.Conn, error) {
 	conn, err := pgx.Connect(context.Background(), uri)
+	redactedUri := utils.GetRedactedURLs([]string{uri})[0]
 	if err != nil {
-		log.Warnf("Failed to connect to %q: %s", uri, err)
+		log.Warnf("Failed to connect to %q: %s", redactedUri, err)
 		return nil, err
 	}
-	redactedUri := utils.GetRedactedURLs([]string{uri})[0]
 	log.Infof("Connected to %q", redactedUri)
 	err = pool.initSession(conn)
 	if err != nil {

--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 var defaultSessionVars = []string{
@@ -88,10 +89,11 @@ func (pool *ConnectionPool) connect(uri string) (*pgx.Conn, error) {
 		log.Warnf("Failed to connect to %q: %s", uri, err)
 		return nil, err
 	}
-	log.Infof("Connected to %q", uri)
+	redactedUri := utils.GetRedactedURLs([]string{uri})[0]
+	log.Infof("Connected to %q", redactedUri)
 	err = pool.initSession(conn)
 	if err != nil {
-		log.Warnf("Failed to set session vars %q: %s", uri, err)
+		log.Warnf("Failed to set session vars %q: %s", redactedUri, err)
 		conn.Close(context.Background())
 		conn = nil
 	}

--- a/yb-voyager/src/tgtdb/target.go
+++ b/yb-voyager/src/tgtdb/target.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/ucarion/redact"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -102,6 +101,6 @@ func generateSSLQueryStringIfNotExists(t *Target) string {
 func GetRedactedTarget(t *Target) *Target {
 	redactedTarget := *t
 	redactedTarget.Uri = utils.GetRedactedURLs([]string{t.Uri})[0]
-	redact.Redact([]string{"Password"}, &redactedTarget)
+	redactedTarget.Password = "XXX"
 	return &redactedTarget
 }

--- a/yb-voyager/src/tgtdb/target.go
+++ b/yb-voyager/src/tgtdb/target.go
@@ -3,6 +3,9 @@ package tgtdb
 import (
 	"fmt"
 	"net/url"
+
+	"github.com/ucarion/redact"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 type Target struct {
@@ -94,4 +97,11 @@ func generateSSLQueryStringIfNotExists(t *Target) string {
 		SSLQueryString = t.SSLQueryString
 	}
 	return SSLQueryString
+}
+
+func GetRedactedTarget(t *Target) *Target {
+	redactedTarget := *t
+	redactedTarget.Uri = utils.GetRedactedURLs([]string{t.Uri})[0]
+	redact.Redact([]string{"Password"}, &redactedTarget)
+	return &redactedTarget
 }

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -311,4 +312,16 @@ func ToCaseInsensitiveNames(names []string) []string {
 		names[i] = strings.ToLower(object)
 	}
 	return names
+}
+
+func GetRedactedURLs(urlList []string) []string {
+	result := []string{}
+	for _, u := range urlList {
+		obj, err := url.Parse(u)
+		if err != nil {
+			ErrExit("invalid URL: %q", u)
+		}
+		result = append(result, obj.Redacted())
+	}
+	return result
 }


### PR DESCRIPTION
[Fixes #386]
This patch ensures to redact all (possible occurrences of) visible passwords within yb-voyager.log across all logging levels.
Note that there are two redact packages being used, one for URLs, and one for structs.