### PR TITLE
Schemas are imported by default when source is PG

### DIFF
--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -92,5 +92,8 @@ func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	} else {
 		finalImportObjectList = utils.SetDifference(importObjectOrderList, excludeObjectList)
 	}
+	if sourceDBType == "postgresql" && !slices.Contains(finalImportObjectList, "SCHEMA") { // Schema should be migrated by default.
+		finalImportObjectList = append([]string{"SCHEMA"}, finalImportObjectList...)
+	}
 	return finalImportObjectList
 }


### PR DESCRIPTION
[Fixes #453]
If the `schema` object type were excluded using either `--object-list` or `--exclude-object-list` when source is PG, migration would fail at the import schema stage as there would be no expected schema to import into; this patch fixes this behaviour.