### PR TITLE
Remove visibility of flags from parent export and import commands

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -874,7 +874,7 @@ var analyzeSchemaCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(analyzeSchemaCmd)
-
+	registerCommonGlobalFlags(analyzeSchemaCmd)
 	analyzeSchemaCmd.PersistentFlags().StringVar(&outputFormat, "output-format", "txt",
 		"allowed report formats: html | txt | json | xml")
 }

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -40,21 +40,12 @@ var exportCmd = &cobra.Command{
 }
 
 func init() {
+	exportCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		utils.MarkGlobalFlagsHiddenExcept(rootCmd, "help")
+		command.Parent().HelpFunc()(command, strings)
+	})
+
 	rootCmd.AddCommand(exportCmd)
-
-	registerCommonExportFlags(exportCmd)
-
-	exportCmd.Flags().StringVar(&source.TableList, "table-list", "",
-		"list of the tables to export data(Note: works only for export data command)")
-
-	exportCmd.Flags().IntVar(&source.NumConnections, "parallel-jobs", 1,
-		"number of Parallel Jobs to extract data from source database")
-
-	exportCmd.Flags().BoolVar(&disablePb, "disable-pb", false,
-		"true - to disable progress bar during data export (default false)")
-
-	exportCmd.Flags().StringVar(&source.ExcludeTableList, "exclude-table-list", "",
-		"List of tables to exclude while exporting data (no-op if --table-list is used) (Note: works only for export data command)")
 }
 
 func registerCommonExportFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -40,11 +40,6 @@ var exportCmd = &cobra.Command{
 }
 
 func init() {
-	exportCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		utils.MarkGlobalFlagsHiddenExcept(rootCmd, "help")
-		command.Parent().HelpFunc()(command, strings)
-	})
-
 	rootCmd.AddCommand(exportCmd)
 }
 

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -54,6 +54,7 @@ var exportDataCmd = &cobra.Command{
 
 func init() {
 	exportCmd.AddCommand(exportDataCmd)
+	registerCommonGlobalFlags(exportDataCmd)
 	registerCommonExportFlags(exportDataCmd)
 	exportDataCmd.Flags().BoolVar(&disablePb, "disable-pb", false,
 		"true - to disable progress bar during data export(default false)")

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -105,7 +105,7 @@ func exportSchema() {
 
 func init() {
 	exportCmd.AddCommand(exportSchemaCmd)
-
+	registerCommonGlobalFlags(exportSchemaCmd)
 	registerCommonExportFlags(exportSchemaCmd)
 	exportSchemaCmd.Flags().BoolVar(&source.UseOrafce, "use-orafce", true,
 		"enable using orafce extension in export schema")

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -38,11 +38,6 @@ var importCmd = &cobra.Command{
 }
 
 func init() {
-	importCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		utils.MarkGlobalFlagsHiddenExcept(rootCmd, "help")
-		command.Parent().HelpFunc()(command, strings)
-	})
-
 	rootCmd.AddCommand(importCmd)
 }
 

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -38,10 +38,12 @@ var importCmd = &cobra.Command{
 }
 
 func init() {
+	importCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		utils.MarkGlobalFlagsHiddenExcept(rootCmd, "help")
+		command.Parent().HelpFunc()(command, strings)
+	})
+
 	rootCmd.AddCommand(importCmd)
-	registerCommonImportFlags(importCmd)
-	registerImportSchemaFlags(importCmd)
-	registerImportDataFlags(importCmd)
 }
 
 func validateImportFlags() {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1007,13 +1007,12 @@ func setTargetSchema(conn *pgx.Conn) {
 	}
 	checkSchemaExistsQuery := fmt.Sprintf("SELECT count(schema_name) FROM information_schema.schemata WHERE schema_name = '%s'", target.Schema)
 	var cntSchemaName int
-	
+
 	if err := conn.QueryRow(context.Background(), checkSchemaExistsQuery).Scan(&cntSchemaName); err != nil {
 		utils.ErrExit("run query %q on target %q to check schema exists: %s", checkSchemaExistsQuery, target.Host, err)
 	} else if cntSchemaName == 0 {
 		utils.ErrExit("schema '%s' does not exist in target", target.Schema)
 	}
-	
 
 	setSchemaQuery := fmt.Sprintf("SET SCHEMA '%s'", target.Schema)
 	_, err := conn.Exec(context.Background(), setSchemaQuery)
@@ -1355,6 +1354,7 @@ func checkSessionVariableSupport(sqlStmt string) bool {
 
 func init() {
 	importCmd.AddCommand(importDataCmd)
+	registerCommonGlobalFlags(importDataCmd)
 	registerCommonImportFlags(importDataCmd)
 	registerImportDataFlags(importDataCmd)
 	target.Schema = strings.ToLower(target.Schema)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -49,6 +49,7 @@ var importSchemaCmd = &cobra.Command{
 
 func init() {
 	importCmd.AddCommand(importSchemaCmd)
+	registerCommonGlobalFlags(importSchemaCmd)
 	registerCommonImportFlags(importSchemaCmd)
 	registerImportSchemaFlags(importSchemaCmd)
 	target.Schema = strings.ToLower(target.Schema)

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -79,21 +79,24 @@ func init() {
 	// will be global for your application.
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 
-	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", "INFO",
+	callhome.ReadEnvSendDiagnostics()
+}
+
+func registerCommonGlobalFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", "INFO",
 		"Logging levels: TRACE, DEBUG, INFO, WARN")
 
-	rootCmd.PersistentFlags().BoolVar(&source.VerboseMode, "verbose", false,
+	cmd.PersistentFlags().BoolVar(&source.VerboseMode, "verbose", false,
 		"enable verbose mode for the console output")
 
-	rootCmd.PersistentFlags().StringVarP(&exportDir, "export-dir", "e", "",
+	cmd.PersistentFlags().StringVarP(&exportDir, "export-dir", "e", "",
 		"export directory to keep all the dump files and metainfo")
 
-	rootCmd.PersistentFlags().BoolVarP(&utils.DoNotPrompt, "yes", "y", false,
+	cmd.PersistentFlags().BoolVarP(&utils.DoNotPrompt, "yes", "y", false,
 		"assume answer as yes for all questions during migration (default false)")
 
-	rootCmd.PersistentFlags().BoolVar(&callhome.SendDiagnostics, "send-diagnostics", true,
+	cmd.PersistentFlags().BoolVar(&callhome.SendDiagnostics, "send-diagnostics", true,
 		"enable or disable the 'send-diagnostics' feature that sends analytics data to Yugabyte.")
-	callhome.ReadEnvSendDiagnostics()
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -29,8 +29,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/yosssi/gohtml"
 	"golang.org/x/exp/slices"
 )
@@ -330,23 +328,4 @@ func GetRedactedURLs(urlList []string) []string {
 		result = append(result, obj.Redacted())
 	}
 	return result
-}
-
-// Contains returns true if the string is in the slice
-func contains(b []string, i string) bool {
-	for _, s := range b {
-		if s == i {
-			return true
-		}
-	}
-	return false
-}
-
-func MarkGlobalFlagsHiddenExcept(command *cobra.Command, unhidden ...string) {
-	command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
-		name := flag.Name
-		if !contains(unhidden, name) {
-			flag.Hidden = true
-		}
-	})
 }

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/yosssi/gohtml"
 	"golang.org/x/exp/slices"
 )
@@ -328,4 +330,23 @@ func GetRedactedURLs(urlList []string) []string {
 		result = append(result, obj.Redacted())
 	}
 	return result
+}
+
+// Contains returns true if the string is in the slice
+func contains(b []string, i string) bool {
+	for _, s := range b {
+		if s == i {
+			return true
+		}
+	}
+	return false
+}
+
+func MarkGlobalFlagsHiddenExcept(command *cobra.Command, unhidden ...string) {
+	command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		name := flag.Name
+		if !contains(unhidden, name) {
+			flag.Hidden = true
+		}
+	})
 }


### PR DESCRIPTION
**Issue:** [Remove visibility of flags from parent export and import commands #617](https://github.com/yugabyte/yb-voyager/issues/617)

**Fix:**
1) Removed the registration of common import and export flags from the init functions of **export.go** and **import.go**
2) I have added a new function **`registerCommonGlobalFlags`** in **root.go** and put the registration of global flags into this function. This function is now invoked in **`analyzeSchema`**, **`importData`**, **`importSchema`**, **`exportData`** and **`exportSchema`**. Since the flags are registered as PersistentFlags, they trickle down to any child commands of **`exportData`**, **`exportSchema`**, **`importData`**, **`importSchema`**.

New Output:
```
Export has various sub-commands to extract schema, data and generate migration report.

Usage:
  yb-voyager export [command]

Available Commands:
  data        This command is used to export table's data from source database to *.sql files
  schema      This command is used to export the schema from source database into .sql files

Flags:
  -h, --help   help for export

Use "yb-voyager export [command] --help" for more information about a command.
```

