### PR TITLE
Move 'ATTACH PARTITION' statements after 'ALTER TABLE ADD PRIMARY KEY' statements to reduce occurrences of error in #612

### DIFF
--- a/migtests/tests/pg-partitions/partitionTables.sql
+++ b/migtests/tests/pg-partitions/partitionTables.sql
@@ -41,6 +41,8 @@ WITH region_list AS (
                 region[1 + mod(n, array_length(region, 1))] 
                     FROM amount_list, region_list, generate_series(1,1000) as n;
 
+CREATE INDEX on p1.sales_region(region);
+
 -- Partition by range
 
 CREATE TABLE sales 

--- a/migtests/tests/pg-partitions/partitionTables.sql
+++ b/migtests/tests/pg-partitions/partitionTables.sql
@@ -41,8 +41,6 @@ WITH region_list AS (
                 region[1 + mod(n, array_length(region, 1))] 
                     FROM amount_list, region_list, generate_series(1,1000) as n;
 
-CREATE INDEX on p1.sales_region(region);
-
 -- Partition by range
 
 CREATE TABLE sales 


### PR DESCRIPTION
Refer to #612 for issue details its well explained there.

This change moves 'ATTACH PARTITION' statements after 'ALTER TABLE ADD PRIMARY` to avoid error in some cases i.e. for the table partitions but for the parent table, DDL is still required to be manually edited.

Testing: Not added as it is not supported by YB, the automation test will also fail.