### PR TITLE
Fixed Bug #585 and enhances the behaviour to use reachable yb servers

### DIFF
--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -290,7 +290,8 @@ func LookupIP(name string) []string {
 
 	ips, err := net.LookupIP(name)
 	if err != nil {
-		ErrExit("Error Resolving name=%s: %v", name, err)
+		log.Infof("Error Resolving name=%s: %v", name, err)
+		return []string{name}
 	}
 
 	for _, ip := range ips {

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -227,7 +227,7 @@ func GetObjectDirPath(schemaDirPath string, objType string) string {
 
 func GetObjectFilePath(schemaDirPath string, objType string) string {
 	var requiredPath string
-	if objType == "INDEX" || objType == "UNIQUE INDEX"{
+	if objType == "INDEX" || objType == "UNIQUE INDEX" {
 		requiredPath = filepath.Join(schemaDirPath, "tables", "INDEXES_table.sql")
 	} else if objType == "FTS_INDEX" {
 		requiredPath = filepath.Join(schemaDirPath, "tables", "FTS_INDEXES_table.sql")
@@ -291,7 +291,7 @@ func LookupIP(name string) []string {
 	ips, err := net.LookupIP(name)
 	if err != nil {
 		log.Infof("Error Resolving name=%s: %v", name, err)
-		return []string{name}
+		return result
 	}
 
 	for _, ip := range ips {


### PR DESCRIPTION
First commit: fixes bug #585
Second commit: change the import data behavior to use the reachable servers instead of using all and failing, if not all.


Testing:
1. Tested a scenario where the output of the yb_servers() gives the DNS of servers which is not resolvable from the client machine, so the provided `target-db-host` is just used for importData
2. Cluster on YB Cloud where LB is present
3. Normal cluster without a load balancer