### PR TITLE
[DB-6923] Throttle COPY commands to match behaviour with old implementation

### DIFF
--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -50,6 +50,8 @@ func (pool *ConnectionPool) WithConn(fn func(*pgx.Conn) (bool, error)) error {
 	for retry {
 		conn, gotIt := <-pool.conns
 		if !gotIt {
+			// The following sleep is intentional. It is added so that voyager does not
+			// overwhelm the database. See the description in PR https://github.com/yugabyte/yb-voyager/pull/920 .
 			time.Sleep(2 * time.Second)
 			continue
 		}

--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -48,7 +48,11 @@ func (pool *ConnectionPool) WithConn(fn func(*pgx.Conn) (bool, error)) error {
 	retry := true
 
 	for retry {
-		conn := <-pool.conns
+		conn, gotIt := <-pool.conns
+		if !gotIt {
+			time.Sleep(2 * time.Second)
+			continue
+		}
 		if conn == nil {
 			conn, err = pool.createNewConnection()
 			if err != nil {

--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -60,14 +60,8 @@ func (pool *ConnectionPool) WithConn(fn func(*pgx.Conn) (bool, error)) error {
 			}
 		}
 
-		startTime := time.Now()
 		retry, err = fn(conn)
-		elapsed := time.Since(startTime)
-		if elapsed > time.Minute {
-			log.Warnf("Query took %s", elapsed)
-			time.Sleep(10 * time.Second) // Slow down if query took too long.
-		}
-		if err != nil || elapsed > time.Minute {
+		if err != nil {
 			// On err, drop the connection.
 			conn.Close(context.Background())
 			pool.conns <- nil


### PR DESCRIPTION
The earlier implementation used an atomic int counter (that acted like a semaphore) to limit the number of batches submitted to target. Unlike a semaphore, voyager checked the counter only once every 2 seconds. That made voyager wake up every 2 second and ensure that there are `parallelism` number of batches in flight. During these 2 seconds, even if some batches finish there import, voyager will not submit new batches.

This behaviour provided some form of consistent throttling.

The refactoring changed this behaviour. Now that the code started using synchronisation primitives (e.g. channels and Pool), as soon as import of a batch finishes, voyager immediately sends the next batch. This caused too much load on the target thereby resulting in increased number of COPY command timeouts.

This PR tweaks the ConnPool implementation so that voyager behaves just like the old implementation.