### PR TITLE
fixed #564 to execute all the UNIQUE INDEX DDLs before FK creation

### DIFF
--- a/migtests/tests/pg-tests/pg-constraints/pg_constraints_automation.sql
+++ b/migtests/tests/pg-tests/pg-constraints/pg_constraints_automation.sql
@@ -97,3 +97,15 @@ insert into foreign_test values (1,3,4);
 insert into foreign_test values (2,2,3);
 insert into foreign_test values (3,2,1);
 insert into foreign_test values (4,1,2);
+
+--test case for foreign key and unique index dependency
+
+create table xyz(id int);
+insert into xyz values(1),(2),(3);
+
+create table abc(name text, xyz_id int);
+
+create unique index idx on xyz using btree(id);
+
+alter table abc add constraint fk FOREIGN KEY (xyz_id) REFERENCES xyz(id);
+insert into abc values('fsdfs', 1),('sfdfds',2),('svss', 3); 

--- a/migtests/tests/pg-tests/pg-constraints/validate
+++ b/migtests/tests/pg-tests/pg-constraints/validate
@@ -31,7 +31,7 @@ QUERIES_CHECK = {
 		'query': "insert into check_test (id, first_name, last_name, age) values (7, 'Tom', 'Stewan', 15);",
 		'code': 23514
 	},
