### PR TITLE
Added a function to drop orafce in yb.py and used it before running validations of oracle/datatypes

### DIFF
--- a/migtests/lib/yb.py
+++ b/migtests/lib/yb.py
@@ -180,3 +180,7 @@ class PostgresDB:
 		cur = self.conn.cursor()
 		cur.execute(f"SELECT schema_name FROM information_schema.schemata where schema_name !~ '^pg_' and schema_name <> 'information_schema'")
 		return set(cur.fetchall())
+
+	def drop_orafce(self):
+		cur = self.conn.cursor()
+		cur.execute(f"DROP EXTENSION orafce CASCADE")

--- a/migtests/tests/oracle/datatypes/validate
+++ b/migtests/tests/oracle/datatypes/validate
@@ -80,6 +80,8 @@ EXPECTED_DATA_TYPES = {
 
 def migration_completed_checks(tgt):
 	# Validation to check for matching row counts
+	tgt.drop_orafce()
+ 
 	got_row_count = tgt.row_count_of_all_tables("public")
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():
 		print(f"table_name: {table_name}, row_count: {got_row_count[table_name]}")


### PR DESCRIPTION
While running the `validations` for `datatypes` test in `oracle`, we need to fetch the columns of each table with their column type etc to validate from the `public` schema of yb. If` orafce` extension is left on, some of the tables created by `orafce` were also getting fetched. That is why I added a function to drop `orafce` in `yb.py`. This can be invoked before the tests that require `orafce` to be turned off. 
`Orafce` creates many functions and this can pose a problem in the future while validating.