### PR TITLE
Removed unnecessary flags from commands

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -47,9 +47,6 @@ func init() {
 	exportCmd.Flags().StringVar(&source.TableList, "table-list", "",
 		"list of the tables to export data(Note: works only for export data command)")
 
-	exportCmd.Flags().StringVar(&migrationMode, "migration-mode", "offline",
-		"mode can be offline | online(applicable only for data migration)")
-
 	exportCmd.Flags().IntVar(&source.NumConnections, "parallel-jobs", 1,
 		"number of Parallel Jobs to extract data from source database")
 
@@ -113,9 +110,6 @@ func registerCommonExportFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&startClean, "start-clean", false,
 		"clean the project's data directory for already existing files before start(Note: works only for export data command)")
-
-	cmd.Flags().BoolVar(&source.UseOrafce, "use-orafce", true,
-		"enable using orafce extension in export schema")
 }
 
 func setExportFlagsDefaults() {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -63,9 +63,6 @@ func init() {
 	exportDataCmd.Flags().StringVar(&source.TableList, "table-list", "",
 		"list of the tables to export data")
 
-	exportDataCmd.Flags().StringVar(&migrationMode, "migration-mode", "offline",
-		"mode can be offline | online")
-
 	exportDataCmd.Flags().IntVar(&source.NumConnections, "parallel-jobs", 4,
 		"number of Parallel Jobs to extract data from source database")
 }
@@ -74,10 +71,10 @@ func exportData() {
 	utils.PrintAndLog("export of data for source type as '%s'", source.DBType)
 
 	var success bool
-	if migrationMode == "offline" {
-		success = exportDataOffline()
-	} else {
+	if migrationMode == "online" {
 		success = exportDataOnline()
+	} else {
+		success = exportDataOffline()
 	}
 
 	if success {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -70,12 +70,7 @@ func init() {
 func exportData() {
 	utils.PrintAndLog("export of data for source type as '%s'", source.DBType)
 
-	var success bool
-	if migrationMode == "online" {
-		success = exportDataOnline()
-	} else {
-		success = exportDataOffline()
-	}
+	success := exportDataOffline()
 
 	if success {
 		createExportDataDoneFlag()
@@ -165,13 +160,6 @@ func exportDataOffline() bool {
 	callhome.UpdateDataStats(exportDir, tableRowCount)
 	callhome.PackAndSendPayload(exportDir)
 	return true
-}
-
-func exportDataOnline() bool {
-	errMsg := "online migration not supported yet\n"
-	utils.ErrExit(errMsg)
-
-	return false
 }
 
 //flagName can be "exclude-table-list" or "table-list"

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -30,12 +30,7 @@ import (
 var exportSchemaCmd = &cobra.Command{
 	Use:   "schema",
 	Short: "This command is used to export the schema from source database into .sql files",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Long:  ``,
 
 	PreRun: func(cmd *cobra.Command, args []string) {
 		setExportFlagsDefaults()
@@ -111,6 +106,8 @@ func init() {
 	exportCmd.AddCommand(exportSchemaCmd)
 
 	registerCommonExportFlags(exportSchemaCmd)
+	exportSchemaCmd.Flags().BoolVar(&source.UseOrafce, "use-orafce", true,
+		"enable using orafce extension in export schema")
 }
 
 func schemaIsExported(exportDir string) bool {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -29,12 +29,11 @@ import (
 )
 
 var (
-	cfgFile       string
-	exportDir     string
-	migrationMode string
-	startClean    bool
-	logLevel      string
-	lockFile      lockfile.Lockfile
+	cfgFile    string
+	exportDir  string
+	startClean bool
+	logLevel   string
+	lockFile   lockfile.Lockfile
 )
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Removed these flags:

`import schema`:
--batch-size int (Made it `import data` only)
--enable-upsert (Made it `import data` only)
--migration-mode string 
--mode string
--parallel-jobs int (Made it `import data` only)
--use-public-ip (Made it `import data` only)
--target-endpoints (Made it `import data` only)
--disable-transactional-writes (Made it `import data` only)

`import data`:
--migration-mode string 
--mode string 
--ignore-exists (Made it `import schema` only)

`export data`:
--migration-mode
--use-orafce (Made it `export schema` only)