### PR TITLE
Reverted the changes for the import data file

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1064,6 +1064,9 @@ func incrementImportProgressBar(tableName string, splitFilePath string) {
 }
 
 func extractCopyStmtForTable(table string, fileToSearchIn string) {
+	if getCopyCommand(table) != "" {
+		return
+	}
 	// pg_dump and ora2pg always have columns - "COPY table (col1, col2) FROM STDIN"
 	copyCommandRegex := regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]+\(.*\) FROM STDIN`, table))
 	if sourceDBType == "postgresql" {


### PR DESCRIPTION
Restore the call to `getCopyCommand()` in `extractCopyStmtForTable()` for the import data file command. Call was removed in commit hash - https://github.com/yugabyte/yb-voyager/commit/60148924d7c2fb023eae3667713393793e78e090 