### PR TITLE
[Fixes #654] Enable running multiple ora2pg instances concurrently.

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -201,7 +201,11 @@ func printExportedRowCount(exportedRowCount map[string]int64) {
 // setup a project having subdirs for various database objects IF NOT EXISTS
 func CreateMigrationProjectIfNotExists(dbType string, exportDir string) {
 	// TODO: add a check/prompt if any directories apart from required ones are present in export-dir
-	var projectSubdirs = []string{"schema", "data", "reports", "metainfo", "metainfo/data", "metainfo/schema", "metainfo/flags", "temp"}
+	var projectSubdirs = []string{
+		"schema", "data", "reports",
+		"metainfo", "metainfo/data", "metainfo/schema", "metainfo/flags",
+		"temp", "temp/ora2pg_temp_dir",
+	}
 
 	// log.Debugf("Creating a project directory...")
 	//Assuming export directory as a project directory

--- a/yb-voyager/src/srcdb/ora2pg_export_data.go
+++ b/yb-voyager/src/srcdb/ora2pg_export_data.go
@@ -63,14 +63,13 @@ func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir stri
 	defer utils.WaitGroup.Done()
 
 	configFilePath := filepath.Join(exportDir, "temp", ".ora2pg.conf")
+	tempDirPath := filepath.Join(exportDir, "temp", "ora2pg_temp_dir")
 	source.PopulateOra2pgConfigFile(configFilePath)
 
 	updateOra2pgConfigFileForExportData(configFilePath, source, tableList)
 
-	// TODO: ora2pg fails to export data from MySQL database when source.NumConnections is greater
-	// than 1.
-	exportDataCommandString := fmt.Sprintf("ora2pg -q -t COPY -P %d -o data.sql -b %s/data -c %s --no_header",
-		source.NumConnections, exportDir, configFilePath)
+	exportDataCommandString := fmt.Sprintf("ora2pg -q -t COPY -P %d -o data.sql -b %s/data -c %s --no_header -T %s",
+		source.NumConnections, exportDir, configFilePath, tempDirPath)
 
 	//Exporting all the tables in the schema
 	log.Infof("Executing command: %s", exportDataCommandString)


### PR DESCRIPTION
The shared `/tmp` dir was not allowing multiple instances to run concurrently.

This patch creates a `export-dir/temp/ora2pg_temp_dir` and passes it to the ora2pg using its `-T` option. This makes each ora2pg to have its own temp dir.