### PR TITLE
Run all tests only on main branch, latest release on PRs

### DIFF
--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -14,7 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
-    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && matrix.version == '2.18.0.0-b65') }}
+    if: (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && matrix.version == '2.18.0.0-b65')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -14,6 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
+    if: github.event_name != 'pull_request' || ${{ matrix.version }} == '2.18.0.0-b65'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -14,7 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
-    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && ${{ matrix.version }} == '2.18.0.0-b65') }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && matrix.version == '2.18.0.0-b65') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -14,7 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
-    if: github.event_name != 'pull_request' || ${{ matrix.version }} == '2.18.0.0-b65'
+    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && ${{ matrix.version }} == '2.18.0.0-b65') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -14,7 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
-    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && ${{ matrix.version }} == '2.18.0.0-b65') }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && matrix.version == '2.18.0.0-b65') }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -14,6 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
+    if: github.event_name != 'pull_request' || ${{ matrix.version }} == '2.18.0.0-b65'
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -14,7 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
-    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && matrix.version == '2.18.0.0-b65') }}
+    if: (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && matrix.version == '2.18.0.0-b65')
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -14,7 +14,7 @@ jobs:
         EXPERIMENTAL_FAST_EXPORT: [0, 1]
     env:
       EXPERIMENTAL_FAST_EXPORT: ${{ matrix.EXPERIMENTAL_FAST_EXPORT }}
-    if: github.event_name != 'pull_request' || ${{ matrix.version }} == '2.18.0.0-b65'
+    if: ${{ (github.event_name != 'pull_request') || (github.event_name== 'pull_request' && ${{ matrix.version }} == '2.18.0.0-b65') }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.1
+	github.com/tebeka/atexit v0.3.0
 	github.com/tevino/abool/v2 v2.0.1
 	github.com/vbauerster/mpb/v7 v7.3.0
 	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4
@@ -80,7 +81,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
-	github.com/tebeka/atexit v0.3.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/net v0.6.0 // indirect


### PR DESCRIPTION
This patch resolves [DB-6689](https://yugabyte.atlassian.net/browse/DB-6689)
Disables automation tests from running on all versions of YugabyteDB during a PR, run only on latest available LTS version; maintain runs on all versions when merging into main branch.