### PR TITLE
Added new short flags -l and -p for installling from local source and only pg support to work with getopt of macos

### DIFF
--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -5,31 +5,11 @@ export LC_CTYPE=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 set -e
-
-OPTS=$(getopt -o "", --long install-from-local-source,only-pg-support --name 'install-yb-voyager' -- "$@")
-
-
-eval set -- "$OPTS"
+ARGS_MACOS=$*
+ARGS_LINUX=$@
 
 VERSION="latest"
 ONLY_PG="false"
-
-while true; do
-	case "$1" in
-		--install-from-local-source ) 
-			VERSION="local"
-			shift
-			;;
-		--only-pg-support ) 
-			ONLY_PG="true"; 
-			shift 
-			;;
-		* ) 
-			break 
-			;;
-	esac
-done
-
 
 trap on_exit EXIT
 
@@ -76,10 +56,12 @@ main() {
 	os=$(uname -s)
 	case ${os} in
 		"Darwin")
+			get_passed_options darwin
 			macos_main
 			exit $?
 			;;
 		"Linux")
+			get_passed_options linux
 			# Proceed to distribution check.
 			;;
 		*)
@@ -185,6 +167,33 @@ macos_main() {
 #=============================================================================
 # COMMON
 #=============================================================================
+
+get_passed_options() {
+	if [ "$1" == "linux" ]
+	then
+		OPTS=$(getopt -o "lp", --long install-from-local-source,only-pg-support --name 'install-yb-voyager' -- $ARGS_LINUX)
+	else
+		OPTS=$(getopt  lp  $ARGS_MACOS)
+	fi
+
+	eval set -- "$OPTS"
+
+	while true; do
+		case "$1" in
+			-l | --install-from-local-source ) 
+				VERSION="local"
+				shift
+				;;
+			-p | --only-pg-support ) 
+				ONLY_PG="true"; 
+				shift 
+				;;
+			* ) 
+				break 
+				;;
+		esac
+	done
+}
 
 check_binutils_version() {
 	output "Checking binutils version."


### PR DESCRIPTION
We use the `getopt` utility to parse the flags passed along while running the installer script. The `getopt` for `macOS` does not have support for `long options` and also processes the flags in a different format. Hence I have added two new flags and the code to parse the flags depending on the `macOS` format or `Linux` format.
The two new flags are:
`-l` : short hand for `--install-from-local-source`
`-p`: short hand for `--only-pg-support`
Let me know if you want the flag names to be changed.