### PR TITLE
Revert "Fixed number type casting from oracle"

### DIFF
--- a/yb-voyager/src/srcdb/data/sample-ora2pg.conf
+++ b/yb-voyager/src/srcdb/data/sample-ora2pg.conf
@@ -705,7 +705,7 @@ PG_NUMERIC_TYPE	1
 # Oracle data type NUMBER(p) or NUMBER are converted to smallint, integer
 # or bigint PostgreSQL data type following the length of the precision. If
 # NUMBER without precision are set to DEFAULT_NUMERIC (see bellow).
-PG_INTEGER_TYPE	0
+PG_INTEGER_TYPE	1
 
 # NUMBER() without precision are converted by default to bigint only if
 # PG_INTEGER_TYPE is true. You can overwrite this value to any PG type,


### PR DESCRIPTION
Reverts yugabyte/yb-voyager#309

Due to this change, the `auto_increment` columns are not getting exported correctly.

1. Current behavior:
Source DB(MySQL): 
```
create table sequence_check_1 (
	id int primary key auto_increment,
	first_name VARCHAR(50),
	last_name VARCHAR(50),
	email VARCHAR(50),
	gender VARCHAR(50),
	ip_address VARCHAR(20)
);
```

Exported Schema:
```
CREATE TABLE sequence_check_1 (
	id numeric(10) NOT NULL,
	first_name varchar(50),
	last_name varchar(50),
	email varchar(50),
	gender varchar(50),
	ip_address varchar(20),
	PRIMARY KEY (id)
) ;
```


2. New behavior after reverting this:
Source DB(MySQL): 
```
create table sequence_check_1 (
	id int primary key auto_increment,
	first_name VARCHAR(50),
	last_name VARCHAR(50),
	email VARCHAR(50),
	gender VARCHAR(50),
	ip_address VARCHAR(20)
);
```

Exported Schema:
```
CREATE TABLE sequence_check_1 (
	id bigserial,
	first_name varchar(50),
	last_name varchar(50),
	email varchar(50),
	gender varchar(50),
	ip_address varchar(20)
) ;
ALTER SEQUENCE sequence_check_1_id_seq RESTART WITH 1;
```