### PR TITLE
fixed a bug in import data file with CSV format, header and delimiter other than ','

### DIFF
--- a/migtests/tests/import-file/run-import-file-test
+++ b/migtests/tests/import-file/run-import-file-test
@@ -33,7 +33,7 @@ main() {
 
 	step "Unzip the data file."
 	[ -f OneMRows.text ] || gunzip -c OneMRows.text.gz > OneMRows.text
-	[ -f accounts_2m_data.sql ] || gunzip -c accounts.zip > accounts_2m_data.sql
+	[ -f accounts_data.csv ] || gunzip -c accounts.zip > accounts_data.csv
 
 	step "Create target table."
 	ysql_import_file ${TARGET_DB_NAME} schema.sql
@@ -58,9 +58,9 @@ main() {
 		--has-header --batch-size 1000
 
 	# Test for --has-header with --batch-size for a table having bigint and varchar columns
-	step "Import data file: accounts_2m_data.sql -> accounts"
+	step "Import data file: accounts_data.csv -> accounts"
 	import_data_file --data-dir ${TEST_DIR} --format csv --delimiter '\t' \
-			--file-table-map "accounts_2m_data.sql:accounts" --has-header --batch-size 10000 --null-string "\N"
+			--file-table-map "accounts_data.csv:accounts" --has-header --batch-size 10000 --null-string "\N"
 
 	# Next 4 tests are right now supported with a special csv format i.e. without new line
 	# for complete support of csv with newline, track this issue - https://github.com/yugabyte/yb-voyager/issues/748
@@ -138,7 +138,7 @@ main() {
 	# Test for csv file with delimiter as backspace char
 	step "Import data file: test_delimiter_backspace.csv -> test_delimiter_backspace"
 	import_data_file --data-dir ${TEST_DIR} --format csv --delimiter '\b' \
-			--file-table-map "test_delimiter_backspace.csv:test_delimiter_backspace" 
+			--file-table-map "test_delimiter_backspace.csv:test_delimiter_backspace"  --has-header
 
 	# Test for txt file with delimiter as backspace char
 	step "Import data file: test_delimiter_backspace_text.txt -> test_delimiter_backspace_text"

--- a/migtests/tests/import-file/test_delimiter_backspace.csv
+++ b/migtests/tests/import-file/test_delimiter_backspace.csv
@@ -1,3 +1,4 @@
+ijk
 11233How is it going?
 21233How is it going ?
 31233How is it going?

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -136,8 +136,9 @@ func prepareCopyCommands() {
 				if err != nil {
 					utils.ErrExit("opening datafile %q to prepare copy command: %v", filePath, err)
 				}
+				columns := strings.Join(strings.Split(df.GetHeader(), delimiter), ",")
 				cmd = fmt.Sprintf(`COPY %s(%s) FROM STDIN WITH (FORMAT %s, DELIMITER E'%c', ESCAPE E'%s', QUOTE E'%s', HEADER, NULL '%s',`,
-					table, df.GetHeader(), fileFormat, []rune(delimiter)[0], escapeChar, quoteChar, nullString)
+					table, columns, fileFormat, []rune(delimiter)[0], escapeChar, quoteChar, nullString)
 				df.Close()
 			} else {
 				cmd = fmt.Sprintf(`COPY %s FROM STDIN WITH (FORMAT %s, DELIMITER E'%c', ESCAPE E'%s', QUOTE E'%s', NULL '%s',`,


### PR DESCRIPTION
Bug - In import data file, CSV datafile with header and delimiter other than a comma (,) will return a syntax error in copy as when a datafile with header has delimiter other than a comma, the columns in the header will be separated with delimiter and hence not with a comma and we are using the same as is in the COPY command as columns assuming that they will be separated with a comma. 
Fix - create comma-separated columns explicitly and pass those in COPY command.