### PR TITLE
Add test result validation framework.

### DIFF
--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install python3 and psycopg2
+      run: |
+        sudo apt install -y python3
+        sudo apt install -y libpq-dev
+        sudo pip3 install psycopg2
+
     - name: Run installer script
       run: |
         yes | ./installer_scripts/install-yb-voyager --install-from-local-source

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -30,10 +30,16 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install python3 and psycopg2
+      run: |
+        sudo apt install -y python3
+        sudo apt install -y libpq-dev
+        sudo pip3 install psycopg2
+
     - name: Run installer script
       run: |
         cd installer_scripts
-        yes | ./install-yb-voyager --install-from-local-source
+        yes | ./install-yb-voyager --install-from-local-source --only-pg-support
       env:
         ON_INSTALLER_ERROR_OUTPUT_LOG: Y
 

--- a/migtests/lib/yb.py
+++ b/migtests/lib/yb.py
@@ -1,0 +1,84 @@
+import os
+import sys
+from typing import Dict, List
+
+import psycopg2
+
+
+def run_checks(checks):
+	if len(sys.argv) != 2:
+		raise StandardError("expected one positional argument tag.")
+	tag = sys.argv[1]
+
+	tgt = new_target_db()
+	tgt.connect()
+	print("Connected")
+	checks[tag](tgt, tag)
+	tgt.close()
+	print("Disconnected")
+
+
+def new_target_db():
+	env = os.environ
+	return PostgresDB(
+		env.get("TARGET_DB_HOST", "127.0.0.1"),
+		env.get("TARGET_DB_PORT", 5433),
+		env.get("TARGET_DB_USER", "yugabyte"),
+		env.get("TARGET_DB_PASSWORD", ""),
+		env["TARGET_DB_NAME"])
+
+
+class PostgresDB:
+	  
+	def __init__(self, host, port, user, password, database):
+		self.host = host
+		self.port = port
+		self.user = user
+		self.password = password
+		self.database = database
+	  
+	def connect(self):
+		self.conn = psycopg2.connect(
+			host=self.host,
+			port=self.port,
+			user=self.user,
+			password=self.password,
+			database=self.database
+		)
+	  
+	def close(self):
+		self.conn.close()
+
+	def table_exists(self, table_name, table_schema="public") -> bool:
+		cur = self.conn.cursor()
+		cur.execute("SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name=%s AND table_schema=%s)", (table_name, table_schema))
+		result = cur.fetchone()
+		return result[0]
+
+	def get_table_names(self, schema="public") -> List[str]:
+		cur = self.conn.cursor()
+		q = "SELECT table_name FROM information_schema.tables WHERE table_schema=%s AND table_type='BASE TABLE'"
+		cur.execute(q, (schema,))
+		return [table[0] for table in cur.fetchall()]
+
+	def get_row_count(self, table_name, schema_name="public") -> int:
+		cur = self.conn.cursor()
+		cur.execute(f"SELECT COUNT(*) FROM {schema_name}.{table_name}")
+		return cur.fetchone()[0]
+
+	def row_count_of_all_tables(self, schema_name="public") -> Dict[str, int]:
+		tables = self.get_table_names(schema_name)
+		return {table: self.get_row_count(table, schema_name) for table in tables}
+
+	def get_objects_of_type(self, object_type, schema_name="public") -> List[str]:
+		object_type = {
+			"TABLE": "r",
+			"VIEW": "v",
+			"INDEX": "i",
+			"SEQUENCE": "S",
+			"MVIEW": "m",
+		}[object_type]
+		cur = self.conn.cursor()
+		cur.execute(f"select relname from pg_class join pg_namespace on pg_class.relnamespace = pg_namespace.oid"+
+			f" where nspname = '{schema_name}' AND relkind = '{object_type}'")
+		return [obj[0] for obj in cur.fetchall()]

--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -18,6 +18,8 @@ export TESTS_DIR="${REPO_ROOT}/migtests/tests"
 export TEST_DIR="${TESTS_DIR}/${TEST_NAME}"
 export EXPORT_DIR=${EXPORT_DIR:-"${TEST_DIR}/export-dir"}
 
+export PYTHONPATH="${REPO_ROOT}/migtests/lib"
+
 # Order of env.sh import matters.
 source ${TEST_DIR}/env.sh
 source ${SCRIPTS}/${SOURCE_DB_TYPE}/env.sh
