### PR TITLE
Clarify between sequences' import being displayed on terminal

### DIFF
--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -101,9 +101,11 @@ func importSchema() {
 		skipFn = func(objType, stmt string) bool {
 			return !isAlterStatement(objType, stmt)
 		}
-		importObjectFilePath := utils.GetObjectFilePath(filepath.Join(exportDir, "schema"), "SEQUENCE")
-		fmt.Printf("\nImporting ALTER TABLE DDLs from %q\n\n", importObjectFilePath)
-		executeSqlFile(importObjectFilePath, "SEQUENCE", skipFn)
+		sequenceFilePath := utils.GetObjectFilePath(filepath.Join(exportDir, "schema"), "SEQUENCE")
+		if utils.FileOrFolderExists(sequenceFilePath) {
+			fmt.Printf("\nImporting ALTER TABLE DDLs from %q\n\n", sequenceFilePath)
+			executeSqlFile(sequenceFilePath, "SEQUENCE", skipFn)
+		}
 	}
 
 	log.Info("Schema import is complete.")

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -22,12 +22,11 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"golang.org/x/exp/slices"
 )
 
-func importSchemaInternal(target *tgtdb.Target, exportDir string, importObjectList []string,
+func importSchemaInternal(exportDir string, importObjectList []string,
 	skipFn func(string, string) bool) {
 	schemaDir := filepath.Join(exportDir, "schema")
 	for _, importObjectType := range importObjectList {
@@ -38,7 +37,6 @@ func importSchemaInternal(target *tgtdb.Target, exportDir string, importObjectLi
 		fmt.Printf("\nImporting %q\n\n", importObjectFilePath)
 		executeSqlFile(importObjectFilePath, importObjectType, skipFn)
 	}
-	log.Info("Schema import is complete.")
 }
 
 func ExtractMetaInfo(exportDir string) utils.ExportMetaInfo {


### PR DESCRIPTION
[Fixes #576]
When importing from Oracle or PG, when the user imports schema, the line `Importing "schema/sequences/sequence.sql"` shows up twice during the migration, despite the import going through as expected.
This happens as we split the import of sequences between `alter table` statements and those which aren't (Refer #433), but the print/log statements were not handled correctly.
This patch refactors this code and provides the user with more transparency into the actual process that yb-voyager carries out.