### PR TITLE
Bug fix for analyze-schema reporting the supported DDL in unsupported case

### DIFF
--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
@@ -176,3 +176,7 @@ CREATE FOREIGN TABLE tbl_f(
 	pid int FOREIGN KEY REFERENCES tbl_p(id)
 );
 
+-- valid
+Alter table only parent_tbl add constraint party_profile_pk primary key (party_profile_id);
+-- alter table not supported
+Alter table only party_profile_part of parent_tbl add constraint party_profile_pk primary key (party_profile_id);

--- a/migtests/tests/analyze-schema/expected_issues.json
+++ b/migtests/tests/analyze-schema/expected_issues.json
@@ -257,7 +257,7 @@
         },
         {
             "objectType": "TABLE",
-            "objectName": "",
+            "objectName": "oldschema.tbl_name",
             "reason": "ALTER TABLE SET SCHEMA not supported yet.",
             "sqlStatement": "ALTER TABLE oldschema.tbl_name SET SCHEMA newschema;",
             "suggestion": "",
@@ -414,6 +414,14 @@
             "sqlStatement": "ALTER TYPE compfoo ADD ATTRIBUTE f3 int;",
             "suggestion": "",
             "GH": "https://github.com/YugaByte/yugabyte-db/issues/1893"
+        },
+        {
+            "objectType": "TABLE",
+            "objectName": "party_profile_part",
+            "reason": "ALTER TABLE OF not supported yet.",
+            "sqlStatement": "Alter table only party_profile_part of parent_tbl add constraint party_profile_pk primary key (party_profile_id);",
+            "suggestion": "",
+            "GH": "https://github.com/YugaByte/yugabyte-db/issues/1124"
         }
 
 ]

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -145,14 +145,14 @@ var (
 	//super user role required, language c is errored as unsafe
 	cLangRegex = re("CREATE", opt("OR REPLACE"), "FUNCTION", capture(ident), anything, "language c")
 
-	alterOfRegex                    = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "OF")
+	alterOfRegex                    = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "OF", anything)
 	alterSchemaRegex                = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "SET SCHEMA")
 	createSchemaRegex               = re("CREATE", "SCHEMA", anything, "CREATE", "TABLE")
 	alterNotOfRegex                 = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "NOT OF")
 	alterColumnStatsRegex           = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "ALTER", "COLUMN", capture(ident), anything, "SET STATISTICS")
 	alterColumnStorageRegex         = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "ALTER", "COLUMN", capture(ident), anything, "SET STORAGE")
 	alterColumnSetAttributesRegex   = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "ALTER", "COLUMN", capture(ident), anything, "SET", `\(`)
-	alterColumnResetAttributesRegex = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "ALTER", "COLUMN", capture(ident), anything, "RESET")
+	alterColumnResetAttributesRegex = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "ALTER", "COLUMN", capture(ident), anything, "RESET", anything)
 	alterConstrRegex                = re("ALTER", opt(capture(unqualifiedIdent)), ifExists, "TABLE", capture(ident), anything, "ALTER", "CONSTRAINT")
 	setOidsRegex                    = re("ALTER", opt(capture(unqualifiedIdent)), "TABLE", ifExists, capture(ident), anything, "SET WITH OIDS")
 	clusterRegex                    = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "CLUSTER")
@@ -173,7 +173,7 @@ var (
 	tblPartitionRegex = re("CREATE", "TABLE", ifNotExists, capture(ident), anything, "PARTITION", "OF", capture(ident))
 	addPrimaryRegex   = re("ALTER", "TABLE", opt("ONLY"), ifExists, capture(ident), anything, "ADD PRIMARY KEY")
 	primRegex         = re("CREATE", "FOREIGN", "TABLE", capture(ident)+`\(`, anything, "PRIMARY KEY")
-	foreignKeyRegex   = re("CREATE", "FOREIGN", "TABLE", capture(ident)+`\(`, anything, "REFERENCES")
+	foreignKeyRegex   = re("CREATE", "FOREIGN", "TABLE", capture(ident)+`\(`, anything, "REFERENCES", anything)
 
 	// unsupported SQLs exported by ora2pg
 	compoundTrigRegex          = re("CREATE", opt("OR REPLACE"), "TRIGGER", capture(ident), anything, "COMPOUND", anything)
@@ -429,16 +429,16 @@ func checkDDL(sqlInfoArr []sqlInfo, fpath string) {
 				"https://github.com/YugaByte/yugabyte-db/issues/1397", "", "TABLE", tbl[2], sqlInfo.formattedStmt)
 		} else if tbl := alterOfRegex.FindStringSubmatch(sqlInfo.stmt); tbl != nil {
 			reportCase(fpath, "ALTER TABLE OF not supported yet.",
-				"https://github.com/YugaByte/yugabyte-db/issues/1124", "", "TABLE", tbl[2], sqlInfo.formattedStmt)
+				"https://github.com/YugaByte/yugabyte-db/issues/1124", "", "TABLE", tbl[3], sqlInfo.formattedStmt)
 		} else if tbl := alterSchemaRegex.FindStringSubmatch(sqlInfo.stmt); tbl != nil {
 			reportCase(fpath, "ALTER TABLE SET SCHEMA not supported yet.",
-				"https://github.com/YugaByte/yugabyte-db/issues/3947", "", "TABLE", tbl[2], sqlInfo.formattedStmt)
+				"https://github.com/YugaByte/yugabyte-db/issues/3947", "", "TABLE", tbl[3], sqlInfo.formattedStmt)
 		} else if createSchemaRegex.MatchString(sqlInfo.stmt) {
 			reportCase(fpath, "CREATE SCHEMA with elements not supported yet.",
 				"https://github.com/YugaByte/yugabyte-db/issues/10865", "", "SCHEMA", "", sqlInfo.formattedStmt)
 		} else if tbl := alterNotOfRegex.FindStringSubmatch(sqlInfo.stmt); tbl != nil {
 			reportCase(fpath, "ALTER TABLE NOT OF not supported yet.",
-				"https://github.com/YugaByte/yugabyte-db/issues/1124", "", "TABLE", "", sqlInfo.formattedStmt)
+				"https://github.com/YugaByte/yugabyte-db/issues/1124", "", "TABLE", tbl[3], sqlInfo.formattedStmt)
 		} else if tbl := alterColumnStatsRegex.FindStringSubmatch(sqlInfo.stmt); tbl != nil {
 			reportCase(fpath, "ALTER TABLE ALTER column SET STATISTICS not supported yet.",
 				"https://github.com/YugaByte/yugabyte-db/issues/1124", "", "TABLE", tbl[3], sqlInfo.formattedStmt)


### PR DESCRIPTION
Fixes - Bug reported by a user in the community slack, where analyze-schema was detecting few supported queries as unsupported, for ex - 
```
Alter table only parent_tbl add constraint party_profile_pk primary key (party_profile_id);
```
this is detected for the case of ALTER TABLE xyz OF case, where OF is part of the identifier name, and previous regex for this case was not considering a space after OF and due to which this query was being matched with the regex and hence reported. Fixed the regex.