### PR TITLE
Added default value in cases where we silently error out while obtain…

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -239,6 +239,9 @@ func fetchDefaultParllelJobs(targets []*tgtdb.Target) int {
 		}
 		totalCores += targetCores
 	}
+	if totalCores == 0 { //if target is running on MacOS, we are unable to determine totalCores
+		return 3
+	}
 	return totalCores / 2
 }
 


### PR DESCRIPTION
…ing core count

When the target is running on a MacOS machine, we are unable to determine to core count for default parallel jobs during import data. This patch adds another failsafe for such scenarios.