### PR TITLE
[DB-6958] Handle relative paths specified in the --data-dir option.

### DIFF
--- a/yb-voyager/src/datastore/localDatastore.go
+++ b/yb-voyager/src/datastore/localDatastore.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 type LocalDataStore struct {
@@ -12,6 +14,11 @@ type LocalDataStore struct {
 }
 
 func NewLocalDataStore(dataDir string) *LocalDataStore {
+	dataDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		utils.ErrExit("failed to get absolute path of directory %q: %s", dataDir, err)
+	}
+	dataDir = filepath.Clean(dataDir)
 	return &LocalDataStore{dataDir: dataDir}
 }
 


### PR DESCRIPTION
`import data file` command concats value of --data-dir and file-name from the --file-table-mapping to get the full path of the data file. The full path is expected to be absolute.

If a relative path is passed to the --data-dir, the computed full-path is also relative. Which eventually breaks the `import data status` command.

This patch converts the --data-dir to absolute path before it is used any further.