### PR TITLE
Shivansh/validation of datatypes mysql

### DIFF
--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -51,26 +51,26 @@ jobs:
         echo "127.0.0.1	yb-tserver-n1" | sudo tee -a /etc/hosts
         psql "postgresql://yugabyte@yb-tserver-n1:5433/yugabyte" -c "SELECT version();"
 
-    # - name: "TEST: mysql-sakila"
-    #   run: migtests/scripts/run-test.sh mysql-sakila
+    - name: "TEST: mysql-sakila"
+      run: migtests/scripts/run-test.sh mysql-sakila
 
     - name: "TEST: mysql-datatypes"
       run: migtests/scripts/run-test.sh mysql-tests/mysql-datatypes
 
-    # - name: "TEST: mysql-constraints"
-    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-constraints
+    - name: "TEST: mysql-constraints"
+      run: migtests/scripts/run-test.sh mysql-tests/mysql-constraints
 
-    # - name: "TEST: mysql-case-indexes"
-    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-indexes
+    - name: "TEST: mysql-case-indexes"
+      run: migtests/scripts/run-test.sh mysql-tests/mysql-indexes
 
-    # - name: "TEST: mysql-functions"
-    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-functions
+    - name: "TEST: mysql-functions"
+      run: migtests/scripts/run-test.sh mysql-tests/mysql-functions
 
-    # - name: "TEST: mysql-case-sequences"
-    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-sequences    
+    - name: "TEST: mysql-case-sequences"
+      run: migtests/scripts/run-test.sh mysql-tests/mysql-sequences    
 
-    # - name: "TEST: mysql-triggers-procedures"
-    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-triggers-procedures   
+    - name: "TEST: mysql-triggers-procedures"
+      run: migtests/scripts/run-test.sh mysql-tests/mysql-triggers-procedures   
 
-    # - name: "TEST: mysql-case-views"
-    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-views
+    - name: "TEST: mysql-case-views"
+      run: migtests/scripts/run-test.sh mysql-tests/mysql-views

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -51,26 +51,26 @@ jobs:
         echo "127.0.0.1	yb-tserver-n1" | sudo tee -a /etc/hosts
         psql "postgresql://yugabyte@yb-tserver-n1:5433/yugabyte" -c "SELECT version();"
 
-    - name: "TEST: mysql-sakila"
-      run: migtests/scripts/run-test.sh mysql-sakila
+    # - name: "TEST: mysql-sakila"
+    #   run: migtests/scripts/run-test.sh mysql-sakila
 
     - name: "TEST: mysql-datatypes"
       run: migtests/scripts/run-test.sh mysql-tests/mysql-datatypes
 
-    - name: "TEST: mysql-constraints"
-      run: migtests/scripts/run-test.sh mysql-tests/mysql-constraints
+    # - name: "TEST: mysql-constraints"
+    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-constraints
 
-    - name: "TEST: mysql-case-indexes"
-      run: migtests/scripts/run-test.sh mysql-tests/mysql-indexes
+    # - name: "TEST: mysql-case-indexes"
+    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-indexes
 
-    - name: "TEST: mysql-functions"
-      run: migtests/scripts/run-test.sh mysql-tests/mysql-functions
+    # - name: "TEST: mysql-functions"
+    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-functions
 
-    - name: "TEST: mysql-case-sequences"
-      run: migtests/scripts/run-test.sh mysql-tests/mysql-sequences    
+    # - name: "TEST: mysql-case-sequences"
+    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-sequences    
 
-    - name: "TEST: mysql-triggers-procedures"
-      run: migtests/scripts/run-test.sh mysql-tests/mysql-triggers-procedures   
+    # - name: "TEST: mysql-triggers-procedures"
+    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-triggers-procedures   
 
-    - name: "TEST: mysql-case-views"
-      run: migtests/scripts/run-test.sh mysql-tests/mysql-views
+    # - name: "TEST: mysql-case-views"
+    #   run: migtests/scripts/run-test.sh mysql-tests/mysql-views

