### PR TITLE
Added context mesaage for incorrect format error during COPY

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -956,8 +956,7 @@ func importSplit(conn *pgx.Conn, task *SplitFileImportTask, file *os.File, copyC
 	if err != nil {
 		var pgerr *pgconn.PgError
 		if errors.As(err, &pgerr) {
-			err = fmt.Errorf("%s, %s", err.Error(), pgerr.Where)
-			return res.RowsAffected(), err
+			err = fmt.Errorf("%s, %s in %s", err.Error(), pgerr.Where, task.SplitFilePath)
 		}
 		return res.RowsAffected(), err
 	}

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -303,11 +303,9 @@ func LookupIP(name string) []string {
 func InsensitiveSliceContains(slice []string, s string) bool {
 	for i := 0; i < len(slice); i++ {
 		if strings.Contains(strings.ToLower(s), strings.ToLower(slice[i])) {
-			log.Infof("string s=%q contains slice[i]=%q", s, slice[i])
 			return true
 		}
 	}
-	log.Infof("string s=%q did not match with any string in %v", s, slice)
 	return false
 }
 


### PR DESCRIPTION
This patch appends the context of the line number in the data file whenever there is a formatting error in a data file being copied from.