### PR TITLE
Added the workarounds for Synonym export from Oracle in analyze-schema in Details section

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -672,7 +672,7 @@ func initializeSummaryMap() {
 		if objType == "PACKAGE" {
 			summaryMap[objType].details["Packages in oracle are exported as schema, please review and edit them(if needed) to match your requirements"] = true
 		} else if objType == "SYNONYM" {
-			summaryMap[objType].details["Synonyms in oracle are exported as view, please review and edit them(if needed) to match your requirements"] = true
+			summaryMap[objType].details["\nSynonyms in oracle are exported as view with full classified name of the object which may have source schema name with object name, which will not be present by default and required to be present in the target database. \nHere are two workarounds, modify the DDLs as per requirement using any of these: \n- Create the schema mentioned in object names and the objects required in that Schema used in those DDLs on the target database.\n- Remove the schema name from all the object names from the DDLs and then it will execute that DDL in the respective target-db-schema passed."] = true
 		}
 	}
 


### PR DESCRIPTION
Added more details for #673 in analyze-schema in Details section of `SYNONYM` object. Here is the screenshot for that in the analyze report - 


<img width="1623" alt="Screenshot 2022-12-16 at 4 00 10 PM" src="https://user-images.githubusercontent.com/95338382/208078997-2a604b3c-74c1-4d8c-81cf-79d5fdb53cf5.png">