--- a/migtests/lib/yb.py
+++ b/migtests/lib/yb.py
@@ -123,13 +123,22 @@ class PostgresDB:
 	def fetch_datatypes_of_all_tables_in_schema(self, schema_name="public") -> Dict[str, List[str]]:
 		cur = self.conn.cursor()
 		cur.execute(f"SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = '{schema_name}'")
-		# tables = {}
-		# for table_name, column_name, data_type in cur.fetchall():
-		# 	if table_name not in tables:
-		# 		tables[table_name] = []
-		# 	tables[table_name].append(data_type)
-		# return tables
-		return cur.fetchall()
+		tables = {}
+		for table_name, column_name, data_type in cur.fetchall():
+			if table_name not in tables:
+				tables[table_name] = []
+			tables[table_name].append(data_type)
+		return tables
+
+	def fetch_datatypes_and_columns_of_all_tables_in_schema(self, schema_name="public") -> Dict[str, Dict[str,str]]:
+		cur = self.conn.cursor()
+		cur.execute(f"SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = '{schema_name}'")
+		tables = {}
+		for table_name, column_name, data_type in cur.fetchall():
+			if table_name not in tables:
+				tables[table_name] = {}
+			tables[table_name][column_name].append(data_type)
+		return tables
 
 	def invalid_index_present(self, table_name, schema_name):
 		cur = self.conn.cursor()

--- a/migtests/lib/yb.py
+++ b/migtests/lib/yb.py
@@ -137,7 +137,7 @@ class PostgresDB:
 		for table_name, column_name, data_type in cur.fetchall():
 			if table_name not in tables:
 				tables[table_name] = {}
-			tables[table_name][column_name].append(data_type)
+			tables[table_name][column_name] = data_type
 		return tables
 
 	def invalid_index_present(self, table_name, schema_name):

--- a/migtests/lib/yb.py
+++ b/migtests/lib/yb.py
@@ -130,7 +130,7 @@ class PostgresDB:
 			tables[table_name].append(data_type)
 		return tables
 
-	def fetch_datatypes_and_columns_of_all_tables_in_schema(self, schema_name="public") -> Dict[str, Dict[str,str]]:
+	def get_column_to_data_type_mapping(self, schema_name="public") -> Dict[str, Dict[str,str]]:
 		cur = self.conn.cursor()
 		cur.execute(f"SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = '{schema_name}'")
 		tables = {}

--- a/migtests/lib/yb.py
+++ b/migtests/lib/yb.py
@@ -123,12 +123,13 @@ class PostgresDB:
 	def fetch_datatypes_of_all_tables_in_schema(self, schema_name="public") -> Dict[str, List[str]]:
 		cur = self.conn.cursor()
 		cur.execute(f"SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = '{schema_name}'")
-		tables = {}
-		for table_name, column_name, data_type in cur.fetchall():
-			if table_name not in tables:
-				tables[table_name] = []
-			tables[table_name].append(data_type)
-		return tables
+		# tables = {}
+		# for table_name, column_name, data_type in cur.fetchall():
+		# 	if table_name not in tables:
+		# 		tables[table_name] = []
+		# 	tables[table_name].append(data_type)
+		# return tables
+		return cur.fetchall()
 
 	def invalid_index_present(self, table_name, schema_name):
 		cur = self.conn.cursor()

