### PR TITLE
Put dbzm conf file in export-dir and call run.sh appropriately

### DIFF
--- a/installer_scripts/install-yb-voyager-debezium
+++ b/installer_scripts/install-yb-voyager-debezium
@@ -10,7 +10,7 @@ YUM="sudo yum install -y -q"
 
 # Remember to update the S3 repo with the correct version of pre-biult debezium-server, if any change in these values.
 DEBEZIUM_VERSION="2.2.0-SNAPSHOT"
-DEBEZIUM_COMMIT_HASH="4c892e5e3d5b4fad26daa4bf6e253cff0eb454a7"
+DEBEZIUM_COMMIT_HASH="d462ff23656ab40c3afecf8d4ef0acf9b6b8c7ff"
 
 on_exit() {
 	rc=$?

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -204,7 +204,7 @@ func CreateMigrationProjectIfNotExists(dbType string, exportDir string) {
 	// TODO: add a check/prompt if any directories apart from required ones are present in export-dir
 	var projectSubdirs = []string{
 		"schema", "data", "reports",
-		"metainfo", "metainfo/data", "metainfo/schema", "metainfo/flags",
+		"metainfo", "metainfo/data", "metainfo/schema", "metainfo/flags", "metainfo/conf",
 		"temp", "temp/ora2pg_temp_dir",
 	}
 

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -299,11 +299,13 @@ func validateTableListFlag(tableListString string, flagName string) {
 func checkDataDirs() {
 	exportDataDir := filepath.Join(exportDir, "data")
 	flagFilePath := filepath.Join(exportDir, "metainfo", "flags", "exportDataDone")
+	propertiesFilePath := filepath.Join(exportDir, "metainfo", "conf", "application.properties")
 	dfdFilePath := exportDir + datafile.DESCRIPTOR_PATH
 	if startClean {
 		utils.CleanDir(exportDataDir)
 		os.Remove(flagFilePath)
 		os.Remove(dfdFilePath)
+		os.Remove(propertiesFilePath)
 	} else {
 		if !utils.IsDirectoryEmpty(exportDataDir) {
 			if !liveMigration || dbzm.IsLiveMigrationInSnapshotMode(exportDir) {

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -42,7 +42,7 @@ func (d *Debezium) Start() error {
 	logFile, _ := filepath.Abs(filepath.Join(d.ExportDir, "logs/debezium.log"))
 	log.Infof("debezium logfile path: %s\n", logFile)
 
-	cmdStr := fmt.Sprintf("%s %s> %s 2>&1", filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH, logFile)
+	cmdStr := fmt.Sprintf("%s %s > %s 2>&1", filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH, logFile)
 	log.Infof("running command: %s\n", cmdStr)
 	d.cmd = exec.Command("/bin/bash", "-c", cmdStr)
 	d.cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var DEBEZIUM_DIST_DIR, DEBEZIUM_CONF_DIR, DEBEZIUM_CONF_FILEPATH string
+var DEBEZIUM_DIST_DIR, DEBEZIUM_CONF_FILEPATH string
 
 type Debezium struct {
 	*Config
@@ -32,7 +32,7 @@ func NewDebezium(config *Config) *Debezium {
 }
 
 func (d *Debezium) Start() error {
-	DEBEZIUM_CONF_FILEPATH = filepath.Join(d.ExportDir, "metainfo/conf/application.properties")
+	DEBEZIUM_CONF_FILEPATH = filepath.Join(d.ExportDir, "metainfo", "conf", "application.properties")
 	err := d.Config.WriteToFile(DEBEZIUM_CONF_FILEPATH)
 	if err != nil {
 		return err

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -25,9 +25,6 @@ func init() {
 	} else {
 		DEBEZIUM_DIST_DIR = "/opt/yb-voyager/debezium-server"
 	}
-
-	DEBEZIUM_CONF_DIR = filepath.Join(DEBEZIUM_DIST_DIR, "conf")
-	DEBEZIUM_CONF_FILEPATH = filepath.Join(DEBEZIUM_CONF_DIR, "application.properties")
 }
 
 func NewDebezium(config *Config) *Debezium {
@@ -35,16 +32,17 @@ func NewDebezium(config *Config) *Debezium {
 }
 
 func (d *Debezium) Start() error {
+	DEBEZIUM_CONF_FILEPATH = filepath.Join(d.ExportDir, "metainfo/conf/application.properties")
 	err := d.Config.WriteToFile(DEBEZIUM_CONF_FILEPATH)
 	if err != nil {
 		return err
 	}
 
 	log.Infof("starting debezium...")
-	logFile, _ := filepath.Abs(filepath.Join(d.ExportDir, "debezium.log"))
+	logFile, _ := filepath.Abs(filepath.Join(d.ExportDir, "logs/debezium.log"))
 	log.Infof("debezium logfile path: %s\n", logFile)
 
-	cmdStr := fmt.Sprintf("cd %q; %s > %s 2>&1", DEBEZIUM_DIST_DIR, filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), logFile)
+	cmdStr := fmt.Sprintf("%s %s> %s 2>&1", filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH, logFile)
 	log.Infof("running command: %s\n", cmdStr)
 	d.cmd = exec.Command("/bin/bash", "-c", cmdStr)
 	d.cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
Changes in https://github.com/yugabyte/debezium/pull/45 involve:
- making run.sh runnable
- the conf file can be passed as an argument

This PR makes corresponding changes on voyager side. 