@@ -45,7 +47,10 @@ main() {
 	tail -20 ${EXPORT_DIR}/reports/report.txt
 
 	step "Fix schema."
-	[ -x "${TEST_DIR}/fix-schema" ] && "${TEST_DIR}/fix-schema"
+	if [ -x "${TEST_DIR}/fix-schema" ]
+	then
+		 "${TEST_DIR}/fix-schema"
+	fi
 
 	step "Analyze schema."
 	analyze_schema
@@ -70,6 +75,12 @@ main() {
 	import_schema --post-import-data
 	run_ysql ${TARGET_DB_NAME} "\di"
 	run_ysql ${TARGET_DB_NAME} "\dft"
+
+	step "Run validations."
+	if [ -x "${TEST_DIR}/validate" ]
+	then
+		 "${TEST_DIR}/validate" MIGRATION_COMPLETED
+	fi
 }
 
 main

--- a/migtests/tests/import-file/run-import-file-test
+++ b/migtests/tests/import-file/run-import-file-test
@@ -11,6 +11,8 @@ export TESTS_DIR="${REPO_ROOT}/migtests/tests"
 export TEST_DIR="${TESTS_DIR}/${TEST_NAME}"
 export EXPORT_DIR=${EXPORT_DIR:-"${TEST_DIR}/export-dir"}
 
+export PYTHONPATH="${REPO_ROOT}/migtests/lib"
+
 export DATA_FILE_NAME="OneMRows.text"
 export COMPRESSED_DATA_FILE_NAME="${DATA_FILE_NAME}.gz"
 
@@ -38,9 +40,9 @@ main() {
 
 	pushd ${TEST_DIR}
 
-        step "Create target database."
-        run_ysql yugabyte "DROP DATABASE IF EXISTS ${TARGET_DB_NAME};"
-        run_ysql yugabyte "CREATE DATABASE ${TARGET_DB_NAME}"
+	step "Create target database."
+	run_ysql yugabyte "DROP DATABASE IF EXISTS ${TARGET_DB_NAME};"
+	run_ysql yugabyte "CREATE DATABASE ${TARGET_DB_NAME}"
 
 	step "Unzip the data file."
 	gunzip ${COMPRESSED_DATA_FILE_NAME}
@@ -51,6 +53,9 @@ main() {
 	step "Import data file"
 	import_data_file --data-dir ${TEST_DIR} --format text --delimiter '|' \
 		--file-table-map "${DATA_FILE_NAME}:${TARGET_TABLE_NAME}"
+
+	step "Run validations."
+	 "${TEST_DIR}/validate" FILE_IMPORT_DONE
 }
 
 main

--- a/migtests/tests/import-file/validate
+++ b/migtests/tests/import-file/validate
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import yb
+
+def main():
+	yb.run_checks({
+		"FILE_IMPORT_DONE": file_import_done_checks,
+	})
+
+
+def file_import_done_checks(tgt, tag):
+	row_count = tgt.get_row_count("target_table")
+	print(f"row_count: {row_count}")
+	assert row_count == 1000000
+
+
+if __name__ == "__main__":
+	main()

--- a/migtests/tests/pg-dvdrental/validate
+++ b/migtests/tests/pg-dvdrental/validate
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import yb
+
+def main():
+	yb.run_checks({
+		"MIGRATION_COMPLETED": migration_completed_checks,
+	})
+
+
+#=============================================================================
+
+EXPECTED_ROW_COUNT = {
+	'actor': 200,
+	'address': 603,
+	'category': 16,
+	'city': 600,
+	'country': 109,
+	'customer': 599,
+	'film_actor': 5462,
+	'film_category': 1000,
+	'film': 1000,
+	'inventory': 4581,
+	'language': 6,
+	'payment': 14596,
+	'rental': 16044,
+	'staff': 2,
+	'store': 2,
+}
+
+def migration_completed_checks(tgt, tag):
+	table_list = tgt.get_table_names("public")
+	print("table_list:", table_list)
+	assert len(table_list) == 15
+
+	view_list = tgt.get_objects_of_type("VIEW")
+	print("view_list:", view_list)
+	assert len(view_list) == 7
+
+	got_row_count = tgt.row_count_of_all_tables("public")
+	for table_name, row_count in EXPECTED_ROW_COUNT.items():
+		print(f"table_name: {table_name}, row_count: {got_row_count[table_name]}")
+		assert row_count == got_row_count[table_name]
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
This PR adds a way for automation tests to run validations against the target DB.
The test driver expects an executable named `validate` in the test-dir. If present, the test-driver invokes the script towards the end of the migration.
The `validate` can be an executable Python script. Such a Python script can use a utility class `PostgresDB` from the `yb` module (`migtests/lib/yb.py`).