### PR TITLE
Added Support for table partitions in MySQL #343

### DIFF
--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -71,15 +71,16 @@ func importSchema() {
 	}
 	var objectList []string
 
+	objectsToImportAfterData := []string{"INDEX", "FTS_INDEX", "PARTITION_INDEX", "TRIGGER"}
 	if !flagPostImportData { // Pre data load.
 		// This list also has defined the order to create object type in target YugabyteDB.
 		objectList = utils.GetSchemaObjectList(sourceDBType)
-		objectList = utils.SetDifference(objectList, []string{"TRIGGER", "INDEX", "PARTITION_INDEX"})
+		objectList = utils.SetDifference(objectList, objectsToImportAfterData)
 		if len(objectList) == 0 {
 			utils.ErrExit("No schema objects to import! Must import at least 1 of the supported schema object types: %v", utils.GetSchemaObjectList(sourceDBType))
 		}
 	} else { // Post data load.
-		objectList = []string{"INDEX", "FTS_INDEX", "PARTITION_INDEX", "TRIGGER"}
+		objectList = objectsToImportAfterData
 	}
 	objectList = applySchemaObjectFilterFlags(objectList)
 	log.Infof("List of schema objects to import: %v", objectList)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -74,12 +74,12 @@ func importSchema() {
 	if !flagPostImportData { // Pre data load.
 		// This list also has defined the order to create object type in target YugabyteDB.
 		objectList = utils.GetSchemaObjectList(sourceDBType)
-		objectList = utils.SetDifference(objectList, []string{"TRIGGER", "INDEX"})
+		objectList = utils.SetDifference(objectList, []string{"TRIGGER", "INDEX", "PARTITION_INDEX"})
 		if len(objectList) == 0 {
 			utils.ErrExit("No schema objects to import! Must import at least 1 of the supported schema object types: %v", utils.GetSchemaObjectList(sourceDBType))
 		}
 	} else { // Post data load.
-		objectList = []string{"INDEX", "FTS_INDEX", "TRIGGER"}
+		objectList = []string{"INDEX", "FTS_INDEX", "PARTITION_INDEX", "TRIGGER"}
 	}
 	objectList = applySchemaObjectFilterFlags(objectList)
 	log.Infof("List of schema objects to import: %v", objectList)

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -46,8 +46,15 @@ func (ms *MySQL) GetTableRowCount(tableName string) int64 {
 
 func (ms *MySQL) GetTableApproxRowCount(tableProgressMetadata *utils.TableProgressMetadata) int64 {
 	var approxRowCount sql.NullInt64 // handles case: value of the row is null, default for int64 is 0
-	query := fmt.Sprintf("SELECT table_rows from information_schema.tables "+
-		"where table_name = '%s'", tableProgressMetadata.TableName) // TODO: approx row count query might be different for table partitions
+	var query string
+	if !tableProgressMetadata.IsPartition {
+		query = fmt.Sprintf("SELECT table_rows from information_schema.tables "+
+			"where table_name = '%s'", tableProgressMetadata.TableName)
+	} else {
+		query = fmt.Sprintf("SELECT table_rows from information_schema.partitions "+
+			"where table_name='%s' and partition_name='%s' and table_schema='%s'",
+			tableProgressMetadata.ParentTable, tableProgressMetadata.TableName, tableProgressMetadata.TableSchema)
+	}
 
 	log.Infof("Querying '%s' approx row count of table %q", query, tableProgressMetadata.TableName)
 	err := ms.db.QueryRow(query).Scan(&approxRowCount)
@@ -88,11 +95,34 @@ func (ms *MySQL) GetAllTableNames() []string {
 		}
 		tableNames = append(tableNames, tableName)
 	}
+	log.Infof("GetAllTableNames(): %s", tableNames)
 	return tableNames
 }
 
 func (ms *MySQL) GetAllPartitionNames(tableName string) []string {
-	panic("Not Implemented")
+	query := fmt.Sprintf(`SELECT partition_name  from information_schema.partitions
+	WHERE table_name='%s' and table_schema='%s' ORDER BY partition_name ASC`,
+		tableName, ms.source.DBName)
+
+	rows, err := ms.db.Query(query)
+	if err != nil {
+		utils.ErrExit("failed to list partitions of table %q: %v", tableName, err)
+	}
+	defer rows.Close()
+
+	var partitionNames []string
+	for rows.Next() {
+		var partitionName sql.NullString
+		err = rows.Scan(&partitionName)
+		if err != nil {
+			utils.ErrExit("error in scanning query rows: %v", err)
+		}
+		if partitionName.Valid {
+			partitionNames = append(partitionNames, partitionName.String)
+		}
+	}
+	log.Infof("Partition Names for parent table %q: %q", tableName, partitionNames)
+	return partitionNames
 }
 
 func (ms *MySQL) getConnectionUri() string {

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -53,7 +53,7 @@ var postgresSchemaObjectList = []string{"SCHEMA", "EXTENSION", "TYPE", "DOMAIN",
 	"MVIEW", "COMMENT" /* GRANT, ROLE*/}
 
 // In MYSQL, TYPE and SEQUENCE are not supported
-var mysqlSchemaObjectList = []string{"TABLE" /*, "PARTITION"*/, "INDEX", "VIEW", /*"GRANT*/
+var mysqlSchemaObjectList = []string{"TABLE", "PARTITION", "INDEX", "VIEW", /*"GRANT*/
 	"TRIGGER", "FUNCTION", "PROCEDURE"}
 
 type ExportMetaInfo struct {

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -231,6 +231,8 @@ func GetObjectFilePath(schemaDirPath string, objType string) string {
 		requiredPath = filepath.Join(schemaDirPath, "tables", "INDEXES_table.sql")
 	} else if objType == "FTS_INDEX" {
 		requiredPath = filepath.Join(schemaDirPath, "tables", "FTS_INDEXES_table.sql")
+	} else if objType == "PARTITION_INDEX" {
+		requiredPath = filepath.Join(schemaDirPath, "partitions", "PARTITION_INDEXES_partition.sql")
 	} else {
 		requiredPath = filepath.Join(schemaDirPath, strings.ToLower(objType)+"s",
 			strings.ToLower(objType)+".sql")


### PR DESCRIPTION
Verified the migration end to end migration with schema of range/hash/list/key table partitions
Also verified if there are indexes present on a table partition


Limitation:
- Subpartitions are still not supported by the underlying tool, once it's there it is expected to work without any changes in voyager https://github.com/yugabyte/yb-voyager/issues/427