### PR TITLE
[Oracle] Bug fix: Qualified table name is required whenever a different(non-schema) user is specified as source-db-user

### DIFF
--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -237,7 +237,7 @@ func (ora *Oracle) FilterUnsupportedTables(tableList []*sqlname.SourceName) []*s
 func (ora *Oracle) FilterEmptyTables(tableList []*sqlname.SourceName) []*sqlname.SourceName {
 	nonEmptyTableList := make([]*sqlname.SourceName, 0)
 	for _, tableName := range tableList {
-		query := fmt.Sprintf("SELECT 1 FROM %s WHERE ROWNUM=1", tableName.ObjectName.MinQuoted)
+		query := fmt.Sprintf("SELECT 1 FROM %s WHERE ROWNUM=1", tableName.Qualified.MinQuoted)
 		if ora.IsNestedTable(tableName) {
 			// query to check empty nested oracle tables
 			query = fmt.Sprintf(`SELECT 1 from dba_segments 


### PR DESCRIPTION
For example: Let's say `source-db-user` is `admin`, but the `source-db-schema` to export is `sakila`. In these kind of cases, it is mandatory to use qualified table names in `Select *` kind of queries, since it is not know which schema to look for. But if `source-db-user` is also `sakila` then it is not mandatory