### PR TITLE
Fixed the issue with SCHEMA object being imported in case of --post-import-data

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
@@ -1024,7 +1025,7 @@ func getIndexName(sqlQuery string, indexName string) (string, error) {
 
 	fullyQualifiedIndexName := indexName
 
-	splits := strings.Fields(sqlQuery)
+	splits := strings.FieldsFunc(sqlQuery, func(c rune) bool { return unicode.IsSpace(c) || c == '(' || c == ')' })
 
 	for index, split := range splits {
 		if strings.EqualFold(split, "ON") {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1023,11 +1023,11 @@ func getIndexName(sqlQuery string, indexName string) (string, error) {
 		return indexName, nil
 	}
 
-	splits := strings.FieldsFunc(sqlQuery, func(c rune) bool { return unicode.IsSpace(c) || c == '(' || c == ')' })
+	parts := strings.FieldsFunc(sqlQuery, func(c rune) bool { return unicode.IsSpace(c) || c == '(' || c == ')' })
 
-	for index, split := range splits {
-		if strings.EqualFold(split, "ON") {
-			tableName := splits[index+1]
+	for index, part := range parts {
+		if strings.EqualFold(part, "ON") {
+			tableName := parts[index+1]
 			schemaName := getTargetSchemaName(tableName)
 			return fmt.Sprintf("%s.%s", schemaName, indexName), nil
 		}

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -92,7 +92,7 @@ func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	} else {
 		finalImportObjectList = utils.SetDifference(importObjectOrderList, excludeObjectList)
 	}
-	if sourceDBType == "postgresql" && !slices.Contains(finalImportObjectList, "SCHEMA") { // Schema should be migrated by default.
+	if sourceDBType == "postgresql" && !slices.Contains(finalImportObjectList, "SCHEMA") && !flagPostImportData { // Schema should be migrated by default.
 		finalImportObjectList = append([]string{"SCHEMA"}, finalImportObjectList...)
 	}
 	return finalImportObjectList


### PR DESCRIPTION
as well and indexes from multiple schemas failing to import.

- Changed a condition in `applySchemaObjectFilterFlags` function in `importSchemaYugabyteDB.go` to fix the issue with SCHEMA object being imported in case of --post-import-data as well.
- Made multiple changes in` importData.go` to extract the schema related to the index name and add it to the index name before trying dropping the index with the mentioned index name.