### PR TITLE
Added enhancement for Gin Index not supported queries in analyze-sche…

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -215,6 +215,10 @@ func checkGin(sqlInfoArr []sqlInfo, fpath string) {
 				}
 			}
 		}
+		if strings.Contains(strings.ToLower(sqlInfo.stmt), "extension btree_gin") {
+			reportCase(fpath, "Schema contains btree_gin extension which is not supported for YB",
+				"https://github.com/yugabyte/yugabyte-db/issues/9958", "", "EXTENSION", "btree_gin", sqlInfo.formattedStmtStr)
+		}
 	}
 }
 


### PR DESCRIPTION
…ma (#428)

Added conditions for Unsupported Gin index queries (Support ticket on DB side : https://github.com/yugabyte/yugabyte-db/issues/7850) -
1. Gin index on Multicolumn 
2. Gin index on column with ASC/DESC/HASH clause. 

Added check for btree_gin extension which can be created which means it exists in the Database but is not supported with YB gin indexes (Support ticket on DB side: https://github.com/yugabyte/yugabyte-db/issues/9958).
