### PR TITLE
Make `import data status` independent of location of export-dir.

### DIFF
--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -287,12 +287,16 @@ func (s *ImportDataState) getTableStateDir(tableName string) string {
 
 func (s *ImportDataState) getFileStateDir(filePath, tableName string) string {
 	// NOTE: filePath must be absolute.
-	hash := computePathHash(filePath)
+	hash := computePathHash(filePath, s.exportDir)
 	baseName := filepath.Base(filePath)
 	return fmt.Sprintf("%s/file::%s::%s", s.getTableStateDir(tableName), baseName, hash)
 }
 
-func computePathHash(filePath string) string {
+func computePathHash(filePath, exportDir string) string {
+	// If filePath starts with exportDir, then this is a case of
+	// import files output by the `export data` command. Stripping the exportDir
+	// from the filePath makes the code independent from the exportDir.
+	filePath = strings.TrimPrefix(filePath, exportDir)
 	hash := sha1.New()
 	hash.Write([]byte(filePath))
 	return hex.EncodeToString(hash.Sum(nil))[0:8]

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/nightlyone/lockfile"
 	"github.com/spf13/cobra"
@@ -127,10 +126,14 @@ func validateExportDirFlag() {
 	}
 	if !utils.FileOrFolderExists(exportDir) {
 		utils.ErrExit("export-dir %q doesn't exists.\n", exportDir)
-	} else if exportDir == "." {
-		fmt.Println("Note: Using current working directory as export directory")
 	} else {
-		exportDir = strings.TrimRight(exportDir, "/")
+		var err error
+		exportDir, err = filepath.Abs(exportDir)
+		if err != nil {
+			utils.ErrExit("Failed to get absolute path for export-dir %q: %v\n", exportDir, err)
+		}
+		exportDir = filepath.Clean(exportDir)
+		fmt.Printf("Note: Using %q as export directory\n", exportDir)
 	}
 }
 


### PR DESCRIPTION
`export data` command outputs its files in the $EXPORT_DIR/data directory. A hash of the absolute path of the data file is included in the name of the import data state directory of the file. If, after the partial/full import of the data, the user moves the export-dir to some other location, the hashes in the import data state directory names will become invalid ( because the hashes were calculated on the abs path of the data files which includes the old export-dir path as well).

This PR fixes the issue by not including the `export-dir` path while calculating the path hashes.