### PR TITLE
Removed the source schema name from the fully classified object names for SYNONYMs in Oracle

### DIFF
--- a/migtests/tests/oracle-tests/ora-trunc-tests/ora-date-trunc-test/trunc_date_schema_data.sql
+++ b/migtests/tests/oracle-tests/ora-trunc-tests/ora-date-trunc-test/trunc_date_schema_data.sql
@@ -20,3 +20,5 @@ BEGIN
     INSERT INTO TRUNC_TEST_1 (d1,d2,d3,tz1,tz2) VALUES(d1_date,d2_date,d3_date,tz1_tz,tz2_ts);
 END;
 /
+
+CREATE OR REPLACE SYNONYM TEST_SYNONYM for TRUNC_TEST_1;

--- a/migtests/tests/oracle-tests/ora-trunc-tests/ora-date-trunc-test/validate
+++ b/migtests/tests/oracle-tests/ora-trunc-tests/ora-date-trunc-test/validate
@@ -16,6 +16,10 @@ def migration_completed_checks(tgt):
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():
 		print(f"table_name: {table_name}, row_count: {got_row_count[table_name]}")
 		assert row_count == got_row_count[table_name]
+	
+	view_list = tgt.get_objects_of_type("VIEW", "test_mysql_views")
+	print("view_list:", view_list)
+	assert len(view_list) == 1
 
 if __name__ == "__main__":
 	main()

--- a/yb-voyager/src/srcdb/common.go
+++ b/yb-voyager/src/srcdb/common.go
@@ -94,24 +94,18 @@ func processImportDirectives(fileName string) error {
 //
 // The following function goes through all the names from the file and replaces
 // all occurrences of `sourceSchemaName.objectName` with just `objectName`.
-func stmtsToStripSourceSchemaNames(fileName string, sourceSchema string) error {
+func stripSourceSchemaNames(fileName string, sourceSchema string) error {
 	if !utils.FileOrFolderExists(fileName) {
 		return nil
 	}
-	// Create a temporary file after appending .tmp extension to the fileName.
 	tmpFileName := fileName + ".tmp"
-	tmpFile, err := os.Create(tmpFileName)
-	if err != nil {
-		return fmt.Errorf("create %q: %w", tmpFileName, err)
-	}
-	defer tmpFile.Close()
 	fileContent, err := os.ReadFile(fileName)
 	if err != nil {
 		return fmt.Errorf("reading %q: %w", fileName, err)
 	}
-	regex := fmt.Sprintf(`(?i)("?)%s\.([a-zA-Z0-9_"]+?)`, sourceSchema)
-	regexForFullClassifiedObjName := regexp.MustCompile(regex)
-	transformedContent := regexForFullClassifiedObjName.ReplaceAllString(string(fileContent), "$1$2")
+	regStr := fmt.Sprintf(`(?i)("?)%s\.([a-zA-Z0-9_"]+?)`, sourceSchema)
+	reg := regexp.MustCompile(regStr)
+	transformedContent := reg.ReplaceAllString(string(fileContent), "$1$2")
 	err = os.WriteFile(tmpFileName, []byte(transformedContent), 0644)
 	if err != nil {
 		return fmt.Errorf("writing to %q: %w", tmpFileName, err)

--- a/yb-voyager/src/srcdb/ora2pg_extract_schema.go
+++ b/yb-voyager/src/srcdb/ora2pg_extract_schema.go
@@ -95,7 +95,7 @@ func ora2pgExtractSchema(source *Source, exportDir string) {
 			utils.ErrExit(err.Error())
 		}
 		if exportObject == "SYNONYM" {
-			if err := stmtsToStripSourceSchemaNames(utils.GetObjectFilePath(schemaDirPath, exportObject), source.Schema); err != nil {
+			if err := stripSourceSchemaNames(utils.GetObjectFilePath(schemaDirPath, exportObject), source.Schema); err != nil {
 				utils.ErrExit(err.Error())
 			}
 		}

--- a/yb-voyager/src/srcdb/ora2pg_extract_schema.go
+++ b/yb-voyager/src/srcdb/ora2pg_extract_schema.go
@@ -95,7 +95,7 @@ func ora2pgExtractSchema(source *Source, exportDir string) {
 			utils.ErrExit(err.Error())
 		}
 		if exportObject == "SYNONYM" {
-			if err := processStmtsToStripSourceSchema(utils.GetObjectFilePath(schemaDirPath, exportObject), source.Schema); err != nil {
+			if err := stmtsToStripSourceSchemaNames(utils.GetObjectFilePath(schemaDirPath, exportObject), source.Schema); err != nil {
 				utils.ErrExit(err.Error())
 			}
 		}

--- a/yb-voyager/src/srcdb/ora2pg_extract_schema.go
+++ b/yb-voyager/src/srcdb/ora2pg_extract_schema.go
@@ -94,6 +94,11 @@ func ora2pgExtractSchema(source *Source, exportDir string) {
 		if err := processImportDirectives(utils.GetObjectFilePath(schemaDirPath, exportObject)); err != nil {
 			utils.ErrExit(err.Error())
 		}
+		if exportObject == "SYNONYM" {
+			if err := processStmtsToStripSourceSchema(utils.GetObjectFilePath(schemaDirPath, exportObject), source.Schema); err != nil {
+				utils.ErrExit(err.Error())
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
Issue - While Synonym Exports from oracle it consist fully classified object names. 
Fix - remove the source-schema from object names having `sourceSchema.objectName` type object names.

Also added the test-case in automation framework for synonym.