### PR TITLE
Dbzm process handling improvements

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -229,6 +229,9 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 		for debezium.IsRunning() {
 			if snapshotComplete == false {
 				snapshotComplete, err = verifyAndHandleDebeziumSnapshotComplete(*debezium)
+				if err != nil {
+					return err
+				}
 				if snapshotComplete {
 					utils.PrintAndLog("Streaming changes to a local queue file...")
 				}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
-	"github.com/tebeka/atexit"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
@@ -125,7 +124,7 @@ func exportDataOffline() bool {
 		createExportDataDoneFlag()
 		dfd := datafile.Descriptor{ExportDir: exportDir}
 		dfd.Save()
-		atexit.Exit(0)
+		os.Exit(0)
 	}
 
 	if liveMigration || useDebezium {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -227,7 +227,7 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 		// monitor the debezium process and mode = snapshot/streaming
 		snapshotComplete := false
 		for debezium.IsRunning() {
-			if snapshotComplete == false {
+			if !snapshotComplete {
 				snapshotComplete, err = verifyAndHandleDebeziumSnapshotComplete(*debezium)
 				if err != nil {
 					return err

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -308,14 +308,12 @@ func checkDataDirs() {
 	exportDataDir := filepath.Join(exportDir, "data")
 	flagFilePath := filepath.Join(exportDir, "metainfo", "flags", "exportDataDone")
 	propertiesFilePath := filepath.Join(exportDir, "metainfo", "conf", "application.properties")
-	debeziumLogsPath := filepath.Join(exportDir, "logs", "debezium.log")
 	dfdFilePath := exportDir + datafile.DESCRIPTOR_PATH
 	if startClean {
 		utils.CleanDir(exportDataDir)
 		os.Remove(flagFilePath)
 		os.Remove(dfdFilePath)
 		os.Remove(propertiesFilePath)
-		os.Remove(debeziumLogsPath)
 	} else {
 		if !utils.IsDirectoryEmpty(exportDataDir) {
 			if liveMigration && dbzm.IsLiveMigrationInStreamingMode(exportDir) {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -87,7 +87,6 @@ func exportData() {
 	} else {
 		color.Red("Export of data failed, retry!! \u274C")
 		log.Error("Export of data failed.")
-		atexit.Exit(1)
 	}
 }
 
@@ -231,7 +230,7 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 			if !snapshotComplete {
 				snapshotComplete, err = verifyAndHandleDebeziumSnapshotComplete(*debezium)
 				if err != nil {
-					return fmt.Errorf("failed to verify debezium export status: %w", err)
+					return err
 				}
 				if snapshotComplete {
 					utils.PrintAndLog("Streaming changes to a local queue file...")
@@ -241,7 +240,7 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 		}
 		err = debezium.Error()
 		if err != nil {
-			return fmt.Errorf("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
+			utils.ErrExit("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
 		}
 	} else {
 		// offline migration.
@@ -251,12 +250,12 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 		}
 		err = debezium.Error()
 		if err != nil {
-			return fmt.Errorf("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
+			utils.ErrExit("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
 		} else {
 			// verify snapshot is complete.
 			snapshotComplete, err := verifyAndHandleDebeziumSnapshotComplete(*debezium)
 			if !snapshotComplete || err != nil {
-				return fmt.Errorf("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
+				utils.ErrExit("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
 			}
 		}
 	}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -230,7 +230,7 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 			if !snapshotComplete {
 				snapshotComplete, err = verifyAndHandleDebeziumSnapshotComplete(*debezium)
 				if err != nil {
-					return err
+					utils.ErrExit("could not verify debezium snapshot status: %w", err)
 				}
 				if snapshotComplete {
 					utils.PrintAndLog("Streaming changes to a local queue file...")

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -85,7 +85,7 @@ func exportData() {
 		color.Green("Export of data complete \u2705")
 		log.Info("Export of data completed.")
 	} else {
-		color.Red("Export of data failed, retry!! \u274C")
+		color.Red("Export of data failed! Check %s/logs for more details. \u274C", exportDir)
 		log.Error("Export of data failed.")
 	}
 }
@@ -131,7 +131,7 @@ func exportDataOffline() bool {
 	if liveMigration || useDebezium {
 		err := debeziumExportData(ctx, finalTableList)
 		if err != nil {
-			utils.PrintAndLog("Failed to run live migration: %s", err)
+			log.Errorf("Export Data using debezium failed: %v", err)
 		}
 		return err == nil
 	}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
+	"github.com/tebeka/atexit"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
@@ -124,7 +125,7 @@ func exportDataOffline() bool {
 		createExportDataDoneFlag()
 		dfd := datafile.Descriptor{ExportDir: exportDir}
 		dfd.Save()
-		os.Exit(0)
+		atexit.Exit(0)
 	}
 
 	if liveMigration || useDebezium {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -223,6 +223,8 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 	}
 	var status *dbzm.ExportStatus
 	exportingSnapshot := true
+	// TODO: check also for debezium.IsRunning here.
+	// Currently, this loops continues forever when debezium exits with some error.
 	for exportingSnapshot {
 		status, err = debezium.GetExportStatus()
 		if err != nil {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -131,7 +131,7 @@ func exportDataOffline() bool {
 	if liveMigration || useDebezium {
 		err := debeziumExportData(ctx, finalTableList)
 		if err != nil {
-			utils.PrintAndLog("Debezium export failed: %s", err)
+			utils.PrintAndLog("Failed to run live migration: %s", err)
 		}
 		return err == nil
 	}
@@ -222,63 +222,45 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName) er
 	if err != nil {
 		return fmt.Errorf("failed to start debezium: %w", err)
 	}
+	var status *dbzm.ExportStatus
+	exportingSnapshot := true
+	for exportingSnapshot {
+		status, err = debezium.GetExportStatus()
+		if err != nil {
+			return fmt.Errorf("failed to read export status: %w", err)
+		}
 
-	if liveMigration {
-		// monitor the debezium process and mode = snapshot/streaming
-		snapshotComplete := false
-		for debezium.IsRunning() {
-			if !snapshotComplete {
-				snapshotComplete, err = verifyAndHandleDebeziumSnapshotComplete(*debezium)
-				if err != nil {
-					utils.ErrExit("could not verify debezium snapshot status: %w", err)
-				}
-				if snapshotComplete {
-					utils.PrintAndLog("Streaming changes to a local queue file...")
-				}
+		if status != nil && exportingSnapshot && status.SnapshotExportIsComplete() {
+			exportingSnapshot = false
+			utils.PrintAndLog("Snapshot export is complete.")
+			createExportDataDoneFlag()
+			err = writeDataFileDescriptor(exportDir, status)
+			if err != nil {
+				return fmt.Errorf("failed to write data file descriptor: %w", err)
 			}
-			time.Sleep(time.Second)
+			outputExportStatus(status)
 		}
-		err = debezium.Error()
-		if err != nil {
-			utils.ErrExit("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
-		}
-	} else {
-		// offline migration.
-		// monitor the debezium process
-		for debezium.IsRunning() {
-			time.Sleep(time.Second)
-		}
-		err = debezium.Error()
-		if err != nil {
-			utils.ErrExit("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
-		} else {
-			// verify snapshot is complete.
-			snapshotComplete, err := verifyAndHandleDebeziumSnapshotComplete(*debezium)
-			if !snapshotComplete || err != nil {
-				utils.ErrExit("debezium exited unexpectedly: %w\nOutput:%s", err, debezium.CombinedOutput())
-			}
-		}
+		time.Sleep(time.Second)
+	}
+	if err := debezium.Error(); err != nil {
+		return fmt.Errorf("debezium failed during initial snapshot phase: %w", err)
+	}
+
+	if !liveMigration && useDebezium {
+		log.Infof("snapshot export is complete, stopping debezium...")
+		return debezium.Stop()
+	}
+
+	// live migration part
+	color.Blue("streaming changes to a local queue file...")
+	for debezium.IsRunning() {
+		time.Sleep(time.Second)
+	}
+	if err := debezium.Error(); err != nil {
+		return fmt.Errorf("debezium failed during live migration phase: %v", err)
 	}
 
 	return nil
-}
-
-func verifyAndHandleDebeziumSnapshotComplete(debezium dbzm.Debezium) (bool, error) {
-	status, err := debezium.GetExportStatus()
-	if err != nil {
-		return false, fmt.Errorf("failed to read export status: %w", err)
-	}
-	if status != nil && status.SnapshotExportIsComplete() {
-		utils.PrintAndLog("Snapshot export is complete.")
-		createExportDataDoneFlag()
-		err := writeDataFileDescriptor(exportDir, status)
-		if err != nil {
-			return false, fmt.Errorf("failed to write data file descriptor: %w", err)
-		}
-		outputExportStatus(status)
-		return true, nil
-	}
-	return false, nil
 }
 
 func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -307,12 +307,14 @@ func checkDataDirs() {
 	exportDataDir := filepath.Join(exportDir, "data")
 	flagFilePath := filepath.Join(exportDir, "metainfo", "flags", "exportDataDone")
 	propertiesFilePath := filepath.Join(exportDir, "metainfo", "conf", "application.properties")
+	debeziumLogsPath := filepath.Join(exportDir, "logs", "debezium.log")
 	dfdFilePath := exportDir + datafile.DESCRIPTOR_PATH
 	if startClean {
 		utils.CleanDir(exportDataDir)
 		os.Remove(flagFilePath)
 		os.Remove(dfdFilePath)
 		os.Remove(propertiesFilePath)
+		os.Remove(debeziumLogsPath)
 	} else {
 		if !utils.IsDirectoryEmpty(exportDataDir) {
 			if liveMigration && dbzm.IsLiveMigrationInStreamingMode(exportDir) {

--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -22,8 +22,7 @@ var exportDataStatusCmd = &cobra.Command{
 		validateExportDirFlag()
 		err := runExportDataStatusCmd()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %s\n", err)
-			os.Exit(1)
+			utils.ErrExit("error: %s\n", err)
 		}
 	},
 }

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1176,7 +1176,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 				errString := "/*\n" + err.Error() + "\n*/\n"
 				failedSqlStmts = append(failedSqlStmts, errString+sqlInfo.formattedStmt)
 			} else {
-				os.Exit(1)
+				utils.ErrExit("error: %s\n", err)
 			}
 		}
 	}

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 var importDataStatusCmd = &cobra.Command{
@@ -22,8 +23,7 @@ var importDataStatusCmd = &cobra.Command{
 		validateExportDirFlag()
 		err := runImportDataStatusCmd()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %s\n", err)
-			os.Exit(1)
+			utils.ErrExit("error: %s\n", err)
 		}
 	},
 }

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nightlyone/lockfile"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/tebeka/atexit"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
@@ -54,7 +55,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			cmd.Help()
-			os.Exit(0)
+			atexit.Exit(0)
 		}
 	},
 
@@ -151,26 +152,22 @@ func createLock(lockFileName string) {
 	var err error
 	lockFile, err = lockfile.New(lockFileName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create lockfile %q: %v\n", lockFileName, err)
-		os.Exit(1)
+		utils.ErrExit("Failed to create lockfile %q: %v\n", lockFileName, err)
 	}
 
 	err = lockFile.TryLock()
 	if err == nil {
 		return
 	} else if err == lockfile.ErrBusy {
-		fmt.Fprintf(os.Stderr, "Another instance of yb-voyager is running in the export-dir = %s\n", exportDir)
-		os.Exit(1)
+		utils.ErrExit("Another instance of yb-voyager is running in the export-dir = %s\n", exportDir)
 	} else {
-		fmt.Fprintf(os.Stderr, "Unable to lock the export-dir: %v\n", err)
-		os.Exit(1)
+		utils.ErrExit("Unable to lock the export-dir: %v\n", err)
 	}
 }
 
 func unlockExportDir() {
 	err := lockFile.Unlock()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to unlock %q: %v\n", lockFile, err)
-		os.Exit(1)
+		utils.ErrExit("Unable to unlock %q: %v\n", lockFile, err)
 	}
 }

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -24,7 +24,6 @@ import (
 	"github.com/nightlyone/lockfile"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/tebeka/atexit"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
@@ -55,7 +54,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			cmd.Help()
-			atexit.Exit(0)
+			os.Exit(0)
 		}
 	},
 

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
+	github.com/tebeka/atexit v0.3.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/net v0.6.0 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -1796,6 +1796,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tebeka/atexit v0.3.0 h1:jleL99H7Ywt80oJKR+VWmJNnezcCOG0CuzcN3CIpsdI=
+github.com/tebeka/atexit v0.3.0/go.mod h1:WJmSUSmMT7WoR7etUOaGBVXk+f5/ZJ+67qwuedq7Fbs=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tevino/abool/v2 v2.0.1 h1:OF7FC5V5z3yAWyixbc32ecEzrgAJCsPkVOsPM2qoZPI=
 github.com/tevino/abool/v2 v2.0.1/go.mod h1:+Lmlqk6bHDWHqN1cbxqhwEAwMPXgc8I1SDEamtseuXY=

--- a/yb-voyager/main.go
+++ b/yb-voyager/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,26 @@ limitations under the License.
 package main
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/tebeka/atexit"
 	"github.com/yugabyte/yb-voyager/yb-voyager/cmd"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 func main() {
+	registerSignalHandlers()
 	cmd.Execute()
+}
+
+func registerSignalHandlers() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigs
+		utils.PrintAndLog("Received signal %s. Exiting...", sig)
+		atexit.Exit(0)
+	}()
 }

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -56,14 +56,8 @@ debezium.source.datatype.propagate.source.type=.*BOX.*,.*LINE.*,.*LSEG.*,.*PATH.
 debezium.source.tombstones.on.delete=false
 
 quarkus.log.level=info
-
-quarkus.log.file.enable=true
-quarkus.log.file.level=INFO
-quarkus.log.file.path=%s
-quarkus.log.file.json=false
-
 quarkus.log.console.json=false
-quarkus.log.console.level=ERROR
+quarkus.log.console.level=INFO
 `
 
 var postgresSrcConfigTemplate = baseSrcConfigTemplate + `
@@ -107,7 +101,6 @@ func (c *Config) String() string {
 	dataDir := filepath.Join(c.ExportDir, "data")
 	offsetFile := filepath.Join(dataDir, "offsets.dat")
 	schemaNames := strings.Join(strings.Split(c.SchemaNames, "|"), ",")
-	logFile, _ := filepath.Abs(filepath.Join(c.ExportDir, "logs", "debezium.log"))
 
 	switch c.SourceDBType {
 	case "postgresql":
@@ -117,7 +110,6 @@ func (c *Config) String() string {
 			offsetFile,
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
-			logFile,
 			c.DatabaseName,
 			schemaNames)
 
@@ -128,7 +120,6 @@ func (c *Config) String() string {
 			offsetFile,
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
-			logFile,
 			c.DatabaseName,
 			schemaNames,
 			filepath.Join(c.ExportDir, "data", "history.dat"),
@@ -141,7 +132,6 @@ func (c *Config) String() string {
 			offsetFile,
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
-			logFile,
 			c.DatabaseName,
 			getDatabaseServerID(),
 			filepath.Join(c.ExportDir, "data", "schema_history.json"))

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -54,8 +54,16 @@ debezium.source.include.unknown.datatypes=true
 debezium.source.datatype.propagate.source.type=.*BOX.*,.*LINE.*,.*LSEG.*,.*PATH.*,.*POLYGON.*,.*CIRCLE.*
 
 debezium.source.tombstones.on.delete=false
-quarkus.log.console.json=false
+
 quarkus.log.level=info
+
+quarkus.log.file.enable=true
+quarkus.log.file.level=INFO
+quarkus.log.file.path=%s
+quarkus.log.file.json=false
+
+quarkus.log.console.json=false
+quarkus.log.console.level=ERROR
 `
 
 var postgresSrcConfigTemplate = baseSrcConfigTemplate + `
@@ -99,6 +107,7 @@ func (c *Config) String() string {
 	dataDir := filepath.Join(c.ExportDir, "data")
 	offsetFile := filepath.Join(dataDir, "offsets.dat")
 	schemaNames := strings.Join(strings.Split(c.SchemaNames, "|"), ",")
+	logFile, _ := filepath.Abs(filepath.Join(c.ExportDir, "logs/debezium.log"))
 
 	switch c.SourceDBType {
 	case "postgresql":
@@ -108,6 +117,7 @@ func (c *Config) String() string {
 			offsetFile,
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
+			logFile,
 			c.DatabaseName,
 			schemaNames)
 
@@ -118,6 +128,7 @@ func (c *Config) String() string {
 			offsetFile,
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
+			logFile,
 			c.DatabaseName,
 			schemaNames,
 			filepath.Join(c.ExportDir, "data", "history.dat"),
@@ -130,6 +141,7 @@ func (c *Config) String() string {
 			offsetFile,
 			c.Host, c.Port, c.Username, c.Password,
 			strings.Join(c.TableList, ","),
+			logFile,
 			c.DatabaseName,
 			getDatabaseServerID(),
 			filepath.Join(c.ExportDir, "data", "schema_history.json"))

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -54,10 +54,8 @@ debezium.source.include.unknown.datatypes=true
 debezium.source.datatype.propagate.source.type=.*BOX.*,.*LINE.*,.*LSEG.*,.*PATH.*,.*POLYGON.*,.*CIRCLE.*
 
 debezium.source.tombstones.on.delete=false
-
-quarkus.log.level=info
 quarkus.log.console.json=false
-quarkus.log.console.level=INFO
+quarkus.log.level=info
 `
 
 var postgresSrcConfigTemplate = baseSrcConfigTemplate + `

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -107,7 +107,7 @@ func (c *Config) String() string {
 	dataDir := filepath.Join(c.ExportDir, "data")
 	offsetFile := filepath.Join(dataDir, "offsets.dat")
 	schemaNames := strings.Join(strings.Split(c.SchemaNames, "|"), ",")
-	logFile, _ := filepath.Abs(filepath.Join(c.ExportDir, "logs/debezium.log"))
+	logFile, _ := filepath.Abs(filepath.Join(c.ExportDir, "logs", "debezium.log"))
 
 	switch c.SourceDBType {
 	case "postgresql":

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -47,21 +47,13 @@ func (d *Debezium) Start() error {
 	}
 
 	log.Infof("starting debezium...")
-	// logFile, _ := filepath.Abs(filepath.Join(d.ExportDir, "logs/debezium.log"))
-	// log.Infof("debezium logfile path: %s\n", logFile)
-
-	// cmdStr := fmt.Sprintf("%s %s > %s 2>&1", filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH, logFile)
-	// log.Infof("running command: %s\n", cmdStr)
-	// d.cmd = exec.Command("/bin/bash", "-c", cmdStr)
 	d.cmd = exec.Command(filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH)
 	// capture stdout, stderr
 	var outbuf bytes.Buffer
 	var errbuf bytes.Buffer
 	d.cmd.Stdout = &outbuf
 	d.cmd.Stderr = &errbuf
-	// d.cmd.SysProcAttr = &syscall.SysProcAttr{
-	// 	Pdeathsig: syscall.SIGKILL, // kill the debezium process if the parent process dies
-	// }
+
 	d.registerExitHandlers()
 	err = d.cmd.Start()
 	if err != nil {

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -23,9 +23,10 @@ var DEBEZIUM_DIST_DIR, DEBEZIUM_CONF_FILEPATH string
 
 type Debezium struct {
 	*Config
-	cmd  *exec.Cmd
-	err  error
-	done bool
+	cmd            *exec.Cmd
+	err            error
+	done           bool
+	combinedOutput string
 }
 
 func init() {
@@ -66,7 +67,7 @@ func (d *Debezium) Start() error {
 		d.done = true
 		if d.err != nil {
 			log.Errorf("Debezium exited with: %v", d.err)
-			utils.ErrExit("Data export failed:\nSTDOUT:%s\nSTDERR:%s", outbuf.String(), errbuf.String())
+			d.combinedOutput = fmt.Sprintf("STDOUT:%s\nSTDERR:%s", outbuf.String(), errbuf.String())
 		}
 	}()
 	return nil
@@ -91,6 +92,10 @@ func (d *Debezium) IsRunning() bool {
 
 func (d *Debezium) Error() error {
 	return d.err
+}
+
+func (d *Debezium) CombinedOutput() string {
+	return d.combinedOutput
 }
 
 func (d *Debezium) GetExportStatus() (*ExportStatus, error) {

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -68,7 +68,10 @@ func (d *Debezium) Start() error {
 }
 
 func (d *Debezium) setupLogFile() error {
-	logFilePath, _ := filepath.Abs(filepath.Join(d.ExportDir, "logs", "debezium.log"))
+	logFilePath, err := filepath.Abs(filepath.Join(d.ExportDir, "logs", "debezium.log"))
+	if err != nil {
+		return fmt.Errorf("failed to create absolute path:%v", err)
+	}
 
 	logRotator := &lumberjack.Logger{
 		Filename:   logFilePath,

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"syscall"
+
+	"github.com/tebeka/atexit"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+
+	// "syscall"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -42,18 +48,37 @@ func (d *Debezium) Start() error {
 	logFile, _ := filepath.Abs(filepath.Join(d.ExportDir, "logs/debezium.log"))
 	log.Infof("debezium logfile path: %s\n", logFile)
 
-	cmdStr := fmt.Sprintf("%s %s > %s 2>&1", filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH, logFile)
-	log.Infof("running command: %s\n", cmdStr)
-	d.cmd = exec.Command("/bin/bash", "-c", cmdStr)
-	d.cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL, // kill the debezium process if the parent process dies
+	// cmdStr := fmt.Sprintf("%s %s > %s 2>&1", filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH, logFile)
+	// log.Infof("running command: %s\n", cmdStr)
+	// d.cmd = exec.Command("/bin/bash", "-c", cmdStr)
+	d.cmd = exec.Command(filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH)
+	// open the out file for writing
+	outfile, err := os.Create(logFile)
+	if err != nil {
+		panic(err)
 	}
+	defer outfile.Close()
+	d.cmd.Stdout = outfile
+	d.cmd.Stderr = outfile
+	// d.cmd.SysProcAttr = &syscall.SysProcAttr{
+	// 	Pdeathsig: syscall.SIGKILL, // kill the debezium process if the parent process dies
+	// }
+
+	atexit.Register(func() {
+		d.Stop()
+	})
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigs
+		utils.PrintAndLog("Received signal %s. Exiting", sig)
+		atexit.Exit(0)
+	}()
 
 	err = d.cmd.Start()
 	if err != nil {
 		return fmt.Errorf("Error starting debezium: %v", err)
 	}
-
 	log.Infof("Debezium started successfully")
 	go func() {
 		d.err = d.cmd.Wait()
@@ -82,10 +107,12 @@ func (d *Debezium) GetExportStatus() (*ExportStatus, error) {
 func (d *Debezium) Stop() error {
 	if d.IsRunning() {
 		log.Infof("Stopping debezium...")
-		err := d.cmd.Process.Kill()
+		err := d.cmd.Process.Signal(syscall.SIGTERM)
 		if err != nil {
 			return fmt.Errorf("Error stopping debezium: %v", err)
 		}
+		d.cmd.Wait()
+		log.Info("Stopped debezium.")
 	}
 	return nil
 }

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/tebeka/atexit"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -61,8 +60,7 @@ func (d *Debezium) Start() error {
 		d.err = d.cmd.Wait()
 		d.done = true
 		if d.err != nil {
-			log.Errorf("Debezium exited with: %v", d.err)
-			utils.ErrExit("Data export failed:\nSTDOUT:%s\nSTDERR:%s", outbuf.String(), errbuf.String())
+			log.Errorf("Debezium export failed:%s\nSTDOUT:%s\nSTDERR:%s", d.err, outbuf.String(), errbuf.String())
 		}
 	}()
 	return nil

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -65,7 +65,7 @@ func (d *Debezium) Start() error {
 		d.err = d.cmd.Wait()
 		d.done = true
 		if d.err != nil {
-			log.Errorf("Debezium export failed: %s", d.err)
+			log.Errorf("Debezium exited with: %v", d.err)
 		}
 	}()
 	return nil

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -56,7 +56,6 @@ func (d *Debezium) Start() error {
 	log.Infof("Debezium started successfully with pid = %d", d.cmd.Process.Pid)
 
 	// wait for process to end.
-	// TODO: move this logic to the debeziumExportData func, and also exit when debezium exits.
 	go func() {
 		d.err = d.cmd.Wait()
 		d.done = true

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -23,10 +23,9 @@ var DEBEZIUM_DIST_DIR, DEBEZIUM_CONF_FILEPATH string
 
 type Debezium struct {
 	*Config
-	cmd            *exec.Cmd
-	err            error
-	done           bool
-	combinedOutput string
+	cmd  *exec.Cmd
+	err  error
+	done bool
 }
 
 func init() {
@@ -67,7 +66,7 @@ func (d *Debezium) Start() error {
 		d.done = true
 		if d.err != nil {
 			log.Errorf("Debezium exited with: %v", d.err)
-			d.combinedOutput = fmt.Sprintf("STDOUT:%s\nSTDERR:%s", outbuf.String(), errbuf.String())
+			utils.ErrExit("Data export failed:\nSTDOUT:%s\nSTDERR:%s", outbuf.String(), errbuf.String())
 		}
 	}()
 	return nil
@@ -101,10 +100,6 @@ func (d *Debezium) IsRunning() bool {
 
 func (d *Debezium) Error() error {
 	return d.err
-}
-
-func (d *Debezium) CombinedOutput() string {
-	return d.combinedOutput
 }
 
 func (d *Debezium) GetExportStatus() (*ExportStatus, error) {

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -1,7 +1,6 @@
 package dbzm
 
 import (
-	// "bytes"
 	"bytes"
 	"fmt"
 	"os"
@@ -12,8 +11,6 @@ import (
 
 	"github.com/tebeka/atexit"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
-
-	// "syscall"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -89,7 +89,6 @@ func (d *Debezium) registerExitHandlers() {
 		err := d.Stop()
 		if err != nil {
 			log.Errorf("Error stopping debezium: %v", err)
-			os.Exit(1)
 		}
 	})
 }

--- a/yb-voyager/src/utils/logging.go
+++ b/yb-voyager/src/utils/logging.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,12 +21,13 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/tebeka/atexit"
 )
 
 func ErrExit(formatString string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, formatString+"\n", args...)
 	log.Errorf(formatString+"\n", args...)
-	os.Exit(1)
+	atexit.Exit(1)
 }
 
 func PrintAndLog(formatString string, args ...interface{}) {


### PR DESCRIPTION
Following changes are made:

- Register an exit handler (using atexit package) that will stop debezium. `os.exit()` replaced with `atexit.exit()` which will call the handler. Signal handler (for SIGTERM, SIGINT) also calls `atexit.exit()`
- Debezium stop process: Send SIGTERM; if process still alive after 100s, send SIGKILL. 
- ~~Logging: INFO logs -> file, ERROR logs -> console (which are captured and displayed on voyager process output)~~
- ~~Refactored the debezium launch flow:~~
  - ~~main goroutine spawns debezium~~
  - ~~main goroutine spawns a goroutine that checks for debezium process to end and marks it as done.~~
  - ~~main goroutine just waits on done flag. After waiting,~~
      - ~~if there is an error, it prints it out and exits;~~
      - ~~if no error, and in snapshot only mode, check the export_status.json to verify that snapshot is complete, and then exit properly (after creating export data done flag and data file descriptor, etc)~~
      - ~~if no error, and in live migration mode - this shouldn't happen! Report that debezium died unexpectedly.~~

Should resolve:
- https://yugabyte.atlassian.net/browse/DB-6275
- https://yugabyte.atlassian.net/browse/DB-6270 (got rid of PdeathSig)
- https://yugabyte.atlassian.net/browse/DB-6195
