### PR TITLE
Added a flag --refresh-mviews to refresh materialised views with post-import-data (default is false) (fixes - #624)

### DIFF
--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -76,8 +76,8 @@ main() {
 	step "Import data."
 	import_data
 	
-	step "Import remaining schema (FK, index, and trigger)."
-	import_schema --post-import-data
+	step "Import remaining schema (FK, index, and trigger) and Refreshing Mviews if present."
+	import_schema --post-import-data --refresh-mviews
 	run_ysql ${TARGET_DB_NAME} "\di"
 	run_ysql ${TARGET_DB_NAME} "\dft" 
 

--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -76,7 +76,7 @@ main() {
 	step "Import data."
 	import_data
 	
-	step "Import remaining schema (FK, index, and trigger) and Refreshing Mviews if present."
+	step "Import remaining schema (FK, index, and trigger) and Refreshing MViews if present."
 	import_schema --post-import-data --refresh-mviews
 	run_ysql ${TARGET_DB_NAME} "\di"
 	run_ysql ${TARGET_DB_NAME} "\dft" 

--- a/migtests/tests/pg-tests/pg-views/validate
+++ b/migtests/tests/pg-tests/pg-views/validate
@@ -27,12 +27,8 @@ def migration_completed_checks(tgt):
 	assert len(view_list) == 3
 
 	materialized_view_list = tgt.get_objects_of_type("MVIEW", "test_views")
-	print("materialized_view_list:", view_list)
+	print("materialized_view_list:", materialized_view_list)
 	assert len(materialized_view_list) == 1
-	
-	chk_err_while_refresh_mview = tgt.run_query_and_chk_error("REFRESH MATERIALIZED VIEW test_views.mv1;", None)
-	print(f"Refreshing materialised views error chk returned - {chk_err_while_refresh_mview}")
-	assert chk_err_while_refresh_mview == False
 
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():
 		cnt = tgt.get_row_count(table_name, "test_views")

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -29,7 +29,6 @@ import (
 )
 
 var sourceDBType string
-var isMViewsPresent bool
 
 // target struct will be populated by CLI arguments parsing
 var target tgtdb.Target
@@ -159,7 +158,7 @@ func registerImportSchemaFlags(cmd *cobra.Command) {
 		"true - to ignore errors if object already exists\n"+
 			"false - throw those errors to the standard output (default false)")
 	cmd.Flags().BoolVar(&flagRefreshMViews, "refresh-mviews", false,
-		"If set, refreshes the materialised views on target after importing data (default false)")
+		"If set, refreshes the materialised views on target during post import data phase (default false")
 }
 
 func validateTargetPortRange() {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -29,6 +29,7 @@ import (
 )
 
 var sourceDBType string
+var isMViewsPresent bool
 
 // target struct will be populated by CLI arguments parsing
 var target tgtdb.Target
@@ -157,6 +158,8 @@ func registerImportSchemaFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&target.IgnoreIfExists, "ignore-exist", false,
 		"true - to ignore errors if object already exists\n"+
 			"false - throw those errors to the standard output (default false)")
+	cmd.Flags().BoolVar(&flagRefreshMViews, "refresh-mviews", false,
+		"If set, refreshes the materialised views on target after importing data (default false)")
 }
 
 func validateTargetPortRange() {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1050,6 +1050,9 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 	}()
 
 	sqlInfoArr := createSqlStrInfoArray(file, objType)
