### PR TITLE
Oracle CDB support for Debezium Live Migration

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -79,8 +79,11 @@ func registerCommonExportFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&source.CDBName, "oracle-cdb-name", "",
 		"[For Oracle Only] Oracle Container Database Name in case you are using a multitenant container database.")
 
+	cmd.Flags().StringVar(&source.CDBSid, "oracle-cdb-sid", "",
+		"[For Oracle Only] Oracle System Identifier (SID) of the Container Database that you wish to use while exporting data from Oracle instances")
+
 	cmd.Flags().StringVar(&source.CDBTNSAlias, "oracle-cdb-tns-alias", "",
-		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle Container Database in case you are using a multitenant container database.. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
+		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle Container Database in case you are using a multitenant container database. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
 
 	cmd.Flags().StringVar(&source.Schema, "source-db-schema", "",
 		"source schema name to export (valid for Oracle, PostgreSQL)\n"+
@@ -245,7 +248,7 @@ func validateOracleParams() {
 		} else if source.CDBName != "" {
 			utils.PrintAndLog("Using CDB Name for export.")
 			source.CDBSid = ""
-		} else if source.DBSid != "" {
+		} else if source.CDBSid != "" {
 			utils.PrintAndLog("Using CDB SID for export.")
 		}
 		if source.DBName == "" {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -77,13 +77,13 @@ func registerCommonExportFlags(cmd *cobra.Command) {
 		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle instance. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
 
 	cmd.Flags().StringVar(&source.CDBName, "oracle-cdb-name", "",
-		"[For Oracle Only] Oracle Container Database Name in case you are using a multitenant container database.")
+		"[For Oracle Only] Oracle Container Database Name in case you are using a multitenant container database. Note: This is only required for live migration.")
 
 	cmd.Flags().StringVar(&source.CDBSid, "oracle-cdb-sid", "",
-		"[For Oracle Only] Oracle System Identifier (SID) of the Container Database that you wish to use while exporting data from Oracle instances")
+		"[For Oracle Only] Oracle System Identifier (SID) of the Container Database that you wish to use while exporting data from Oracle instances.  Note: This is only required for live migration.")
 
 	cmd.Flags().StringVar(&source.CDBTNSAlias, "oracle-cdb-tns-alias", "",
-		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle Container Database in case you are using a multitenant container database. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
+		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle Container Database in case you are using a multitenant container database. Refer to documentation to learn more about configuring tnsnames.ora and aliases. Note: This is only required for live migration.")
 
 	cmd.Flags().StringVar(&source.Schema, "source-db-schema", "",
 		"source schema name to export (valid for Oracle, PostgreSQL)\n"+

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -76,6 +76,12 @@ func registerCommonExportFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&source.TNSAlias, "oracle-tns-alias", "",
 		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle instance. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
 
+	cmd.Flags().StringVar(&source.CDBName, "oracle-cdb-name", "",
+		"[For Oracle Only] Oracle Container Database Name in case you are using a multitenant container database.")
+
+	cmd.Flags().StringVar(&source.CDBTNSAlias, "oracle-cdb-tns-alias", "",
+		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle Container Database in case you are using a multitenant container database.. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
+
 	cmd.Flags().StringVar(&source.Schema, "source-db-schema", "",
 		"source schema name to export (valid for Oracle, PostgreSQL)\n"+
 			"Note: in case of PostgreSQL, it can be a single or comma separated list of schemas")
@@ -228,6 +234,23 @@ func validateOracleParams() {
 		source.DBSid = ""
 	} else if source.DBSid != "" {
 		utils.PrintAndLog("Using SID for export.")
+	}
+	if source.IsOracleCDBSetup() {
+		//Priority order for Oracle: oracle-tns-alias > source-db-name > oracle-db-sid
+		if source.CDBTNSAlias != "" {
+			//Priority order for Oracle: oracle-tns-alias > source-db-name > oracle-db-sid
+			utils.PrintAndLog("Using CDB TNS Alias for export.")
+			source.CDBName = ""
+			source.CDBSid = ""
+		} else if source.CDBName != "" {
+			utils.PrintAndLog("Using CDB Name for export.")
+			source.CDBSid = ""
+		} else if source.DBSid != "" {
+			utils.PrintAndLog("Using CDB SID for export.")
+		}
+		if source.DBName == "" {
+			utils.ErrExit(`Error: When using Container DB setup, specify PDB via oracle-tns-alias or oracle-db-sid is not allowed. Please specify PDB name via source-db-name`)
+		}
 	}
 
 }

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -249,7 +249,7 @@ func validateOracleParams() {
 			utils.PrintAndLog("Using CDB SID for export.")
 		}
 		if source.DBName == "" {
-			utils.ErrExit(`Error: When using Container DB setup, specify PDB via oracle-tns-alias or oracle-db-sid is not allowed. Please specify PDB name via source-db-name`)
+			utils.ErrExit(`Error: When using Container DB setup, specifying PDB via oracle-tns-alias or oracle-db-sid is not allowed. Please specify PDB name via source-db-name`)
 		}
 	}
 

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -157,7 +157,7 @@ func exportDataOffline() bool {
 		fmt.Println("no tables present to export, exiting...")
 		createExportDataDoneFlag()
 		dfd := datafile.Descriptor{
-			ExportDir: exportDir,
+			ExportDir:    exportDir,
 			DataFileList: make([]*datafile.FileEntry, 0),
 		}
 		dfd.Save()
@@ -298,10 +298,17 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName, ta
 		SnapshotMode: snapshotMode,
 	}
 	if source.DBType == "oracle" {
-		config.Uri, err = getConnectionUriForDebezium(source)
-		if err != nil {
-			return fmt.Errorf("failed to generate uri connection string: %v", err)
+		jdbcConnectionStringPrefix := "jdbc:oracle:thin:@"
+		if source.IsOracleCDBSetup() {
+			// uri = cdb uri
+			connectionString := srcdb.GetOracleConnectionString(source.Host, source.Port, source.CDBName, source.CDBSid, source.CDBTNSAlias)
+			config.Uri = fmt.Sprintf("%s%s", jdbcConnectionStringPrefix, connectionString)
+			config.PDBName = source.DBName
+		} else {
+			connectionString := srcdb.GetOracleConnectionString(source.Host, source.Port, source.DBName, source.DBSid, source.TNSAlias)
+			config.Uri = fmt.Sprintf("%s%s", jdbcConnectionStringPrefix, connectionString)
 		}
+
 		config.TNSAdmin, err = getTNSAdmin(source)
 		if err != nil {
 			return fmt.Errorf("failed to get tns admin: %w", err)
@@ -358,21 +365,6 @@ func debeziumExportData(ctx context.Context, tableList []*sqlname.SourceName, ta
 
 	log.Info("Debezium exited normally.")
 	return nil
-}
-
-// source.Uri in case of oracle is a string of the format `user="%s" password="%s" connectString="(DESCRIPTION=(...))`
-// this function extracts the connectString part of the URI, which is what is passed to debezium config.
-func getConnectionUriForDebezium(s srcdb.Source) (string, error) {
-	if s.DBType == "oracle" {
-		connectionStringRegex := regexp.MustCompile(`.*connectString="(?P<connectString>.*)".*`)
-		match := connectionStringRegex.FindStringSubmatch(s.Uri)
-		if match == nil || len(match) != 2 {
-			return "", fmt.Errorf("unexpected URI format. regex matches = %v", match)
-		}
-		connectionString := fmt.Sprintf("jdbc:oracle:thin:@%s", match[1])
-		return connectionString, nil
-	}
-	return s.Uri, nil
 }
 
 // oracle wallet location can be optionally set in $TNS_ADMIN/ojdbc.properties as

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Password string
 
 	DatabaseName                string
+	PDBName                     string
 	SchemaNames                 string
 	TableList                   []string
 	ColumnSequenceMap           []string
@@ -131,6 +132,10 @@ debezium.source.schema.history.internal.store.only.captured.databases.ddl=true
 debezium.source.include.schema.changes=false
 `
 
+var oracleSrcPDBConfigTemplate = `
+debezium.source.database.pdb.name=%s
+`
+
 var oracleConfigTemplate = baseConfigTemplate +
 	baseSrcConfigTemplate +
 	oracleSrcConfigTemplate +
@@ -209,6 +214,10 @@ func (c *Config) String() string {
 
 			dataDir,
 			strings.Join(c.ColumnSequenceMap, ","))
+		if c.PDBName != "" {
+			// cdb setup.
+			conf = conf + fmt.Sprintf(oracleSrcPDBConfigTemplate, c.PDBName)
+		}
 
 	case "mysql":
 		conf = fmt.Sprintf(mysqlConfigTemplate,

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -151,20 +151,6 @@ func (ora *Oracle) getConnectionUri() string {
 	connectionString := GetOracleConnectionString(source.Host, source.Port, source.DBName, source.DBSid, source.TNSAlias)
 	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, source.User, source.Password, connectionString)
 	return source.Uri
-	// switch true {
-	// case source.DBSid != "":
-	// 	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SID=%s)))"`,
-	// 		source.User, source.Password, source.Host, source.Port, source.DBSid)
-
-	// case source.TNSAlias != "":
-	// 	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, source.User, source.Password, source.TNSAlias)
-
-	// case source.DBName != "":
-	// 	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SERVICE_NAME=%s)))"`,
-	// 		source.User, source.Password, source.Host, source.Port, source.DBName)
-	// }
-
-	// return source.Uri
 }
 
 func GetOracleConnectionString(host string, port int, dbname string, dbsid string, tnsalias string) string {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -148,20 +148,39 @@ func (ora *Oracle) getConnectionUri() string {
 		return source.Uri
 	}
 
-	switch true {
-	case source.DBSid != "":
-		source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SID=%s)))"`,
-			source.User, source.Password, source.Host, source.Port, source.DBSid)
-
-	case source.TNSAlias != "":
-		source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, source.User, source.Password, source.TNSAlias)
-
-	case source.DBName != "":
-		source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SERVICE_NAME=%s)))"`,
-			source.User, source.Password, source.Host, source.Port, source.DBName)
-	}
-
+	connectionString := GetOracleConnectionString(source.Host, source.Port, source.DBName, source.DBSid, source.TNSAlias)
+	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, source.User, source.Password, connectionString)
 	return source.Uri
