### PR TITLE
Fixes #640 Upper/Mixed case issue with target-db-schema

### DIFF
--- a/migtests/tests/mysql-tests/mysql-constraints/env.sh
+++ b/migtests/tests/mysql-tests/mysql-constraints/env.sh
@@ -1,2 +1,3 @@
 export SOURCE_DB_TYPE="mysql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"mysql_constraints"}
+export TARGET_DB_SCHEMA="Test_Mysql_Constraints"

--- a/migtests/tests/mysql-tests/mysql-constraints/validate
+++ b/migtests/tests/mysql-tests/mysql-constraints/validate
@@ -18,30 +18,30 @@ EXPECTED_ROW_COUNT = {
 }
 QUERIES_CHECK = {
 	'NULL_CHECK': {
-		'query': "insert into not_null_check(id, first_name, last_name, email, gender, ip_address) values (7, NULL, 'something', 'msomething@java.com', 'Female', '230.188.87.42');",
+		'query': "insert into test_mysql_constraints.not_null_check(id, first_name, last_name, email, gender, ip_address) values (7, NULL, 'something', 'msomething@java.com', 'Female', '230.188.87.42');",
 		'code': 23502
 	}, 
 	'UNIQUE_CHECK': {
-		'query': "insert into unique_test(id, first_name, last_name, email, gender, ip_address) values (8, 'Milzie', 'something', 'msomething@java.com', 'Female', '230.188.87.42');",
+		'query': "insert into test_mysql_constraints.unique_test(id, first_name, last_name, email, gender, ip_address) values (8, 'Milzie', 'something', 'msomething@java.com', 'Female', '230.188.87.42');",
 		'code': 23505
 	},
 	'CHECK_CONDITION': {
-		'query': "insert into check_test (id, first_name, last_name, age) values (7, 'Tom', 'Stewan', 15);",
+		'query': "insert into test_mysql_constraints.check_test (id, first_name, last_name, age) values (7, 'Tom', 'Stewan', 15);",
 		'code': 23514
 	},
 	'FORIEGN_CHECK': {
-		'query': "insert into foreign_test values (5,1,7);",
+		'query': "insert into test_mysql_constraints.foreign_test values (5,1,7);",
 		'code': 23503
 	}
 }	
 
 def migration_completed_checks(tgt):
-	table_list = tgt.get_table_names("public")
+	table_list = tgt.get_table_names("test_mysql_constraints")
 	print("table_list:", table_list)
 	assert len(table_list) == 6
 
 
-	got_row_count = tgt.row_count_of_all_tables("public")
+	got_row_count = tgt.row_count_of_all_tables("test_mysql_constraints")
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():
 		print(f"table_name: {table_name}, row_count: {got_row_count[table_name]}")
 		assert row_count == got_row_count[table_name]
@@ -52,11 +52,11 @@ def migration_completed_checks(tgt):
 		print(f"Checking {type_check} ..", code, {chk_err_returned} )
 		assert chk_err_returned == True
 		
-	DEFAULT_CHECK_QUERY = "insert into default_test (first_name, last_name) values ('Yugabyte', 'Rohlfing');"
+	DEFAULT_CHECK_QUERY = "insert into test_mysql_constraints.default_test (first_name, last_name) values ('Yugabyte', 'Rohlfing');"
 	chk_err_default_constraint = tgt.run_query_and_chk_error(DEFAULT_CHECK_QUERY, None)
 	assert chk_err_default_constraint == False
 
-	SELECT__DEFAULT_ID_QUERY = f"select age from public.default_test where first_name = 'Yugabyte';"
+	SELECT__DEFAULT_ID_QUERY = f"select age from test_mysql_constraints.default_test where first_name = 'Yugabyte';"
 	age_returned = tgt.execute_query(SELECT__DEFAULT_ID_QUERY)
 	print(f"for {table_name}, Age returned- {age_returned} and expected age - {18}")
 	assert age_returned == 18

--- a/migtests/tests/mysql-tests/mysql-indexes/env.sh
+++ b/migtests/tests/mysql-tests/mysql-indexes/env.sh
@@ -1,2 +1,3 @@
 export SOURCE_DB_TYPE="mysql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"mysql_indexes"}
+export TARGET_DB_SCHEMA="TEST_MYSQL_INDEXES"

--- a/migtests/tests/mysql-tests/mysql-indexes/validate
+++ b/migtests/tests/mysql-tests/mysql-indexes/validate
@@ -27,16 +27,16 @@ EXPECTED_INDEX_COUNT = {
 }
 
 def migration_completed_checks(tgt):
-	table_list = tgt.get_table_names("public")
+	table_list = tgt.get_table_names("test_mysql_indexes")
 	print("table_list:", table_list)
 	assert len(table_list) == 6
 
-	got_row_count = tgt.row_count_of_all_tables("public")
+	got_row_count = tgt.row_count_of_all_tables("test_mysql_indexes")
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():
 		print(f"table_name: {table_name}, row_count: {got_row_count[table_name]}")
 		assert row_count == got_row_count[table_name]
 
-	get_index_cnt = tgt.get_count_index_on_table("public")
+	get_index_cnt = tgt.get_count_index_on_table("test_mysql_indexes")
 	for table_name, index_count in EXPECTED_INDEX_COUNT.items():
 		print(f"table_name: {table_name}, index_count: {get_index_cnt[table_name]}")
 		assert index_count == get_index_cnt[table_name]

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -297,6 +297,7 @@ func importData() {
 	if err != nil {
 		utils.ErrExit("Failed to connect to the target DB: %s", err)
 	}
+	target.Schema = strings.ToLower(target.Schema)
 	targetDBVersion := target.DB().GetVersion()
 	fmt.Printf("Target YugabyteDB version: %s\n", targetDBVersion)
 
@@ -1357,5 +1358,4 @@ func init() {
 	registerCommonGlobalFlags(importDataCmd)
 	registerCommonImportFlags(importDataCmd)
 	registerImportDataFlags(importDataCmd)
-	target.Schema = strings.ToLower(target.Schema)
 }

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -281,7 +281,6 @@ func init() {
 	importDataCmd.AddCommand(importDataFileCmd)
 	registerCommonImportFlags(importDataFileCmd)
 	registerImportDataFlags(importDataFileCmd)
-	target.Schema = strings.ToLower(target.Schema)
 
 	importDataFileCmd.Flags().StringVar(&fileFormat, "format", "csv",
 		fmt.Sprintf("supported data file types: %s", supportedFileFormats))

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -52,7 +52,6 @@ func init() {
 	registerCommonGlobalFlags(importSchemaCmd)
 	registerCommonImportFlags(importSchemaCmd)
 	registerImportSchemaFlags(importSchemaCmd)
-	target.Schema = strings.ToLower(target.Schema)
 }
 
 var flagPostImportData bool
@@ -63,6 +62,7 @@ func importSchema() {
 	if err != nil {
 		utils.ErrExit("Failed to connect to target YB cluster: %s", err)
 	}
+	target.Schema = strings.ToLower(target.Schema)
 	conn := target.DB().Conn()
 	targetDBVersion := target.DB().GetVersion()
 	utils.PrintAndLog("YugabyteDB version: %s\n", targetDBVersion)


### PR DESCRIPTION
Fixes - #640 
Issue - When schema name in target-db-schema is passed in Mixed/Upper case throwing error schema not exist, bcz schema was not being converted into lower.

Fix - changed the line of converting the target-db-schema in lower to main functions of commands, which executed first when command start its working.

Test cases - Added cases in MySQL for Mixed and Upper both.