### PR TITLE
Import Full Text Search Indexes in YugabyteDB if present in export-dir #366

### DIFF
--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -77,7 +77,7 @@ func importSchema() {
 			utils.ErrExit("No schema objects to import! Must import at least 1 of the supported schema object types: %v", utils.GetSchemaObjectList(sourceDBType))
 		}
 	} else { // Post data load.
-		objectList = []string{"INDEX", "TRIGGER"}
+		objectList = []string{"INDEX", "FTS_INDEX", "TRIGGER"}
 	}
 	objectList = applySchemaObjectFilterFlags(objectList)
 	log.Infof("List of schema objects to import: %v", objectList)

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -229,6 +229,8 @@ func GetObjectFilePath(schemaDirPath string, objType string) string {
 	var requiredPath string
 	if objType == "INDEX" {
 		requiredPath = filepath.Join(schemaDirPath, "tables", "INDEXES_table.sql")
+	} else if objType == "FTS_INDEX" {
+		requiredPath = filepath.Join(schemaDirPath, "tables", "FTS_INDEXES_table.sql")
 	} else {
 		requiredPath = filepath.Join(schemaDirPath, strings.ToLower(objType)+"s",
 			strings.ToLower(objType)+".sql")


### PR DESCRIPTION
- The FTS indexes are created under /export-dir/schema/tables/FTS_INDEXES_table.sql which also needs to be imported during the postImportData phase.