### PR TITLE
[DB-6922] During import skip nested tables exported from Oracle.

### DIFF
--- a/yb-voyager/src/srcdb/common.go
+++ b/yb-voyager/src/srcdb/common.go
@@ -19,6 +19,12 @@ func getExportedDataFileList(tablesMetadata map[string]*utils.TableProgressMetad
 	for key := range tablesMetadata {
 		tableMetadata := tablesMetadata[key]
 		targetTableName := strings.TrimSuffix(filepath.Base(tableMetadata.FinalFilePath), "_data.sql")
+		if !utils.FileOrFolderExists(tableMetadata.FinalFilePath) {
+			// This can happen in case of nested tables in Oracle.
+			log.Infof("File %q does not exist. Not including table %q in the descriptor.",
+				tableMetadata.FinalFilePath, targetTableName)
+			continue
+		}
 		fileEntry := &datafile.FileEntry{
 			FilePath:  filepath.Base(tableMetadata.FinalFilePath),
 			TableName: targetTableName,


### PR DESCRIPTION
ora2pg does not create a separate data file for the "nested table". Instead, the data is directly included in the parent table itself.

Before 069aa4f1, the `import data` codepath would look into the EXPORT_DIR/data to find out file-to-table mapping. Because the file for the "nested" table was never generated by the ora2pg, the import data code path never tried to import them.

But after the commit, `import data` started extracting the file-to-table mapping from the dataFileDescriptor.json (without ever looking into the data/ directory). Because, the `export data` code path included the nested table entry in the dataFileDescriptor.json, the `import data` code path started trying to import the non-existent (nested) table.

This patch fixes the issue by changing the `export data` to not write nested table entry in the dataFileDescriptor.json file.