### PR TITLE
Bug fix: Invalid config value for database.server.id, only numeric values are allowed

### DIFF
--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -2,6 +2,7 @@ package dbzm
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,7 +78,7 @@ var mysqlSrcConfigTemplate = baseSrcConfigTemplate + `
 debezium.source.connector.class=io.debezium.connector.mysql.MySqlConnector
 
 debezium.source.database.include.list=%s
-debezium.source.database.server.id=ybvoyager-dbzm
+debezium.source.database.server.id=%d
 
 
 
@@ -123,6 +124,7 @@ func (c *Config) String() string {
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
 			c.DatabaseName,
+			rand.Int(),
 			filepath.Join(c.ExportDir, "data", "schema_history.json"))
 	default:
 		panic(fmt.Sprintf("unknown source db type %s", c.SourceDBType))

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -2,9 +2,12 @@ package dbzm
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -124,7 +127,7 @@ func (c *Config) String() string {
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
 			c.DatabaseName,
-			rand.Int(),
+			getDatabaseServerID(),
 			filepath.Join(c.ExportDir, "data", "schema_history.json"))
 	default:
 		panic(fmt.Sprintf("unknown source db type %s", c.SourceDBType))
@@ -138,4 +141,39 @@ func (c *Config) WriteToFile(filePath string) error {
 		return fmt.Errorf("failed to write config file %s: %v", filePath, err)
 	}
 	return nil
+}
+
+// read config file DEBEZIUM_CONF_FILEPATH into a string
+func readConfigFile() (string, error) {
+	configFile, err := os.ReadFile(DEBEZIUM_CONF_FILEPATH)
+	if err != nil {
+		return "", fmt.Errorf("failed to read config file %s: %w", DEBEZIUM_CONF_FILEPATH, err)
+	}
+
+	return string(configFile), nil
+}
+
+// generate/fetch the value for 'debezium.source.database.server.id' property for MySQL
+func getDatabaseServerID() int {
+	databaseServerId := rand.Intn(100000)
+	configFile, err := readConfigFile()
+	if err != nil {
+		log.Fatalf("failed to read config file: %v", err)
+		return databaseServerId
+	}
+
+	// if config file exists, read the value of 'debezium.source.database.server.id' property
+	if strings.Contains(configFile, "debezium.source.database.server.id") {
+		re := regexp.MustCompile(`(?m)^debezium.source.database.server.id=(\d+)$`)
+		matches := re.FindStringSubmatch(configFile)
+		if len(matches) == 2 {
+			databaseServerId, err = strconv.Atoi(matches[1])
+			if err != nil {
+				log.Fatalf("failed to convert database server id to int: %v", err)
+				return databaseServerId
+			}
+		}
+	}
+
+	return databaseServerId
 }

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -2,13 +2,15 @@ package dbzm
 
 import (
 	"fmt"
-	"log"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type Config struct {
@@ -145,31 +147,31 @@ func (c *Config) WriteToFile(filePath string) error {
 
 // read config file DEBEZIUM_CONF_FILEPATH into a string
 func readConfigFile() (string, error) {
-	configFile, err := os.ReadFile(DEBEZIUM_CONF_FILEPATH)
+	config, err := os.ReadFile(DEBEZIUM_CONF_FILEPATH)
 	if err != nil {
 		return "", fmt.Errorf("failed to read config file %s: %w", DEBEZIUM_CONF_FILEPATH, err)
 	}
 
-	return string(configFile), nil
+	return string(config), nil
 }
 
 // generate/fetch the value for 'debezium.source.database.server.id' property for MySQL
 func getDatabaseServerID() int {
-	databaseServerId := rand.Intn(100000)
-	configFile, err := readConfigFile()
+	databaseServerId := rand.Intn(math.MaxInt-10000) + 10000
+	config, err := readConfigFile()
 	if err != nil {
-		log.Fatalf("failed to read config file: %v", err)
+		log.Errorf("failed to read config file: %v", err)
 		return databaseServerId
 	}
 
 	// if config file exists, read the value of 'debezium.source.database.server.id' property
-	if strings.Contains(configFile, "debezium.source.database.server.id") {
+	if strings.Contains(config, "debezium.source.database.server.id") {
 		re := regexp.MustCompile(`(?m)^debezium.source.database.server.id=(\d+)$`)
-		matches := re.FindStringSubmatch(configFile)
+		matches := re.FindStringSubmatch(config)
 		if len(matches) == 2 {
 			databaseServerId, err = strconv.Atoi(matches[1])
 			if err != nil {
-				log.Fatalf("failed to convert database server id to int: %v", err)
+				log.Errorf("failed to convert database server id to int: %v", err)
 				return databaseServerId
 			}
 		}

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -158,6 +158,7 @@ func readConfigFile() (string, error) {
 // generate/fetch the value for 'debezium.source.database.server.id' property for MySQL
 func getDatabaseServerID() int {
 	databaseServerId := rand.Intn(math.MaxInt-10000) + 10000
+	log.Infof("randomly generated database server id: %d", databaseServerId)
 	config, err := readConfigFile()
 	if err != nil {
 		log.Errorf("failed to read config file: %v", err)
@@ -176,6 +177,6 @@ func getDatabaseServerID() int {
 			}
 		}
 	}
-
+	log.Infof("final database server id: %d", databaseServerId)
 	return databaseServerId
 }


### PR DESCRIPTION
- using random number generator to generate and assign a unique value for the migration

Not using a constant fixed numeric value since multiple migrations might be running at source MySQL using debezium/yb-voyager

doc reference: [link](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-property-database-server-id)