--- a/migtests/tests/mysql-tests/mysql-datatypes/validate
+++ b/migtests/tests/mysql-tests/mysql-datatypes/validate
@@ -53,16 +53,16 @@ EXPECTED_SUM_OF_COLUMN = {
 EXPECTED_ENUM_VALUES = ['low', 'high', 'med']
 
 EXPECTED_DATA_TYPES = {
-	'bit_types': ['numeric'],
-	'bool_types': ['double precision'],
-	'date_time_types': ['timestamp','timestamp','timestamp with time zone','timestamp with time zone'],
-	'enum_types': [],   
-	'fixed_point_types': [],
-	'floating_point_types': [], 
-  	'int_types': [''],     
- 	'json_types': [],          
- 	'string_types': [],        
-	'uuid_try': [] 
+	'floating_point_types': {'double_type': 'double precision', 'real_type': 'double precision', 'id': 'bigint', 'float_type': 'double precision'},
+ 	'fixed_point_types': {'d_us': 'numeric', 'fixed_type': 'numeric', 'numeric_type': 'numeric', 'dec_type': 'numeric'}, 
+  	'string_types': {'text_item': 'text', 'varchar_item': 'character varying', 'char_item': 'character', 'varbinary_item': 'bytea', 'longtext_item': 'text', 'binary_item': 'bytea', 'mediumtext_item': 'text'}, 
+   	'date_time_types': {'date_time_type': 'timestamp without time zone', 'time_stamp_type': 'timestamp without time zone', 'date_type': 'timestamp without time zone', 'year_type': 'smallint', 'time_type': 'time without time zone'}, 
+    'json_types': {'json_val': 'json'}, 
+    'int_types': {'iint_u': 'bigint', 'mint_u': 'integer', 'tint_s': 'smallint', 'sint_u': 'integer', 'iint_s': 'bigint', 'iinteger_s': 'bigint', 'sint_s': 'integer', 'tint_u': 'smallint', 'bint_u': 'numeric', 'iinteger_u': 'bigint', 'bint_s': 'bigint', 'mint_s': 'integer'}, 
+    'bool_types': {'val': 'smallint', 'id': 'bigint'}, 
+    'enum_types': {'title': 'character varying', 'priority': 'USER-DEFINED', 'id': 'bigint'}, 
+    'uuid_try': {'name': 'character varying', 'id': 'bytea'}, 
+    'bit_types': {'bit_type': 'bit varying'} 
 }
 
 def migration_completed_checks(tgt):
@@ -97,10 +97,11 @@ def migration_completed_checks(tgt):
 	fetched_datatypes_schema = tgt.fetch_datatypes_and_columns_of_all_tables_in_schema("public")
  
 	print(fetched_datatypes_schema)
-	# for table_name, data_types in fetched_datatypes_schema.items():
-	# 	print(f"Table Name: {table_name}, data_types: {fetched_datatypes_schema[table_name]}")
-	# 	# assert set(EXPECTED_DATA_TYPES[table_name]) == set(fetched_datatypes_schema[table_name])
-		
+	for table_name, columns in fetched_datatypes_schema.items():
+		print(f"table_name: {table_name} ---- ")
+		for column_name, datatype in columns.items():
+			print(f"column_name: {column_name}, datatype: {datatype}")
+			assert datatype == EXPECTED_DATA_TYPES[table_name][column_name]
 
 if __name__ == "__main__":
 	main() 

--- a/migtests/tests/mysql-tests/mysql-datatypes/validate
+++ b/migtests/tests/mysql-tests/mysql-datatypes/validate
@@ -52,6 +52,19 @@ EXPECTED_SUM_OF_COLUMN = {
 
 EXPECTED_ENUM_VALUES = ['low', 'high', 'med']
 
+EXPECTED_DATA_TYPES = {
+	'bit_types': ['numeric'],
+	'bool_types': ['double precision'],
+	'date_time_types': ['timestamp','timestamp','timestamp with time zone','timestamp with time zone'],
+	'enum_types': [],   
+	'fixed_point_types': [],
+	'floating_point_types': [], 
+  	'int_types': [],     
+ 	'json_types': [],          
+ 	'string_types': [],        
+	'uuid_try': [] 
+}
+
 def migration_completed_checks(tgt):
 	table_list = tgt.get_table_names("public")
 	print("table_list:", table_list)
@@ -80,7 +93,12 @@ def migration_completed_checks(tgt):
 	for distinct_value in distinct_values_bool_types:
 		print(f"{distinct_value}")
 		assert distinct_value == 0 or distinct_value == 1
+	
+	fetched_datatypes_schema = tgt.fetch_datatypes_of_all_tables_in_schema("public")
+	for table_name, data_types in fetched_datatypes_schema.items():
+		print(f"Table Name: {table_name}, data_types: {fetched_datatypes_schema[table_name]}")
+		# assert set(EXPECTED_DATA_TYPES[table_name]) == set(fetched_datatypes_schema[table_name])
 		
 
 if __name__ == "__main__":
-	main()
+	main() 

--- a/migtests/tests/mysql-tests/mysql-datatypes/validate
+++ b/migtests/tests/mysql-tests/mysql-datatypes/validate
@@ -59,7 +59,7 @@ EXPECTED_DATA_TYPES = {
 	'enum_types': [],   
 	'fixed_point_types': [],
 	'floating_point_types': [], 
-  	'int_types': [],     
+  	'int_types': [''],     
  	'json_types': [],          
  	'string_types': [],        
 	'uuid_try': [] 
@@ -95,9 +95,11 @@ def migration_completed_checks(tgt):
 		assert distinct_value == 0 or distinct_value == 1
 	
 	fetched_datatypes_schema = tgt.fetch_datatypes_of_all_tables_in_schema("public")
-	for table_name, data_types in fetched_datatypes_schema.items():
-		print(f"Table Name: {table_name}, data_types: {fetched_datatypes_schema[table_name]}")
-		# assert set(EXPECTED_DATA_TYPES[table_name]) == set(fetched_datatypes_schema[table_name])
+ 
+	print(fetched_datatypes_schema)
+	# for table_name, data_types in fetched_datatypes_schema.items():
+	# 	print(f"Table Name: {table_name}, data_types: {fetched_datatypes_schema[table_name]}")
+	# 	# assert set(EXPECTED_DATA_TYPES[table_name]) == set(fetched_datatypes_schema[table_name])
 		
 
 if __name__ == "__main__":

--- a/migtests/tests/mysql-tests/mysql-datatypes/validate
+++ b/migtests/tests/mysql-tests/mysql-datatypes/validate
@@ -94,7 +94,7 @@ def migration_completed_checks(tgt):
 		print(f"{distinct_value}")
 		assert distinct_value == 0 or distinct_value == 1
 	
-	fetched_datatypes_schema = tgt.fetch_datatypes_of_all_tables_in_schema("public")
+	fetched_datatypes_schema = tgt.fetch_datatypes_and_columns_of_all_tables_in_schema("public")
  
 	print(fetched_datatypes_schema)
 	# for table_name, data_types in fetched_datatypes_schema.items():

--- a/migtests/tests/mysql-tests/mysql-datatypes/validate
+++ b/migtests/tests/mysql-tests/mysql-datatypes/validate
@@ -53,16 +53,67 @@ EXPECTED_SUM_OF_COLUMN = {
 EXPECTED_ENUM_VALUES = ['low', 'high', 'med']
 
 EXPECTED_DATA_TYPES = {
-	'floating_point_types': {'double_type': 'double precision', 'real_type': 'double precision', 'id': 'bigint', 'float_type': 'double precision'},
- 	'fixed_point_types': {'d_us': 'numeric', 'fixed_type': 'numeric', 'numeric_type': 'numeric', 'dec_type': 'numeric'}, 
-  	'string_types': {'text_item': 'text', 'varchar_item': 'character varying', 'char_item': 'character', 'varbinary_item': 'bytea', 'longtext_item': 'text', 'binary_item': 'bytea', 'mediumtext_item': 'text'}, 
-   	'date_time_types': {'date_time_type': 'timestamp without time zone', 'time_stamp_type': 'timestamp without time zone', 'date_type': 'timestamp without time zone', 'year_type': 'smallint', 'time_type': 'time without time zone'}, 
-    'json_types': {'json_val': 'json'}, 
-    'int_types': {'iint_u': 'bigint', 'mint_u': 'integer', 'tint_s': 'smallint', 'sint_u': 'integer', 'iint_s': 'bigint', 'iinteger_s': 'bigint', 'sint_s': 'integer', 'tint_u': 'smallint', 'bint_u': 'numeric', 'iinteger_u': 'bigint', 'bint_s': 'bigint', 'mint_s': 'integer'}, 
-    'bool_types': {'val': 'smallint', 'id': 'bigint'}, 
-    'enum_types': {'title': 'character varying', 'priority': 'USER-DEFINED', 'id': 'bigint'}, 
-    'uuid_try': {'name': 'character varying', 'id': 'bytea'}, 
-    'bit_types': {'bit_type': 'bit varying'} 
+	'floating_point_types': {
+     	'double_type': 'double precision', 
+     	'real_type': 'double precision', 
+     	'id': 'bigint', 
+     	'float_type': 'double precision'
+     },
+ 	'fixed_point_types': {
+      	'd_us': 'numeric',
+       	'fixed_type': 'numeric',
+        'numeric_type': 'numeric',
+        'dec_type': 'numeric'
+    }, 
+  	'string_types': {
+       	'text_item': 'text',
+        'varchar_item': 'character varying',
+        'char_item': 'character',
+        'varbinary_item': 'bytea', 
+        'longtext_item': 'text',
+        'binary_item': 'bytea', 
+        'mediumtext_item': 'text'
+    }, 
+   	'date_time_types': {
+        'date_time_type': 'timestamp without time zone',
+        'time_stamp_type': 'timestamp without time zone',
+        'date_type': 'timestamp without time zone', 
+        'year_type': 'smallint', 
+        'time_type': 'time without time zone'
+    }, 
+    'json_types': {
+        'json_val': 'json'
+    }, 
+    'int_types': {
+        'iint_u': 'bigint',
+        'mint_u': 'integer',
+        'tint_s': 'smallint',
+        'sint_u': 'integer',
+        'iint_s': 'bigint',
+        'iinteger_s': 'bigint',
+        'sint_s': 'integer',
+        'tint_u': 'smallint',
+        'bint_u': 'numeric',
+        'iinteger_u': 'bigint',
+        'bint_s': 'bigint',
+        'mint_s': 'integer'
+    }, 
+    'bool_types': {
+        'val': 'smallint',
+        'id': 'bigint'
+    }, 
+    'enum_types': {
+        'title': 'character varying',
+        'priority': 'USER-DEFINED',
+        'id': 'bigint'
+    }, 
+    'uuid_try': {
+        'name': 'character varying',
+        'id': 'bytea'
+    }, 
+    'bit_types': {
+        'bit_type': 'bit varying'
+    } 
 }
 
 def migration_completed_checks(tgt):
@@ -94,7 +145,7 @@ def migration_completed_checks(tgt):
 		print(f"{distinct_value}")
 		assert distinct_value == 0 or distinct_value == 1
 	
-	fetched_datatypes_schema = tgt.fetch_datatypes_and_columns_of_all_tables_in_schema("public")
+	fetched_datatypes_schema = tgt.get_column_to_data_type_mapping("public")
  
 	print(fetched_datatypes_schema)
 	for table_name, columns in fetched_datatypes_schema.items():
@@ -104,4 +155,4 @@ def migration_completed_checks(tgt):
 			assert datatype == EXPECTED_DATA_TYPES[table_name][column_name]
 
 if __name__ == "__main__":
-	main() 
+	main()


### PR DESCRIPTION
**Issue**: https://github.com/yugabyte/yb-voyager/issues/556 : **[MySQL] For Datatype validation, validate mapping as well**.

**Enhancement:**
1) Added a function **`fetch_datatypes_and_columns_of_all_tables_in_schema`** in **`yb.py`** which fetches the **columns** and **datatypes** of those columns of all the tables **imported** into **YB**.
2) Used the returning value of the above function to **`assert`** with the **`expected data types`** for each **column** in **`migtests/tests/mysql-tests/mysql-datatypes/validate`**.