### PR TITLE
Fixed analyze-schema reporting supported cases for partition table without PK

### DIFF
--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
@@ -16,8 +16,8 @@ CREATE TABLE sales (
 	PRIMARY KEY (bill_date)
 ) PARTITION BY RANGE (extract(year from date(bill_date))) ;
 
-
-CREATE TABLE t1 (
+-- this table has PK but not include all partition keys as PK, hence reported in analyze-schema
+CREATE TABLE test_1 (
 	id numeric NOT NULL,
 	country_code varchar(3),
 	record_type varchar(5),
@@ -25,18 +25,14 @@ CREATE TABLE t1 (
 	PRIMARY KEY (id)
 ) PARTITION BY LIST (country_code, record_type) ;
 
-CREATE TABLE test_1 (
-	id numeric NOT NULL,
-	country_code varchar(3),
-	record_type varchar(5)
-) PARTITION BY RANGE (id) ;
-
+-- this table has Partition but not has any PK which is supported, hence not reported in analyze-report
 CREATE TABLE test_2 (
 	id numeric,
 	country_code varchar,
 	record_type varchar(2)
 ) PARTITION BY RANGE (id) ;
 
+-- this table has Partition by list but not has any PK which is supported, hence not reported in analyze-report
 CREATE TABLE test_3 (
 	id numeric,
 	country_code varchar,

--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
@@ -25,15 +25,23 @@ CREATE TABLE test_1 (
 	PRIMARY KEY (id)
 ) PARTITION BY LIST (country_code, record_type) ;
 
--- no PK constraint, no need to report during analyze-schema
+-- all partition keys are not included in the PK constraint, to be reported during analyze-schema
 CREATE TABLE test_2 (
+	id numeric NOT NULL PRIMARY KEY,
+	country_code varchar(3),
+	record_type varchar(5),
+	descriptions varchar(50)
+) PARTITION BY LIST (country_code, record_type) ;
+
+-- no PK constraint, no need to report during analyze-schema
+CREATE TABLE test_3 (
 	id numeric,
 	country_code varchar,
 	record_type varchar(2)
 ) PARTITION BY RANGE (id) ;
 
 --  no PK constraint, no need to report during analyze-schema
-CREATE TABLE test_3 (
+CREATE TABLE test_4 (
 	id numeric,
 	country_code varchar,
 	record_type varchar

--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
@@ -16,7 +16,7 @@ CREATE TABLE sales (
 	PRIMARY KEY (bill_date)
 ) PARTITION BY RANGE (extract(year from date(bill_date))) ;
 
--- this table has PK but not include all partition keys as PK, hence reported in analyze-schema
+-- all partition keys are not included in the PK constraint, to be reported during analyze-schema
 CREATE TABLE test_1 (
 	id numeric NOT NULL,
 	country_code varchar(3),
@@ -25,14 +25,14 @@ CREATE TABLE test_1 (
 	PRIMARY KEY (id)
 ) PARTITION BY LIST (country_code, record_type) ;
 
--- this table has Partition but not has any PK which is supported, hence not reported in analyze-report
+-- no PK constraint, no need to report during analyze-schema
 CREATE TABLE test_2 (
 	id numeric,
 	country_code varchar,
 	record_type varchar(2)
 ) PARTITION BY RANGE (id) ;
 
--- this table has Partition by list but not has any PK which is supported, hence not reported in analyze-report
+--  no PK constraint, no need to report during analyze-schema
 CREATE TABLE test_3 (
 	id numeric,
 	country_code varchar,

--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
@@ -24,3 +24,21 @@ CREATE TABLE t1 (
 	descriptions varchar(50),
 	PRIMARY KEY (id)
 ) PARTITION BY LIST (country_code, record_type) ;
+
+CREATE TABLE test_1 (
+	id numeric NOT NULL,
+	country_code varchar(3),
+	record_type varchar(5)
+) PARTITION BY RANGE (id) ;
+
+CREATE TABLE test_2 (
+	id numeric,
+	country_code varchar,
+	record_type varchar(2)
+) PARTITION BY RANGE (id) ;
+
+CREATE TABLE test_3 (
+	id numeric,
+	country_code varchar,
+	record_type varchar
+) PARTITION BY LIST (id) ;

--- a/migtests/tests/analyze-schema/expected_issues.json
+++ b/migtests/tests/analyze-schema/expected_issues.json
@@ -33,9 +33,9 @@
         }, 
         {
             "objectType": "TABLE",
-            "objectName": "t1",
+            "objectName": "test_1",
             "reason": "cannot use \"list\" partition strategy with more than one column",
-            "sqlStatement": "CREATE TABLE t1 (\n\tid numeric NOT NULL,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50),\n\tPRIMARY KEY (id)\n) PARTITION BY LIST (country_code, record_type) ;",
+            "sqlStatement": "CREATE TABLE test_1 (\n\tid numeric NOT NULL,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50),\n\tPRIMARY KEY (id)\n) PARTITION BY LIST (country_code, record_type) ;",
             "suggestion": "Make it a single column partition by list or choose other supported Partitioning methods",
             "GH": "https://github.com/yugabyte/yb-voyager/issues/699"
         }

--- a/migtests/tests/analyze-schema/expected_issues.json
+++ b/migtests/tests/analyze-schema/expected_issues.json
@@ -38,5 +38,13 @@
             "sqlStatement": "CREATE TABLE test_1 (\n\tid numeric NOT NULL,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50),\n\tPRIMARY KEY (id)\n) PARTITION BY LIST (country_code, record_type) ;",
             "suggestion": "Make it a single column partition by list or choose other supported Partitioning methods",
             "GH": "https://github.com/yugabyte/yb-voyager/issues/699"
+        },
+        {
+            "objectType": "TABLE",
+            "objectName": "test_2",
+            "reason": "cannot use \"list\" partition strategy with more than one column",
+            "sqlStatement": "CREATE TABLE test_2 (\n\tid numeric NOT NULL PRIMARY KEY,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50)\n) PARTITION BY LIST (country_code, record_type) ;",
+            "suggestion": "Make it a single column partition by list or choose other supported Partitioning methods",
+            "GH": "https://github.com/yugabyte/yb-voyager/issues/699"
         }
 ]

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -461,6 +461,12 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 			partitionColumnsList := utils.CsvStringToSlice(partitionColumns)
 			primaryKeyColumnsList := utils.CsvStringToSlice(primaryKeyColumns)
 			sort.Strings(primaryKeyColumnsList)
+			if len(primaryKeyColumnsList) == 0 || len(allColumnsList) == 1 {
+				continue
+			}
+			if len(allColumnsList) > 1 && !strings.Contains(strings.ToLower(allColumnsList[len(allColumnsList)-2]), "primary key") {
+				continue
+			}
 			if len(partitionColumnsList) == 1 {
 				expressionChk := partitionColumnsList[0]
 				if strings.ContainsAny(expressionChk, "()[]{}|/!@$#%^&*-+=") {
@@ -468,7 +474,6 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 					"https://github.com/yugabyte/yb-voyager/issues/698", "Remove the Constriant from the table definition", "TABLE", regMatch[2], sqlInfo.formattedStmt)
 					continue
 				}
-
 			} 
 			if strings.ToLower(regMatch[4]) == "list" {
 				if len(partitionColumnsList) > 1 {

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -21,12 +21,12 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	"golang.org/x/exp/slices"
 
 	"os"
 	"regexp"
@@ -456,35 +456,33 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 		} else if regMatch := partitionColumnsRegex.FindStringSubmatch(sqlInfo.stmt); regMatch != nil {
 			// example1 - CREATE TABLE example1( 	id numeric NOT NULL, 	country_code varchar(3), 	record_type varchar(5), PRIMARY KEY (id) ) PARTITION BY RANGE (country_code, record_type) ; 
 			// example2 - CREATE TABLE example2 ( 	id numeric NOT NULL PRIMARY KEY, 	country_code varchar(3), 	record_type varchar(5) ) PARTITION BY RANGE (country_code, record_type) ; 
-			allColumns := strings.Trim(regMatch[3], "() ")
-			allColumnsList := utils.CsvStringToSlice(allColumns) 
+			columnList := utils.CsvStringToSlice(strings.Trim(regMatch[3], "() ")) 
 			// example1 - allColumnsList: [id numeric NOT NULL country_code varchar(3) record_type varchar(5) PRIMARY KEY (id]
 			// example2 - allColumnsList: [id numeric NOT NULL PRIMARY KEY country_code varchar(3) record_type varchar(5]
-			primaryKey := allColumnsList[len(allColumnsList)-1] 
+			primaryKey := columnList[len(columnList)-1] 
 			// example1 - primaryKey: PRIMARY KEY (id
 			// example2 - primaryKey: record_type varchar(5
 			var primaryKeyColumnsList []string
-			if !strings.Contains(strings.ToLower(primaryKey), "primary key") { //true for example2 
+			if strings.Contains(strings.ToLower(primaryKey), "primary key") { //false for example2 
+				primaryKeySplit := strings.Split(primaryKey, "(")
+				primaryKeyColumns := primaryKeySplit[1] 
+				primaryKeyColumnsList = utils.CsvStringToSlice(primaryKeyColumns)
+			} else {
 				//this case can come by manual intervention
-				for _, columnDefinition := range allColumnsList {
+				for _, columnDefinition := range columnList {
 					if strings.Contains(strings.ToLower(columnDefinition), "primary key") {
 						partsOfColumnDefinition := strings.Split(columnDefinition, " ")
 						columnName := partsOfColumnDefinition[0]
-						primaryKeyColumnsList = append(primaryKeyColumnsList, columnName) // example2 - primaryKey: [id]
+						primaryKeyColumnsList = append(primaryKeyColumnsList, columnName)
 						break
 					}
 				}
-			} else {
-				primaryKeySplit := strings.Split(primaryKey, "(")// [PRIMARY KEY  id]
-				primaryKeyColumns := primaryKeySplit[1] 
-				primaryKeyColumnsList = utils.CsvStringToSlice(primaryKeyColumns) // [id]
 			}
-			partitionColumns := strings.Trim(regMatch[5], `()`)
-			partitionColumnsList := utils.CsvStringToSlice(partitionColumns) // [country_code record_type]
-			sort.Strings(primaryKeyColumnsList)
 			if len(primaryKeyColumnsList) == 0 { // if non-PK table, then no need to report
 				continue
 			}
+			partitionColumns := strings.Trim(regMatch[5], `()`)
+			partitionColumnsList := utils.CsvStringToSlice(partitionColumns)
 			if len(partitionColumnsList) == 1 {
 				expressionChk := partitionColumnsList[0]
 				if strings.ContainsAny(expressionChk, "()[]{}|/!@$#%^&*-+=") {
@@ -493,18 +491,16 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 					continue
 				}
 			} 
-			if strings.ToLower(regMatch[4]) == "list" {
-				if len(partitionColumnsList) > 1 {
-					reportCase(fpath, `cannot use "list" partition strategy with more than one column`,
-					"https://github.com/yugabyte/yb-voyager/issues/699", "Make it a single column partition by list or choose other supported Partitioning methods", "TABLE", regMatch[2], sqlInfo.formattedStmt)
-					continue
-				} 
+			if strings.ToLower(regMatch[4]) == "list" && len(partitionColumnsList) > 1{
+				reportCase(fpath, `cannot use "list" partition strategy with more than one column`,
+				"https://github.com/yugabyte/yb-voyager/issues/699", "Make it a single column partition by list or choose other supported Partitioning methods", "TABLE", regMatch[2], sqlInfo.formattedStmt)
+				continue
 			}
 			countPartitionColumnNotInPK := 0 
-			for _, eachPartitionColumn := range partitionColumnsList {
-				idxInPrimaryKeyColumns := sort.SearchStrings(primaryKeyColumnsList, eachPartitionColumn)
-				if idxInPrimaryKeyColumns == len(primaryKeyColumnsList) || primaryKeyColumnsList[idxInPrimaryKeyColumns] != eachPartitionColumn { //partition key not in PK 
+			for _, partitionColumn := range partitionColumnsList {
+				if slices.Contains(primaryKeyColumnsList, partitionColumn) { //partition key not in PK 
 					countPartitionColumnNotInPK++
+					break
 				}
 			}
 			if countPartitionColumnNotInPK > 0 {

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -457,8 +457,8 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 			// example1 - CREATE TABLE example1( 	id numeric NOT NULL, 	country_code varchar(3), 	record_type varchar(5), PRIMARY KEY (id) ) PARTITION BY RANGE (country_code, record_type) ; 
 			// example2 - CREATE TABLE example2 ( 	id numeric NOT NULL PRIMARY KEY, 	country_code varchar(3), 	record_type varchar(5) ) PARTITION BY RANGE (country_code, record_type) ; 
 			columnList := utils.CsvStringToSlice(strings.Trim(regMatch[3], " ")) 
-			// example1 - allColumnsList: [id numeric NOT NULL country_code varchar(3) record_type varchar(5) PRIMARY KEY (id]
-			// example2 - allColumnsList: [id numeric NOT NULL PRIMARY KEY country_code varchar(3) record_type varchar(5]
+			// example1 - columnList: [id numeric NOT NULL country_code varchar(3) record_type varchar(5) PRIMARY KEY (id]
+			// example2 - columnList: [id numeric NOT NULL PRIMARY KEY country_code varchar(3) record_type varchar(5]
 			primaryKey := columnList[len(columnList)-1] 
 			// example1 - primaryKey: PRIMARY KEY (id
 			// example2 - primaryKey: record_type varchar(5


### PR DESCRIPTION
Fixed analyze-schema reporting supported cases for partition table without PK and added the test cases in automation which will not come in analyze report now.
Fix - checking if PrimaryColumnList is empty or in create table definition `PRIMARY KEY(col1, col2)` is not there.