### PR TITLE
Exit early when partitions are empty during export data

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -113,8 +113,8 @@ func exportDataOffline() bool {
 	}
 
 	exportDataStart := make(chan bool)
-	quitChan := make(chan bool)          //for checking failure/errors of the parallel goroutines
-	exportSuccessChan := make(chan bool) //Check if underlying tool has exited successfully.
+	quitChan := make(chan bool)             //for checking failure/errors of the parallel goroutines
+	exportSuccessChan := make(chan bool, 1) //Check if underlying tool has exited successfully.
 	go func() {
 		q := <-quitChan
 		if q {
@@ -147,9 +147,6 @@ func exportDataOffline() bool {
 	if !disablePb {
 		utils.WaitGroup.Add(1)
 		exportDataStatus(ctx, tablesProgressMetadata, quitChan, exportSuccessChan)
-	} else if source.DBType == MYSQL || source.DBType == ORACLE {
-		// TODO: Update tables metadata when PB are disabled.
-		<-exportSuccessChan
 	}
 
 	utils.WaitGroup.Wait() // waiting for the dump and progress bars to complete

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -147,6 +147,9 @@ func exportDataOffline() bool {
 	if !disablePb {
 		utils.WaitGroup.Add(1)
 		exportDataStatus(ctx, tablesProgressMetadata, quitChan, exportSuccessChan)
+	} else {
+		// TODO: Update tables metadata when PB are disabled.
+		<-exportSuccessChan
 	}
 
 	utils.WaitGroup.Wait() // waiting for the dump and progress bars to complete

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -147,7 +147,7 @@ func exportDataOffline() bool {
 	if !disablePb {
 		utils.WaitGroup.Add(1)
 		exportDataStatus(ctx, tablesProgressMetadata, quitChan, exportSuccessChan)
-	} else {
+	} else if source.DBType == MYSQL || source.DBType == ORACLE {
 		// TODO: Update tables metadata when PB are disabled.
 		<-exportSuccessChan
 	}

--- a/yb-voyager/cmd/exportDataStatus.go
+++ b/yb-voyager/cmd/exportDataStatus.go
@@ -105,15 +105,22 @@ func initializeExportTablePartitionMetadata(tableList []string) {
 	}
 }
 
-func exportDataStatus(ctx context.Context, tablesProgressMetadata map[string]*utils.TableProgressMetadata, quitChan chan bool) {
+func exportDataStatus(ctx context.Context, tablesProgressMetadata map[string]*utils.TableProgressMetadata, quitChan, exportSuccessChan chan bool) {
 	defer utils.WaitGroup.Done()
+	// TODO: Figure out if we require quitChan2 (along with the entire goroutine below which updates quitChan).
 	quitChan2 := make(chan bool)
 	quit := false
+	updateMetadataAndExit := false
+	safeExit := false
 	go func() {
 		quit = <-quitChan2
 		if quit {
 			quitChan <- true
 		}
+	}()
+
+	go func() {
+		updateMetadataAndExit = <-exportSuccessChan
 	}()
 
 	numTables := len(tablesProgressMetadata)
@@ -122,7 +129,7 @@ func exportDataStatus(ctx context.Context, tablesProgressMetadata map[string]*ut
 	doneCount := 0
 	var exportedTables []string
 	sortedKeys := utils.GetSortedKeys(tablesProgressMetadata)
-	for doneCount < numTables && !quit { //TODO: wait for export data to start
+	for doneCount < numTables && !quit && !safeExit { //TODO: wait for export data to start
 		for _, key := range sortedKeys {
 			if quit {
 				break
@@ -152,13 +159,20 @@ func exportDataStatus(ctx context.Context, tablesProgressMetadata map[string]*ut
 			fmt.Println(ctx.Err())
 			break
 		}
+		// Wait for metadata to update and then exit (fix for empty partitions in MySQL, Oracle)
+		if updateMetadataAndExit && (source.DBType == MYSQL || source.DBType == ORACLE) {
+			safeExit = true
+			for _, key := range sortedKeys {
+				if tablesProgressMetadata[key].Status == utils.TABLE_MIGRATION_IN_PROGRESS || tablesProgressMetadata[key].Status == utils.TABLE_MIGRATION_DONE {
+					safeExit = false
+					break
+				}
+			}
+		}
 		time.Sleep(1 * time.Second)
 	}
-
 	progressContainer.Wait() //shouldn't be needed as the previous loop is doing the same
-
 	printExportedTables(exportedTables)
-
 	//TODO: print remaining/unable-to-export tables
 }
 

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -161,8 +161,8 @@ func (ms *MySQL) ExportSchema(exportDir string) {
 	ora2pgExtractSchema(ms.source, exportDir)
 }
 
-func (ms *MySQL) ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool) {
-	ora2pgExportDataOffline(ctx, ms.source, exportDir, tableList, quitChan, exportDataStart)
+func (ms *MySQL) ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart, exportSuccessChan chan bool) {
+	ora2pgExportDataOffline(ctx, ms.source, exportDir, tableList, quitChan, exportDataStart, exportSuccessChan)
 }
 
 func (ms *MySQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {

--- a/yb-voyager/src/srcdb/ora2pg_export_data.go
+++ b/yb-voyager/src/srcdb/ora2pg_export_data.go
@@ -59,7 +59,7 @@ func updateOra2pgConfigFileForExportData(configFilePath string, source *Source, 
 	}
 }
 
-func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool) {
+func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool, exportSuccessChan chan bool) {
 	defer utils.WaitGroup.Done()
 
 	configFilePath := filepath.Join(exportDir, "temp", ".ora2pg.conf")
@@ -97,6 +97,7 @@ func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir stri
 
 	// move to ALTER SEQUENCE commands to postdata.sql file
 	extractAlterSequenceStatements(exportDir)
+	exportSuccessChan <- true
 }
 
 func extractAlterSequenceStatements(exportDir string) {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -161,8 +161,8 @@ func (ora *Oracle) ExportSchema(exportDir string) {
 	ora2pgExtractSchema(ora.source, exportDir)
 }
 
-func (ora *Oracle) ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool) {
-	ora2pgExportDataOffline(ctx, ora.source, exportDir, tableList, quitChan, exportDataStart)
+func (ora *Oracle) ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart, exportSuccessChan chan bool) {
+	ora2pgExportDataOffline(ctx, ora.source, exportDir, tableList, quitChan, exportDataStart, exportSuccessChan)
 }
 
 func (ora *Oracle) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -29,7 +29,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
-func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri string, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool) {
+func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri string, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool, exportSuccessChan chan bool) {
 	defer utils.WaitGroup.Done()
 
 	dataDirPath := exportDir + "/data"
@@ -79,6 +79,7 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 		quitChan <- true
 		runtime.Goexit()
 	}
+	exportSuccessChan <- true
 }
 
 func parseAndCreateTocTextFile(dataDirPath string) {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -81,7 +81,7 @@ func (pg *PostgreSQL) GetVersion() string {
 	return version
 }
 
-func (pg *PostgreSQL) checkSchemasExists() []string{
+func (pg *PostgreSQL) checkSchemasExists() []string {
 	list := strings.Split(pg.source.Schema, "|")
 	var trimmedList []string
 	for _, schema := range list {
@@ -175,8 +175,8 @@ func (pg *PostgreSQL) ExportSchema(exportDir string) {
 	pgdumpExtractSchema(pg.source, pg.getConnectionUri(), exportDir)
 }
 
-func (pg *PostgreSQL) ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool) {
-	pgdumpExportDataOffline(ctx, pg.source, pg.getConnectionUri(), exportDir, tableList, quitChan, exportDataStart)
+func (pg *PostgreSQL) ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart, exportSuccessChan chan bool) {
+	pgdumpExportDataOffline(ctx, pg.source, pg.getConnectionUri(), exportDir, tableList, quitChan, exportDataStart) // No need to use exportSuccessChan
 }
 
 func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -176,7 +176,7 @@ func (pg *PostgreSQL) ExportSchema(exportDir string) {
 }
 
 func (pg *PostgreSQL) ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart, exportSuccessChan chan bool) {
-	pgdumpExportDataOffline(ctx, pg.source, pg.getConnectionUri(), exportDir, tableList, quitChan, exportDataStart) // No need to use exportSuccessChan
+	pgdumpExportDataOffline(ctx, pg.source, pg.getConnectionUri(), exportDir, tableList, quitChan, exportDataStart, exportSuccessChan)
 }
 
 func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -16,7 +16,7 @@ type SourceDB interface {
 	GetAllTableNames() []string
 	GetAllPartitionNames(tableName string) []string
 	ExportSchema(exportDir string)
-	ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool)
+	ExportData(ctx context.Context, exportDir string, tableList []string, quitChan chan bool, exportDataStart chan bool, exportSuccessChan chan bool)
 	ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata)
 	GetCharset() (string, error)
 }


### PR DESCRIPTION
[Fixes #668]
During export data, if a partition is empty (contains no data within it), yb-voyager would hang, expecting a file corresponding to this partition to be exported. ora2pg no longer exports data files for empty partitions, owing to the need for this patch to be brought up.
This patch adds a new channel which allows us to know when `ora2pg` has successfully exit, making use of which, we can allow `yb-voyager` to safely exit.
Automation tests for the same to be covered as a part of #451 