+	// switch true {
+	// case source.DBSid != "":
+	// 	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SID=%s)))"`,
+	// 		source.User, source.Password, source.Host, source.Port, source.DBSid)
+
+	// case source.TNSAlias != "":
+	// 	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, source.User, source.Password, source.TNSAlias)
+
+	// case source.DBName != "":
+	// 	source.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SERVICE_NAME=%s)))"`,
+	// 		source.User, source.Password, source.Host, source.Port, source.DBName)
+	// }
+
+	// return source.Uri
+}
+
+func GetOracleConnectionString(host string, port int, dbname string, dbsid string, tnsalias string) string {
+	switch true {
+	case dbsid != "":
+		return fmt.Sprintf(`(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SID=%s)))`,
+			host, port, dbsid)
+
+	case tnsalias != "":
+		return tnsalias
+
+	case dbname != "":
+		return fmt.Sprintf(`(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SERVICE_NAME=%s)))`,
+			host, port, dbname)
+	}
+	return ""
 }
 
 func (ora *Oracle) ExportSchema(exportDir string) {

--- a/yb-voyager/src/srcdb/source.go
+++ b/yb-voyager/src/srcdb/source.go
@@ -40,9 +40,12 @@ type Source struct {
 	User                  string
 	Password              string
 	DBName                string
+	CDBName               string
 	DBSid                 string
+	CDBSid                string
 	OracleHome            string
 	TNSAlias              string
+	CDBTNSAlias           string
 	Schema                string
 	SSLMode               string
 	SSLCertPath           string
@@ -78,6 +81,10 @@ func (s *Source) GetOracleHome() string {
 	} else {
 		return "/usr/lib/oracle/21/client64"
 	}
+}
+
+func (s *Source) IsOracleCDBSetup() bool {
+	return (s.CDBName != "" || s.CDBTNSAlias != "" || s.CDBSid != "")
 }
 
 func parseSSLString(source *Source) {


### PR DESCRIPTION
This adds new params to exportData
- oracle-cdb-name
- oracle-cdb-tns-alias
- oracle-cdb-sid

which allow specifying the cdb identifiers needed to perform live migration with debezium. 
One constraint is:
if specifying cdb identifiers, then the only way you can specify the pdb is via --source-db-name (because that's what debezium allows)