-	'FORIEGN_CHECK': {
+	'FOREIGN_CHECK': {
 		'query': "insert into foreign_test values (5,1,7);",
 		'code': 23503
 	},
@@ -39,7 +39,7 @@ QUERIES_CHECK = {
 		'query': "insert into xyz values(3);",
 		'code': 23505
 	},
-	'FORIEGN_CHECK_WITH_UNIQUE_INDEX': {
+	'FOREIGN_CHECK_WITH_UNIQUE_INDEX': {
 		'query': "insert into abc values ('dsfs', 4);",
 		'code': 23503
 	},

--- a/migtests/tests/pg-tests/pg-constraints/validate
+++ b/migtests/tests/pg-tests/pg-constraints/validate
@@ -14,7 +14,9 @@ EXPECTED_ROW_COUNT = {
 	'foreign_test': 4,         
 	'not_null_check': 6,
 	'primary_test': 6,  
-	'unique_test': 5
+	'unique_test': 5,
+	'xyz':3,
+	'abc':3
 }
 QUERIES_CHECK = {
 	'NULL_CHECK': {
@@ -32,13 +34,22 @@ QUERIES_CHECK = {
 	'FORIEGN_CHECK': {
 		'query': "insert into foreign_test values (5,1,7);",
 		'code': 23503
-	}
+	},
+	'UNIQUE_INDEX': {
+		'query': "insert into xyz values(3);",
+		'code': 23505
+	},
+	'FORIEGN_CHECK_WITH_UNIQUE_INDEX': {
+		'query': "insert into abc values ('dsfs', 4);",
+		'code': 23503
+	},
+
 }	
 
 def migration_completed_checks(tgt):
 	table_list = tgt.get_table_names("public")
 	print("table_list:", table_list)
-	assert len(table_list) == 6
+	assert len(table_list) == 8
 
 
 	got_row_count = tgt.row_count_of_all_tables("public")

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1047,9 +1047,9 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 		}
 
 		stmt := strings.ToUpper(strings.TrimSpace(sqlInfo.stmt))
-        if objType == "UNIQUE INDEX" && !strings.Contains(stmt, objType) {
-            continue
-        } else if objType == "INDEX" && strings.Contains(stmt, "UNIQUE INDEX") {
+		if objType == "UNIQUE INDEX" && !strings.Contains(stmt, objType) {
+			continue
+		} else if objType == "INDEX" && strings.Contains(stmt, "UNIQUE INDEX") {
 			continue
 		}
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1046,13 +1046,6 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 			conn = newTargetConn()
 		}
 
-		stmt := strings.ToUpper(strings.TrimSpace(sqlInfo.stmt))
-		if objType == "UNIQUE INDEX" && !strings.Contains(stmt, objType) {
-			continue
-		} else if objType == "INDEX" && strings.Contains(stmt, "UNIQUE INDEX") {
-			continue
-		}
-
 		setOrSelectStmt := strings.HasPrefix(strings.ToUpper(sqlInfo.stmt), "SET ") ||
 			strings.HasPrefix(strings.ToUpper(sqlInfo.stmt), "SELECT ")
 		if !setOrSelectStmt && skipFn != nil && skipFn(objType, sqlInfo.stmt) {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1046,6 +1046,13 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 			conn = newTargetConn()
 		}
 
+		stmt := strings.ToUpper(strings.TrimSpace(sqlInfo.stmt))
+        if objType == "UNIQUE INDEX" && !strings.Contains(stmt, objType) {
+            continue
+        } else if objType == "INDEX" && strings.Contains(stmt, "UNIQUE INDEX") {
+			continue
+		}
+
 		setOrSelectStmt := strings.HasPrefix(strings.ToUpper(sqlInfo.stmt), "SET ") ||
 			strings.HasPrefix(strings.ToUpper(sqlInfo.stmt), "SELECT ")
 		if !setOrSelectStmt && skipFn != nil && skipFn(objType, sqlInfo.stmt) {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -96,20 +96,24 @@ func importSchema() {
 	skipFn := isAlterStatement
 	importSchemaInternal(exportDir, objectList, skipFn)
 
-	// Import the skipped ALTER TABLE statements from sequence.sql if it exists
+	// Import the skipped ALTER TABLE statements from sequence.sql and table.sql if it exists
 	if slices.Contains(objectList, "SEQUENCE") || slices.Contains(objectList, "TABLE") {
 		skipFn = func(objType, stmt string) bool {
 			return !isAlterStatement(objType, stmt)
 		}
-		sequenceFilePath := utils.GetObjectFilePath(filepath.Join(exportDir, "schema"), "SEQUENCE")
-		if utils.FileOrFolderExists(sequenceFilePath) {
-			fmt.Printf("\nImporting ALTER TABLE DDLs from %q\n\n", sequenceFilePath)
-			executeSqlFile(sequenceFilePath, "SEQUENCE", skipFn)
+		if slices.Contains(objectList, "SEQUENCE") {
+			sequenceFilePath := utils.GetObjectFilePath(filepath.Join(exportDir, "schema"), "SEQUENCE")
+			if utils.FileOrFolderExists(sequenceFilePath) {
+				fmt.Printf("\nImporting ALTER TABLE DDLs from %q\n\n", sequenceFilePath)
+				executeSqlFile(sequenceFilePath, "SEQUENCE", skipFn)
+			}
 		}
-		tableFilePath := utils.GetObjectFilePath(filepath.Join(exportDir, "schema"), "TABLE")
-		if utils.FileOrFolderExists(tableFilePath) {
-			fmt.Printf("\nImporting ALTER TABLE DDLs from %q\n\n", tableFilePath)
-			executeSqlFile(tableFilePath, "TABLE", skipFn)
+		if slices.Contains(objectList, "TABLE") {
+			tableFilePath := utils.GetObjectFilePath(filepath.Join(exportDir, "schema"), "TABLE")
+			if utils.FileOrFolderExists(tableFilePath) {
+				fmt.Printf("\nImporting ALTER TABLE DDLs from %q\n\n", tableFilePath)
+				executeSqlFile(tableFilePath, "TABLE", skipFn)
+			}
 		}
 	}
 

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -34,7 +34,7 @@ func importSchemaInternal(exportDir string, importObjectList []string,
 		if !utils.FileOrFolderExists(importObjectFilePath) {
 			continue
 		}
-		fmt.Printf("\nImporting %q\n\n", importObjectFilePath)
+		fmt.Printf("\nImporting %s DDLs from %q\n\n", importObjectType, importObjectFilePath)
 		executeSqlFile(importObjectFilePath, importObjectType, skipFn)
 	}
 }
@@ -101,6 +101,9 @@ func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	}
 	if sourceDBType == "postgresql" && !slices.Contains(finalImportObjectList, "SCHEMA") && !flagPostImportData { // Schema should be migrated by default.
 		finalImportObjectList = append([]string{"SCHEMA"}, finalImportObjectList...)
+	}
+	if !flagPostImportData {
+		finalImportObjectList = append(finalImportObjectList, []string{"UNIQUE INDEX"}...)
 	}
 	return finalImportObjectList
 }

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -227,7 +227,7 @@ func GetObjectDirPath(schemaDirPath string, objType string) string {
 
 func GetObjectFilePath(schemaDirPath string, objType string) string {
 	var requiredPath string
-	if objType == "INDEX" {
+	if objType == "INDEX" || objType == "UNIQUE INDEX"{
 		requiredPath = filepath.Join(schemaDirPath, "tables", "INDEXES_table.sql")
 	} else if objType == "FTS_INDEX" {
 		requiredPath = filepath.Join(schemaDirPath, "tables", "FTS_INDEXES_table.sql")


### PR DESCRIPTION
1. fixed #564 
2. Added a case in `migtests/tests/pg-tests/pg-constraints` for the same with validation.