### PR TITLE
Determine the number of parallel jobs to use by default during import data

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -208,6 +208,7 @@ func fetchDefaultParllelJobs(targets []*tgtdb.Target) int {
 	totalCores := 0
 	targetCores := 0
 	for _, target := range targets {
+		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs([]string{target.Uri})[0])
 		conn, err := pgx.Connect(context.Background(), target.Uri)
 		if err != nil {
 			log.Warnf("Unable to reach target while querying cores: %v", err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -195,7 +195,7 @@ func getYBServers() []*tgtdb.Target {
 
 	if parallelImportJobs == -1 {
 		parallelImportJobs = fetchParllelJobs(targets)
-		fmt.Printf("Parallel Jobs: %d\n", parallelImportJobs)
+		utils.PrintAndLog("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", parallelImportJobs)
 	}
 
 	if loadBalancerUsed { // if load balancer is used no need to check direct connectivity

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/godror/godror v0.30.2
 	github.com/google/uuid v1.1.2
 	github.com/gosuri/uitable v0.0.4
+	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgx/v4 v4.14.1
+	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/nightlyone/lockfile v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
@@ -27,11 +29,9 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/godror/knownpb v0.1.0 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
@@ -41,7 +41,6 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -236,8 +236,6 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=


### PR DESCRIPTION
[Fixes #468]
For PG 9.3+, superusers are allowed to fire (and use the returned output of) shell commands from within the PG session. We make use of this functionality to gather the number of cores for each node in the cluster, based on which the default value of `--parallel-jobs` is decided. The current workflow is like so:
- If we fail to query even a single node in the cluster, default value is `len(nodes) * 2`
- [Edited] If we query all nodes in the cluster, default value is `(total_cores/2)`.
- [Edited] The older version of this patch extrapolated partially failed cases over the number of nodes in the cluster, this is no longer the case.

P.S. review does not have to be done commit-by-commit, some implementations were incorrect in the previous versions of this patch