### PR TITLE
Bug #632: Storing uncategorized ALTER SEQUENCE DDLs in schema/sequence.sql file

### DIFF
--- a/migtests/tests/pg-tests/pg-sequences/validate
+++ b/migtests/tests/pg-tests/pg-sequences/validate
@@ -50,7 +50,23 @@ def migration_completed_checks(tgt):
 	print(f"for sequence_check2, Id returned- {id_returned} and expected id - 8")
 	assert id_returned == 8
 
+	# this validation check has been as added for issue - https://github.com/yugabyte/yb-voyager/issues/632
+	SEQUENCE_NAMES = ["sequence_check1_id_seq", "sequence_check2_id_seq", "sequence_check3_id_seq"]
+	SEQUENCE_OWNER_COLUMNS = ["sequence_check1.id", "sequence_check2.id", "sequence_check3.id"]
+	
+	for i in range(len(SEQUENCE_NAMES)):
+		FETCH_SEQUENCE_OWNER_QUERY = f"""SELECT CONCAT(d.refobjid::regclass, '.', a.attname)
+FROM   pg_depend    d
+JOIN   pg_attribute a ON a.attrelid = d.refobjid
+AND a.attnum   = d.refobjsubid
+WHERE  d.objid = '{SEQUENCE_NAMES[i]}'::regclass
+AND    d.refobjsubid > 0
+AND    d.classid = 'pg_class'::regclass"""
+		FETCHED_SEQUENCE_OWNER_COLUMN = tgt.execute_query(FETCH_SEQUENCE_OWNER_QUERY)
 
+		print(f"fetched owner column of sequence {SEQUENCE_NAMES[i]} is: {SEQUENCE_OWNER_COLUMNS[i]}, expected owner: {FETCHED_SEQUENCE_OWNER_COLUMN}")
+		assert FETCHED_SEQUENCE_OWNER_COLUMN == SEQUENCE_OWNER_COLUMNS[i]
+ 
 
 if __name__ == "__main__":
 	main()

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -94,7 +94,8 @@ func importSchema() {
 		switch objType {
 		case "SEQUENCE":
 			// ALTER TABLE table_name ALTER COLUMN column_name ... ('sequence_name');
-			return strings.HasPrefix(stmt, "ALTER TABLE")
+			// ALTER SEQUENCE sequence_name OWNED BY table_name.column_name;
+			return strings.HasPrefix(stmt, "ALTER TABLE") || strings.HasPrefix(stmt, "ALTER SEQUENCE")
 		case "TABLE":
 			// skips the ALTER TABLE table_name ADD CONSTRAINT constraint_name FOREIGN KEY (column_name) REFERENCES another_table_name(another_column_name);
 			return strings.Contains(stmt, "ALTER TABLE") && strings.Contains(stmt, "FOREIGN KEY")

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -118,9 +118,11 @@ func parseSchemaFile(exportDir string) int {
 			delimiterLine := lines[delimiterIndexes[i]]
 			sqlType := extractSqlTypeFromComment(delimiterLine)
 			switch sqlType {
-			case "SCHEMA", "TYPE", "DOMAIN", "SEQUENCE", "RULE", "FUNCTION",
+			case "SCHEMA", "TYPE", "DOMAIN", "RULE", "FUNCTION",
 				"AGGREGATE", "PROCEDURE", "VIEW", "TRIGGER", "EXTENSION", "COMMENT":
 				objSqlStmts[sqlType].WriteString(stmts)
+			case "SEQUENCE", "SEQUENCE OWNED BY":
+				objSqlStmts["SEQUENCE"].WriteString(stmts)
 			case "INDEX", "INDEX ATTACH":
 				objSqlStmts["INDEX"].WriteString(stmts)
 			case "TABLE", "DEFAULT", "CONSTRAINT", "FK CONSTRAINT":


### PR DESCRIPTION
For example: 
```
ALTER SEQUENCE public.users_user_id_seq OWNED BY public.users.user_id;
```

These DDLs should be a part of `sequence.sql` ideally, but they should run after the TABLE creation.
So, now we will run `ALTER SEQUENCE` stmts at the end of the import schema after everything is done along with `ALTER TABLE` statements

Testing: Added a commit, to check the fetched owner with the expected owner of the sequences
