### PR TITLE
fix the failing go build, due to package path/filepath not imported in importSchema.go

### DIFF
--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/jackc/pgx/v4"


### PR DESCRIPTION
Fix failing go build on main.