### PR TITLE
Made DEBEZIUM_RELEASE_TAG, DEBEZIUM_VERSION and ORA2PG_VERSION variables overridable in the installer script.

### DIFF
--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -233,7 +233,7 @@ get_passed_options() {
 				shift
 				;;
 			-d | --install-debezium-server-latest )
-        		DEBEZIUM_VERSION=latest
+				DEBEZIUM_VERSION=latest
 				DEBEZIUM_RELEASE_TAG=voyager-debezium
 				shift
 				;;

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -11,8 +11,8 @@ ARGS_LINUX=$@
 VERSION="latest"
 
 # This needs to be changed to the latest debezium release tag
-DEBEZIUM_RELEASE_TAG="2.2.0-1.3.0"
-DEBEZIUM_VERSION="2.2.0-1.3.0"
+DEBEZIUM_RELEASE_TAG=${DEBEZIUM_RELEASE_TAG:-"2.2.0-1.3.0"}
+DEBEZIUM_VERSION=${DEBEZIUM_VERSION:-"2.2.0-1.3.0"}
 
 # the hash corresponds to the yb-voyager/v1.3.0 tag
 YB_VOYAGER_GIT_HASH="b783beaffe9fc2c2852ffa89e0a9d9bcae15ed5e" # this is one commit later than v1.3.0 tag commit
@@ -219,9 +219,9 @@ install_debezium_server() {
 get_passed_options() {
 	if [ "$1" == "linux" ]
 	then
-		OPTS=$(getopt -o "lpd", --long install-from-local-source,only-pg-support,install-debezium-server-latest --name 'install-yb-voyager' -- $ARGS_LINUX)
+		OPTS=$(getopt -o "lp", --long install-from-local-source,only-pg-support --name 'install-yb-voyager' -- $ARGS_LINUX)
 	else
-		OPTS=$(getopt  lpd  $ARGS_MACOS)
+		OPTS=$(getopt  lp  $ARGS_MACOS)
 	fi
 
 	eval set -- "$OPTS"
@@ -230,11 +230,6 @@ get_passed_options() {
 		case "$1" in
 			-l | --install-from-local-source ) 
 				VERSION="local"
-				shift
-				;;
-			-d | --install-debezium-server-latest )
-				DEBEZIUM_VERSION=latest
-				DEBEZIUM_RELEASE_TAG=voyager-debezium
 				shift
 				;;
 			-p | --only-pg-support ) 

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -31,7 +31,7 @@ LOG_FILE=/tmp/install-yb-voyager.log
 
 # commit hash in main branch after release 23.2
 # issues #489 #492 #247 in ora2pg were fixed after this change
-ORA2PG_VERSION="f08d47a4e5c20ff7d348e535ed05ab571b4bb350"
+ORA2PG_VERSION=${ORA2PG_VERSION:-"f08d47a4e5c20ff7d348e535ed05ab571b4bb350"}
 
 # separate file for bashrc related settings
 RC_FILE="$HOME/.yb-voyager.rc"

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -205,7 +205,7 @@ check_java() {
 }
 
 install_debezium_server() {
-	output "Installing debezium"
+	output "Installing debezium:${DEBEZIUM_VERSION}"
 	debezium_server_filename="debezium-server-${DEBEZIUM_VERSION}.tar.gz"
 	# download
 	wget -nv "https://github.com/yugabyte/debezium/releases/download/${DEBEZIUM_RELEASE_TAG}/${debezium_server_filename}"

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -233,10 +233,10 @@ get_passed_options() {
 				shift
 				;;
 			-d | --install-debezium-server-latest )
-                DEBEZIUM_VERSION=latest
-                DEBEZIUM_RELEASE_TAG=voyager-debezium
-                shift
-                ;;
+        		DEBEZIUM_VERSION=latest
+				DEBEZIUM_RELEASE_TAG=voyager-debezium
+				shift
+				;;
 			-p | --only-pg-support ) 
 				ONLY_PG="true"; 
 				shift 

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -200,7 +200,7 @@ check_java() {
         output "Found sufficient java version = ${JAVA_COMPLETE_VERSION}"
     else
         output "ERROR: Java not found or insuffiencient version ${JAVA_COMPLETE_VERSION}. Please install java>=${MIN_REQUIRED_MAJOR_VERSION}"
-                exit 1;
+        exit 1;
     fi
 }
 
@@ -219,9 +219,9 @@ install_debezium_server() {
 get_passed_options() {
 	if [ "$1" == "linux" ]
 	then
-		OPTS=$(getopt -o "lp", --long install-from-local-source,only-pg-support --name 'install-yb-voyager' -- $ARGS_LINUX)
+		OPTS=$(getopt -o "lpd", --long install-from-local-source,only-pg-support,install-debezium-server-latest --name 'install-yb-voyager' -- $ARGS_LINUX)
 	else
-		OPTS=$(getopt  lp  $ARGS_MACOS)
+		OPTS=$(getopt  lpd  $ARGS_MACOS)
 	fi
 
 	eval set -- "$OPTS"
@@ -230,9 +230,13 @@ get_passed_options() {
 		case "$1" in
 			-l | --install-from-local-source ) 
 				VERSION="local"
-				DEBEZIUM_TARBALL_VERSION="latest"
 				shift
 				;;
+			-d | --install-debezium-server-latest )
+                DEBEZIUM_VERSION=latest
+                DEBEZIUM_RELEASE_TAG=voyager-debezium
+                shift
+                ;;
 			-p | --only-pg-support ) 
 				ONLY_PG="true"; 
 				shift 


### PR DESCRIPTION
1) `DEBEZIUM_RELEASE_TAG`, `DEBEZIUM_VERSION`: You can export these variables before running the script to specify what version of debezium you want to install.
2) `ORA2PG_VERSION`: You can export this variable before running the script to install a particular hash of ora2pg. 

Both of these additions are for testing purposes in the Jenkins pipeline.