### PR TITLE
Improve Error Handling: Change utils.ErrExit -> return err

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -152,17 +152,17 @@ func exportDataOffline() bool {
 		finalTableList = filterTablePartitions(finalTableList)
 		err := debeziumExportData(ctx, finalTableList, tablesColumnList)
 		if err != nil {
-			log.Errorf("Export Data using debezium failed: %w", err)
+			log.Errorf("Export Data using debezium failed: %v", err)
 			return false
 		}
 		err = renameDbzmExportedDataFiles()
 		if err != nil {
-			log.Errorf("Failed to rename dbzm exported data files: %w", err)
+			log.Errorf("Failed to rename dbzm exported data files: %v", err)
 			return false
 		}
 		err = createResumeSequencesFile()
 		if err != nil {
-			log.Errorf("Failed to create resume sequences files: %w", err)
+			log.Errorf("Failed to create resume sequences files: %v", err)
 			return false
 		}
 		return true

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -377,7 +377,7 @@ func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error 
 func createResumeSequencesFile() error {
 	status, err := dbzm.ReadExportStatus(filepath.Join(exportDir, "data", "export_status.json"))
 	if err != nil {
-		return fmt.Errorf("Failed to read export status during creating resume sequence file: %v", err)
+		return fmt.Errorf("failed to read export status during creating resume sequence file: %w", err)
 	}
 
 	var sqlStmts []string
@@ -393,7 +393,7 @@ func createResumeSequencesFile() error {
 		file := filepath.Join(exportDir, "data", "postdata.sql")
 		err = os.WriteFile(file, []byte(strings.Join(sqlStmts, "")), 0644)
 		if err != nil {
-			return fmt.Errorf("Failed to write resume sequence file: %v", err)
+			return fmt.Errorf("failed to write resume sequence file: %w", err)
 		}
 	}
 	return nil
@@ -403,10 +403,10 @@ func createResumeSequencesFile() error {
 func renameDbzmExportedDataFiles() error {
 	status, err := dbzm.ReadExportStatus(filepath.Join(exportDir, "data", "export_status.json"))
 	if err != nil {
-		return fmt.Errorf("Failed to read export status during renaming exported data files: %v", err)
+		return fmt.Errorf("failed to read export status during renaming exported data files: %w", err)
 	}
 	if status == nil {
-		return fmt.Errorf("Export status is empty during renaming exported data files")
+		return fmt.Errorf("export status is empty during renaming exported data files")
 	}
 
 	for i := 0; i < len(status.Tables); i++ {
@@ -426,7 +426,7 @@ func renameDbzmExportedDataFiles() error {
 		log.Infof("Renaming %s to %s", oldFilePath, newFilePath)
 		err = os.Rename(oldFilePath, newFilePath)
 		if err != nil {
-			return fmt.Errorf("Failed to rename dbzm exported data file: %v", err)
+			return fmt.Errorf("failed to rename dbzm exported data file: %w", err)
 		}
 	}
 	return nil

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -152,17 +152,17 @@ func exportDataOffline() bool {
 		finalTableList = filterTablePartitions(finalTableList)
 		err := debeziumExportData(ctx, finalTableList, tablesColumnList)
 		if err != nil {
-			log.Errorf("Export Data using debezium failed: %v", err)
+			log.Errorf("Export Data using debezium failed: %w", err)
 			return false
 		}
 		err = renameDbzmExportedDataFiles()
 		if err != nil {
-			log.Errorf("Failed to rename dbzm exported data files: %v", err)
+			log.Errorf("Failed to rename dbzm exported data files: %w", err)
 			return false
 		}
 		err = createResumeSequencesFile()
 		if err != nil {
-			log.Errorf("Failed to create resume sequences files: %v", err)
+			log.Errorf("Failed to create resume sequences files: %w", err)
 			return false
 		}
 		return true


### PR DESCRIPTION
With the current use of utils.ErrExit, the UX is confusing. It just errors out without any context - 
<img width="677" alt="image" src="https://github.com/yugabyte/yb-voyager/assets/6829754/21f695ab-78af-4013-bb9e-73a3c9423c3c">


Changed it to return err objects, which results in something like: 
<img width="660" alt="image" src="https://github.com/yugabyte/yb-voyager/assets/6829754/909f697f-ccef-4cb5-823a-cf77e1f2c65a">
