### PR TITLE
Ask for password if not already provided as an argument

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -143,7 +143,7 @@ func setDefaultSSLMode() {
 	}
 }
 
-func validateExportFlags() {
+func validateExportFlags(cmd *cobra.Command) {
 	validateExportDirFlag()
 	validateSourceDBType()
 	validateSourceSchema()
@@ -156,7 +156,7 @@ func validateExportFlags() {
 	}
 	validateTableListFlag(source.TableList, "table-list")
 	validateTableListFlag(source.ExcludeTableList, "exclude-table-list")
-	validateSourcePassword()
+	validateSourcePassword(cmd)
 
 	// checking if wrong flag is given used for a db type
 	if source.DBType != ORACLE {
@@ -241,8 +241,8 @@ func validateOracleParams() {
 
 }
 
-func validateSourcePassword() {
-	if source.Password != "" {
+func validateSourcePassword(cmd *cobra.Command) {
+	if cmd.Flags().Changed("source-db-password") {
 		return
 	}
 	fmt.Print("Password to connect to source:")

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -18,10 +18,12 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"golang.org/x/exp/slices"
+	"golang.org/x/term"
 
 	"github.com/spf13/cobra"
 )
@@ -154,6 +156,7 @@ func validateExportFlags() {
 	}
 	validateTableListFlag(source.TableList, "table-list")
 	validateTableListFlag(source.ExcludeTableList, "exclude-table-list")
+	validateSourcePassword()
 
 	// checking if wrong flag is given used for a db type
 	if source.DBType != ORACLE {
@@ -238,11 +241,24 @@ func validateOracleParams() {
 
 }
 
+func validateSourcePassword() {
+	if source.Password != "" {
+		return
+	}
+	fmt.Print("Password to connect to source:")
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		utils.ErrExit("read password: %v", err)
+		return
+	}
+	fmt.Print("\n")
+	source.Password = string(bytePassword)
+}
+
 func markFlagsRequired(cmd *cobra.Command) {
 	// mandatory for all
 	cmd.MarkFlagRequired("source-db-type")
 	cmd.MarkFlagRequired("source-db-user")
-	cmd.MarkFlagRequired("source-db-password")
 
 	switch source.DBType {
 	case POSTGRESQL, ORACLE: // schema and database names are mandatory

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -42,7 +42,7 @@ var exportDataCmd = &cobra.Command{
 
 	PreRun: func(cmd *cobra.Command, args []string) {
 		setExportFlagsDefaults()
-		validateExportFlags()
+		validateExportFlags(cmd)
 		markFlagsRequired(cmd)
 	},
 

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -34,7 +34,7 @@ var exportSchemaCmd = &cobra.Command{
 
 	PreRun: func(cmd *cobra.Command, args []string) {
 		setExportFlagsDefaults()
-		validateExportFlags()
+		validateExportFlags(cmd)
 		markFlagsRequired(cmd)
 	},
 

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -46,7 +46,7 @@ func init() {
 	registerImportDataFlags(importCmd)
 }
 
-func validateImportFlags() {
+func validateImportFlags(cmd *cobra.Command) {
 	validateExportDirFlag()
 	checkOrSetDefaultTargetSSLMode()
 	validateTargetPortRange()
@@ -66,7 +66,7 @@ func validateImportFlags() {
 		fmt.Println("WARNING: The --disable-transactional-writes feature is in the experimental phase, not for production use case.")
 	}
 	validateBatchSizeFlag(numLinesInASplit)
-	validateTargetPassword()
+	validateTargetPassword(cmd)
 }
 
 func registerCommonImportFlags(cmd *cobra.Command) {
@@ -174,8 +174,8 @@ func validateTargetSchemaFlag() {
 	}
 }
 
-func validateTargetPassword() {
-	if target.Password != "" {
+func validateTargetPassword(cmd *cobra.Command) {
+	if cmd.Flags().Changed("target-db-password") {
 		return
 	}
 	fmt.Print("Password to connect to target:")

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -66,6 +66,7 @@ func validateImportFlags() {
 		fmt.Println("WARNING: The --disable-transactional-writes feature is in the experimental phase, not for production use case.")
 	}
 	validateBatchSizeFlag(numLinesInASplit)
+	validateTargetPassword()
 }
 
 func registerCommonImportFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -18,10 +18,12 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"golang.org/x/exp/slices"
+	"golang.org/x/term"
 
 	"github.com/spf13/cobra"
 )
@@ -79,7 +81,6 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&target.Password, "target-db-password", "",
 		"Password with which to connect to the target YugabyteDB server")
-	cmd.MarkFlagRequired("target-db-password")
 
 	cmd.Flags().StringVar(&target.DBName, "target-db-name", YUGABYTEDB_DEFAULT_DATABASE,
 		"Name of the database on the target YugabyteDB server on which import needs to be done")
@@ -170,6 +171,20 @@ func validateTargetSchemaFlag() {
 	if target.Schema != YUGABYTEDB_DEFAULT_SCHEMA && sourceDBType == "postgresql" {
 		utils.ErrExit("Error: --target-db-schema flag is not valid for export from 'postgresql' db type")
 	}
+}
+
+func validateTargetPassword() {
+	if target.Password != "" {
+		return
+	}
+	fmt.Print("Password to connect to target:")
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		utils.ErrExit("read password: %v", err)
+		return
+	}
+	fmt.Print("\n")
+	target.Password = string(bytePassword)
 }
 
 func validateImportObjectsFlag(importObjectsString string, flagName string) {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -97,7 +97,7 @@ var importDataCmd = &cobra.Command{
 	Long:  `This command will import the data exported from the source database into YugabyteDB database.`,
 
 	PreRun: func(cmd *cobra.Command, args []string) {
-		validateImportFlags()
+		validateImportFlags(cmd)
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -36,7 +36,7 @@ var importSchemaCmd = &cobra.Command{
 	Long:  ``,
 
 	PreRun: func(cmd *cobra.Command, args []string) {
-		validateImportFlags()
+		validateImportFlags(cmd)
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -52,7 +52,8 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/net v0.0.0-20220111093109-d55c255bac03 // indirect
-	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
+	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/vbauerster/mpb/v7 v7.3.0
 	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
+	golang.org/x/term v0.2.0
 )
 
 require (
@@ -53,7 +54,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/net v0.0.0-20220111093109-d55c255bac03 // indirect
 	golang.org/x/sys v0.2.0 // indirect
-	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -676,8 +676,12 @@ golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211214234402-4825e8c3871d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f h1:8w7RhxzTVgUzw/AH/9mUV5q0vMgy40SQRursCcfmkCw=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.2.0 h1:z85xZCsEl7bi/KwbNADeBYoOP0++7W1ipu+aGnpwzRM=
+golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -674,8 +674,6 @@ golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211214234402-4825e8c3871d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f h1:8w7RhxzTVgUzw/AH/9mUV5q0vMgy40SQRursCcfmkCw=
-golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=


### PR DESCRIPTION
[Fixes #597]
This patch removes the need to provide a source or target DB password as a command-line argument. If not provided, the user is prompted for the password before beginning a migration. This hides the password from the command `ps -aef | grep voyager`

P.S. Adding an automation test case is not applicable here, in order to make sure the user inputs do not echo to the terminal session, I used a `term` package which additionally ensures that the input coming in must be from a terminal instance; buffered input errors out with this error: `inappropriate ioctl for device`
[Additional details](https://unix.stackexchange.com/questions/382747/should-i-try-to-get-rid-of-inappropriate-ioctl-for-device-in-strace-output-for)