### PR TITLE
Config changes for oracle debezium to prevent DDL related issues

### DIFF
--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -125,6 +125,9 @@ debezium.source.database.history=io.debezium.relational.history.FileDatabaseHist
 debezium.source.database.history.file.filename=%s
 debezium.source.schema.history.internal=io.debezium.storage.file.history.FileSchemaHistory
 debezium.source.schema.history.internal.file.filename=%s
+debezium.source.schema.history.internal.skip.unparseable.ddl=true
+debezium.source.schema.history.internal.store.only.captured.tables.ddl=true
+debezium.source.schema.history.internal.store.only.captured.databases.ddl=true
 debezium.source.include.schema.changes=false
 `
 


### PR DESCRIPTION
- `debezium.source.schema.history.internal.skip.unparseable.ddl=true` ensures that the connector doesn't error out when it runs into an unparseable error.
- `debezium.source.schema.history.internal.store.only.captured.*.ddl=true` ensures that the connector doesn't capture and track schema changes unrelated to the table list provided by user

Jenkins - https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/781/