### PR TITLE
Report progress of all files imported using the same export-dir

### DIFF
--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -29,8 +29,8 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/gcs"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/az"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/gcs"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/s3"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
@@ -86,9 +86,6 @@ func prepareForImportDataCmd() {
 		escapeCharBytes := []byte(escapeChar)
 		dataFileDescriptor.EscapeChar = escapeCharBytes[0]
 	}
-	// `import data status` depends on the saved descriptor file for the file-sizes.
-	// Can't get rid of it until we extract the file-size info out of descriptor file.
-	dataFileDescriptor.Save()
 
 	escapeFileOptsCharsIfRequired() // escaping for COPY command should be done after saving fileOpts in data file descriptor
 	prepareCopyCommands()
@@ -386,10 +383,10 @@ func init() {
 
 	importDataFileCmd.Flags().StringVar(&dataDir, "data-dir", "",
 		"path to the directory which contains data files to import into table(s)\n"+
-		"Note: data-dir can be a local directory or a cloud storage URL\n" +
-		"\tfor AWS S3, e.g. s3://<bucket-name>/<path-to-data-dir>\n" +
-		"\tfor GCS buckets, e.g. gs://<bucket-name>/<path-to-data-dir>\n"+
-		"\tfor Azure blob storage, e.g. https://<account_name>.blob.core.windows.net/<container_name>/<path-to-data-dir>")
+			"Note: data-dir can be a local directory or a cloud storage URL\n"+
+			"\tfor AWS S3, e.g. s3://<bucket-name>/<path-to-data-dir>\n"+
+			"\tfor GCS buckets, e.g. gs://<bucket-name>/<path-to-data-dir>\n"+
+			"\tfor Azure blob storage, e.g. https://<account_name>.blob.core.windows.net/<container_name>/<path-to-data-dir>")
 	err := importDataFileCmd.MarkFlagRequired("data-dir")
 	if err != nil {
 		utils.ErrExit("mark 'data-dir' flag required: %v", err)
@@ -397,7 +394,7 @@ func init() {
 
 	importDataFileCmd.Flags().StringVar(&fileTableMapping, "file-table-map", "",
 		"comma separated list of mapping between file name in '--data-dir' to a table in database")
-	
+
 	err = importDataFileCmd.MarkFlagRequired("file-table-map")
 	if err != nil {
 		utils.ErrExit("mark 'file-table-map' flag required: %v", err)

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -114,15 +115,14 @@ func prepareDummyDescriptor(state *ImportDataState) (*datafile.Descriptor, error
 	}
 	for tableName, filePaths := range tableToFilesMapping {
 		for _, filePath := range filePaths {
-			fi, err := os.Stat(filePath)
+			fileSize, err := datastore.NewDataStore(filePath).FileSize(filePath)
 			if err != nil {
-				return nil, fmt.Errorf("stat file %q: %w", filePath, err)
+				return nil, fmt.Errorf("get file size of %q: %w", filePath, err)
 			}
-
 			dataFileDescriptor.DataFileList = append(dataFileDescriptor.DataFileList, &datafile.FileEntry{
 				FilePath:  filePath,
 				TableName: tableName,
-				FileSize:  fi.Size(),
+				FileSize:  fileSize,
 				RowCount:  -1,
 			})
 		}


### PR DESCRIPTION
Issue:

Consider a case where `import data file` command is used to import file F1 and F2 to table T. The `import data status` command reports status of the two files as DONE. Now, if another `import data file` command is executed to import file F3 (using the same export dir), the `import data status` would report only the status of the F3 i.e. it will not output the status of F1 and F2.

Cause:

Before the import data refactoring, the `import data status` command would discover the table->file mapping from the dataDir. The refactoring removed the need to populate dataDir during the `import data file` command. The table->file mapping was then populated in the `dataFileDescriptor.json` file. The `import data status` command was also modified to extract table->file mapping from the descriptor.

But, `import data file` overwrites the descriptor file on each run with the details of only the files imported in that specific run. Which means, the descriptor would contain details of only the last run of `import data file`. And hence, the `import data status` command was also reporting status of only the last run.

Fix:

This PR again modifies the `import data status` to discover the table->file mapping from the import state.