### PR TITLE
Bug #610: Fetched Parent Table already has schema name in it if its non-public, add public if there is no schema name

### DIFF
--- a/migtests/tests/pg-partitions/env.sh
+++ b/migtests/tests/pg-partitions/env.sh
@@ -1,3 +1,3 @@
 export SOURCE_DB_TYPE="postgresql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"partitions"}
-export SOURCE_DB_SCHEMA="public"
+export SOURCE_DB_SCHEMA="public,p1,p2"

--- a/migtests/tests/pg-partitions/validate
+++ b/migtests/tests/pg-partitions/validate
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import yb
+
+def main():
+	yb.run_checks(migration_completed_checks)
+
+
+#=============================================================================
+
+EXPECTED_ROW_COUNT = {
+	"public.boston":       		334,
+	# check only for parent table in case of HASH partitioning
+ 	# "public.cust_active":		750, 
+  	# "public.cust_arr_small":	371,
+	# "public.cust_arr_large":	354,
+ 	# "public.cust_other":   	250,
+	# "public.cust_part11":  	192,
+	# "public.cust_part12":  	179,
+	# "public.cust_part21":  	205,
+	# "public.cust_part22":  	174,
+	"public.customers": 		1000,
+	"public.emp":        		1000,
+ 	"public.emp_0":        		324,
+	"public.emp_1":        		333,
+	"public.emp_2":        		343,
+	"public.london":       		333,
+ 	"public.sales":        		1000,	
+  	"public.sales_2019_q4":		333,
+	"public.sales_2020_q1":		334,
+	"public.sales_2020_q2":		333,
+ 	"public.sales_region":		1000,
+  	"public.sydney": 			333,
+	"p1.sales_region":			1000,
+	"p2.boston":    			334,
+	"p2.london":    			333,
+	"p2.sydney":    			333,
+}
+
+def migration_completed_checks(tgt):    
+	table_list = tgt.get_table_names("public")
+	print("table_list:", table_list)
+	assert len(table_list) == 21
+ 
+	table_list = tgt.get_table_names("p1")
+	print("table_list:", table_list)
+	assert len(table_list) == 1
+ 
+	table_list = tgt.get_table_names("p2")
+	print("table_list:", table_list)
+	assert len(table_list) == 3
+ 
+	for table_name, row_count in EXPECTED_ROW_COUNT.items():
+		schema = table_name.split(".")[0]
+		table = table_name.split(".")[1]
+		got_row_count = tgt.get_row_count(table, schema)
+		print(f"table_name: {table_name}, row_count: {got_row_count}")
+		assert row_count == got_row_count	
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
[Fixes #610]
This change fixes the scenario when the table and its partitions are in a different schema by correctly fetching the parent table name and copy command for it. 
For more details about the refer to the filed bug


Tests: 
1. Updated the test `migtests/tests/pg-partitions` in the automation framework
2. Also added validations for the `pg-partitions` test case.