### PR TITLE
Added a case in analyze-schema to check for the insufficient columns …

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -465,9 +465,6 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 
 			partitionColumnsList := utils.CsvStringToSlice(partitionColumns)
 			primaryKeyColumnsList := utils.CsvStringToSlice(primaryKeyColumns)
-			for _, eachPrimaryColumn := range primaryKeyColumnsList {
-				eachPrimaryColumn = strings.Trim(eachPrimaryColumn, " ")
-			}
 			for _, eachPartitionColumn := range partitionColumnsList {
 				eachPartitionColumn = strings.Trim(eachPartitionColumn, " ")
 				idxInPrimaryKeyColumns := sort.SearchStrings(primaryKeyColumnsList, eachPartitionColumn)

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -90,7 +90,7 @@ var (
 	amRegex              = regexp.MustCompile(`(?i)CREATE ACCESS METHOD ([a-zA-Z0-9_."]+)`)
 	idxConcRegex         = regexp.MustCompile(`(?i)REINDEX .*CONCURRENTLY ([a-zA-Z0-9_."]+)`)
 	storedRegex          = regexp.MustCompile(`(?i)([a-zA-Z0-9_]+) [a-zA-Z0-9_]+ GENERATED ALWAYS .* STORED`)
-	partitionColumnsRegex           = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS)?([A-Za-z0-9]+) ([^,]+(?:,[^,]+){0,} \([^,]+(?:,[^,]+){0,}\)) PARTITION BY RANGE ([^,]+(?:,[^,]+){0,}) ;`)
+	partitionColumnsRegex           = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS)?([A-Za-z0-9]+) ([^,]+(?:,[^,]+){0,}) PARTITION BY RANGE ([^,]+(?:,[^,]+){0,}) ;`)
 	likeAllRegex         = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*LIKE .*INCLUDING ALL`)
 	likeRegex            = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*\(like`)
 	inheritRegex         = regexp.MustCompile(`(?i)CREATE ([a-zA-Z_]+ )?TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+).*INHERITS[ |(]`)

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -457,13 +457,10 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 		} else if regMatch := partitionColumnsRegex.FindStringSubmatch(sqlInfo.stmt); regMatch !=nil {
 			allColumns := strings.Trim(regMatch[3], "() ")
 			allColumnsList := strings.Split(allColumns, "(")
-
 			primaryKeyColumns := allColumnsList[len(allColumnsList)-1]
 			partitionColumns := strings.Trim(regMatch[4], `()`)
-
 			partitionColumnsList := utils.CsvStringToSlice(partitionColumns)
 			primaryKeyColumnsList := utils.CsvStringToSlice(primaryKeyColumns)
-
 			sort.Strings(primaryKeyColumnsList)
 			for _, eachPartitionColumn := range partitionColumnsList {
 				idxInPrimaryKeyColumns := sort.SearchStrings(primaryKeyColumnsList, eachPartitionColumn)

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -453,7 +453,7 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 			reportCase(fpath, "LANGUAGE C not supported yet.",
 				"", "", "FUNCTION", tbl[2], sqlInfo.formattedStmt)
 			summaryMap["FUNCTION"].invalidCount++
-		} else if regMatch := createTableRegex.FindStringSubmatch(sqlInfo.stmt); regMatch !=nil {
+		} else if regMatch := createTableRegex.FindStringSubmatch(strings.Join(strings.Fields(sqlInfo.stmt), " ")); regMatch !=nil {
 			primaryKeyColumns := strings.Trim(regMatch[3], `()`)
 			partitionColumns := strings.Trim(regMatch[4], `()`)
 			partitionColumnsList := strings.Split(partitionColumns, ",")

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -455,18 +455,17 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 				"", "", "FUNCTION", tbl[2], sqlInfo.formattedStmt)
 			summaryMap["FUNCTION"].invalidCount++
 		} else if regMatch := partitionColumnsRegex.FindStringSubmatch(sqlInfo.stmt); regMatch !=nil {
-			allColumns := strings.Trim(regMatch[3], `()`)
-			allColumns = strings.Trim(allColumns, " ")
+			allColumns := strings.Trim(regMatch[3], "() ")
 			allColumnsList := strings.Split(allColumns, "(")
 
 			primaryKeyColumns := allColumnsList[len(allColumnsList)-1]
-			primaryKeyColumns = strings.Trim(primaryKeyColumns, `()`)
 			partitionColumns := strings.Trim(regMatch[4], `()`)
 
 			partitionColumnsList := utils.CsvStringToSlice(partitionColumns)
 			primaryKeyColumnsList := utils.CsvStringToSlice(primaryKeyColumns)
+
+			sort.Strings(primaryKeyColumnsList)
 			for _, eachPartitionColumn := range partitionColumnsList {
-				eachPartitionColumn = strings.Trim(eachPartitionColumn, " ")
 				idxInPrimaryKeyColumns := sort.SearchStrings(primaryKeyColumnsList, eachPartitionColumn)
 				if idxInPrimaryKeyColumns == len(primaryKeyColumnsList) || primaryKeyColumnsList[idxInPrimaryKeyColumns] != eachPartitionColumn {
 					reportCase(fpath, "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE",


### PR DESCRIPTION
…in PRIMARY KEY constraint (#578), fixed #581

Explanation - 
1. Match regex to fetch object name, all the columns info and the partition columns info.
2. fetch the Primary key column info from all the columns info, which is present at the end in `()`.
3. check one by one each partition column present in primary column list. 