### PR TITLE
[DB-6897] Do not quote identifiers coming from Oracle.

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -379,12 +379,8 @@ func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error 
 	dataFileList := make([]*datafile.FileEntry, 0)
 	for _, table := range status.Tables {
 		// TODO: TableName and FilePath must be quoted by debezium plugin.
-		tableName := table.TableName
-		if (sqlname.IsCaseSensitive(tableName, source.DBType) || sqlname.IsReservedKeyword(tableName)) &&
-			!sqlname.IsQuoted(tableName) {
-			tableName = fmt.Sprintf(`"%s"`, tableName)
-		}
-		if table.SchemaName != "public" && source.DBType == POSTGRESQL {
+		tableName := quoteIdentifierIfRequired(table.TableName)
+		if source.DBType == POSTGRESQL && table.SchemaName != "public" {
 			tableName = fmt.Sprintf("%s.%s", table.SchemaName, tableName)
 		}
 		fileEntry := &datafile.FileEntry{

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1026,13 +1026,20 @@ Valid cases requiring column name quoting:
 func quoteColumnNamesIfRequired(csvHeader string) string {
 	columnNames := strings.Split(csvHeader, ",")
 	for i := 0; i < len(columnNames); i++ {
-		columnNames[i] = strings.TrimSpace(columnNames[i])
-		if sqlname.IsReservedKeyword(columnNames[i]) || (sourceDBType == POSTGRESQL && sqlname.IsCaseSensitive(columnNames[i], sourceDBType)) {
-			columnNames[i] = fmt.Sprintf(`"%s"`, columnNames[i])
-		}
+		columnNames[i] = quoteIdentifierIfRequired(strings.TrimSpace(columnNames[i]))
 	}
-
 	return strings.Join(columnNames, ",")
+}
+
+func quoteIdentifierIfRequired(identifier string) string {
+	if sqlname.IsQuoted(identifier) {
+		return identifier
+	}
+	if sqlname.IsReservedKeyword(identifier) ||
+		(sourceDBType == POSTGRESQL && sqlname.IsCaseSensitive(identifier, sourceDBType)) {
+		return fmt.Sprintf(`"%s"`, identifier)
+	}
+	return identifier
 }
 
 func extractCopyStmtForTable(table string, fileToSearchIn string) {


### PR DESCRIPTION
This is a regression caused by my previous commit. We do not honour case-sensitivity for Oracle identifiers (like ora2pg). But the refactoring missed this part.