### PR TITLE
 added single quotes around connection url for pg_dump to pass specia…

### DIFF
--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -45,9 +45,9 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 
 	pgDumpArgs := fmt.Sprintf(`--no-blobs --data-only --no-owner --compress=0 %s -Fd --file %s --jobs %d --no-privileges --no-tablespaces --load-via-partition-root`,
 		tableListPatterns, dataDirPath, source.NumConnections)
-	cmd := fmt.Sprintf(`%s "%s" %s`, pgDumpPath, connectionUri, pgDumpArgs)
+	cmd := fmt.Sprintf(`%s '%s' %s`, pgDumpPath, connectionUri, pgDumpArgs)
 	redactedUri := utils.GetRedactedURLs([]string{connectionUri})[0]
-	redactedCmd := fmt.Sprintf(`%s "%s" %s`, pgDumpPath, redactedUri, pgDumpArgs)
+	redactedCmd := fmt.Sprintf(`%s '%s' %s`, pgDumpPath, redactedUri, pgDumpArgs)
 	log.Infof("Running command: %s", redactedCmd)
 
 	var outbuf bytes.Buffer

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -23,9 +23,9 @@ func pgdumpExtractSchema(schemaList string, connectionUri string, exportDir stri
 
 	pgDumpArgs := fmt.Sprintf(`--schema-only --schema "%s" --no-owner -f %s --no-privileges --no-tablespaces --load-via-partition-root`,
 	schemaList, filepath.Join(exportDir, "temp", "schema.sql"))
-	cmd := fmt.Sprintf(`%s "%s" %s`, pgDumpPath, connectionUri, pgDumpArgs)
+	cmd := fmt.Sprintf(`%s '%s' %s`, pgDumpPath, connectionUri, pgDumpArgs)
 	redactedUri := utils.GetRedactedURLs([]string{connectionUri})[0]
-	redactedCmd := fmt.Sprintf(`%s "%s" %s`, pgDumpPath, redactedUri, pgDumpArgs)
+	redactedCmd := fmt.Sprintf(`%s '%s' %s`, pgDumpPath, redactedUri, pgDumpArgs)
 	log.Infof("Running command: %s", redactedCmd)
 
 	preparedPgdumpCommand := exec.Command("/bin/bash", "-c", cmd)


### PR DESCRIPTION
…l chars in password correctly related to #377

In this #377, we want to document about few characters which needs to be escaped before passing it in the `target-db-password` but we can just pass the password string in `single quotes` and it will work fine but in the `pg_dump` command we also have pass the ConnectionUrl in `single quotes` to make it also work. So, this PR fixes that. 
Now, we just need to document that pass the password string in single quoted if there are special characters.