### PR TITLE
[DB-6992, DB-7006] Updates to help message for import data file

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -105,7 +105,7 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 		"target SSL Root Certificate Revocation List (CRL)")
 
 	cmd.Flags().BoolVar(&startClean, "start-clean", false,
-		"delete all existing schema objects before importing schema. Delete all existing data before importing the data")
+		"import schema: delete all existing schema objects \nimport data / import data file: starts a fresh import of data or incremental data load")
 
 	cmd.Flags().BoolVar(&target.VerboseMode, "verbose", false,
 		"verbose mode for some extra details during execution of command")

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -53,7 +53,7 @@ var (
 
 var importDataFileCmd = &cobra.Command{
 	Use:   "file",
-	Short: "This command imports data from given files into YugabyteDB database",
+	Short: "This command imports data from given files into YugabyteDB database. The files can be present either in local directories or cloud storages like AWS S3, GCS buckets and Azure blob storage. Incremental data load is also supported.",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		reportProgressInBytes = true
@@ -381,7 +381,7 @@ func init() {
 		`character used as delimiter in rows of the table(s)(default is comma for CSV and tab for TEXT format)`)
 
 	importDataFileCmd.Flags().StringVar(&dataDir, "data-dir", "",
-		"path to the directory contains data files to import into table(s)\n"+
+		"path to the directory which contains data files to import into table(s)\n"+
 		"Note: data-dir can be a local directory or a cloud storage URL\n" +
 		"\tfor AWS S3, e.g. s3://<bucket-name>/<path-to-data-dir>\n" +
 		"\tfor GCS buckets, e.g. gs://<bucket-name>/<path-to-data-dir>\n"+
@@ -392,8 +392,7 @@ func init() {
 	}
 
 	importDataFileCmd.Flags().StringVar(&fileTableMapping, "file-table-map", "",
-		"comma separated list of mapping between file name in '--data-dir' to a table in database\n" +
-			"Note: default will be to import all the files in --data-dir with given format, for eg: table1.csv to import into table1 on target database.")
+		"comma separated list of mapping between file name in '--data-dir' to a table in database")
 	
 	err = importDataFileCmd.MarkFlagRequired("file-table-map")
 	if err != nil {

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -381,16 +381,24 @@ func init() {
 		`character used as delimiter in rows of the table(s)(default is comma for CSV and tab for TEXT format)`)
 
 	importDataFileCmd.Flags().StringVar(&dataDir, "data-dir", "",
-		"path to the directory contains data files to import into table(s)")
+		"path to the directory contains data files to import into table(s)\n"+
+		"Note: data-dir can be a local directory or a cloud storage URL\n" +
+		"\tfor AWS S3, e.g. s3://<bucket-name>/<path-to-data-dir>\n" +
+		"\tfor GCS buckets, e.g. gs://<bucket-name>/<path-to-data-dir>\n"+
+		"\tfor Azure blob storage, e.g. https://<account_name>.blob.core.windows.net/<container_name>/<path-to-data-dir>")
 	err := importDataFileCmd.MarkFlagRequired("data-dir")
 	if err != nil {
 		utils.ErrExit("mark 'data-dir' flag required: %v", err)
 	}
 
 	importDataFileCmd.Flags().StringVar(&fileTableMapping, "file-table-map", "",
-		"comma separated list of mapping between file name in '--data-dir' to a table in database.\n"+
+		"comma separated list of mapping between file name in '--data-dir' to a table in database\n" +
 			"Note: default will be to import all the files in --data-dir with given format, for eg: table1.csv to import into table1 on target database.")
-
+	
+	err = importDataFileCmd.MarkFlagRequired("file-table-map")
+	if err != nil {
+		utils.ErrExit("mark 'file-table-map' flag required: %v", err)
+	}
 	importDataFileCmd.Flags().BoolVar(&hasHeader, "has-header", false,
 		"true - if first line of data file is a list of columns for rows (default false)\n"+
 			"(Note: only works for csv file type)")
@@ -411,4 +419,7 @@ func init() {
 
 	importDataFileCmd.Flags().StringVar(&nullString, "null-string", "",
 		`string that represents null value in the data file (default for csv: ""(empty string), for text: '\N')`)
+
+	importDataFileCmd.Flags().MarkHidden("table-list")
+	importDataFileCmd.Flags().MarkHidden("exclude-table-list")
 }


### PR DESCRIPTION
1. removed the --table-list and --exclude-table-list from help msg of import data file (fixes - [DB-6992](https://yugabyte.atlassian.net/browse/DB-6992))

2. enhanced the description of the --data-dir flag for the cloud storage Urls (fixes - [DB-7006](https://yugabyte.atlassian.net/browse/DB-7006))

3. marked the --file-table-map flag as required.