### PR TITLE
Accept file names containing whitespaces within import directives

### DIFF
--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -48,7 +48,7 @@ main() {
 
 	step "Export schema."
 	export_schema
-	find ${EXPORT_DIR}/schema -name '*.sql' | xargs grep -wh CREATE
+	find ${EXPORT_DIR}/schema -name '*.sql' -printf "'%p'\n"| xargs grep -wh CREATE
 
 	step "Analyze schema."
 	analyze_schema

--- a/migtests/tests/mysql-tests/mysql-views/mysql_views_automation.sql
+++ b/migtests/tests/mysql-tests/mysql-views/mysql_views_automation.sql
@@ -59,7 +59,14 @@ create view v3 as select a.first_name,b.last_name from view_table1 a inner join 
 
 select * from v3;
 
+drop view if exists `whitespace view`;
+
+create view `whitespace view` as select * from view_table1;
+
+select * from `whitespace view`;
+
 desc v1;
 -- desc v2;
 desc v3;
+desc `whitespace view`;
 

--- a/migtests/tests/mysql-tests/mysql-views/validate
+++ b/migtests/tests/mysql-tests/mysql-views/validate
@@ -12,7 +12,8 @@ EXPECTED_ROW_COUNT = {
 	'view_table1': 10,
 	'view_table2': 9,
 	'v1': 6,
-	'v3': 9
+	'v3': 9,
+	'"whitespace view"':10
 }
 
 def migration_completed_checks(tgt):
@@ -22,7 +23,7 @@ def migration_completed_checks(tgt):
 
 	view_list = tgt.get_objects_of_type("VIEW", "test_mysql_views")
 	print("view_list:", view_list)
-	assert len(view_list) == 2
+	assert len(view_list) == 3
 
 	
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():

--- a/migtests/tests/mysql-tests/mysql-views/validate
+++ b/migtests/tests/mysql-tests/mysql-views/validate
@@ -13,7 +13,7 @@ EXPECTED_ROW_COUNT = {
 	'view_table2': 9,
 	'v1': 6,
 	'v3': 9,
-	'"whitespace view"':10
+	'whitespace view':10
 }
 
 def migration_completed_checks(tgt):

--- a/yb-voyager/src/srcdb/common.go
+++ b/yb-voyager/src/srcdb/common.go
@@ -44,17 +44,11 @@ func processImportDirectives(fileName string) error {
 	// Create a new scanner and read the file line by line.
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line:=scanner.Text()
+		line := scanner.Text()
 		// Check if the line contains the import directive.
 		if strings.HasPrefix(line, "\\i ") {
-			// Split the line into tokens.
-			tokens := strings.Split(line, " ")
-			// Check if the line contains the correct number of tokens.
-			if len(tokens) != 2 {
-				return fmt.Errorf("invalid token count in %q: %s", fileName, line)
-			}
 			// Check if the file exists.
-			importFileName := strings.Trim(tokens[1], "'")
+			importFileName := strings.Trim(line[3:], "' ")
 			log.Infof("Inlining contents of %q in %q", importFileName, fileName)
 			if _, err = os.Stat(importFileName); err != nil {
 				return fmt.Errorf("error while opening file %s: %v", importFileName, err)
@@ -71,7 +65,7 @@ func processImportDirectives(fileName string) error {
 			}
 		} else {
 			// Write the line to the temporary file.
-			_, err = tmpFile.WriteString(line+"\n")
+			_, err = tmpFile.WriteString(line + "\n")
 			if err != nil {
 				return fmt.Errorf("write a line to %q: %w", tmpFileName, err)
 			}


### PR DESCRIPTION
When import directives (`\i 'filename.sql'`) are such that the filename contains whitespace characters, we would only take the first token, separated by whitespaces, as the entire file name while parsing it internally. This patch now regards the entire contents of the string between the two quotation marks `'` ahead of the directive `\i` as the file name to be considered.

This patch also adds a case to our automation test framework for the same.