### PR TITLE
Refactored Import Schema Code for print 

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -21,8 +21,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"sort"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
@@ -82,20 +82,20 @@ var (
 	dropSeqRegex       = regexp.MustCompile(`(?i)DROP SEQUENCE (IF EXISTS )?[a-zA-Z0-9_."]+[ ]*(,)([ ]*(,)?[ ]*[a-zA-Z0-9_."]+)+`)
 	dropForeignRegex   = regexp.MustCompile(`(?i)DROP FOREIGN TABLE (IF EXISTS )?[a-zA-Z0-9_."]+[ ]*(,)([ ]*(,)?[ ]*[a-zA-Z0-9_."]+)+`)
 	// dropMatViewRegex   = regexp.MustCompile("(?i)DROP MATERIALIZED VIEW")
-	createIdxConcurRegex = regexp.MustCompile(`(?i)CREATE (UNIQUE )?INDEX CONCURRENTLY (IF NOT EXISTS )?([a-zA-Z0-9_."]+)`)
-	dropIdxConcurRegex   = regexp.MustCompile(`(?i)DROP INDEX CONCURRENTLY (IF EXISTS )?([a-zA-Z0-9_."]+)`)
-	trigRefRegex         = regexp.MustCompile(`(?i)CREATE TRIGGER ([a-zA-Z0-9_."]+).*REFERENCING`)
-	constrTrgRegex       = regexp.MustCompile(`(?i)CREATE CONSTRAINT TRIGGER ([a-zA-Z0-9_."]+)`)
-	currentOfRegex       = regexp.MustCompile(`(?i)WHERE CURRENT OF`)
-	amRegex              = regexp.MustCompile(`(?i)CREATE ACCESS METHOD ([a-zA-Z0-9_."]+)`)
-	idxConcRegex         = regexp.MustCompile(`(?i)REINDEX .*CONCURRENTLY ([a-zA-Z0-9_."]+)`)
-	storedRegex          = regexp.MustCompile(`(?i)([a-zA-Z0-9_]+) [a-zA-Z0-9_]+ GENERATED ALWAYS .* STORED`)
-	partitionColumnsRegex           = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS)?([a-zA-Z0-9_."]+) ([^,]+(?:,[^,]+){0,}) PARTITION BY ([A-Za-z]+) ([^,]+(?:,[^,]+){0,}) ;`)
-	likeAllRegex         = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*LIKE .*INCLUDING ALL`)
-	likeRegex            = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*\(like`)
-	inheritRegex         = regexp.MustCompile(`(?i)CREATE ([a-zA-Z_]+ )?TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+).*INHERITS[ |(]`)
-	withOidsRegex        = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*WITH OIDS`)
-	intvlRegex           = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*interval PRIMARY`)
+	createIdxConcurRegex  = regexp.MustCompile(`(?i)CREATE (UNIQUE )?INDEX CONCURRENTLY (IF NOT EXISTS )?([a-zA-Z0-9_."]+)`)
+	dropIdxConcurRegex    = regexp.MustCompile(`(?i)DROP INDEX CONCURRENTLY (IF EXISTS )?([a-zA-Z0-9_."]+)`)
+	trigRefRegex          = regexp.MustCompile(`(?i)CREATE TRIGGER ([a-zA-Z0-9_."]+).*REFERENCING`)
+	constrTrgRegex        = regexp.MustCompile(`(?i)CREATE CONSTRAINT TRIGGER ([a-zA-Z0-9_."]+)`)
+	currentOfRegex        = regexp.MustCompile(`(?i)WHERE CURRENT OF`)
+	amRegex               = regexp.MustCompile(`(?i)CREATE ACCESS METHOD ([a-zA-Z0-9_."]+)`)
+	idxConcRegex          = regexp.MustCompile(`(?i)REINDEX .*CONCURRENTLY ([a-zA-Z0-9_."]+)`)
+	storedRegex           = regexp.MustCompile(`(?i)([a-zA-Z0-9_]+) [a-zA-Z0-9_]+ GENERATED ALWAYS .* STORED`)
+	partitionColumnsRegex = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS)?([a-zA-Z0-9_."]+) ([^,]+(?:,[^,]+){0,}) PARTITION BY ([A-Za-z]+) ([^,]+(?:,[^,]+){0,}) ;`)
+	likeAllRegex          = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*LIKE .*INCLUDING ALL`)
+	likeRegex             = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*\(like`)
+	inheritRegex          = regexp.MustCompile(`(?i)CREATE ([a-zA-Z_]+ )?TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+).*INHERITS[ |(]`)
+	withOidsRegex         = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*WITH OIDS`)
+	intvlRegex            = regexp.MustCompile(`(?i)CREATE TABLE (IF NOT EXISTS )?([a-zA-Z0-9_."]+) .*interval PRIMARY`)
 	//super user role required, language c is errored as unsafe
 	cLangRegex = regexp.MustCompile(`(?i)CREATE (OR REPLACE )?FUNCTION ([a-zA-Z0-9_."]+).*language c`)
 
@@ -466,7 +466,7 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 				idxInPrimaryKeyColumns := sort.SearchStrings(primaryKeyColumnsList, eachPartitionColumn)
 				if idxInPrimaryKeyColumns == len(primaryKeyColumnsList) || primaryKeyColumnsList[idxInPrimaryKeyColumns] != eachPartitionColumn {
 					reportCase(fpath, "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE",
-				"https://github.com/yugabyte/yb-voyager/issues/578", "Add all Partition columns to Primary Key", "TABLE", regMatch[2], sqlInfo.formattedStmt)
+						"https://github.com/yugabyte/yb-voyager/issues/578", "Add all Partition columns to Primary Key", "TABLE", regMatch[2], sqlInfo.formattedStmt)
 				}
 			}
 		}
