### PR TITLE
Categorize the DDLs with 'INDEX ATTACH' type in pg_dump's schema.sql to INDEX object type

### DIFF
--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -67,6 +67,10 @@ jobs:
 
     - name: "TEST: pg-partitions"
       run: migtests/scripts/run-test.sh pg-partitions
+    
+    - name: "TEST: pg-partitions-with-index"
+      run: migtests/scripts/run-test.sh pg-partitions-with-indexes
+      if: matrix.version != '2.15.3.2-b1'
 
     - name: "TEST: pg-constraints"
       run: migtests/scripts/run-test.sh pg-tests/pg-constraints

--- a/migtests/lib/yb.py
+++ b/migtests/lib/yb.py
@@ -129,3 +129,13 @@ class PostgresDB:
 				tables[table_name] = []
 			tables[table_name].append(data_type)
 		return tables
+
+	def invalid_index_present(self, table_name, schema_name):
+		cur = self.conn.cursor()
+		cur.execute(f"select indisvalid from pg_index where indrelid = '{schema_name}.{table_name}'::regclass::oid")
+
+		for indIsValid in cur.fetchall():
+			if indIsValid == False:
+				return True
+
+		return False

--- a/migtests/tests/pg-partitions-with-indexes/env.sh
+++ b/migtests/tests/pg-partitions-with-indexes/env.sh
@@ -1,0 +1,3 @@
+export SOURCE_DB_TYPE="postgresql"
+export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"partitions"}
+export SOURCE_DB_SCHEMA="public,p1,p2"

--- a/migtests/tests/pg-partitions-with-indexes/init-db
+++ b/migtests/tests/pg-partitions-with-indexes/init-db
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+source ${SCRIPTS}/functions.sh
+
+echo "Creating ${SOURCE_DB_NAME} database on source"
+run_psql postgres "DROP DATABASE IF EXISTS ${SOURCE_DB_NAME};"
+run_psql postgres "CREATE DATABASE ${SOURCE_DB_NAME};"
+
+echo "Initialising source database."
+psql "postgresql://${SOURCE_DB_USER}:${SOURCE_DB_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}" -f partitionTables.sql
+
+echo "Check source database."
+run_psql ${SOURCE_DB_NAME} "SELECT count(*) FROM sales_region"

