### PR TITLE
Added a flag --straight-order which when specified imports the schema objects in the order specified

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -148,6 +148,8 @@ func registerImportSchemaFlags(cmd *cobra.Command) {
 		"List of schema object types to include while importing schema")
 	cmd.Flags().StringVar(&target.ExcludeImportObjects, "exclude-object-list", "",
 		"List of schema object types to exclude while importing schema (no-op if --object-list is used)")
+	cmd.Flags().BoolVar(&importObjectsInStraightOrder, "straight-order", false,
+		"If set, objects will be imported in the order specified while listing them")
 	cmd.Flags().BoolVar(&flagPostImportData, "post-import-data", false,
 		"If set, creates indexes, foreign-keys, and triggers in target db")
 	cmd.Flags().BoolVar(&target.IgnoreIfExists, "ignore-exist", false,

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -53,6 +53,7 @@ func init() {
 }
 
 var flagPostImportData bool
+var importObjectsInStraightOrder bool
 
 func importSchema() {
 	err := target.DB().Connect()

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -83,10 +83,19 @@ func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 		for i, item := range includeObjectList {
 			includeObjectList[i] = strings.ToUpper(item)
 		}
-		// Maintain the order of importing the objects.
-		for _, supportedObject := range importObjectOrderList {
-			if slices.Contains(includeObjectList, supportedObject) {
-				finalImportObjectList = append(finalImportObjectList, supportedObject)
+		if importObjectsInStraightOrder {
+			// Import the objects in the same order as when listed by the user.
+			for _, listedObject := range includeObjectList {
+				if slices.Contains(importObjectOrderList, listedObject) {
+					finalImportObjectList = append(finalImportObjectList, listedObject)
+				}
+			}
+		} else {
+			// Import the objects in the default order.
+			for _, supportedObject := range importObjectOrderList {
+				if slices.Contains(includeObjectList, supportedObject) {
+					finalImportObjectList = append(finalImportObjectList, supportedObject)
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Added a flag --straight-order which when specified imports the scheme objects in the order specified by the user. Also added the required code.