@@ -559,7 +559,7 @@ func getCreateObjRegex(objType string) (*regexp.Regexp, int) {
 	return createObjRegex, objNameIndex
 }
 
-func processCollectedSql(fpath string, stmt *string, formattedStmt *string, objType string, sqlInfoArr *[]sqlInfo, reportNextSql *int) {
+func processCollectedSql(fpath string, stmt *string, formattedStmt *string, objType string, sqlInfoArr *[]sqlInfo, reportNextSql *int, skipFn func(string, string) bool) {
 	createObjRegex, objNameIndex := getCreateObjRegex(objType)
 	var objName = "" // to extract from sql statement
 
@@ -585,12 +585,15 @@ func processCollectedSql(fpath string, stmt *string, formattedStmt *string, objT
 		stmt:          *stmt,
 		formattedStmt: *formattedStmt,
 	}
-	*sqlInfoArr = append(*sqlInfoArr, sqlInfo)
+
+	if skipFn != nil && !skipFn(objType, sqlInfo.stmt) {
+		*sqlInfoArr = append(*sqlInfoArr, sqlInfo)
+	}
 	(*stmt) = ""
 	(*formattedStmt) = ""
 }
 
-func createSqlStrInfoArray(path string, objType string) []sqlInfo {
+func createSqlStrInfoArray(path string, objType string, skipFn func(string, string) bool) []sqlInfo {
 	log.Infof("Reading %s in dir %s", objType, path)
 
 	var sqlInfoArr []sqlInfo
@@ -637,7 +640,7 @@ func createSqlStrInfoArray(path string, objType string) []sqlInfo {
 				codeBlockDelimiter = matches[0]
 			} else if strings.Contains(currLine, ";") { // in case, there is no body part
 				//one liner sql string created, now will check for obj count and report cases
-				processCollectedSql(path, &stmt, &formattedStmt, objType, &sqlInfoArr, &reportNextSql)
+				processCollectedSql(path, &stmt, &formattedStmt, objType, &sqlInfoArr, &reportNextSql, skipFn)
 			}
 		} else if dollarQuoteFlag == 1 {
 			if strings.Contains(currLine, codeBlockDelimiter) {
@@ -646,7 +649,7 @@ func createSqlStrInfoArray(path string, objType string) []sqlInfo {
 		}
 		if dollarQuoteFlag == 2 {
 			if strings.Contains(currLine, ";") {
-				processCollectedSql(path, &stmt, &formattedStmt, objType, &sqlInfoArr, &reportNextSql)
+				processCollectedSql(path, &stmt, &formattedStmt, objType, &sqlInfoArr, &reportNextSql, skipFn)
 				//reset for parsing other sqls
 				dollarQuoteFlag = 0
 				codeBlockDelimiter = ""
@@ -801,7 +804,7 @@ func analyzeSchemaInternal() utils.Report {
 			continue
 		}
 
-		sqlInfoArr := createSqlStrInfoArray(filePath, objType)
+		sqlInfoArr := createSqlStrInfoArray(filePath, objType, nil)
 		// fmt.Printf("SqlStrArray for '%s' is: %v\n", objType, sqlInfoArr)
 		checker(sqlInfoArr, filePath)
 	}

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -586,7 +586,7 @@ func processCollectedSql(fpath string, stmt *string, formattedStmt *string, objT
 		formattedStmt: *formattedStmt,
 	}
 
-	if skipFn != nil && !skipFn(objType, sqlInfo.stmt) {
+	if skipFn == nil || (skipFn != nil && !skipFn(objType, sqlInfo.stmt)) {
 		*sqlInfoArr = append(*sqlInfoArr, sqlInfo)
 	}
 	(*stmt) = ""

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1057,10 +1057,6 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 	}()
 
 	sqlInfoArr := createSqlStrInfoArray(file, objType, skipFn)
-	if len(sqlInfoArr) == 0 {
-		fmt.Printf("- no more DDLs to execute from %s\n", file)
-		return
-	}
 	for _, sqlInfo := range sqlInfoArr {
 		if conn == nil {
 			conn = newTargetConn()
@@ -1103,7 +1099,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 		}
 		_, err = (*conn).Exec(context.Background(), sqlInfo.formattedStmt)
 		if err == nil {
-			utils.PrintSqlStmtIfDDL(sqlInfo.stmt)
+			utils.PrintSqlStmtIfDDL(sqlInfo.stmt, utils.GetObjectFileName(filepath.Join(exportDir, "schema"), objType))
 			return nil
 		}
 
@@ -1145,7 +1141,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 		if missingRequiredSchemaObject(err) {
 			// Do nothing
 		} else {
-			utils.PrintSqlStmtIfDDL(sqlInfo.stmt)
+			utils.PrintSqlStmtIfDDL(sqlInfo.stmt, utils.GetObjectFileName(filepath.Join(exportDir, "schema"), objType))
 			color.Red(fmt.Sprintf("%s\n", err.Error()))
 			if target.ContinueOnError {
 				log.Infof("appending stmt to failedSqlStmts list: %s\n", utils.GetSqlStmtToPrint(sqlInfo.stmt))

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1056,10 +1056,16 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 		}
 	}()
 
-	sqlInfoArr := createSqlStrInfoArray(file, objType, skipFn)
+	sqlInfoArr := createSqlStrInfoArray(file, objType)
 	for _, sqlInfo := range sqlInfoArr {
 		if conn == nil {
 			conn = newTargetConn()
+		}
+
+		setOrSelectStmt := strings.HasPrefix(strings.ToUpper(sqlInfo.stmt), "SET ") ||
+			strings.HasPrefix(strings.ToUpper(sqlInfo.stmt), "SELECT ")
+		if !setOrSelectStmt && skipFn != nil && skipFn(objType, sqlInfo.stmt) {
+			continue
 		}
 
 		err := executeSqlStmtWithRetries(&conn, sqlInfo, objType)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -114,7 +114,7 @@ func importSchema() {
 	}
 	skipFn := isSkipStatement
 	importSchemaInternal(exportDir, objectList, skipFn)
-	fmt.Printf("\n\nImporting deferred DDL statements.\n")
+	
 	// Import the skipped ALTER TABLE statements from sequence.sql and table.sql if it exists
 	skipFn = func(objType, stmt string) bool {
 		return !isSkipStatement(objType, stmt)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -114,7 +114,7 @@ func importSchema() {
 	}
 	skipFn := isSkipStatement
 	importSchemaInternal(exportDir, objectList, skipFn)
-	
+
 	// Import the skipped ALTER TABLE statements from sequence.sql and table.sql if it exists
 	skipFn = func(objType, stmt string) bool {
 		return !isSkipStatement(objType, stmt)
@@ -165,6 +165,7 @@ func dumpStatements(stmts []sqlInfo, filePath string) {
 			utils.ErrExit("failed writing in file %s: %v", filePath, err)
 		}
 	}
+
 	msg := fmt.Sprintf("\nSQL statements failed during migration are present in %q file\n", filePath)
 	color.Red(msg)
 	log.Info(msg)
@@ -194,7 +195,7 @@ func getDDLStmts(objType string) []sqlInfo {
 	schemaDir := filepath.Join(exportDir, "schema")
 	importMViewFilePath := utils.GetObjectFilePath(schemaDir, objType)
 	if utils.FileOrFolderExists(importMViewFilePath) {
-		sqlInfoArr = createSqlStrInfoArray(importMViewFilePath, objType, nil)
+		sqlInfoArr = createSqlStrInfoArray(importMViewFilePath, objType)
 	}
 	return sqlInfoArr
 }

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -141,7 +141,6 @@ func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	} else {
 		finalImportObjectList = utils.SetDifference(importObjectOrderList, excludeObjectList)
 	}
-
 	if sourceDBType == "postgresql" && !slices.Contains(finalImportObjectList, "SCHEMA") && !flagPostImportData { // Schema should be migrated by default.
 		finalImportObjectList = append([]string{"SCHEMA"}, finalImportObjectList...)
 	}

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -143,6 +143,7 @@ func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	} else {
 		finalImportObjectList = utils.SetDifference(importObjectOrderList, excludeObjectList)
 	}
+
 	if sourceDBType == "postgresql" && !slices.Contains(finalImportObjectList, "SCHEMA") && !flagPostImportData { // Schema should be migrated by default.
 		finalImportObjectList = append([]string{"SCHEMA"}, finalImportObjectList...)
 	}

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +37,6 @@ func importSchemaInternal(exportDir string, importObjectList []string,
 		if !utils.FileOrFolderExists(importObjectFilePath) {
 			continue
 		}
-		fmt.Printf("\nImporting %s DDLs from %q\n\n", importObjectType, importObjectFilePath)
 		executeSqlFile(importObjectFilePath, importObjectType, skipFn)
 	}
 

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -339,10 +339,10 @@ func GetSqlStmtToPrint(stmt string) string {
 	}
 }
 
-func PrintSqlStmtIfDDL(stmt string) {
+func PrintSqlStmtIfDDL(stmt string, fileName string) {
 	setOrSelectStmt := strings.HasPrefix(strings.ToUpper(stmt), "SET ") ||
 		strings.HasPrefix(strings.ToUpper(stmt), "SELECT ")
 	if !setOrSelectStmt {
-		fmt.Printf("%s\n", GetSqlStmtToPrint(stmt))
+		fmt.Printf("%s: %s\n", fileName, GetSqlStmtToPrint(stmt))
 	}
 }

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -338,3 +338,11 @@ func GetSqlStmtToPrint(stmt string) string {
 		return fmt.Sprintf("%s ...", stmt[:80])
 	}
 }
+
+func PrintSqlStmtIfDDL(stmt string) {
+	setOrSelectStmt := strings.HasPrefix(strings.ToUpper(stmt), "SET ") ||
+		strings.HasPrefix(strings.ToUpper(stmt), "SELECT ")
+	if !setOrSelectStmt {
+		fmt.Printf("%s\n", GetSqlStmtToPrint(stmt))
+	}
+}


### PR DESCRIPTION
1. Refactored the code to ignore DDLs based on skipFn during the parsing of `.sql` files itself.

2. Not printing of the DDLs in case of ignore exists
3. Print something if the statement is deferred due to doesn't exists error? Also currently the statement is printed on console even in case of error, which might give wrong idea to user.
2 and 3 are fixed by printing DDLs after execution

4. Print `.sql` file name along with DDL statement in import schema.