+	if objType == "MVIEW" && len(sqlInfoArr) > 0 {
+		isMViewsPresent = true
+	} 
 	for _, sqlInfo := range sqlInfoArr {
 		if conn == nil {
 			conn = newTargetConn()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1050,9 +1050,6 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 	}()
 
 	sqlInfoArr := createSqlStrInfoArray(file, objType)
-	if objType == "MVIEW" && len(sqlInfoArr) > 0 {
-		isMViewsPresent = true
-	} 
 	for _, sqlInfo := range sqlInfoArr {
 		if conn == nil {
 			conn = newTargetConn()

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -111,37 +111,43 @@ func importSchema() {
 	}
 
 	log.Info("Schema import is complete.")
-	if isMViewsPresent {
-		utils.PrintAndLog("Materialised Views are present in the imported schema, use --refresh-mviews flag with --post-import-data to refresh mviews after importing data.\n\n")
-	}
-	if flagPostImportData && flagRefreshMViews  {
-		refreshMViewsPostImportData(conn)
+	if flagPostImportData {
+		if flagRefreshMViews {
+			refreshMViews(conn)
+		}
+	} else {
+		utils.PrintAndLog("NOTE: Materialised Views are not populated by default. To populate them, pass --refresh-mviews while executing `import schema --post-import-data`.")
 	}
 	callhome.PackAndSendPayload(exportDir)
 }
 
-func refreshMViewsPostImportData(conn *pgx.Conn) {
+func refreshMViews(conn *pgx.Conn) {
 	utils.PrintAndLog("\nRefreshing Materialised Views..\n\n")
-	var listOfMViewsImported []string
-	schemaDir := filepath.Join(exportDir, "schema")
-	importMViewFilePath := utils.GetObjectFilePath(schemaDir, "MVIEW")
-	if !utils.FileOrFolderExists(importMViewFilePath) {
-		return
-	}
-	mviewsSqlInfoArr := createSqlStrInfoArray(importMViewFilePath, "MVIEW")
-	for _, eachMviewSql := range mviewsSqlInfoArr {
-		if strings.Contains(eachMviewSql.stmt, "CREATE MATERIALIZED VIEW") {
-			listOfMViewsImported = append(listOfMViewsImported, eachMviewSql.objName)
+	var mViewNames []string
+	mViewsSqlInfoArr := getDDLStmts("MVIEW")
+	for _, eachMviewSql := range mViewsSqlInfoArr {
+		if strings.Contains(strings.ToUpper(eachMviewSql.stmt), "CREATE MATERIALIZED VIEW") {
+			mViewNames = append(mViewNames, eachMviewSql.objName)
 		}
 	}
-	log.Infof("List of Mviews Imported to refresh - %v", listOfMViewsImported)
-	for _, eachMView := range listOfMViewsImported{
-		queryRefreshMViews := fmt.Sprintf("REFRESH MATERIALIZED VIEW %s", eachMView)
-		_, err := conn.Exec(context.Background(), queryRefreshMViews)
+	log.Infof("List of Mviews Imported to refresh - %v", mViewNames)
+	for _, mViewName := range mViewNames {
+		query := fmt.Sprintf("REFRESH MATERIALIZED VIEW %s", mViewName)
+		_, err := conn.Exec(context.Background(), query)
 		if err != nil {
-			utils.ErrExit("error in refreshing the materialised view %s: %v\n",eachMView, err)
+			utils.ErrExit("error in refreshing the materialised view %s: %v", mViewName, err)
 		}
 	}
+}
+
+func getDDLStmts(objType string) []sqlInfo {
+	var sqlInfoArr []sqlInfo
+	schemaDir := filepath.Join(exportDir, "schema")
+	importMViewFilePath := utils.GetObjectFilePath(schemaDir, objType)
+	if utils.FileOrFolderExists(importMViewFilePath) {
+		sqlInfoArr = createSqlStrInfoArray(importMViewFilePath, objType)
+	}
+	return sqlInfoArr
 }
 
 func createTargetSchemas(conn *pgx.Conn) {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -124,10 +124,10 @@ func refreshMViewsPostImportData(conn *pgx.Conn) {
 	fmt.Printf("\nRefreshing Materialised Views..\n\n")
 	fetchMViewsQuery := "select relname,nspname from pg_class join pg_namespace on pg_class.relnamespace = pg_namespace.oid where relkind = 'm';"
 	rows, err := conn.Query(context.Background(),fetchMViewsQuery)
-	defer rows.Close()
 	if err != nil {
 		utils.ErrExit("Failed to run query to fetch mviews %q: %s", fetchMViewsQuery, err)
 	}
+	defer rows.Close()
 	var mview_name, schema_name string
 	var listOfMViews []string
 	for rows.Next(){


### PR DESCRIPTION
fixes - #624 
Issue - Materialised views are not populated by default.

Fix - Added a flag `--refresh-mviews`, if this flag is used with `--post-import-data` then all the Mviews will be refreshed, but default is false. Also, added a warning message on prompt after import schema is completed to tell the user that Mviews are present in schema and to refresh them use `--refresh-mviews` flag with `--post-import-data`.

Test cases - Added this flag in the automation framework, and removed the explicit refreshing mviews from the validation of `pg-tests/pg-views`
