### PR TITLE
[import data] Abstract access to the target db.

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -231,7 +231,7 @@ func reportSummary() {
 		utils.ErrExit("unable to load migration info: %s", err)
 	}
 
-	if !target.ImportMode { // this info is available only if we are exporting from source
+	if !tconf.ImportMode { // this info is available only if we are exporting from source
 		reportStruct.Summary.DBName = miginfo.SourceDBName
 		reportStruct.Summary.SchemaName = miginfo.SourceDBSchema
 		reportStruct.Summary.DBVersion = miginfo.SourceDBVersion

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -46,9 +46,3 @@ var validSSLModes = map[string][]string{
 	"mysql":      {"disable", "prefer", "require", "verify-ca", "verify-full"},
 	"postgresql": {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"},
 }
-
-var NonRetryCopyErrors = []string{
-	"Sending too long RPC message",
-	"invalid input syntax",
-	"violates unique constraint",
-}

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -19,7 +19,6 @@ const (
 	FOUR_MB                      = 4 * 1024 * 1024
 	META_INFO_DIR_NAME           = "metainfo"
 	NEWLINE                      = '\n'
-	GET_YB_SERVERS_QUERY         = "SELECT host, port, num_connections, node_type, cloud, region, zone, public_ip FROM yb_servers()"
 	ORACLE_DEFAULT_PORT          = 1521
 	MYSQL_DEFAULT_PORT           = 3306
 	POSTGRES_DEFAULT_PORT        = 5432
@@ -39,14 +38,6 @@ const (
 	INDEX_RETRY_COUNT            = 5
 	DDL_MAX_RETRY_COUNT          = 5
 	SCHEMA_VERSION_MISMATCH_ERR  = "Query error: schema version mismatch for table"
-)
-
-// import session parameters
-const (
-	SET_CLIENT_ENCODING_TO_UTF8           = "SET client_encoding TO 'UTF8'"
-	SET_SESSION_REPLICATE_ROLE_TO_REPLICA = "SET session_replication_role TO replica" //Disable triggers or fkeys constraint checks.
-	SET_YB_ENABLE_UPSERT_MODE             = "SET yb_enable_upsert_mode to true"
-	SET_YB_DISABLE_TRANSACTIONAL_WRITES   = "SET yb_disable_transactional_writes to true" // Disable transactions to improve ingestion throughput.
 )
 
 var supportedSourceDBTypes = []string{ORACLE, MYSQL, POSTGRESQL}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -478,7 +478,7 @@ func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error 
 	}
 	dfd := datafile.Descriptor{
 		FileFormat:   datafile.TEXT,
-		Delimiter:    ",",
+		Delimiter:    "\t",
 		HasHeader:    true,
 		ExportDir:    exportDir,
 		DataFileList: dataFileList,

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -64,7 +64,7 @@ func validateImportFlags(cmd *cobra.Command) {
 	validateImportObjectsFlag(tconf.ExcludeImportObjects, "exclude-object-list")
 	validateTargetSchemaFlag()
 	// For beta2.0 release (and onwards until further notice)
-	if disableTransactionalWrites {
+	if tconf.DisableTransactionalWrites {
 		fmt.Println("WARNING: The --disable-transactional-writes feature is in the experimental phase, not for production use case.")
 	}
 	validateBatchSizeFlag(batchSize)
@@ -126,23 +126,23 @@ func registerImportDataFlags(cmd *cobra.Command) {
 		"list of tables to import data")
 	cmd.Flags().Int64Var(&batchSize, "batch-size", DEFAULT_BATCH_SIZE,
 		"maximum number of rows in each batch generated during import.")
-	cmd.Flags().IntVar(&parallelism, "parallel-jobs", -1,
+	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", -1,
 		"number of parallel copy command jobs to target database. "+
 			"By default, voyager will try if it can determine the total number of cores N and use N/2 as parallel jobs. "+
 			"Otherwise, it fall back to using twice the number of nodes in the cluster")
-	cmd.Flags().BoolVar(&enableUpsert, "enable-upsert", true,
+	cmd.Flags().BoolVar(&tconf.EnableUpsert, "enable-upsert", true,
 		"true - to enable UPSERT mode on target tables\n"+
 			"false - to disable UPSERT mode on target tables")
-	cmd.Flags().BoolVar(&usePublicIp, "use-public-ip", false,
+	cmd.Flags().BoolVar(&tconf.UsePublicIP, "use-public-ip", false,
 		"true - to use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import (default false)\n"+
 			"Note: you might need to configure database to have public_ip available by setting server-broadcast-addresses.\n"+
 			"Refer: https://docs.yugabyte.com/latest/reference/configuration/yb-tserver/#server-broadcast-addresses")
-	cmd.Flags().StringVar(&targetEndpoints, "target-endpoints", "",
+	cmd.Flags().StringVar(&tconf.TargetEndpoints, "target-endpoints", "",
 		"comma separated list of node's endpoint to use for parallel import of data(default is to use all the nodes in the cluster).\n"+
 			"For example: \"host1:port1,host2:port2\" or \"host1,host2\"\n"+
 			"Note: use-public-ip flag will be ignored if this is used.")
 	// flag existence depends on fix of this gh issue: https://github.com/yugabyte/yugabyte-db/issues/12464
-	cmd.Flags().BoolVar(&disableTransactionalWrites, "disable-transactional-writes", false,
+	cmd.Flags().BoolVar(&tconf.DisableTransactionalWrites, "disable-transactional-writes", false,
 		"true - to disable transactional writes in tables for faster data ingestion (default false)\n"+
 			"(Note: this is a interim flag until the issues related to 'yb_disable_transactional_writes' session variable are fixed. Refer: https://github.com/yugabyte/yugabyte-db/issues/12464)")
 	// Hidden for beta2.0 release (and onwards until further notice).

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -34,8 +34,7 @@ var enableOrafce bool
 // tconf struct will be populated by CLI arguments parsing
 var tconf tgtdb.TargetConf
 
-// TODO tdb should be an interface, not a concrete type.
-var tdb *tgtdb.TargetYugabyteDB
+var tdb tgtdb.TargetDB
 
 var importCmd = &cobra.Command{
 	Use:   "import",

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -34,6 +34,9 @@ var enableOrafce bool
 // tconf struct will be populated by CLI arguments parsing
 var tconf tgtdb.TargetConf
 
+// TODO tdb should be an interface, not a concrete type.
+var tdb *tgtdb.TargetYugabyteDB
+
 var importCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Import schema and data from compatible source database(Oracle, MySQL, PostgreSQL)",

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -287,10 +287,14 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 
 func getImportBatchArgsProto(tableName string) *tgtdb.ImportBatchArgs {
 	columns := dataFileDescriptor.TableNameToExportedColumns[tableName]
+	fileFormat := dataFileDescriptor.FileFormat
+	if fileFormat == "sql" {
+		fileFormat = "text"
+	}
 	return &tgtdb.ImportBatchArgs{
 		TableName:  tableName,
 		Columns:    columns,
-		FileFormat: dataFileDescriptor.FileFormat,
+		FileFormat: fileFormat,
 		Delimiter:  dataFileDescriptor.Delimiter,
 		HasHeader:  dataFileDescriptor.HasHeader,
 		QuoteChar:  dataFileDescriptor.QuoteChar,

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -190,11 +190,7 @@ func importData(importFileTasks []*ImportFileTask) {
 
 	if liveMigration {
 		fmt.Println("streaming changes to target DB...")
-		targetSchema := tconf.Schema
-		if sourceDBType == POSTGRESQL {
-			targetSchema = ""
-		}
-		err = streamChanges(tdb.ConnPool(), targetSchema)
+		err = streamChanges()
 		if err != nil {
 			utils.ErrExit("Failed to stream changes from source DB: %s", err)
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -341,11 +341,11 @@ func getCloneConnectionUri(clone *tgtdb.TargetConf) string {
 
 func importData(importFileTasks []*ImportFileTask) {
 	tdb = tgtdb.NewTargetDB(&tconf)
-	err := tdb.Connect()
+	err := tdb.Init()
 	if err != nil {
-		utils.ErrExit("Failed to connect to the target DB: %s", err)
+		utils.ErrExit("Failed to initialize the target DB: %s", err)
 	}
-	defer tdb.Disconnect()
+	defer tdb.Finalize()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
 	targetDBVersion := tdb.GetVersion()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -340,17 +340,18 @@ func getCloneConnectionUri(clone *tgtdb.TargetConf) string {
 }
 
 func importData(importFileTasks []*ImportFileTask) {
-	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
-	err := tconf.DB().Connect()
+	tdb = tgtdb.NewTargetDB(&tconf)
+	err := tdb.Connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to the target DB: %s", err)
 	}
-	defer tconf.DB().Disconnect()
+	defer tdb.Disconnect()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
-	targetDBVersion := tconf.DB().GetVersion()
+	targetDBVersion := tdb.GetVersion()
 	fmt.Printf("Target YugabyteDB version: %s\n", targetDBVersion)
 
+	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
 	payload := callhome.GetPayload(exportDir)
 	payload.TargetDBVersion = targetDBVersion
 	tconfs := getYBServers()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -459,7 +459,7 @@ func importBatch(batch *Batch, importBatchArgsProto *tgtdb.ImportBatchArgs) {
 
 	importBatchArgs := *importBatchArgsProto
 	importBatchArgs.FilePath = batch.FilePath
-	importBatchArgs.RowsPerTransaction = int(batch.OffsetEnd - batch.OffsetStart)
+	importBatchArgs.RowsPerTransaction = batch.OffsetEnd - batch.OffsetStart
 
 	var rowsAffected int64
 	sleepIntervalSec := 0

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -184,7 +184,7 @@ func importData(importFileTasks []*ImportFileTask) {
 			updateProgressFn := func(progressAmount int64) {
 				progressReporter.AddProgressAmount(task, progressAmount)
 			}
-			importFile(state, task, tdb.ConnPool(), updateProgressFn)
+			importFile(state, task, updateProgressFn)
 			batchImportPool.Wait()                // Wait for the file import to finish.
 			progressReporter.FileImportDone(task) // Remove the progress-bar for the file.
 		}
@@ -287,8 +287,7 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 }
 
-func importFile(state *ImportDataState, task *ImportFileTask, connPool *tgtdb.ConnectionPool,
-	updateProgressFn func(int64)) {
+func importFile(state *ImportDataState, task *ImportFileTask, updateProgressFn func(int64)) {
 
 	origDataFile := task.FilePath
 	extractCopyStmtForTable(task.TableName, origDataFile)
@@ -304,14 +303,14 @@ func importFile(state *ImportDataState, task *ImportFileTask, connPool *tgtdb.Co
 		utils.ErrExit("recovering state for table %q: %s", task.TableName, err)
 	}
 	for _, batch := range pendingBatches {
-		submitBatch(batch, connPool, updateProgressFn)
+		submitBatch(batch, updateProgressFn)
 	}
 	if !fileFullySplit {
-		splitFilesForTable(state, origDataFile, task.TableName, connPool, lastBatchNumber, lastOffset, updateProgressFn)
+		splitFilesForTable(state, origDataFile, task.TableName, lastBatchNumber, lastOffset, updateProgressFn)
 	}
 }
 
-func splitFilesForTable(state *ImportDataState, filePath string, t string, connPool *tgtdb.ConnectionPool,
+func splitFilesForTable(state *ImportDataState, filePath string, t string,
 	lastBatchNumber int64, lastOffset int64, updateProgressFn func(int64)) {
 	log.Infof("Split data file %q: tableName=%q, largestSplit=%v, largestOffset=%v", filePath, t, lastBatchNumber, lastOffset)
 	batchNum := lastBatchNumber + 1
@@ -384,7 +383,7 @@ func splitFilesForTable(state *ImportDataState, filePath string, t string, connP
 			}
 			batchWriter = nil
 			dataFile.ResetBytesRead()
-			submitBatch(batch, connPool, updateProgressFn)
+			submitBatch(batch, updateProgressFn)
 
 			if !isLastBatch {
 				batchNum += 1
@@ -394,12 +393,12 @@ func splitFilesForTable(state *ImportDataState, filePath string, t string, connP
 	log.Infof("splitFilesForTable: done splitting data file %q for table %q", filePath, t)
 }
 
-func submitBatch(batch *Batch, connPool *tgtdb.ConnectionPool, updateProgressFn func(int64)) {
+func submitBatch(batch *Batch, updateProgressFn func(int64)) {
 	batchImportPool.Go(func() {
 		// There are `poolSize` number of competing go-routines trying to invoke COPY.
 		// But the `connPool` will allow only `parallelism` number of connections to be
 		// used at a time. Thus limiting the number of concurrent COPYs to `parallelism`.
-		doOneImport(batch, connPool)
+		doOneImport(batch)
 		if reportProgressInBytes {
 			updateProgressFn(batch.ByteCount)
 		} else {
@@ -417,7 +416,8 @@ func executePostImportDataSqls() {
 	}
 }
 
-func doOneImport(batch *Batch, connPool *tgtdb.ConnectionPool) {
+func doOneImport(batch *Batch) {
+	connPool := tdb.ConnPool()
 	err := batch.MarkPending()
 	if err != nil {
 		utils.ErrExit("marking batch %d as pending: %s", batch.Number, err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -396,7 +396,7 @@ func submitBatch(batch *Batch, updateProgressFn func(int64)) {
 		// There are `poolSize` number of competing go-routines trying to invoke COPY.
 		// But the `connPool` will allow only `parallelism` number of connections to be
 		// used at a time. Thus limiting the number of concurrent COPYs to `parallelism`.
-		doOneImport(batch)
+		importBatch(batch)
 		if reportProgressInBytes {
 			updateProgressFn(batch.ByteCount)
 		} else {
@@ -414,7 +414,7 @@ func executePostImportDataSqls() {
 	}
 }
 
-func doOneImport(batch *Batch) {
+func importBatch(batch *Batch) {
 	err := batch.MarkPending()
 	if err != nil {
 		utils.ErrExit("marking batch %d as pending: %s", batch.Number, err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -306,6 +306,7 @@ func getImportBatchArgsProto(tableName string) *tgtdb.ImportBatchArgs {
 func importFile(state *ImportDataState, task *ImportFileTask, updateProgressFn func(int64)) {
 
 	origDataFile := task.FilePath
+	// TODO: Remove the following call to extractCopyStmtForTable().
 	extractCopyStmtForTable(task.TableName, origDataFile)
 	importBatchArgsProto := getImportBatchArgsProto(task.TableName)
 	log.Infof("Start splitting table %q: data-file: %q", task.TableName, origDataFile)
@@ -440,18 +441,6 @@ func importBatch(batch *Batch, importBatchArgsProto *tgtdb.ImportBatchArgs) {
 	}
 	log.Infof("Importing %q", batch.FilePath)
 
-	copyCommand := getCopyCommand(batch.TableName)
-	// copyCommand is empty when there are no rows for that table
-	if copyCommand == "" {
-		err = batch.MarkDone()
-		if err != nil {
-			utils.ErrExit("marking batch %q as done: %s", batch.FilePath, err)
-		}
-		return
-	}
-	copyCommand = fmt.Sprintf(copyCommand, (batch.OffsetEnd - batch.OffsetStart))
-	log.Infof("COPY command: %s", copyCommand)
-
 	importBatchArgs := *importBatchArgsProto
 	importBatchArgs.FilePath = batch.FilePath
 	importBatchArgs.RowsPerTransaction = int(batch.OffsetEnd - batch.OffsetStart)
@@ -472,9 +461,9 @@ func importBatch(batch *Batch, importBatchArgsProto *tgtdb.ImportBatchArgs) {
 			sleepIntervalSec, batch.FilePath, attempt)
 		time.Sleep(time.Duration(sleepIntervalSec) * time.Second)
 	}
-	log.Infof("%q => %d rows affected", copyCommand, rowsAffected)
+	log.Infof("%q => %d rows affected", batch.FilePath, rowsAffected)
 	if err != nil {
-		utils.ErrExit("COPY %q FROM file %q: %s", batch.TableName, batch.FilePath, err)
+		utils.ErrExit("import %q into %s: %s", batch.FilePath, batch.TableName, err)
 	}
 	err = batch.MarkDone()
 	if err != nil {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -271,7 +271,7 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	defer conn.Close(context.Background())
 
 	tableNames := importFileTasksToTableNames(tasks)
-	nonEmptyTableNames := getNonEmptyTables(conn, tableNames)
+	nonEmptyTableNames := tdb.GetNonEmptyTables(tableNames)
 	if len(nonEmptyTableNames) > 0 {
 		utils.PrintAndLog("Following tables are not empty. "+
 			"TRUNCATE them before importing data with --start-clean.\n%s",
@@ -288,26 +288,6 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 			utils.ErrExit("failed to clean import data state for table %q: %s", task.TableName, err)
 		}
 	}
-}
-
-func getNonEmptyTables(conn *pgx.Conn, tables []string) []string {
-	result := []string{}
-
-	for _, table := range tables {
-		log.Infof("Checking if table %q is empty.", table)
-		tmp := false
-		stmt := fmt.Sprintf("SELECT TRUE FROM %s LIMIT 1;", table)
-		err := conn.QueryRow(context.Background(), stmt).Scan(&tmp)
-		if err == pgx.ErrNoRows {
-			continue
-		}
-		if err != nil {
-			utils.ErrExit("failed to check whether table %q empty: %s", table, err)
-		}
-		result = append(result, table)
-	}
-	log.Infof("non empty tables: %v", result)
-	return result
 }
 
 func importFile(state *ImportDataState, task *ImportFileTask, connPool *tgtdb.ConnectionPool,
@@ -566,6 +546,7 @@ func newTargetConn() *pgx.Conn {
 	return conn
 }
 
+// TODO: Eventually get rid of this function in favour of TargetYugabyteDB.setTargetSchema().
 func setTargetSchema(conn *pgx.Conn) {
 	if sourceDBType == POSTGRESQL || tconf.Schema == YUGABYTEDB_DEFAULT_SCHEMA {
 		// For PG, schema name is already included in the object name.

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -285,10 +285,25 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 }
 
+func getImportBatchArgsProto(tableName string) *tgtdb.ImportBatchArgs {
+	columns := dataFileDescriptor.TableNameToExportedColumns[tableName]
+	return &tgtdb.ImportBatchArgs{
+		TableName:  tableName,
+		Columns:    columns,
+		FileFormat: dataFileDescriptor.FileFormat,
+		Delimiter:  dataFileDescriptor.Delimiter,
+		HasHeader:  dataFileDescriptor.HasHeader,
+		QuoteChar:  dataFileDescriptor.QuoteChar,
+		EscapeChar: dataFileDescriptor.EscapeChar,
+		NullString: nullString,
+	}
+}
+
 func importFile(state *ImportDataState, task *ImportFileTask, updateProgressFn func(int64)) {
 
 	origDataFile := task.FilePath
 	extractCopyStmtForTable(task.TableName, origDataFile)
+	importBatchArgsProto := getImportBatchArgsProto(task.TableName)
 	log.Infof("Start splitting table %q: data-file: %q", task.TableName, origDataFile)
 
 	err := state.PrepareForFileImport(task.FilePath, task.TableName)
@@ -301,15 +316,15 @@ func importFile(state *ImportDataState, task *ImportFileTask, updateProgressFn f
 		utils.ErrExit("recovering state for table %q: %s", task.TableName, err)
 	}
 	for _, batch := range pendingBatches {
-		submitBatch(batch, updateProgressFn)
+		submitBatch(batch, updateProgressFn, importBatchArgsProto)
 	}
 	if !fileFullySplit {
-		splitFilesForTable(state, origDataFile, task.TableName, lastBatchNumber, lastOffset, updateProgressFn)
+		splitFilesForTable(state, origDataFile, task.TableName, lastBatchNumber, lastOffset, updateProgressFn, importBatchArgsProto)
 	}
 }
 
 func splitFilesForTable(state *ImportDataState, filePath string, t string,
-	lastBatchNumber int64, lastOffset int64, updateProgressFn func(int64)) {
+	lastBatchNumber int64, lastOffset int64, updateProgressFn func(int64), importBatchArgsProto *tgtdb.ImportBatchArgs) {
 	log.Infof("Split data file %q: tableName=%q, largestSplit=%v, largestOffset=%v", filePath, t, lastBatchNumber, lastOffset)
 	batchNum := lastBatchNumber + 1
 	numLinesTaken := lastOffset
@@ -381,7 +396,7 @@ func splitFilesForTable(state *ImportDataState, filePath string, t string,
 			}
 			batchWriter = nil
 			dataFile.ResetBytesRead()
-			submitBatch(batch, updateProgressFn)
+			submitBatch(batch, updateProgressFn, importBatchArgsProto)
 
 			if !isLastBatch {
 				batchNum += 1
@@ -391,12 +406,12 @@ func splitFilesForTable(state *ImportDataState, filePath string, t string,
 	log.Infof("splitFilesForTable: done splitting data file %q for table %q", filePath, t)
 }
 
-func submitBatch(batch *Batch, updateProgressFn func(int64)) {
+func submitBatch(batch *Batch, updateProgressFn func(int64), importBatchArgsProto *tgtdb.ImportBatchArgs) {
 	batchImportPool.Go(func() {
 		// There are `poolSize` number of competing go-routines trying to invoke COPY.
 		// But the `connPool` will allow only `parallelism` number of connections to be
 		// used at a time. Thus limiting the number of concurrent COPYs to `parallelism`.
-		importBatch(batch)
+		importBatch(batch, importBatchArgsProto)
 		if reportProgressInBytes {
 			updateProgressFn(batch.ByteCount)
 		} else {
@@ -414,7 +429,7 @@ func executePostImportDataSqls() {
 	}
 }
 
-func importBatch(batch *Batch) {
+func importBatch(batch *Batch, importBatchArgsProto *tgtdb.ImportBatchArgs) {
 	err := batch.MarkPending()
 	if err != nil {
 		utils.ErrExit("marking batch %d as pending: %s", batch.Number, err)
@@ -433,10 +448,14 @@ func importBatch(batch *Batch) {
 	copyCommand = fmt.Sprintf(copyCommand, (batch.OffsetEnd - batch.OffsetStart))
 	log.Infof("COPY command: %s", copyCommand)
 
+	importBatchArgs := *importBatchArgsProto
+	importBatchArgs.FilePath = batch.FilePath
+	importBatchArgs.RowsPerTransaction = int(batch.OffsetEnd - batch.OffsetStart)
+
 	var rowsAffected int64
 	sleepIntervalSec := 0
 	for attempt := 0; attempt < COPY_MAX_RETRY_COUNT; attempt++ {
-		rowsAffected, err = tdb.ImportBatch(batch, copyCommand)
+		rowsAffected, err = tdb.ImportBatch(batch, &importBatchArgs)
 		if err == nil || tdb.IsNonRetryableCopyError(err) {
 			break
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -267,9 +267,6 @@ func classifyTasks(state *ImportDataState, tasks []*ImportFileTask) (pendingTask
 }
 
 func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
-	conn := newTargetConn()
-	defer conn.Close(context.Background())
-
 	tableNames := importFileTasksToTableNames(tasks)
 	nonEmptyTableNames := tdb.GetNonEmptyTables(tableNames)
 	if len(nonEmptyTableNames) > 0 {
@@ -283,7 +280,7 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 
 	for _, task := range tasks {
-		err := state.Clean(task.FilePath, task.TableName, conn)
+		err := state.Clean(task.FilePath, task.TableName)
 		if err != nil {
 			utils.ErrExit("failed to clean import data state for table %q: %s", task.TableName, err)
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -701,6 +701,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 	return err
 }
 
+// TODO: This function is a duplicate of the one in tgtdb/yb.go. Consolidate the two.
 func getTargetSchemaName(tableName string) string {
 	parts := strings.Split(tableName, ".")
 	if len(parts) == 2 {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -49,7 +49,6 @@ import (
 
 var metaInfoDirName = META_INFO_DIR_NAME
 var batchSize = int64(0)
-var parallelism = 0
 var batchImportPool *pool.Pool
 var tablesProgressMetadata map[string]*utils.TableProgressMetadata
 
@@ -153,11 +152,6 @@ func importData(importFileTasks []*ImportFileTask) {
 		utils.ErrExit("Failed to create voyager metadata schema on target DB: %s", err)
 	}
 
-	log.Infof("parallelism=%v", parallelism)
-	payload.ParallelJobs = parallelism
-	if tconf.VerboseMode {
-		fmt.Printf("Number of parallel imports jobs at a time: %d\n", parallelism)
-	}
 	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
 	var pendingTasks, completedTasks []*ImportFileTask
 	state := NewImportDataState(exportDir)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -299,23 +299,27 @@ func getImportBatchArgsProto(tableName, filePath string) *tgtdb.ImportBatchArgs 
 		if err != nil {
 			utils.ErrExit("opening datafile %q: %v", filePath, err)
 		}
-		columns = strings.Split(df.GetHeader(), dataFileDescriptor.Delimiter)
+		header := df.GetHeader()
+		columns = strings.Split(header, dataFileDescriptor.Delimiter)
+		log.Infof("read header from file %q: %s", filePath, header)
+		log.Infof("header row split using delimiter %q: %v\n", dataFileDescriptor.Delimiter, columns)
 		df.Close()
 	}
-	for i, column := range columns {
-		columns[i] = quoteIdentifierIfRequired(strings.TrimSpace(column))
+	columns, err := tdb.IfRequiredQuoteColumnNames(tableName, columns)
+	if err != nil {
+		utils.ErrExit("if required quote column names: %s", err)
 	}
 	// If `columns` is unset at this point, no attribute list is passed in the COPY command.
 	fileFormat := dataFileDescriptor.FileFormat
-	if fileFormat == "sql" {
-		fileFormat = "text"
+	if fileFormat == datafile.SQL {
+		fileFormat = datafile.TEXT
 	}
 	importBatchArgsProto := &tgtdb.ImportBatchArgs{
 		TableName:  tableName,
 		Columns:    columns,
 		FileFormat: fileFormat,
 		Delimiter:  dataFileDescriptor.Delimiter,
-		HasHeader:  dataFileDescriptor.HasHeader,
+		HasHeader:  dataFileDescriptor.HasHeader && fileFormat == datafile.CSV,
 		QuoteChar:  dataFileDescriptor.QuoteChar,
 		EscapeChar: dataFileDescriptor.EscapeChar,
 		NullString: nullString,

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -159,7 +159,7 @@ func setImportTableListFlag() {
 	for _, task := range importFileTasks {
 		tableList[task.TableName] = true
 	}
-	target.TableList = strings.Join(maps.Keys(tableList), ",")
+	tconf.TableList = strings.Join(maps.Keys(tableList), ",")
 }
 
 func prepareImportFileTasks() []*ImportFileTask {

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -77,6 +77,7 @@ func prepareForImportDataCmd() {
 		Delimiter:    delimiter,
 		HasHeader:    hasHeader,
 		ExportDir:    exportDir,
+		NullString:   nullString,
 	}
 	if quoteChar != "" {
 		quoteCharBytes := []byte(quoteChar)

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -28,7 +28,12 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"golang.org/x/exp/slices"
+)
+
+const (
+	BATCH_METADATA_TABLE_NAME = tgtdb.BATCH_METADATA_TABLE_NAME
 )
 
 /*

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -155,7 +155,7 @@ func (s *ImportDataState) Recover(filePath, tableName string) ([]*Batch, int64, 
 	return pendingBatches, lastBatchNumber, lastOffset, fileFullySplit, nil
 }
 
-func (s *ImportDataState) Clean(filePath string, tableName string, conn *pgx.Conn) error {
+func (s *ImportDataState) Clean(filePath string, tableName string) error {
 	log.Infof("Cleaning import data state for table %q.", tableName)
 	fileStateDir := s.getFileStateDir(filePath, tableName)
 	log.Infof("Removing %q.", fileStateDir)

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -48,7 +48,10 @@ type ImportDataState struct {
 }
 
 func NewImportDataState(exportDir string) *ImportDataState {
-	return &ImportDataState{exportDir: exportDir, stateDir: filepath.Join(exportDir, "metainfo", "import_data_state")}
+	return &ImportDataState{
+		exportDir: exportDir,
+		stateDir:  filepath.Join(exportDir, "metainfo", "import_data_state"),
+	}
 }
 
 func (s *ImportDataState) PrepareForFileImport(filePath, tableName string) error {

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -528,7 +528,7 @@ func (batch *Batch) GetQueryIsBatchAlreadyImported() string {
 	return query
 }
 
-func (batch *Batch) GetCommandToRecordEntryInDB(rowsAffected int64) string {
+func (batch *Batch) GetQueryToRecordEntryInDB(rowsAffected int64) string {
 	// Record an entry in ${BATCH_METADATA_TABLE_NAME}, that the split is imported.
 	schemaName := getTargetSchemaName(batch.TableName)
 	cmd := fmt.Sprintf(

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -164,16 +164,10 @@ func (s *ImportDataState) Clean(filePath string, tableName string, conn *pgx.Con
 		return fmt.Errorf("error while removing %q: %w", fileStateDir, err)
 	}
 
-	// Delete all entries from ${BATCH_METADATA_TABLE_NAME} for this table.
-	schemaName := getTargetSchemaName(tableName)
-	cmd := fmt.Sprintf(
-		`DELETE FROM %s WHERE data_file_name = '%s' AND schema_name = '%s' AND table_name = '%s'`,
-		BATCH_METADATA_TABLE_NAME, filePath, schemaName, tableName)
-	res, err := conn.Exec(context.Background(), cmd)
+	err = tdb.CleanFileImportState(filePath, tableName)
 	if err != nil {
-		return fmt.Errorf("remove %q related entries from %s: %w", tableName, BATCH_METADATA_TABLE_NAME, err)
+		return fmt.Errorf("error while cleaning file import state for %q: %w", tableName, err)
 	}
-	log.Infof("query: [%s] => rows affected %v", cmd, res.RowsAffected())
 	return nil
 }
 

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -62,11 +62,11 @@ var flagRefreshMViews bool
 
 func importSchema() {
 	tdb = tgtdb.NewTargetDB(&tconf)
-	err := tdb.Connect()
+	err := tdb.Init()
 	if err != nil {
-		utils.ErrExit("Failed to connect to target YB cluster: %s", err)
+		utils.ErrExit("Failed to initialize the target DB: %s", err)
 	}
-	defer tdb.Disconnect()
+	defer tdb.Finalize()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
 	conn := tdb.Conn()

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -61,6 +61,8 @@ var importObjectsInStraightOrder bool
 var flagRefreshMViews bool
 
 func importSchema() {
+	tconf.Schema = strings.ToLower(tconf.Schema)
+
 	tdb = tgtdb.NewTargetDB(&tconf)
 	err := tdb.Init()
 	if err != nil {
@@ -68,9 +70,12 @@ func importSchema() {
 	}
 	defer tdb.Finalize()
 
-	tconf.Schema = strings.ToLower(tconf.Schema)
-	conn := tdb.Conn()
-	targetDBVersion := tdb.GetVersion()
+	ybdb, ok := tdb.(*tgtdb.TargetYugabyteDB)
+	if !ok {
+		utils.ErrExit("The target DB must be YugabyteDB")
+	}
+	conn := ybdb.Conn()
+	targetDBVersion := ybdb.GetVersion()
 	utils.PrintAndLog("YugabyteDB version: %s\n", targetDBVersion)
 
 	payload := callhome.GetPayload(exportDir)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -60,15 +61,16 @@ var importObjectsInStraightOrder bool
 var flagRefreshMViews bool
 
 func importSchema() {
-	err := tconf.DB().Connect()
+	tdb = tgtdb.NewTargetDB(&tconf)
+	err := tdb.Connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to target YB cluster: %s", err)
 	}
-	defer tconf.DB().Disconnect()
+	defer tdb.Disconnect()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
-	conn := tconf.DB().Conn()
-	targetDBVersion := tconf.DB().GetVersion()
+	conn := tdb.Conn()
+	targetDBVersion := tdb.GetVersion()
 	utils.PrintAndLog("YugabyteDB version: %s\n", targetDBVersion)
 
 	payload := callhome.GetPayload(exportDir)

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -118,12 +118,12 @@ func ExtractMetaInfo(exportDir string) utils.ExportMetaInfo {
 
 func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	var finalImportObjectList []string
-	excludeObjectList := utils.CsvStringToSlice(target.ExcludeImportObjects)
+	excludeObjectList := utils.CsvStringToSlice(tconf.ExcludeImportObjects)
 	for i, item := range excludeObjectList {
 		excludeObjectList[i] = strings.ToUpper(item)
 	}
-	if target.ImportObjects != "" {
-		includeObjectList := utils.CsvStringToSlice(target.ImportObjects)
+	if tconf.ImportObjects != "" {
+		includeObjectList := utils.CsvStringToSlice(tconf.ImportObjects)
 		for i, item := range includeObjectList {
 			includeObjectList[i] = strings.ToUpper(item)
 		}

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -16,96 +16,18 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
-type Event struct {
-	Op         string            `json:"op"`
-	SchemaName string            `json:"schema_name"`
-	TableName  string            `json:"table_name"`
-	Key        map[string]string `json:"key"`
-	Fields     map[string]string `json:"fields"`
-}
-
-func (e *Event) GetSQLStmt(targetSchema string) string {
-	switch e.Op {
-	case "c":
-		return e.getInsertStmt(targetSchema)
-	case "u":
-		return e.getUpdateStmt(targetSchema)
-	case "d":
-		return e.getDeleteStmt(targetSchema)
-	default:
-		panic("unknown op: " + e.Op)
-	}
-}
-
-const insertTemplate = "INSERT INTO %s (%s) VALUES (%s);"
-const updateTemplate = "UPDATE %s SET %s WHERE %s;"
-const deleteTemplate = "DELETE FROM %s WHERE %s;"
-
-func (event *Event) getInsertStmt(targetSchema string) string {
-	tableName := event.SchemaName + "." + event.TableName
-	if targetSchema != "" {
-		tableName = targetSchema + "." + event.TableName
-	}
-	columnList := make([]string, 0, len(event.Fields))
-	valueList := make([]string, 0, len(event.Fields))
-	for column, value := range event.Fields {
-		columnList = append(columnList, column)
-		valueList = append(valueList, value)
-	}
-	columns := strings.Join(columnList, ", ")
-	values := strings.Join(valueList, ", ")
-	stmt := fmt.Sprintf(insertTemplate, tableName, columns, values)
-	return stmt
-}
-
-func (event *Event) getUpdateStmt(targetSchema string) string {
-	tableName := event.SchemaName + "." + event.TableName
-	if targetSchema != "" {
-		tableName = targetSchema + "." + event.TableName
-	}
-	var setClauses []string
-	for column, value := range event.Fields {
-		setClauses = append(setClauses, fmt.Sprintf("%s = %s", column, value))
-	}
-	setClause := strings.Join(setClauses, ", ")
-	var whereClauses []string
-	for column, value := range event.Key {
-		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
-	}
-	whereClause := strings.Join(whereClauses, " AND ")
-	return fmt.Sprintf(updateTemplate, tableName, setClause, whereClause)
-}
-
-func (event *Event) getDeleteStmt(targetSchema string) string {
-	tableName := event.SchemaName + "." + event.TableName
-	if targetSchema != "" {
-		tableName = targetSchema + "." + event.TableName
-	}
-	var whereClauses []string
-	for column, value := range event.Key {
-		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
-	}
-	whereClause := strings.Join(whereClauses, " AND ")
-	return fmt.Sprintf(deleteTemplate, tableName, whereClause)
-}
-
-//==================================================================================
-
-func streamChanges(connPool *tgtdb.ConnectionPool, targetSchema string) error {
+func streamChanges() error {
 	queueFilePath := filepath.Join(exportDir, "data", "queue.json")
 	log.Infof("Streaming changes from %s", queueFilePath)
 	file, err := os.OpenFile(queueFilePath, os.O_CREATE, 0640)
@@ -119,13 +41,13 @@ func streamChanges(connPool *tgtdb.ConnectionPool, targetSchema string) error {
 	log.Infof("Waiting for changes in %s", queueFilePath)
 	// TODO: Batch the changes.
 	for dec.More() {
-		var event Event
+		var event tgtdb.Event
 		err := dec.Decode(&event)
 		if err != nil {
 			return fmt.Errorf("error decoding change: %v", err)
 		}
 
-		err = handleEvent(connPool, &event, targetSchema)
+		err = handleEvent(&event)
 		if err != nil {
 			return fmt.Errorf("error handling event: %v", err)
 		}
@@ -133,24 +55,14 @@ func streamChanges(connPool *tgtdb.ConnectionPool, targetSchema string) error {
 	return nil
 }
 
-func handleEvent(connPool *tgtdb.ConnectionPool, event *Event, targetSchema string) error {
+func handleEvent(event *tgtdb.Event) error {
 	log.Debugf("Handling event: %v", event)
-	stmt := event.GetSQLStmt(targetSchema)
-	log.Debug(stmt)
-	err := connPool.WithConn(func(conn *pgx.Conn) (bool, error) {
-		tag, err := conn.Exec(context.Background(), stmt)
-		if err != nil {
-			log.Errorf("Error executing stmt: %v", err)
-		}
-		log.Debugf("Executed stmt [ %s ]: rows affected => %v", stmt, tag.RowsAffected())
-		return false, err
-	})
-	// Idempotency considerations:
-	// Note: Assuming PK column value is not changed via UPDATEs
-	// INSERT: The connPool sets `yb_enable_upsert_mode to true`. Hece the insert will be
-	// successful even if the row already exists.
-	// DELETE does NOT fail if the row does not exist. Rows affected will be 0.
-	// UPDATE statement does not fail if the row does not exist. Rows affected will be 0.
 
-	return err
+	// TODO: Convert values in the event to make it suitable for target DB.
+	batch := []*tgtdb.Event{event}
+	err := tdb.ExecuteBatch(batch)
+	if err != nil {
+		return fmt.Errorf("error executing batch: %v", err)
+	}
+	return nil
 }

--- a/yb-voyager/src/datafile/descriptor.go
+++ b/yb-voyager/src/datafile/descriptor.go
@@ -48,13 +48,14 @@ type FileEntry struct {
 }
 
 type Descriptor struct {
-	FileFormat   string       `json:"FileFormat"`
-	Delimiter    string       `json:"Delimiter"`
-	HasHeader    bool         `json:"HasHeader"`
-	ExportDir    string       `json:"-"`
-	QuoteChar    byte         `json:"QuoteChar,omitempty"`
-	EscapeChar   byte         `json:"EscapeChar,omitempty"`
-	DataFileList []*FileEntry `json:"FileList"`
+	FileFormat                 string              `json:"FileFormat"`
+	Delimiter                  string              `json:"Delimiter"`
+	HasHeader                  bool                `json:"HasHeader"`
+	ExportDir                  string              `json:"-"`
+	QuoteChar                  byte                `json:"QuoteChar,omitempty"`
+	EscapeChar                 byte                `json:"EscapeChar,omitempty"`
+	DataFileList               []*FileEntry        `json:"FileList"`
+	TableNameToExportedColumns map[string][]string `json:"TableNameToExportedColumns"`
 }
 
 func OpenDescriptor(exportDir string) *Descriptor {

--- a/yb-voyager/src/datafile/descriptor.go
+++ b/yb-voyager/src/datafile/descriptor.go
@@ -54,6 +54,7 @@ type Descriptor struct {
 	ExportDir                  string              `json:"-"`
 	QuoteChar                  byte                `json:"QuoteChar,omitempty"`
 	EscapeChar                 byte                `json:"EscapeChar,omitempty"`
+	NullString                 string              `json:"NullString,omitempty"`
 	DataFileList               []*FileEntry        `json:"FileList"`
 	TableNameToExportedColumns map[string][]string `json:"TableNameToExportedColumns"`
 }

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -171,6 +171,7 @@ func (ms *MySQL) ExportDataPostProcessing(exportDir string, tablesProgressMetada
 		Delimiter:                  "\t",
 		HasHeader:                  false,
 		ExportDir:                  exportDir,
+		NullString:                 `\N`,
 		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
 		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -167,11 +167,12 @@ func (ms *MySQL) ExportData(ctx context.Context, exportDir string, tableList []*
 func (ms *MySQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	renameDataFilesForReservedWords(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileFormat:   datafile.SQL,
-		Delimiter:    "\t",
-		HasHeader:    false,
-		ExportDir:    exportDir,
-		DataFileList: getExportedDataFileList(tablesProgressMetadata),
+		FileFormat:                 datafile.SQL,
+		Delimiter:                  "\t",
+		HasHeader:                  false,
+		ExportDir:                  exportDir,
+		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
+		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 	dfd.Save()
 }

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -180,6 +180,7 @@ func (ora *Oracle) ExportDataPostProcessing(exportDir string, tablesProgressMeta
 		Delimiter:                  "\t",
 		HasHeader:                  false,
 		ExportDir:                  exportDir,
+		NullString:                 `\N`,
 		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 	dfd.Save()

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -175,11 +175,12 @@ func (ora *Oracle) ExportData(ctx context.Context, exportDir string, tableList [
 func (ora *Oracle) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	renameDataFilesForReservedWords(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileFormat:   datafile.SQL,
-		DataFileList: getExportedDataFileList(tablesProgressMetadata),
-		Delimiter:    "\t",
-		HasHeader:    false,
-		ExportDir:    exportDir,
+		FileFormat:                 datafile.SQL,
+		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
+		Delimiter:                  "\t",
+		HasHeader:                  false,
+		ExportDir:                  exportDir,
+		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 	dfd.Save()
 

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -236,6 +236,8 @@ func (pg *PostgreSQL) getExportedColumnsMap(
 
 	result := make(map[string][]string)
 	for _, tableMetadata := range tablesMetadata {
+		// TODO: Use tableMetadata.TableName instead of parsing the file name.
+		// We need a new method in sqlname.SourceName that returns MaybeQuoted and MaybeQualified names.
 		tableName := strings.TrimSuffix(filepath.Base(tableMetadata.FinalFilePath), "_data.sql")
 		result[tableName] = pg.getExportedColumnsListForTable(exportDir, tableName)
 	}

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -251,16 +251,12 @@ func (pg *PostgreSQL) getExportedColumnsListForTable(exportDir, tableName string
 		re = regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]+\((.*)\) FROM STDIN`, tableName))
 	}
 	tocFilePath := filepath.Join(exportDir, "data", "toc.dat")
-	err := utils.ForEachLineInFile(tocFilePath, func(line string) bool {
-		matches := re.FindStringSubmatch(line)
-		if len(matches) > 0 {
-			columnsList = strings.Split(matches[1], ",")
-			for i, column := range columnsList {
-				columnsList[i] = strings.TrimSpace(column)
-			}
-			return false // stop reading file
+	err := utils.ForEachMatchingLineInFile(tocFilePath, re, func(matches []string) bool {
+		columnsList = strings.Split(matches[1], ",")
+		for i, column := range columnsList {
+			columnsList[i] = strings.TrimSpace(column)
 		}
-		return true
+		return false // stop reading file
 	})
 	if err != nil {
 		utils.ErrExit("error in reading toc file: %v\n", err)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v4"
@@ -217,13 +219,54 @@ func (pg *PostgreSQL) ExportData(ctx context.Context, exportDir string, tableLis
 func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	renameDataFiles(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileFormat:   datafile.TEXT,
-		DataFileList: getExportedDataFileList(tablesProgressMetadata),
-		Delimiter:    "\t",
-		HasHeader:    false,
-		ExportDir:    exportDir,
+		FileFormat:                 datafile.TEXT,
+		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
+		Delimiter:                  "\t",
+		HasHeader:                  false,
+		ExportDir:                  exportDir,
+		TableNameToExportedColumns: pg.getExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
+
 	dfd.Save()
+}
+
+func (pg *PostgreSQL) getExportedColumnsMap(
+	exportDir string, tablesMetadata map[string]*utils.TableProgressMetadata) map[string][]string {
+
+	result := make(map[string][]string)
+	for _, tableMetadata := range tablesMetadata {
+		tableName := strings.TrimSuffix(filepath.Base(tableMetadata.FinalFilePath), "_data.sql")
+		result[tableName] = pg.getExportedColumnsListForTable(exportDir, tableName)
+	}
+	return result
+}
+
+func (pg *PostgreSQL) getExportedColumnsListForTable(exportDir, tableName string) []string {
+	var columnsList []string
+	var re *regexp.Regexp
+	if len(strings.Split(tableName, ".")) == 1 {
+		// happens only when table is in public schema, use public schema with table name for regexp
+		re = regexp.MustCompile(fmt.Sprintf(`(?i)COPY public.%s[\s]+\((.*)\) FROM STDIN`, tableName))
+	} else {
+		re = regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]+\((.*)\) FROM STDIN`, tableName))
+	}
+	tocFilePath := filepath.Join(exportDir, "data", "toc.dat")
+	err := utils.ForEachLineInFile(tocFilePath, func(line string) bool {
+		matches := re.FindStringSubmatch(line)
+		if len(matches) > 0 {
+			columnsList = strings.Split(matches[1], ",")
+			for i, column := range columnsList {
+				columnsList[i] = strings.TrimSpace(column)
+			}
+			return false // stop reading file
+		}
+		return true
+	})
+	if err != nil {
+		utils.ErrExit("error in reading toc file: %v\n", err)
+	}
+	log.Infof("columns list for table %s: %v", tableName, columnsList)
+	return columnsList
 }
 
 // Given a PG command name ("pg_dump", "pg_restore"), find absolute path of

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -224,6 +224,7 @@ func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressM
 		Delimiter:                  "\t",
 		HasHeader:                  false,
 		ExportDir:                  exportDir,
+		NullString:                 `\N`,
 		TableNameToExportedColumns: pg.getExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -1,3 +1,18 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package tgtdb
 
 import (

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -1,0 +1,79 @@
+package tgtdb
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Event struct {
+	Op         string            `json:"op"`
+	SchemaName string            `json:"schema_name"`
+	TableName  string            `json:"table_name"`
+	Key        map[string]string `json:"key"`
+	Fields     map[string]string `json:"fields"`
+}
+
+func (e *Event) GetSQLStmt(targetSchema string) string {
+	switch e.Op {
+	case "c":
+		return e.getInsertStmt(targetSchema)
+	case "u":
+		return e.getUpdateStmt(targetSchema)
+	case "d":
+		return e.getDeleteStmt(targetSchema)
+	default:
+		panic("unknown op: " + e.Op)
+	}
+}
+
+const insertTemplate = "INSERT INTO %s (%s) VALUES (%s);"
+const updateTemplate = "UPDATE %s SET %s WHERE %s;"
+const deleteTemplate = "DELETE FROM %s WHERE %s;"
+
+func (event *Event) getInsertStmt(targetSchema string) string {
+	tableName := event.SchemaName + "." + event.TableName
+	if targetSchema != "" {
+		tableName = targetSchema + "." + event.TableName
+	}
+	columnList := make([]string, 0, len(event.Fields))
+	valueList := make([]string, 0, len(event.Fields))
+	for column, value := range event.Fields {
+		columnList = append(columnList, column)
+		valueList = append(valueList, value)
+	}
+	columns := strings.Join(columnList, ", ")
+	values := strings.Join(valueList, ", ")
+	stmt := fmt.Sprintf(insertTemplate, tableName, columns, values)
+	return stmt
+}
+
+func (event *Event) getUpdateStmt(targetSchema string) string {
+	tableName := event.SchemaName + "." + event.TableName
+	if targetSchema != "" {
+		tableName = targetSchema + "." + event.TableName
+	}
+	var setClauses []string
+	for column, value := range event.Fields {
+		setClauses = append(setClauses, fmt.Sprintf("%s = %s", column, value))
+	}
+	setClause := strings.Join(setClauses, ", ")
+	var whereClauses []string
+	for column, value := range event.Key {
+		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
+	}
+	whereClause := strings.Join(whereClauses, " AND ")
+	return fmt.Sprintf(updateTemplate, tableName, setClause, whereClause)
+}
+
+func (event *Event) getDeleteStmt(targetSchema string) string {
+	tableName := event.SchemaName + "." + event.TableName
+	if targetSchema != "" {
+		tableName = targetSchema + "." + event.TableName
+	}
+	var whereClauses []string
+	for column, value := range event.Key {
+		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
+	}
+	whereClause := strings.Join(whereClauses, " AND ")
+	return fmt.Sprintf(deleteTemplate, tableName, whereClause)
+}

--- a/yb-voyager/src/tgtdb/target.go
+++ b/yb-voyager/src/tgtdb/target.go
@@ -22,7 +22,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
-type Target struct {
+type TargetConf struct {
 	Host                 string
 	Port                 int
 	User                 string
@@ -49,20 +49,20 @@ type Target struct {
 	db *TargetDB
 }
 
-func (t *Target) Clone() *Target {
+func (t *TargetConf) Clone() *TargetConf {
 	clone := *t
 	clone.db = nil
 	return &clone
 }
 
-func (t *Target) DB() *TargetDB {
+func (t *TargetConf) DB() *TargetDB {
 	if t.db == nil {
 		t.db = newTargetDB(t)
 	}
 	return t.db
 }
 
-func (t *Target) GetConnectionUri() string {
+func (t *TargetConf) GetConnectionUri() string {
 	if t.Uri == "" {
 		hostAndPort := fmt.Sprintf("%s:%d", t.Host, t.Port)
 		targetUrl := &url.URL{
@@ -80,7 +80,7 @@ func (t *Target) GetConnectionUri() string {
 }
 
 // this function is only triggered when t.Uri==""
-func generateSSLQueryStringIfNotExists(t *Target) string {
+func generateSSLQueryStringIfNotExists(t *TargetConf) string {
 	SSLQueryString := ""
 	if t.SSLMode == "" {
 		t.SSLMode = "prefer"
@@ -113,9 +113,9 @@ func generateSSLQueryStringIfNotExists(t *Target) string {
 	return SSLQueryString
 }
 
-func GetRedactedTarget(t *Target) *Target {
-	redactedTarget := *t
-	redactedTarget.Uri = utils.GetRedactedURLs([]string{t.Uri})[0]
-	redactedTarget.Password = "XXX"
-	return &redactedTarget
+func GetRedactedTargetConf(t *TargetConf) *TargetConf {
+	redacted := *t
+	redacted.Uri = utils.GetRedactedURLs([]string{t.Uri})[0]
+	redacted.Password = "XXX"
+	return &redacted
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -1,18 +1,9 @@
 package tgtdb
 
-// Not used yet.
-type ImportBatchArgs struct {
-	TableName string
-	Columns   []string
-	Format    *string
-	Header    *bool
-	Delimiter *rune
-	Quote     *rune
-	Escape    *rune
-	Null      *string
-
-	RowsPerTransaction int
-}
+import (
+	"fmt"
+	"strings"
+)
 
 type TargetDB interface {
 	Init() error
@@ -23,12 +14,54 @@ type TargetDB interface {
 	CreateVoyagerSchema() error
 	GetNonEmptyTables(tableNames []string) []string
 	IsNonRetryableCopyError(err error) bool
-	// TODO: Replace `copyCommand` with `*ImportBatchArgs`.
-	ImportBatch(batch Batch, copyCommand string) (int64, error)
+	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
 	// TODO: ConnPool() is a temporary method. It should eventually be removed.
 	ConnPool() *ConnectionPool
 }
 
 func NewTargetDB(tconf *TargetConf) TargetDB {
 	return newTargetYugabyteDB(tconf)
+}
+
+type ImportBatchArgs struct {
+	FilePath  string
+	TableName string
+	Columns   []string
+
+	FileFormat string
+	HasHeader  bool
+	Delimiter  string
+	QuoteChar  byte
+	EscapeChar byte
+	NullString string
+
+	RowsPerTransaction int
+}
+
+func (args *ImportBatchArgs) GetYBCopyStatement() string {
+	columns := ""
+	if len(args.Columns) > 0 {
+		columns = fmt.Sprintf("(%s)", strings.Join(args.Columns, ", "))
+	}
+	options := []string{
+		fmt.Sprintf("FORMAT '%s'", args.FileFormat),
+		fmt.Sprintf("ROWS_PER_TRANSACTION %v", args.RowsPerTransaction),
+	}
+	if args.HasHeader {
+		options = append(options, "HEADER")
+	}
+	if args.Delimiter != "" {
+		options = append(options, fmt.Sprintf("DELIMITER E'%c'", []rune(args.Delimiter)[0]))
+	}
+	if args.QuoteChar != 0 {
+		// TODO: confirm if the following cast to string is correct.
+		options = append(options, fmt.Sprintf("QUOTE E'%s'", string(args.QuoteChar)))
+	}
+	if args.EscapeChar != 0 {
+		options = append(options, fmt.Sprintf("ESCAPE E'%s'", string(args.EscapeChar)))
+	}
+	if args.NullString != "" {
+		options = append(options, fmt.Sprintf("NULL '%s'", args.NullString))
+	}
+	return fmt.Sprintf(`COPY %s %s FROM STDIN WITH (%s)`, args.TableName, columns, strings.Join(options, ", "))
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -16,8 +16,7 @@ type TargetDB interface {
 	IsNonRetryableCopyError(err error) bool
 	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
 	IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error)
-	// TODO: ConnPool() is a temporary method. It should eventually be removed.
-	ConnPool() *ConnectionPool
+	ExecuteBatch(batch []*Event) error
 }
 
 func NewTargetDB(tconf *TargetConf) TargetDB {

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -1,7 +1,23 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package tgtdb
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -17,6 +33,13 @@ type TargetDB interface {
 	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
 	IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error)
 	ExecuteBatch(batch []*Event) error
+}
+
+type Batch interface {
+	Open() (*os.File, error)
+	GetFilePath() string
+	GetQueryIsBatchAlreadyImported() string
+	GetQueryToRecordEntryInDB(rowsAffected int64) string
 }
 
 func NewTargetDB(tconf *TargetConf) TargetDB {
@@ -35,7 +58,7 @@ type ImportBatchArgs struct {
 	EscapeChar byte
 	NullString string
 
-	RowsPerTransaction int
+	RowsPerTransaction int64
 }
 
 func (args *ImportBatchArgs) GetYBCopyStatement() string {

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -15,6 +15,7 @@ type TargetDB interface {
 	GetNonEmptyTables(tableNames []string) []string
 	IsNonRetryableCopyError(err error) bool
 	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
+	IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error)
 	// TODO: ConnPool() is a temporary method. It should eventually be removed.
 	ConnPool() *ConnectionPool
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -1,0 +1,6 @@
+package tgtdb
+
+// TODO Define a Target interface and make TargetYugabyteDB implement it.
+func NewTargetDB(tconf *TargetConf) *TargetYugabyteDB {
+	return newTargetYugabyteDB(tconf)
+}

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -54,11 +54,18 @@ func (args *ImportBatchArgs) GetYBCopyStatement() string {
 		options = append(options, fmt.Sprintf("DELIMITER E'%c'", []rune(args.Delimiter)[0]))
 	}
 	if args.QuoteChar != 0 {
-		// TODO: confirm if the following cast to string is correct.
-		options = append(options, fmt.Sprintf("QUOTE E'%s'", string(args.QuoteChar)))
+		quoteChar := string(args.QuoteChar)
+		if quoteChar == `'` || quoteChar == `\` {
+			quoteChar = `\` + quoteChar
+		}
+		options = append(options, fmt.Sprintf("QUOTE E'%s'", quoteChar))
 	}
 	if args.EscapeChar != 0 {
-		options = append(options, fmt.Sprintf("ESCAPE E'%s'", string(args.EscapeChar)))
+		escapeChar := string(args.EscapeChar)
+		if escapeChar == `'` || escapeChar == `\` {
+			escapeChar = `\` + escapeChar
+		}
+		options = append(options, fmt.Sprintf("ESCAPE E'%s'", escapeChar))
 	}
 	if args.NullString != "" {
 		options = append(options, fmt.Sprintf("NULL '%s'", args.NullString))

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -1,6 +1,34 @@
 package tgtdb
 
-// TODO Define a Target interface and make TargetYugabyteDB implement it.
-func NewTargetDB(tconf *TargetConf) *TargetYugabyteDB {
+// Not used yet.
+type ImportBatchArgs struct {
+	TableName string
+	Columns   []string
+	Format    *string
+	Header    *bool
+	Delimiter *rune
+	Quote     *rune
+	Escape    *rune
+	Null      *string
+
+	RowsPerTransaction int
+}
+
+type TargetDB interface {
+	Init() error
+	Finalize()
+	InitConnPool() error
+	CleanFileImportState(filePath, tableName string) error
+	GetVersion() string
+	CreateVoyagerSchema() error
+	GetNonEmptyTables(tableNames []string) []string
+	IsNonRetryableCopyError(err error) bool
+	// TODO: Replace `copyCommand` with `*ImportBatchArgs`.
+	ImportBatch(batch Batch, copyCommand string) (int64, error)
+	// TODO: ConnPool() is a temporary method. It should eventually be removed.
+	ConnPool() *ConnectionPool
+}
+
+func NewTargetDB(tconf *TargetConf) TargetDB {
 	return newTargetYugabyteDB(tconf)
 }

--- a/yb-voyager/src/tgtdb/tconf.go
+++ b/yb-voyager/src/tgtdb/tconf.go
@@ -45,21 +45,11 @@ type TargetConf struct {
 	ImportObjects        string
 	ExcludeImportObjects string
 	dbVersion            string
-
-	db *TargetDB
 }
 
 func (t *TargetConf) Clone() *TargetConf {
 	clone := *t
-	clone.db = nil
 	return &clone
-}
-
-func (t *TargetConf) DB() *TargetDB {
-	if t.db == nil {
-		t.db = newTargetDB(t)
-	}
-	return t.db
 }
 
 func (t *TargetConf) GetConnectionUri() string {

--- a/yb-voyager/src/tgtdb/tconf.go
+++ b/yb-voyager/src/tgtdb/tconf.go
@@ -45,6 +45,12 @@ type TargetConf struct {
 	ImportObjects        string
 	ExcludeImportObjects string
 	dbVersion            string
+
+	TargetEndpoints            string
+	UsePublicIP                bool
+	EnableUpsert               bool
+	DisableTransactionalWrites bool
+	Parallelism                int
 }
 
 func (t *TargetConf) Clone() *TargetConf {

--- a/yb-voyager/src/tgtdb/yb.go
+++ b/yb-voyager/src/tgtdb/yb.go
@@ -16,20 +16,28 @@ limitations under the License.
 package tgtdb
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 type TargetYugabyteDB struct {
 	sync.Mutex
-	tconf *TargetConf
-	conn  *pgx.Conn
+	tconf    *TargetConf
+	conn     *pgx.Conn
+	connPool *ConnectionPool
 }
 
 func newTargetYugabyteDB(tconf *TargetConf) *TargetYugabyteDB {
@@ -100,4 +108,314 @@ func (yb *TargetYugabyteDB) GetVersion() string {
 		utils.ErrExit("get target db version: %s", err)
 	}
 	return yb.tconf.dbVersion
+}
+
+func (yb *TargetYugabyteDB) InitConnPool() error {
+	tconfs := yb.getYBServers()
+	var targetUriList []string
+	for _, tconf := range tconfs {
+		targetUriList = append(targetUriList, tconf.Uri)
+	}
+	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
+
+	if yb.tconf.Parallelism == -1 {
+		yb.tconf.Parallelism = fetchDefaultParllelJobs(tconfs)
+		utils.PrintAndLog("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", yb.tconf.Parallelism)
+	} else {
+		utils.PrintAndLog("Using %d parallel jobs", yb.tconf.Parallelism)
+	}
+
+	params := &ConnectionParams{
+		NumConnections:    yb.tconf.Parallelism,
+		ConnUriList:       targetUriList,
+		SessionInitScript: getYBSessionInitScript(yb.tconf),
+	}
+	yb.connPool = NewConnectionPool(params)
+	return nil
+}
+
+// TODO Do not export this method. This is temporary--until we refactor all target db access.
+func (yb *TargetYugabyteDB) ConnPool() *ConnectionPool {
+	return yb.connPool
+}
+
+const (
+	LB_WARN_MSG = "--target-db-host is a load balancer IP which will be used to create connections for data import.\n" +
+		"\t To control the parallelism and servers used, refer to help for --parallel-jobs and --target-endpoints flags.\n"
+
+	GET_YB_SERVERS_QUERY = "SELECT host, port, num_connections, node_type, cloud, region, zone, public_ip FROM yb_servers()"
+)
+
+func (yb *TargetYugabyteDB) getYBServers() []*TargetConf {
+	var tconfs []*TargetConf
+	var loadBalancerUsed bool
+
+	tconf := yb.tconf
+
+	if tconf.TargetEndpoints != "" {
+		msg := fmt.Sprintf("given yb-servers for import data: %q\n", tconf.TargetEndpoints)
+		utils.PrintIfTrue(msg, tconf.VerboseMode)
+		log.Infof(msg)
+
+		ybServers := utils.CsvStringToSlice(tconf.TargetEndpoints)
+		for _, ybServer := range ybServers {
+			clone := tconf.Clone()
+
+			if strings.Contains(ybServer, ":") {
+				clone.Host = strings.Split(ybServer, ":")[0]
+				var err error
+				clone.Port, err = strconv.Atoi(strings.Split(ybServer, ":")[1])
+
+				if err != nil {
+					utils.ErrExit("error in parsing useYbServers flag: %v", err)
+				}
+			} else {
+				clone.Host = ybServer
+			}
+
+			clone.Uri = getCloneConnectionUri(clone)
+			log.Infof("using yb server for import data: %+v", GetRedactedTargetConf(clone))
+			tconfs = append(tconfs, clone)
+		}
+	} else {
+		loadBalancerUsed = true
+		url := tconf.GetConnectionUri()
+		conn, err := pgx.Connect(context.Background(), url)
+		if err != nil {
+			utils.ErrExit("Unable to connect to database: %v", err)
+		}
+		defer conn.Close(context.Background())
+
+		rows, err := conn.Query(context.Background(), GET_YB_SERVERS_QUERY)
+		if err != nil {
+			utils.ErrExit("error in query rows from yb_servers(): %v", err)
+		}
+		defer rows.Close()
+
+		var hostPorts []string
+		for rows.Next() {
+			clone := tconf.Clone()
+			var host, nodeType, cloud, region, zone, public_ip string
+			var port, num_conns int
+			if err := rows.Scan(&host, &port, &num_conns,
+				&nodeType, &cloud, &region, &zone, &public_ip); err != nil {
+				utils.ErrExit("error in scanning rows of yb_servers(): %v", err)
+			}
+
+			// check if given host is one of the server in cluster
+			if loadBalancerUsed {
+				if isSeedTargetHost(tconf, host, public_ip) {
+					loadBalancerUsed = false
+				}
+			}
+
+			if tconf.UsePublicIP {
+				if public_ip != "" {
+					clone.Host = public_ip
+				} else {
+					var msg string
+					if host == "" {
+						msg = fmt.Sprintf("public ip is not available for host: %s."+
+							"Refer to help for more details for how to enable public ip.", host)
+					} else {
+						msg = fmt.Sprintf("public ip is not available for host: %s but private ip are available. "+
+							"Either refer to help for how to enable public ip or remove --use-public-up flag and restart the import", host)
+					}
+					utils.ErrExit(msg)
+				}
+			} else {
+				clone.Host = host
+			}
+
+			clone.Port = port
+			clone.Uri = getCloneConnectionUri(clone)
+			tconfs = append(tconfs, clone)
+
+			hostPorts = append(hostPorts, fmt.Sprintf("%s:%v", host, port))
+		}
+		log.Infof("Target DB nodes: %s", strings.Join(hostPorts, ","))
+	}
+
+	if loadBalancerUsed { // if load balancer is used no need to check direct connectivity
+		utils.PrintAndLog(LB_WARN_MSG)
+		tconfs = []*TargetConf{tconf}
+	} else {
+		tconfs = testAndFilterYbServers(tconfs)
+	}
+	return tconfs
+}
+
+func getCloneConnectionUri(clone *TargetConf) string {
+	var cloneConnectionUri string
+	if clone.Uri == "" {
+		//fallback to constructing the URI from individual parameters. If URI was not set for target, then its other necessary parameters must be non-empty (or default values)
+		cloneConnectionUri = clone.GetConnectionUri()
+	} else {
+		targetConnectionUri, err := url.Parse(clone.Uri)
+		if err == nil {
+			targetConnectionUri.Host = fmt.Sprintf("%s:%d", clone.Host, clone.Port)
+			cloneConnectionUri = fmt.Sprint(targetConnectionUri)
+		} else {
+			panic(err)
+		}
+	}
+	return cloneConnectionUri
+}
+
+func isSeedTargetHost(tconf *TargetConf, names ...string) bool {
+	var allIPs []string
+	for _, name := range names {
+		if name != "" {
+			allIPs = append(allIPs, utils.LookupIP(name)...)
+		}
+	}
+
+	seedHostIPs := utils.LookupIP(tconf.Host)
+	for _, seedHostIP := range seedHostIPs {
+		if slices.Contains(allIPs, seedHostIP) {
+			log.Infof("Target.Host=%s matched with one of ips in %v\n", seedHostIP, allIPs)
+			return true
+		}
+	}
+	return false
+}
+
+// this function will check the reachability to each of the nodes and returns list of ones which are reachable
+func testAndFilterYbServers(tconfs []*TargetConf) []*TargetConf {
+	var availableTargets []*TargetConf
+
+	for _, tconf := range tconfs {
+		log.Infof("testing server: %s\n", spew.Sdump(GetRedactedTargetConf(tconf)))
+		conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
+		if err != nil {
+			utils.PrintAndLog("unable to use yb-server %q: %v", tconf.Host, err)
+		} else {
+			availableTargets = append(availableTargets, tconf)
+			conn.Close(context.Background())
+		}
+	}
+
+	if len(availableTargets) == 0 {
+		utils.ErrExit("no yb servers available for data import")
+	}
+	return availableTargets
+}
+
+func fetchDefaultParllelJobs(tconfs []*TargetConf) int {
+	totalCores := 0
+	targetCores := 0
+	for _, tconf := range tconfs {
+		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs([]string{tconf.Uri})[0])
+		conn, err := pgx.Connect(context.Background(), tconf.Uri)
+		if err != nil {
+			log.Warnf("Unable to reach target while querying cores: %v", err)
+			return len(tconfs) * 2
+		}
+		defer conn.Close(context.Background())
+
+		cmd := "CREATE TEMP TABLE yb_voyager_cores(num_cores int);"
+		_, err = conn.Exec(context.Background(), cmd)
+		if err != nil {
+			log.Warnf("Unable to create tables on target DB: %v", err)
+			return len(tconfs) * 2
+		}
+
+		cmd = "COPY yb_voyager_cores(num_cores) FROM PROGRAM 'grep processor /proc/cpuinfo|wc -l';"
+		_, err = conn.Exec(context.Background(), cmd)
+		if err != nil {
+			log.Warnf("Error while running query %s on host %s: %v", cmd, utils.GetRedactedURLs([]string{tconf.Uri}), err)
+			return len(tconfs) * 2
+		}
+
+		cmd = "SELECT num_cores FROM yb_voyager_cores;"
+		if err = conn.QueryRow(context.Background(), cmd).Scan(&targetCores); err != nil {
+			log.Warnf("Error while running query %s: %v", cmd, err)
+			return len(tconfs) * 2
+		}
+		totalCores += targetCores
+	}
+	if totalCores == 0 { //if target is running on MacOS, we are unable to determine totalCores
+		return 3
+	}
+	return totalCores / 2
+}
+
+// import session parameters
+const (
+	SET_CLIENT_ENCODING_TO_UTF8           = "SET client_encoding TO 'UTF8'"
+	SET_SESSION_REPLICATE_ROLE_TO_REPLICA = "SET session_replication_role TO replica" //Disable triggers or fkeys constraint checks.
+	SET_YB_ENABLE_UPSERT_MODE             = "SET yb_enable_upsert_mode to true"
+	SET_YB_DISABLE_TRANSACTIONAL_WRITES   = "SET yb_disable_transactional_writes to true" // Disable transactions to improve ingestion throughput.
+)
+
+func getYBSessionInitScript(tconf *TargetConf) []string {
+	var sessionVars []string
+	if checkSessionVariableSupport(tconf, SET_CLIENT_ENCODING_TO_UTF8) {
+		sessionVars = append(sessionVars, SET_CLIENT_ENCODING_TO_UTF8)
+	}
+	if checkSessionVariableSupport(tconf, SET_SESSION_REPLICATE_ROLE_TO_REPLICA) {
+		sessionVars = append(sessionVars, SET_SESSION_REPLICATE_ROLE_TO_REPLICA)
+	}
+
+	if tconf.EnableUpsert {
+		// upsert_mode parameters was introduced later than yb_disable_transactional writes in yb releases
+		// hence if upsert_mode is supported then its safe to assume yb_disable_transactional_writes is already there
+		if checkSessionVariableSupport(tconf, SET_YB_ENABLE_UPSERT_MODE) {
+			sessionVars = append(sessionVars, SET_YB_ENABLE_UPSERT_MODE)
+			// 	SET_YB_DISABLE_TRANSACTIONAL_WRITES is used only with & if upsert_mode is supported
+			if tconf.DisableTransactionalWrites {
+				if checkSessionVariableSupport(tconf, SET_YB_DISABLE_TRANSACTIONAL_WRITES) {
+					sessionVars = append(sessionVars, SET_YB_DISABLE_TRANSACTIONAL_WRITES)
+				} else {
+					tconf.DisableTransactionalWrites = false
+				}
+			}
+		} else {
+			log.Infof("Falling back to transactional inserts of batches during data import")
+		}
+	}
+
+	sessionVarsPath := "/etc/yb-voyager/ybSessionVariables.sql"
+	if !utils.FileOrFolderExists(sessionVarsPath) {
+		log.Infof("YBSessionInitScript: %v\n", sessionVars)
+		return sessionVars
+	}
+
+	varsFile, err := os.Open(sessionVarsPath)
+	if err != nil {
+		utils.PrintAndLog("Unable to open %s : %v. Using default values.", sessionVarsPath, err)
+		log.Infof("YBSessionInitScript: %v\n", sessionVars)
+		return sessionVars
+	}
+	defer varsFile.Close()
+	fileScanner := bufio.NewScanner(varsFile)
+
+	var curLine string
+	for fileScanner.Scan() {
+		curLine = strings.TrimSpace(fileScanner.Text())
+		if curLine != "" && checkSessionVariableSupport(tconf, curLine) {
+			sessionVars = append(sessionVars, curLine)
+		}
+	}
+	log.Infof("YBSessionInitScript: %v\n", sessionVars)
+	return sessionVars
+}
+
+func checkSessionVariableSupport(tconf *TargetConf, sqlStmt string) bool {
+	conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
+	if err != nil {
+		utils.ErrExit("error while creating connection for checking session parameter(%q) support: %v", sqlStmt, err)
+	}
+	defer conn.Close(context.Background())
+
+	_, err = conn.Exec(context.Background(), sqlStmt)
+	if err != nil {
+		if !strings.Contains(err.Error(), "unrecognized configuration parameter") {
+			utils.ErrExit("error while executing sqlStatement=%q: %v", sqlStmt, err)
+		} else {
+			log.Warnf("Warning: %q is not supported: %v", sqlStmt, err)
+		}
+	}
+
+	return err == nil
 }

--- a/yb-voyager/src/tgtdb/yb.go
+++ b/yb-voyager/src/tgtdb/yb.go
@@ -36,6 +36,14 @@ func newTargetYugabyteDB(tconf *TargetConf) *TargetYugabyteDB {
 	return &TargetYugabyteDB{tconf: tconf}
 }
 
+func (yb *TargetYugabyteDB) Init() error {
+	return yb.connect()
+}
+
+func (yb *TargetYugabyteDB) Finalize() {
+	yb.disconnect()
+}
+
 // TODO We should not export `Conn`. This is temporary--until we refactor all target db access.
 func (yb *TargetYugabyteDB) Conn() *pgx.Conn {
 	if yb.conn == nil {
@@ -44,7 +52,7 @@ func (yb *TargetYugabyteDB) Conn() *pgx.Conn {
 	return yb.conn
 }
 
-func (yb *TargetYugabyteDB) Connect() error {
+func (yb *TargetYugabyteDB) connect() error {
 	if yb.conn != nil {
 		// Already connected.
 		return nil
@@ -60,7 +68,7 @@ func (yb *TargetYugabyteDB) Connect() error {
 	return nil
 }
 
-func (yb *TargetYugabyteDB) Disconnect() {
+func (yb *TargetYugabyteDB) disconnect() {
 	if yb.conn == nil {
 		log.Infof("No connection to the target database to close")
 	}
@@ -72,7 +80,7 @@ func (yb *TargetYugabyteDB) Disconnect() {
 }
 
 func (yb *TargetYugabyteDB) EnsureConnected() {
-	err := yb.Connect()
+	err := yb.connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to the target DB: %s", err)
 	}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -236,13 +236,6 @@ func (yb *TargetYugabyteDB) CleanFileImportState(filePath, tableName string) err
 	return nil
 }
 
-type Batch interface {
-	Open() (*os.File, error)
-	GetFilePath() string
-	GetQueryIsBatchAlreadyImported() string
-	GetCommandToRecordEntryInDB(rowsAffected int64) string
-}
-
 func (yb *TargetYugabyteDB) ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error) {
 	var rowsAffected int64
 	var err error
@@ -752,7 +745,7 @@ func (yb *TargetYugabyteDB) isBatchAlreadyImported(tx pgx.Tx, batch Batch) (bool
 }
 
 func (yb *TargetYugabyteDB) recordEntryInDB(tx pgx.Tx, batch Batch, rowsAffected int64) error {
-	cmd := batch.GetCommandToRecordEntryInDB(rowsAffected)
+	cmd := batch.GetQueryToRecordEntryInDB(rowsAffected)
 	_, err := tx.Exec(context.Background(), cmd)
 	if err != nil {
 		return fmt.Errorf("insert into %s: %w", BATCH_METADATA_TABLE_NAME, err)

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -378,6 +379,16 @@ func GenerateRandomString(length int) string {
 		buf[i], buf[j] = buf[j], buf[i]
 	})
 	return string(buf)
+}
+
+func ForEachMatchingLineInFile(filePath string, re *regexp.Regexp, callback func(matches []string) bool) error {
+	return ForEachLineInFile(filePath, func(line string) bool {
+		matches := re.FindStringSubmatch(line)
+		if len(matches) > 0 {
+			return callback(matches)
+		}
+		return true // Continue with next line.
+	})
 }
 
 func ForEachLineInFile(filePath string, callback func(line string) bool) error {

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -379,3 +379,24 @@ func GenerateRandomString(length int) string {
 	})
 	return string(buf)
 }
+
+func ForEachLineInFile(filePath string, callback func(line string) bool) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("error opening file %s: %v", filePath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		cont := callback(scanner.Text())
+		if !cont {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading file %s: %v", filePath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
This patch introduces `tgtdb.TargetDB` interface which abstracts access
to the target db from the `import data` code path. The interface will
allow us supporting other databases e.g. PG, Oracle, and MySQL as
target databases (which is a requirement for fall-forward use-cases).

The TargetDB interface is not complete yet. It still "leaks" YB specific
details in couple of its methods:
-- `ImportBatch()` takes YB specific `copyCommand` as input.
-- `ConnPool()` returns YB specific *ConnectionPool instance.
These limitations will be fixed in followup updates to this PR.