--- a/migtests/tests/pg-partitions-with-indexes/partitionTables.sql
+++ b/migtests/tests/pg-partitions-with-indexes/partitionTables.sql
@@ -41,6 +41,8 @@ WITH region_list AS (
                 region[1 + mod(n, array_length(region, 1))] 
                     FROM amount_list, region_list, generate_series(1,1000) as n;
 
+CREATE INDEX on p1.sales_region(region);
+
 -- Partition by range
 
 CREATE TABLE sales 
@@ -104,3 +106,4 @@ WITH status_list AS (
                     (RANDOM()*200)::INTEGER
                         FROM generate_series(1,1000) AS n, status_list;
 
+CREATE INDEX on customers(statuses);

--- a/migtests/tests/pg-partitions-with-indexes/validate
+++ b/migtests/tests/pg-partitions-with-indexes/validate
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import yb
+
+def main():
+	yb.run_checks(migration_completed_checks)
+
+
+#=============================================================================
+
+EXPECTED_ROW_COUNT = {
+	"public.boston":       		334,
+	# check only for parent table in case of HASH partitioning
+ 	# "public.cust_active":		750, 
+  	# "public.cust_arr_small":	371,
+	# "public.cust_arr_large":	354,
+ 	# "public.cust_other":   	250,
+	# "public.cust_part11":  	192,
+	# "public.cust_part12":  	179,
+	# "public.cust_part21":  	205,
+	# "public.cust_part22":  	174,
+	"public.customers": 		1000,
+	"public.emp":        		1000,
+ 	"public.emp_0":        		324,
+	"public.emp_1":        		333,
+	"public.emp_2":        		343,
+	"public.london":       		333,
+ 	"public.sales":        		1000,	
+  	"public.sales_2019_q4":		333,
+	"public.sales_2020_q1":		334,
+	"public.sales_2020_q2":		333,
+ 	"public.sales_region":		1000,
+  	"public.sydney": 			333,
+	"p1.sales_region":			1000,
+	"p2.boston":    			334,
+	"p2.london":    			333,
+	"p2.sydney":    			333,
+}
+
+def migration_completed_checks(tgt):    
+	table_list = tgt.get_table_names("public")
+	print("table_list:", table_list)
+	assert len(table_list) == 21
+ 
+	table_list = tgt.get_table_names("p1")
+	print("table_list:", table_list)
+	assert len(table_list) == 1
+ 
+	table_list = tgt.get_table_names("p2")
+	print("table_list:", table_list)
+	assert len(table_list) == 3
+
+	for table_name, row_count in EXPECTED_ROW_COUNT.items():
+		schema = table_name.split(".")[0]
+		table = table_name.split(".")[1]
+		got_row_count = tgt.get_row_count(table, schema)
+		print(f"table_name: {table_name}, row_count: {got_row_count}")
+		assert row_count == got_row_count
+  		
+    	# check whether all the indexes on a table are valid
+		print("checking all indexes valid on table: {table_name} are valid")
+		assert tgt.invalid_index_present(table, schema) == False
+
+if __name__ == "__main__":
+	main()

--- a/migtests/tests/pg-partitions/partitionTables.sql
+++ b/migtests/tests/pg-partitions/partitionTables.sql
@@ -41,6 +41,8 @@ WITH region_list AS (
                 region[1 + mod(n, array_length(region, 1))] 
                     FROM amount_list, region_list, generate_series(1,1000) as n;
 
+CREATE INDEX on p1.sales_region(region);
+
 -- Partition by range
 
 CREATE TABLE sales 
@@ -104,5 +106,5 @@ WITH status_list AS (
                     (RANDOM()*200)::INTEGER
                         FROM generate_series(1,1000) AS n, status_list;
 
-
+CREATE INDEX on customers(statuses);
 

--- a/migtests/tests/pg-partitions/validate
+++ b/migtests/tests/pg-partitions/validate
@@ -54,11 +54,11 @@ def migration_completed_checks(tgt):
 		schema = table_name.split(".")[0]
 		table = table_name.split(".")[1]
 		got_row_count = tgt.get_row_count(table, schema)
-		print(f"table_name: {table_name}, row_count: {got_row_count}")
+		print(f"table_name: {table_name}, target row_count: {got_row_count}")
 		assert row_count == got_row_count
   		
     	# check whether all the indexes on a table are valid
-		print("checking all indexes valid on table: {table_name} are valid")
+		print(f"checking all indexes valid on table: {table_name} are valid")
 		assert tgt.invalid_index_present(table, schema) == False
 
 if __name__ == "__main__":

--- a/migtests/tests/pg-partitions/validate
+++ b/migtests/tests/pg-partitions/validate
@@ -49,13 +49,17 @@ def migration_completed_checks(tgt):
 	table_list = tgt.get_table_names("p2")
 	print("table_list:", table_list)
 	assert len(table_list) == 3
- 
+
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():
 		schema = table_name.split(".")[0]
 		table = table_name.split(".")[1]
 		got_row_count = tgt.get_row_count(table, schema)
 		print(f"table_name: {table_name}, row_count: {got_row_count}")
-		assert row_count == got_row_count	
+		assert row_count == got_row_count
+  		
+    	# check whether all the indexes on a table are valid
+		print("checking all indexes valid on table: {table_name} are valid")
+		assert tgt.invalid_index_present(table, schema) == False
 
 if __name__ == "__main__":
 	main()

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -118,9 +118,11 @@ func parseSchemaFile(exportDir string) int {
 			delimiterLine := lines[delimiterIndexes[i]]
 			sqlType := extractSqlTypeFromComment(delimiterLine)
 			switch sqlType {
-			case "SCHEMA", "TYPE", "DOMAIN", "SEQUENCE", "INDEX", "RULE", "FUNCTION",
+			case "SCHEMA", "TYPE", "DOMAIN", "SEQUENCE", "RULE", "FUNCTION",
 				"AGGREGATE", "PROCEDURE", "VIEW", "TRIGGER", "EXTENSION", "COMMENT":
 				objSqlStmts[sqlType].WriteString(stmts)
+			case "INDEX", "INDEX ATTACH":
+				objSqlStmts["INDEX"].WriteString(stmts)
 			case "TABLE", "DEFAULT", "CONSTRAINT", "FK CONSTRAINT", "TABLE ATTACH":
 				objSqlStmts["TABLE"].WriteString(stmts)
 			case "MATERIALIZED VIEW":


### PR DESCRIPTION
[Fixes #603, #613]

For detailed description of the issue please refer to #603, in short we were not attaching child partition's index to parent table's index.


Testing: 
1. Added a scenario in `pg-partitions` for this.
2. Also added validation check for verifying whether the INDEX is invalid or not

