### PR TITLE
[DB-6975] Count the empty lines in the CSV files as well.

### DIFF
--- a/migtests/tests/import-file/t1_newline.csv
+++ b/migtests/tests/import-file/t1_newline.csv
@@ -3,4 +3,5 @@
 2,,,"Hello
 World"
 1,,,Hello World
+
 5,,,Hello\tWorld

--- a/yb-voyager/cmd/importDataProgressReporter.go
+++ b/yb-voyager/cmd/importDataProgressReporter.go
@@ -27,16 +27,18 @@ import (
 
 type ImportDataProgressReporter struct {
 	sync.Mutex
-	disablePb    bool
-	progress     *mpb.Progress
-	progressBars map[int]*mpb.Bar
+	disablePb           bool
+	progress            *mpb.Progress
+	progressBars        map[int]*mpb.Bar
+	totalProgressAmount map[int]int64
 }
 
 func NewImportDataProgressReporter(disablePb bool) *ImportDataProgressReporter {
 	pr := &ImportDataProgressReporter{
-		disablePb:    disablePb,
-		progress:     mpb.New(),
-		progressBars: make(map[int]*mpb.Bar),
+		disablePb:           disablePb,
+		progress:            mpb.New(),
+		progressBars:        make(map[int]*mpb.Bar),
+		totalProgressAmount: make(map[int]int64),
 	}
 	return pr
 }
@@ -67,6 +69,7 @@ func (pr *ImportDataProgressReporter) ImportFileStarted(task *ImportFileTask, to
 		),
 	)
 	pr.progressBars[task.ID] = bar
+	pr.totalProgressAmount[task.ID] = totalProgressAmount
 }
 
 func (pr *ImportDataProgressReporter) AddProgressAmount(task *ImportFileTask, progressAmount int64) {
@@ -88,5 +91,5 @@ func (pr *ImportDataProgressReporter) FileImportDone(task *ImportFileTask) {
 		return
 	}
 	progressBar := pr.progressBars[task.ID]
-	progressBar.SetTotal(-1, true)
+	progressBar.SetCurrent(pr.totalProgressAmount[task.ID])
 }

--- a/yb-voyager/src/datafile/csvdatafile.go
+++ b/yb-voyager/src/datafile/csvdatafile.go
@@ -34,9 +34,10 @@ func (df *CsvDataFile) SkipLines(numLines int64) error {
 func (df *CsvDataFile) NextLine() (string, error) {
 	var line string
 	var err error
+	var skippedByteCount int
 	for {
-		line, err = df.reader.Read()
-		df.bytesRead += int64(len(line))
+		line, skippedByteCount, err = df.reader.Read()
+		df.bytesRead += int64(len(line)) + int64(skippedByteCount)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Because, the new csv.Reader was ignoring empty new lines, the CsvDataFile was not getting any chance to account bytes of new-line. This caused mismatch in totalByteCount and importedByteCount during `import data status`.

This patch fixes the issue by reporting the number of bytes it skipped before returning the current line. This gives the caller a chance to account for the skipped bytes.

Updated an existing test-case to import CSV file containing empty lines.