### PR TITLE
Added error context to failed ddl file

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1173,7 +1173,8 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 			color.Red(fmt.Sprintf("%s\n", err.Error()))
 			if target.ContinueOnError {
 				log.Infof("appending stmt to failedSqlStmts list: %s\n", utils.GetSqlStmtToPrint(sqlInfo.stmt))
-				failedSqlStmts = append(failedSqlStmts, sqlInfo)
+				errString := "/*\n ERROR: " + err.Error() + "\n*/\n"
+				failedSqlStmts = append(failedSqlStmts, errString+sqlInfo.formattedStmt)
 			} else {
 				os.Exit(1)
 			}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1173,7 +1173,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 			color.Red(fmt.Sprintf("%s\n", err.Error()))
 			if target.ContinueOnError {
 				log.Infof("appending stmt to failedSqlStmts list: %s\n", utils.GetSqlStmtToPrint(sqlInfo.stmt))
-				errString := "/*\n ERROR: " + err.Error() + "\n*/\n"
+				errString := "/*\n" + err.Error() + "\n*/\n"
 				failedSqlStmts = append(failedSqlStmts, errString+sqlInfo.formattedStmt)
 			} else {
 				os.Exit(1)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -151,7 +151,7 @@ func importSchema() {
 	callhome.PackAndSendPayload(exportDir)
 }
 
-func dumpStatements(stmts []sqlInfo, filePath string) {
+func dumpStatements(stmts []string, filePath string) {
 	if len(stmts) == 0 {
 		if utils.FileOrFolderExists(filePath) {
 			err := os.Remove(filePath)
@@ -169,7 +169,7 @@ func dumpStatements(stmts []sqlInfo, filePath string) {
 	}
 
 	for i := 0; i < len(stmts); i++ {
-		_, err = file.WriteString(stmts[i].formattedStmt + "\n\n")
+		_, err = file.WriteString(stmts[i] + "\n\n")
 		if err != nil {
 			utils.ErrExit("failed writing in file %s: %v", filePath, err)
 		}

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -74,7 +74,7 @@ func importDefferedStatements() {
 				log.Infof("failed retry of deffered stmt: %s\n%v", utils.GetSqlStmtToPrint(defferedSqlStmts[j].stmt), err)
 				// fails to execute in final attempt
 				if i == maxIterations {
-					errString = "/*\n ERROR: " + err.Error() + "\n*/\n"
+					errString = "/*\n" + err.Error() + "\n*/\n"
 					failedSqlStmts = append(failedSqlStmts, errString+defferedSqlStmts[j].formattedStmt)
 				}
 				conn.Close(context.Background())

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -60,7 +60,6 @@ func importDefferedStatements() {
 	defer func() { conn.Close(context.Background()) }()
 
 	var err error
-	var errString string
 	// max loop iterations to remove all errors
 	for i := 1; i <= maxIterations && len(defferedSqlStmts) > 0; i++ {
 		for j := 0; j < len(defferedSqlStmts); {
@@ -74,7 +73,7 @@ func importDefferedStatements() {
 				log.Infof("failed retry of deffered stmt: %s\n%v", utils.GetSqlStmtToPrint(defferedSqlStmts[j].stmt), err)
 				// fails to execute in final attempt
 				if i == maxIterations {
-					errString = "/*\n" + err.Error() + "\n*/\n"
+					errString := "/*\n" + err.Error() + "\n*/\n"
 					failedSqlStmts = append(failedSqlStmts, errString+defferedSqlStmts[j].formattedStmt)
 				}
 				conn.Close(context.Background())


### PR DESCRIPTION
This patch helps voyager append the error message of failed DDL statements to the respective DDL statements which failed within the failed.sql file