### PR TITLE
Implemented import into oracle using target db interface

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -294,6 +294,7 @@ import_data() {
 		--target-db-password ${TARGET_DB_PASSWORD:-''} \
 		--target-db-name ${TARGET_DB_NAME} \
 		--target-db-schema ${TARGET_DB_SCHEMA} \
+		--target-db-type "postgres" \
 		--disable-pb \
 		--send-diagnostics=false \
 		--start-clean

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -231,7 +231,7 @@ func reportSummary() {
 		utils.ErrExit("unable to load migration info: %s", err)
 	}
 
-	if !target.ImportMode { // this info is available only if we are exporting from source
+	if !tconf.ImportMode { // this info is available only if we are exporting from source
 		reportStruct.Summary.DBName = miginfo.SourceDBName
 		reportStruct.Summary.SchemaName = miginfo.SourceDBSchema
 		reportStruct.Summary.DBVersion = miginfo.SourceDBVersion

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -46,9 +46,3 @@ var validSSLModes = map[string][]string{
 	"mysql":      {"disable", "prefer", "require", "verify-ca", "verify-full"},
 	"postgresql": {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"},
 }
-
-var NonRetryCopyErrors = []string{
-	"Sending too long RPC message",
-	"invalid input syntax",
-	"violates unique constraint",
-}

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -19,7 +19,6 @@ const (
 	FOUR_MB                      = 4 * 1024 * 1024
 	META_INFO_DIR_NAME           = "metainfo"
 	NEWLINE                      = '\n'
-	GET_YB_SERVERS_QUERY         = "SELECT host, port, num_connections, node_type, cloud, region, zone, public_ip FROM yb_servers()"
 	ORACLE_DEFAULT_PORT          = 1521
 	MYSQL_DEFAULT_PORT           = 3306
 	POSTGRES_DEFAULT_PORT        = 5432
@@ -39,14 +38,6 @@ const (
 	INDEX_RETRY_COUNT            = 5
 	DDL_MAX_RETRY_COUNT          = 5
 	SCHEMA_VERSION_MISMATCH_ERR  = "Query error: schema version mismatch for table"
-)
-
-// import session parameters
-const (
-	SET_CLIENT_ENCODING_TO_UTF8           = "SET client_encoding TO 'UTF8'"
-	SET_SESSION_REPLICATE_ROLE_TO_REPLICA = "SET session_replication_role TO replica" //Disable triggers or fkeys constraint checks.
-	SET_YB_ENABLE_UPSERT_MODE             = "SET yb_enable_upsert_mode to true"
-	SET_YB_DISABLE_TRANSACTIONAL_WRITES   = "SET yb_disable_transactional_writes to true" // Disable transactions to improve ingestion throughput.
 )
 
 var supportedSourceDBTypes = []string{ORACLE, MYSQL, POSTGRESQL}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -475,7 +475,7 @@ func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error 
 	}
 	dfd := datafile.Descriptor{
 		FileFormat:   datafile.TEXT,
-		Delimiter:    ",",
+		Delimiter:    "\t",
 		HasHeader:    true,
 		ExportDir:    exportDir,
 		DataFileList: dataFileList,

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -64,7 +64,7 @@ func validateImportFlags(cmd *cobra.Command) {
 	validateImportObjectsFlag(tconf.ExcludeImportObjects, "exclude-object-list")
 	validateTargetSchemaFlag()
 	// For beta2.0 release (and onwards until further notice)
-	if disableTransactionalWrites {
+	if tconf.DisableTransactionalWrites {
 		fmt.Println("WARNING: The --disable-transactional-writes feature is in the experimental phase, not for production use case.")
 	}
 	validateBatchSizeFlag(batchSize)
@@ -126,23 +126,23 @@ func registerImportDataFlags(cmd *cobra.Command) {
 		"list of tables to import data")
 	cmd.Flags().Int64Var(&batchSize, "batch-size", DEFAULT_BATCH_SIZE,
 		"maximum number of rows in each batch generated during import.")
-	cmd.Flags().IntVar(&parallelism, "parallel-jobs", -1,
+	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", -1,
 		"number of parallel copy command jobs to target database. "+
 			"By default, voyager will try if it can determine the total number of cores N and use N/2 as parallel jobs. "+
 			"Otherwise, it fall back to using twice the number of nodes in the cluster")
-	cmd.Flags().BoolVar(&enableUpsert, "enable-upsert", true,
+	cmd.Flags().BoolVar(&tconf.EnableUpsert, "enable-upsert", true,
 		"true - to enable UPSERT mode on target tables\n"+
 			"false - to disable UPSERT mode on target tables")
-	cmd.Flags().BoolVar(&usePublicIp, "use-public-ip", false,
+	cmd.Flags().BoolVar(&tconf.UsePublicIP, "use-public-ip", false,
 		"true - to use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import (default false)\n"+
 			"Note: you might need to configure database to have public_ip available by setting server-broadcast-addresses.\n"+
 			"Refer: https://docs.yugabyte.com/latest/reference/configuration/yb-tserver/#server-broadcast-addresses")
-	cmd.Flags().StringVar(&targetEndpoints, "target-endpoints", "",
+	cmd.Flags().StringVar(&tconf.TargetEndpoints, "target-endpoints", "",
 		"comma separated list of node's endpoint to use for parallel import of data(default is to use all the nodes in the cluster).\n"+
 			"For example: \"host1:port1,host2:port2\" or \"host1,host2\"\n"+
 			"Note: use-public-ip flag will be ignored if this is used.")
 	// flag existence depends on fix of this gh issue: https://github.com/yugabyte/yugabyte-db/issues/12464
-	cmd.Flags().BoolVar(&disableTransactionalWrites, "disable-transactional-writes", false,
+	cmd.Flags().BoolVar(&tconf.DisableTransactionalWrites, "disable-transactional-writes", false,
 		"true - to disable transactional writes in tables for faster data ingestion (default false)\n"+
 			"(Note: this is a interim flag until the issues related to 'yb_disable_transactional_writes' session variable are fixed. Refer: https://github.com/yugabyte/yugabyte-db/issues/12464)")
 	// Hidden for beta2.0 release (and onwards until further notice).

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -34,8 +34,7 @@ var enableOrafce bool
 // tconf struct will be populated by CLI arguments parsing
 var tconf tgtdb.TargetConf
 
-// TODO tdb should be an interface, not a concrete type.
-var tdb *tgtdb.TargetYugabyteDB
+var tdb tgtdb.TargetDB
 
 var importCmd = &cobra.Command{
 	Use:   "import",

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -71,6 +71,9 @@ func validateImportFlags(cmd *cobra.Command) {
 }
 
 func registerCommonImportFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&tconf.TargetDBType, "target-db-type", "",
+		"type of the target database (oracle, mysql, postgresql)")
+
 	cmd.Flags().StringVar(&tconf.Host, "target-db-host", "127.0.0.1",
 		"host on which the YugabyteDB server is running")
 
@@ -84,10 +87,19 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tconf.Password, "target-db-password", "",
 		"password with which to connect to the target YugabyteDB server")
 
-	cmd.Flags().StringVar(&tconf.DBName, "target-db-name", YUGABYTEDB_DEFAULT_DATABASE,
+	cmd.Flags().StringVar(&tconf.DBName, "target-db-name", "",
 		"name of the database on the target YugabyteDB server on which import needs to be done")
 
-	cmd.Flags().StringVar(&tconf.Schema, "target-db-schema", YUGABYTEDB_DEFAULT_SCHEMA,
+	cmd.Flags().StringVar(&tconf.DBSid, "target-db-sid", "",
+		"[For Oracle Only] Oracle System Identifier (SID) that you wish to use while importing data to Oracle instances")
+
+	cmd.Flags().StringVar(&tconf.OracleHome, "oracle-home", "",
+		"[For Oracle Only] Path to set $ORACLE_HOME environment variable. tnsnames.ora is found in $ORACLE_HOME/network/admin")
+
+	cmd.Flags().StringVar(&tconf.TNSAlias, "oracle-tns-alias", "",
+		"[For Oracle Only] Name of TNS Alias you wish to use to connect to Oracle instance. Refer to documentation to learn more about configuring tnsnames.ora and aliases")
+
+	cmd.Flags().StringVar(&tconf.Schema, "target-db-schema", "",
 		"target schema name in YugabyteDB (Note: works only for source as Oracle and MySQL, in case of PostgreSQL you can ALTER schema name post import)")
 
 	// TODO: SSL related more args might come. Need to explore SSL part completely.

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -34,6 +34,9 @@ var enableOrafce bool
 // tconf struct will be populated by CLI arguments parsing
 var tconf tgtdb.TargetConf
 
+// TODO tdb should be an interface, not a concrete type.
+var tdb *tgtdb.TargetYugabyteDB
+
 var importCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Import schema and data from compatible source database(Oracle, MySQL, PostgreSQL)",

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -284,10 +284,14 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 
 func getImportBatchArgsProto(tableName string) *tgtdb.ImportBatchArgs {
 	columns := dataFileDescriptor.TableNameToExportedColumns[tableName]
+	fileFormat := dataFileDescriptor.FileFormat
+	if fileFormat == "sql" {
+		fileFormat = "text"
+	}
 	return &tgtdb.ImportBatchArgs{
 		TableName:  tableName,
 		Columns:    columns,
-		FileFormat: dataFileDescriptor.FileFormat,
+		FileFormat: fileFormat,
 		Delimiter:  dataFileDescriptor.Delimiter,
 		HasHeader:  dataFileDescriptor.HasHeader,
 		QuoteChar:  dataFileDescriptor.QuoteChar,

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -338,11 +338,11 @@ func getCloneConnectionUri(clone *tgtdb.TargetConf) string {
 
 func importData(importFileTasks []*ImportFileTask) {
 	tdb = tgtdb.NewTargetDB(&tconf)
-	err := tdb.Connect()
+	err := tdb.Init()
 	if err != nil {
-		utils.ErrExit("Failed to connect to the target DB: %s", err)
+		utils.ErrExit("Failed to initialize the target DB: %s", err)
 	}
-	defer tdb.Disconnect()
+	defer tdb.Finalize()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
 	targetDBVersion := tdb.GetVersion()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -461,7 +461,7 @@ func importBatch(batch *Batch, importBatchArgsProto *tgtdb.ImportBatchArgs) {
 	var rowsAffected int64
 	sleepIntervalSec := 0
 	for attempt := 0; attempt < COPY_MAX_RETRY_COUNT; attempt++ {
-		rowsAffected, err = tdb.ImportBatch(batch, &importBatchArgs)
+		rowsAffected, err = tdb.ImportBatch(batch, &importBatchArgs, exportDir)
 		if err == nil || tdb.IsNonRetryableCopyError(err) {
 			break
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -182,7 +182,7 @@ func importData(importFileTasks []*ImportFileTask) {
 		}
 		time.Sleep(time.Second * 2)
 	}
-	executePostImportDataSqls()
+	// executePostImportDataSqls()
 	callhome.PackAndSendPayload(exportDir)
 
 	if liveMigration {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -49,7 +49,6 @@ import (
 
 var metaInfoDirName = META_INFO_DIR_NAME
 var batchSize = int64(0)
-var parallelism = 0
 var batchImportPool *pool.Pool
 var tablesProgressMetadata map[string]*utils.TableProgressMetadata
 
@@ -150,11 +149,6 @@ func importData(importFileTasks []*ImportFileTask) {
 		utils.ErrExit("Failed to create voyager metadata schema on target DB: %s", err)
 	}
 
-	log.Infof("parallelism=%v", parallelism)
-	payload.ParallelJobs = parallelism
-	if tconf.VerboseMode {
-		fmt.Printf("Number of parallel imports jobs at a time: %d\n", parallelism)
-	}
 	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
 	var pendingTasks, completedTasks []*ImportFileTask
 	state := NewImportDataState(exportDir)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -21,11 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -63,19 +61,9 @@ var tablesProgressMetadata map[string]*utils.TableProgressMetadata
 
 // stores the data files description in a struct
 var dataFileDescriptor *datafile.Descriptor
-
-var usePublicIp bool
-var targetEndpoints string
 var copyTableFromCommands = sync.Map{}
-var loadBalancerUsed bool           // specifies whether load balancer is used in front of yb servers
-var enableUpsert bool               // upsert instead of insert for import data
-var disableTransactionalWrites bool // to disable transactional writes for copy command
-var truncateSplits bool             // to truncate *.D splits after import
 
-const (
-	LB_WARN_MSG = "Warning: Based on internal anaylsis, --target-db-host is identified as a load balancer IP which will be used to create connections for data import.\n" +
-		"\t To control the parallelism and servers used, refer to help for --parallel-jobs and --target-endpoints flags.\n"
-)
+var truncateSplits bool // to truncate *.D splits after import
 
 var importDataCmd = &cobra.Command{
 	Use:   "data",
@@ -141,202 +129,11 @@ func applyTableListFilter(importFileTasks []*ImportFileTask) []*ImportFileTask {
 	return result
 }
 
-func getYBServers() []*tgtdb.TargetConf {
-	var tconfs []*tgtdb.TargetConf
-
-	if targetEndpoints != "" {
-		msg := fmt.Sprintf("given yb-servers for import data: %q\n", targetEndpoints)
-		utils.PrintIfTrue(msg, tconf.VerboseMode)
-		log.Infof(msg)
-
-		ybServers := utils.CsvStringToSlice(targetEndpoints)
-		for _, ybServer := range ybServers {
-			clone := tconf.Clone()
-
-			if strings.Contains(ybServer, ":") {
-				clone.Host = strings.Split(ybServer, ":")[0]
-				var err error
-				clone.Port, err = strconv.Atoi(strings.Split(ybServer, ":")[1])
-
-				if err != nil {
-					utils.ErrExit("error in parsing useYbServers flag: %v", err)
-				}
-			} else {
-				clone.Host = ybServer
-			}
-
-			clone.Uri = getCloneConnectionUri(clone)
-			log.Infof("using yb server for import data: %+v", tgtdb.GetRedactedTargetConf(clone))
-			tconfs = append(tconfs, clone)
-		}
-	} else {
-		loadBalancerUsed = true
-		url := tconf.GetConnectionUri()
-		conn, err := pgx.Connect(context.Background(), url)
-		if err != nil {
-			utils.ErrExit("Unable to connect to database: %v", err)
-		}
-		defer conn.Close(context.Background())
-
-		rows, err := conn.Query(context.Background(), GET_YB_SERVERS_QUERY)
-		if err != nil {
-			utils.ErrExit("error in query rows from yb_servers(): %v", err)
-		}
-		defer rows.Close()
-
-		var hostPorts []string
-		for rows.Next() {
-			clone := tconf.Clone()
-			var host, nodeType, cloud, region, zone, public_ip string
-			var port, num_conns int
-			if err := rows.Scan(&host, &port, &num_conns,
-				&nodeType, &cloud, &region, &zone, &public_ip); err != nil {
-				utils.ErrExit("error in scanning rows of yb_servers(): %v", err)
-			}
-
-			// check if given host is one of the server in cluster
-			if loadBalancerUsed {
-				if isSeedTargetHost(host, public_ip) {
-					loadBalancerUsed = false
-				}
-			}
-
-			if usePublicIp {
-				if public_ip != "" {
-					clone.Host = public_ip
-				} else {
-					var msg string
-					if host == "" {
-						msg = fmt.Sprintf("public ip is not available for host: %s."+
-							"Refer to help for more details for how to enable public ip.", host)
-					} else {
-						msg = fmt.Sprintf("public ip is not available for host: %s but private ip are available. "+
-							"Either refer to help for how to enable public ip or remove --use-public-up flag and restart the import", host)
-					}
-					utils.ErrExit(msg)
-				}
-			} else {
-				clone.Host = host
-			}
-
-			clone.Port = port
-			clone.Uri = getCloneConnectionUri(clone)
-			tconfs = append(tconfs, clone)
-
-			hostPorts = append(hostPorts, fmt.Sprintf("%s:%v", host, port))
-		}
-		log.Infof("Target DB nodes: %s", strings.Join(hostPorts, ","))
-	}
-
-	if loadBalancerUsed { // if load balancer is used no need to check direct connectivity
-		utils.PrintAndLog(LB_WARN_MSG)
-		if parallelism == -1 {
-			parallelism = 2 * len(tconfs)
-			utils.PrintAndLog("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", parallelism)
-		}
-		tconfs = []*tgtdb.TargetConf{&tconf}
-	} else {
-		tconfs = testAndFilterYbServers(tconfs)
-	}
-	return tconfs
-}
-
-func fetchDefaultParllelJobs(tconfs []*tgtdb.TargetConf) int {
-	totalCores := 0
-	targetCores := 0
-	for _, tconf := range tconfs {
-		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs([]string{tconf.Uri})[0])
-		conn, err := pgx.Connect(context.Background(), tconf.Uri)
-		if err != nil {
-			log.Warnf("Unable to reach target while querying cores: %v", err)
-			return len(tconfs) * 2
-		}
-		defer conn.Close(context.Background())
-
-		cmd := "CREATE TEMP TABLE yb_voyager_cores(num_cores int);"
-		_, err = conn.Exec(context.Background(), cmd)
-		if err != nil {
-			log.Warnf("Unable to create tables on target DB: %v", err)
-			return len(tconfs) * 2
-		}
-
-		cmd = "COPY yb_voyager_cores(num_cores) FROM PROGRAM 'grep processor /proc/cpuinfo|wc -l';"
-		_, err = conn.Exec(context.Background(), cmd)
-		if err != nil {
-			log.Warnf("Error while running query %s on host %s: %v", cmd, utils.GetRedactedURLs([]string{tconf.Uri}), err)
-			return len(tconfs) * 2
-		}
-
-		cmd = "SELECT num_cores FROM yb_voyager_cores;"
-		if err = conn.QueryRow(context.Background(), cmd).Scan(&targetCores); err != nil {
-			log.Warnf("Error while running query %s: %v", cmd, err)
-			return len(tconfs) * 2
-		}
-		totalCores += targetCores
-	}
-	if totalCores == 0 { //if target is running on MacOS, we are unable to determine totalCores
-		return 3
-	}
-	return totalCores / 2
-}
-
-// this function will check the reachability to each of the nodes and returns list of ones which are reachable
-func testAndFilterYbServers(tconfs []*tgtdb.TargetConf) []*tgtdb.TargetConf {
-	var availableTargets []*tgtdb.TargetConf
-
-	for _, tconf := range tconfs {
-		log.Infof("testing server: %s\n", spew.Sdump(tgtdb.GetRedactedTargetConf(tconf)))
-		conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
-		if err != nil {
-			utils.PrintAndLog("unable to use yb-server %q: %v", tconf.Host, err)
-		} else {
-			availableTargets = append(availableTargets, tconf)
-			conn.Close(context.Background())
-		}
-	}
-
-	if len(availableTargets) == 0 {
-		utils.ErrExit("no yb servers available for data import")
-	}
-	return availableTargets
-}
-
-func isSeedTargetHost(names ...string) bool {
-	var allIPs []string
-	for _, name := range names {
-		if name != "" {
-			allIPs = append(allIPs, utils.LookupIP(name)...)
-		}
-	}
-
-	seedHostIPs := utils.LookupIP(tconf.Host)
-	for _, seedHostIP := range seedHostIPs {
-		if slices.Contains(allIPs, seedHostIP) {
-			log.Infof("Target.Host=%s matched with one of ips in %v\n", seedHostIP, allIPs)
-			return true
-		}
-	}
-	return false
-}
-
-func getCloneConnectionUri(clone *tgtdb.TargetConf) string {
-	var cloneConnectionUri string
-	if clone.Uri == "" {
-		//fallback to constructing the URI from individual parameters. If URI was not set for target, then its other necessary parameters must be non-empty (or default values)
-		cloneConnectionUri = clone.GetConnectionUri()
-	} else {
-		targetConnectionUri, err := url.Parse(clone.Uri)
-		if err == nil {
-			targetConnectionUri.Host = fmt.Sprintf("%s:%d", clone.Host, clone.Port)
-			cloneConnectionUri = fmt.Sprint(targetConnectionUri)
-		} else {
-			panic(err)
-		}
-	}
-	return cloneConnectionUri
-}
-
 func importData(importFileTasks []*ImportFileTask) {
+	payload := callhome.GetPayload(exportDir)
+
+	tconf.Schema = strings.ToLower(tconf.Schema)
+
 	tdb = tgtdb.NewTargetDB(&tconf)
 	err := tdb.Init()
 	if err != nil {
@@ -344,34 +141,17 @@ func importData(importFileTasks []*ImportFileTask) {
 	}
 	defer tdb.Finalize()
 
-	tconf.Schema = strings.ToLower(tconf.Schema)
+	err = tdb.InitConnPool()
+	if err != nil {
+		utils.ErrExit("Failed to initialize the target DB connection pool: %s", err)
+	}
+
 	targetDBVersion := tdb.GetVersion()
 	fmt.Printf("Target YugabyteDB version: %s\n", targetDBVersion)
-
-	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
-	payload := callhome.GetPayload(exportDir)
 	payload.TargetDBVersion = targetDBVersion
-	tconfs := getYBServers()
-	payload.NodeCount = len(tconfs)
+	//payload.NodeCount = len(tconfs) // TODO: Figure out way to populate NodeCount.
 
-	var targetUriList []string
-	for _, tconf := range tconfs {
-		targetUriList = append(targetUriList, tconf.Uri)
-	}
-	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
-
-	if parallelism == -1 {
-		parallelism = fetchDefaultParllelJobs(tconfs)
-		utils.PrintAndLog("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", parallelism)
-	}
-
-	params := &tgtdb.ConnectionParams{
-		NumConnections:    parallelism,
-		ConnUriList:       targetUriList,
-		SessionInitScript: getYBSessionInitScript(),
-	}
-	connPool := tgtdb.NewConnectionPool(params)
-	err = createVoyagerSchemaOnTarget(connPool)
+	err = createVoyagerSchemaOnTarget(tdb.ConnPool())
 	if err != nil {
 		utils.ErrExit("Failed to create voyager metadata schema on target DB: %s", err)
 	}
@@ -381,7 +161,7 @@ func importData(importFileTasks []*ImportFileTask) {
 	if tconf.VerboseMode {
 		fmt.Printf("Number of parallel imports jobs at a time: %d\n", parallelism)
 	}
-
+	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
 	var pendingTasks, completedTasks []*ImportFileTask
 	state := NewImportDataState(exportDir)
 	if startClean {
@@ -399,7 +179,7 @@ func importData(importFileTasks []*ImportFileTask) {
 		utils.PrintAndLog("All the tables are already imported, nothing left to import\n")
 	} else {
 		utils.PrintAndLog("Tables to import: %v", importFileTasksToTableNames(pendingTasks))
-		poolSize := parallelism * 2
+		poolSize := tconf.Parallelism * 2
 		progressReporter := NewImportDataProgressReporter(disablePb)
 		for _, task := range pendingTasks {
 			// The code can produce `poolSize` number of batches at a time. But, it can consume only
@@ -413,7 +193,7 @@ func importData(importFileTasks []*ImportFileTask) {
 			updateProgressFn := func(progressAmount int64) {
 				progressReporter.AddProgressAmount(task, progressAmount)
 			}
-			importFile(state, task, connPool, updateProgressFn)
+			importFile(state, task, tdb.ConnPool(), updateProgressFn)
 			batchImportPool.Wait()                // Wait for the file import to finish.
 			progressReporter.FileImportDone(task) // Remove the progress-bar for the file.
 		}
@@ -428,7 +208,7 @@ func importData(importFileTasks []*ImportFileTask) {
 		if sourceDBType == POSTGRESQL {
 			targetSchema = ""
 		}
-		err = streamChanges(connPool, targetSchema)
+		err = streamChanges(tdb.ConnPool(), targetSchema)
 		if err != nil {
 			utils.ErrExit("Failed to stream changes from source DB: %s", err)
 		}
@@ -1160,78 +940,6 @@ func getCopyCommand(table string) string {
 		log.Infof("No COPY command for table %q", table)
 	}
 	return "" // no-op
-}
-
-func getYBSessionInitScript() []string {
-	var sessionVars []string
-	if checkSessionVariableSupport(SET_CLIENT_ENCODING_TO_UTF8) {
-		sessionVars = append(sessionVars, SET_CLIENT_ENCODING_TO_UTF8)
-	}
-	if checkSessionVariableSupport(SET_SESSION_REPLICATE_ROLE_TO_REPLICA) {
-		sessionVars = append(sessionVars, SET_SESSION_REPLICATE_ROLE_TO_REPLICA)
-	}
-
-	if enableUpsert {
-		// upsert_mode parameters was introduced later than yb_disable_transactional writes in yb releases
-		// hence if upsert_mode is supported then its safe to assume yb_disable_transactional_writes is already there
-		if checkSessionVariableSupport(SET_YB_ENABLE_UPSERT_MODE) {
-			sessionVars = append(sessionVars, SET_YB_ENABLE_UPSERT_MODE)
-			// 	SET_YB_DISABLE_TRANSACTIONAL_WRITES is used only with & if upsert_mode is supported
-			if disableTransactionalWrites {
-				if checkSessionVariableSupport(SET_YB_DISABLE_TRANSACTIONAL_WRITES) {
-					sessionVars = append(sessionVars, SET_YB_DISABLE_TRANSACTIONAL_WRITES)
-				} else {
-					disableTransactionalWrites = false
-				}
-			}
-		} else {
-			log.Infof("Falling back to transactional inserts of batches during data import")
-		}
-	}
-
-	sessionVarsPath := "/etc/yb-voyager/ybSessionVariables.sql"
-	if !utils.FileOrFolderExists(sessionVarsPath) {
-		log.Infof("YBSessionInitScript: %v\n", sessionVars)
-		return sessionVars
-	}
-
-	varsFile, err := os.Open(sessionVarsPath)
-	if err != nil {
-		utils.PrintAndLog("Unable to open %s : %v. Using default values.", sessionVarsPath, err)
-		log.Infof("YBSessionInitScript: %v\n", sessionVars)
-		return sessionVars
-	}
-	defer varsFile.Close()
-	fileScanner := bufio.NewScanner(varsFile)
-
-	var curLine string
-	for fileScanner.Scan() {
-		curLine = strings.TrimSpace(fileScanner.Text())
-		if curLine != "" && checkSessionVariableSupport(curLine) {
-			sessionVars = append(sessionVars, curLine)
-		}
-	}
-	log.Infof("YBSessionInitScript: %v\n", sessionVars)
-	return sessionVars
-}
-
-func checkSessionVariableSupport(sqlStmt string) bool {
-	conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
-	if err != nil {
-		utils.ErrExit("error while creating connection for checking session parameter(%q) support: %v", sqlStmt, err)
-	}
-	defer conn.Close(context.Background())
-
-	_, err = conn.Exec(context.Background(), sqlStmt)
-	if err != nil {
-		if !strings.Contains(err.Error(), "unrecognized configuration parameter") {
-			utils.ErrExit("error while executing sqlStatement=%q: %v", sqlStmt, err)
-		} else {
-			log.Warnf("Warning: %q is not supported: %v", sqlStmt, err)
-		}
-	}
-
-	return err == nil
 }
 
 func checkExportDataDoneFlag() {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -187,11 +187,7 @@ func importData(importFileTasks []*ImportFileTask) {
 
 	if liveMigration {
 		fmt.Println("streaming changes to target DB...")
-		targetSchema := tconf.Schema
-		if sourceDBType == POSTGRESQL {
-			targetSchema = ""
-		}
-		err = streamChanges(tdb.ConnPool(), targetSchema)
+		err = streamChanges()
 		if err != nil {
 			utils.ErrExit("Failed to stream changes from source DB: %s", err)
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -16,13 +16,11 @@ limitations under the License.
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -39,7 +37,6 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -667,49 +664,6 @@ func getTargetSchemaName(tableName string) string {
 	return tconf.Schema // default set to "public"
 }
 
-func findCopyCommandForDebeziumExportedFiles(tableName, dataFilePath string) (string, error) {
-	exportStatusFilePath := filepath.Join(exportDir, "data", "export_status.json")
-	status, err := dbzm.ReadExportStatus(exportStatusFilePath)
-	if err != nil {
-		return "", err
-	}
-	if status == nil {
-		// export_status.json is not present. This is the case of Offline migration.
-		// The data is exported using pg_dump or ora2pg.
-		return "", nil
-	}
-
-	dfd := datafile.OpenDescriptor(exportDir)
-	reader, err := dataStore.Open(dataFilePath)
-	if err != nil {
-		utils.ErrExit("preparing reader to find copy command %q: %v", dataFilePath, err)
-	}
-
-	df, err := datafile.NewDataFile(dataFilePath, reader, dfd)
-	if err != nil {
-		utils.ErrExit("opening datafile %q to prepare copy command: %v", err)
-	}
-	defer df.Close()
-	columnNames := quoteColumnNamesIfRequired(df.GetHeader())
-	stmt := fmt.Sprintf(
-		`COPY %s(%s) FROM STDIN WITH (FORMAT TEXT, ROWS_PER_TRANSACTION %%v);`,
-		tableName, columnNames)
-	return stmt, nil
-}
-
-/*
-Valid cases requiring column name quoting:
-1. ReservedKeyWords in case of any source database type
-2. CaseSensitive column names in case of PostgreSQL(Oracle and MySQL columns are exported as case-insensitive by ora2pg)
-*/
-func quoteColumnNamesIfRequired(txtHeader string) string {
-	columnNames := strings.Split(txtHeader, "\t")
-	for i := 0; i < len(columnNames); i++ {
-		columnNames[i] = quoteIdentifierIfRequired(strings.TrimSpace(columnNames[i]))
-	}
-	return strings.Join(columnNames, ",")
-}
-
 func quoteIdentifierIfRequired(identifier string) string {
 	if sqlname.IsQuoted(identifier) {
 		return identifier
@@ -726,107 +680,6 @@ func quoteIdentifierIfRequired(identifier string) string {
 		return fmt.Sprintf(`"%s"`, identifier)
 	}
 	return identifier
-}
-
-func extractCopyStmtForTable(table string, fileToSearchIn string) {
-	if getCopyCommand(table) != "" {
-		return
-	}
-	// When snapshot is exported by Debezium, the data files are in CSV format,
-	// irrespective of the source database type.
-	stmt, err := findCopyCommandForDebeziumExportedFiles(table, fileToSearchIn)
-	// If the export_status.json file is not present, the err will be nil and stmt will be empty.
-	if err != nil {
-		utils.ErrExit("could not extract copy statement for table %q: %v", table, err)
-	}
-	if stmt != "" {
-		copyTableFromCommands.Store(table, stmt)
-		log.Infof("copyTableFromCommand for table %q is %q", table, stmt)
-		return
-	}
-	// pg_dump and ora2pg always have columns - "COPY table (col1, col2) FROM STDIN"
-	var copyCommandRegex *regexp.Regexp
-	if sourceDBType == "postgresql" {
-		// find the line from toc.txt file
-		fileToSearchIn = exportDir + "/data/toc.txt"
-
-		conn := newTargetConn()
-		defer conn.Close(context.Background())
-
-		parentTable := getParentTable(table, conn)
-		tableInCopyRegex := table
-		if parentTable != "" { // needed to find COPY command for table partitions
-			tableInCopyRegex = parentTable
-		}
-		if len(strings.Split(tableInCopyRegex, ".")) == 1 {
-			// happens only when table is in public schema, use public schema with table name for regexp
-			copyCommandRegex = regexp.MustCompile(fmt.Sprintf(`(?i)COPY public.%s[\s]+\(.*\) FROM STDIN`, tableInCopyRegex))
-		} else {
-			copyCommandRegex = regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]+\(.*\) FROM STDIN`, tableInCopyRegex))
-		}
-		log.Infof("parentTable=%s for table=%s", parentTable, table)
-	} else if sourceDBType == "oracle" || sourceDBType == "mysql" {
-		// For oracle, there is only unique COPY per datafile
-		// In case of table partitions, parent table name is used in COPY
-		copyCommandRegex = regexp.MustCompile(`(?i)COPY .*[\s]+\(.*\) FROM STDIN`)
-	}
-
-	file, err := os.Open(fileToSearchIn)
-	if err != nil {
-		utils.ErrExit("could not open file during extraction of copy stmt from file %q: %v", fileToSearchIn, err)
-	}
-	defer file.Close()
-
-	reader := bufio.NewReader(file)
-	for {
-		line, err := utils.Readline(reader)
-		if err == io.EOF { // EOF will mean NO COPY command
-			return
-		} else if err != nil {
-			utils.ErrExit("error while readline for extraction of copy stmt from file %q: %v", fileToSearchIn, err)
-		}
-		if copyCommandRegex.MatchString(line) {
-			line = strings.Trim(line, ";") + ` WITH (ROWS_PER_TRANSACTION %v)`
-			copyTableFromCommands.Store(table, line)
-			log.Infof("copyTableFromCommand for table %q is %q", table, line)
-			return
-		}
-	}
-}
-
-// get the parent table if its a partitioned table in yugabytedb
-// also covers the case when the partitions are further subpartitioned to multiple levels
-func getParentTable(table string, conn *pgx.Conn) string {
-	var parentTable string
-	query := fmt.Sprintf(`SELECT inhparent::pg_catalog.regclass
-	FROM pg_catalog.pg_class c JOIN pg_catalog.pg_inherits ON c.oid = inhrelid
-	WHERE c.oid = '%s'::regclass::oid`, table)
-
-	var currentParentTable string
-	err := conn.QueryRow(context.Background(), query).Scan(&currentParentTable)
-	if err != pgx.ErrNoRows && err != nil {
-		utils.ErrExit("Error in querying parent tablename for table=%s: %v", table, err)
-	}
-
-	if len(currentParentTable) == 0 {
-		return ""
-	} else {
-		parentTable = getParentTable(currentParentTable, conn)
-		if len(parentTable) == 0 {
-			parentTable = currentParentTable
-		}
-	}
-
-	return parentTable
-}
-
-func getCopyCommand(table string) string {
-	if copyCommand, ok := copyTableFromCommands.Load(table); ok {
-		return copyCommand.(string)
-	} else {
-		log.Infof("No COPY command for table %q", table)
-	}
-	return "" // no-op
 }
 
 func checkExportDataDoneFlag() {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -282,13 +282,32 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 }
 
-func getImportBatchArgsProto(tableName string) *tgtdb.ImportBatchArgs {
-	columns := dataFileDescriptor.TableNameToExportedColumns[tableName]
+func getImportBatchArgsProto(tableName, filePath string) *tgtdb.ImportBatchArgs {
+	var columns []string
+	if dataFileDescriptor.TableNameToExportedColumns != nil {
+		columns = dataFileDescriptor.TableNameToExportedColumns[tableName]
+	} else if dataFileDescriptor.HasHeader {
+		// File is either exported from debezium OR this is `import data file` case.
+		reader, err := dataStore.Open(filePath)
+		if err != nil {
+			utils.ErrExit("datastore.Open %q: %v", filePath, err)
+		}
+		df, err := datafile.NewDataFile(filePath, reader, dataFileDescriptor)
+		if err != nil {
+			utils.ErrExit("opening datafile %q: %v", filePath, err)
+		}
+		columns = strings.Split(df.GetHeader(), dataFileDescriptor.Delimiter)
+		df.Close()
+	}
+	for i, column := range columns {
+		columns[i] = quoteIdentifierIfRequired(strings.TrimSpace(column))
+	}
+	// If `columns` is unset at this point, no attribute list is passed in the COPY command.
 	fileFormat := dataFileDescriptor.FileFormat
 	if fileFormat == "sql" {
 		fileFormat = "text"
 	}
-	return &tgtdb.ImportBatchArgs{
+	importBatchArgsProto := &tgtdb.ImportBatchArgs{
 		TableName:  tableName,
 		Columns:    columns,
 		FileFormat: fileFormat,
@@ -298,14 +317,14 @@ func getImportBatchArgsProto(tableName string) *tgtdb.ImportBatchArgs {
 		EscapeChar: dataFileDescriptor.EscapeChar,
 		NullString: nullString,
 	}
+	log.Infof("ImportBatchArgs: %v", spew.Sdump(importBatchArgsProto))
+	return importBatchArgsProto
 }
 
 func importFile(state *ImportDataState, task *ImportFileTask, updateProgressFn func(int64)) {
 
 	origDataFile := task.FilePath
-	// TODO: Remove the following call to extractCopyStmtForTable().
-	extractCopyStmtForTable(task.TableName, origDataFile)
-	importBatchArgsProto := getImportBatchArgsProto(task.TableName)
+	importBatchArgsProto := getImportBatchArgsProto(task.TableName, task.FilePath)
 	log.Infof("Start splitting table %q: data-file: %q", task.TableName, origDataFile)
 
 	err := state.PrepareForFileImport(task.FilePath, task.TableName)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -264,9 +264,6 @@ func classifyTasks(state *ImportDataState, tasks []*ImportFileTask) (pendingTask
 }
 
 func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
-	conn := newTargetConn()
-	defer conn.Close(context.Background())
-
 	tableNames := importFileTasksToTableNames(tasks)
 	nonEmptyTableNames := tdb.GetNonEmptyTables(tableNames)
 	if len(nonEmptyTableNames) > 0 {
@@ -280,7 +277,7 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 
 	for _, task := range tasks {
-		err := state.Clean(task.FilePath, task.TableName, conn)
+		err := state.Clean(task.FilePath, task.TableName)
 		if err != nil {
 			utils.ErrExit("failed to clean import data state for table %q: %s", task.TableName, err)
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -337,17 +337,18 @@ func getCloneConnectionUri(clone *tgtdb.TargetConf) string {
 }
 
 func importData(importFileTasks []*ImportFileTask) {
-	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
-	err := tconf.DB().Connect()
+	tdb = tgtdb.NewTargetDB(&tconf)
+	err := tdb.Connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to the target DB: %s", err)
 	}
-	defer tconf.DB().Disconnect()
+	defer tdb.Disconnect()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
-	targetDBVersion := tconf.DB().GetVersion()
+	targetDBVersion := tdb.GetVersion()
 	fmt.Printf("Target YugabyteDB version: %s\n", targetDBVersion)
 
+	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
 	payload := callhome.GetPayload(exportDir)
 	payload.TargetDBVersion = targetDBVersion
 	tconfs := getYBServers()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -31,7 +30,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/color"
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
 	"github.com/sourcegraph/conc/pool"
@@ -414,7 +412,6 @@ func executePostImportDataSqls() {
 }
 
 func doOneImport(batch *Batch) {
-	connPool := tdb.ConnPool()
 	err := batch.MarkPending()
 	if err != nil {
 		utils.ErrExit("marking batch %d as pending: %s", batch.Number, err)
@@ -432,17 +429,13 @@ func doOneImport(batch *Batch) {
 	}
 	copyCommand = fmt.Sprintf(copyCommand, (batch.OffsetEnd - batch.OffsetStart))
 	log.Infof("COPY command: %s", copyCommand)
+
 	var rowsAffected int64
-	attempt := 0
 	sleepIntervalSec := 0
-	copyFn := func(conn *pgx.Conn) (bool, error) {
-		var err error
-		attempt++
-		rowsAffected, err = importBatch(conn, batch, copyCommand)
-		if err == nil ||
-			utils.InsensitiveSliceContains(NonRetryCopyErrors, err.Error()) ||
-			attempt == COPY_MAX_RETRY_COUNT {
-			return false, err
+	for attempt := 0; attempt < COPY_MAX_RETRY_COUNT; attempt++ {
+		rowsAffected, err = tdb.ImportBatch(batch, copyCommand)
+		if err == nil || tdb.IsNonRetryableCopyError(err) {
+			break
 		}
 		log.Warnf("COPY FROM file %q: %s", batch.FilePath, err)
 		sleepIntervalSec += 10
@@ -452,9 +445,7 @@ func doOneImport(batch *Batch) {
 		log.Infof("sleep for %d seconds before retrying the file %s (attempt %d)",
 			sleepIntervalSec, batch.FilePath, attempt)
 		time.Sleep(time.Duration(sleepIntervalSec) * time.Second)
-		return true, err
 	}
-	err = connPool.WithConn(copyFn)
 	log.Infof("%q => %d rows affected", copyCommand, rowsAffected)
 	if err != nil {
 		utils.ErrExit("COPY %q FROM file %q: %s", batch.TableName, batch.FilePath, err)
@@ -463,69 +454,6 @@ func doOneImport(batch *Batch) {
 	if err != nil {
 		utils.ErrExit("marking batch %q as done: %s", batch.FilePath, err)
 	}
-}
-
-func importBatch(conn *pgx.Conn, batch *Batch, copyCmd string) (rowsAffected int64, err error) {
-	var file *os.File
-	file, err = batch.Open()
-	if err != nil {
-		utils.ErrExit("opening batch %s: %s", batch.FilePath, err)
-	}
-	defer file.Close()
-
-	//setting the schema so that COPY command can acesss the table
-	setTargetSchema(conn)
-
-	// NOTE: DO NOT DEFINE A NEW err VARIABLE IN THIS FUNCTION. ELSE, IT WILL MASK THE err FROM RETURN LIST.
-	ctx := context.Background()
-	var tx pgx.Tx
-	tx, err = conn.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return 0, fmt.Errorf("begin transaction: %w", err)
-	}
-	defer func() {
-		var err2 error
-		if err != nil {
-			err2 = tx.Rollback(ctx)
-			if err2 != nil {
-				rowsAffected = 0
-				err = fmt.Errorf("rollback txn: %w (while processing %s)", err2, err)
-			}
-		} else {
-			err2 = tx.Commit(ctx)
-			if err2 != nil {
-				rowsAffected = 0
-				err = fmt.Errorf("commit txn: %w", err2)
-			}
-		}
-	}()
-
-	// Check if the split is already imported.
-	var alreadyImported bool
-	alreadyImported, rowsAffected, err = batch.IsAlreadyImported(tx)
-	if err != nil {
-		return 0, err
-	}
-	if alreadyImported {
-		return rowsAffected, nil
-	}
-
-	// Import the split using COPY command.
-	var res pgconn.CommandTag
-	res, err = tx.Conn().PgConn().CopyFrom(context.Background(), file, copyCmd)
-	if err != nil {
-		var pgerr *pgconn.PgError
-		if errors.As(err, &pgerr) {
-			err = fmt.Errorf("%s, %s in %s", err.Error(), pgerr.Where, batch.FilePath)
-		}
-		return res.RowsAffected(), err
-	}
-
-	err = batch.RecordEntryInDB(tx, res.RowsAffected())
-	if err != nil {
-		err = fmt.Errorf("record entry in DB for batch %q: %w", batch.FilePath, err)
-	}
-	return res.RowsAffected(), err
 }
 
 func newTargetConn() *pgx.Conn {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -698,6 +698,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 	return err
 }
 
+// TODO: This function is a duplicate of the one in tgtdb/yb.go. Consolidate the two.
 func getTargetSchemaName(tableName string) string {
 	parts := strings.Split(tableName, ".")
 	if len(parts) == 2 {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -47,12 +47,6 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
-// The _v2 is appended in the table name so that the import code doesn't
-// try to use the similar table created by the voyager 1.3 and earlier.
-// Voyager 1.4 uses import data state format that is incompatible from
-// the earlier versions.
-const BATCH_METADATA_TABLE_NAME = "ybvoyager_metadata.ybvoyager_import_data_batches_metainfo_v2"
-
 var metaInfoDirName = META_INFO_DIR_NAME
 var batchSize = int64(0)
 var parallelism = 0
@@ -151,7 +145,7 @@ func importData(importFileTasks []*ImportFileTask) {
 	payload.TargetDBVersion = targetDBVersion
 	//payload.NodeCount = len(tconfs) // TODO: Figure out way to populate NodeCount.
 
-	err = createVoyagerSchemaOnTarget(tdb.ConnPool())
+	err = tdb.CreateVoyagerSchema()
 	if err != nil {
 		utils.ErrExit("Failed to create voyager metadata schema on target DB: %s", err)
 	}
@@ -242,49 +236,6 @@ func getImportedProgressAmount(task *ImportFileTask, state *ImportDataState) int
 		}
 		return rowCount
 	}
-}
-
-// TODO: Move this to importDataState.go .
-func createVoyagerSchemaOnTarget(connPool *tgtdb.ConnectionPool) error {
-	cmds := []string{
-		"CREATE SCHEMA IF NOT EXISTS ybvoyager_metadata",
-		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-			data_file_name VARCHAR(250),
-			batch_number INT,
-			schema_name VARCHAR(250),
-			table_name VARCHAR(250),
-			rows_imported BIGINT,
-			PRIMARY KEY (data_file_name, batch_number, schema_name, table_name)
-		);`, BATCH_METADATA_TABLE_NAME),
-	}
-
-	maxAttempts := 12
-	var conn *pgx.Conn
-	var err error
-outer:
-	for _, cmd := range cmds {
-		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			log.Infof("Executing on target: [%s]", cmd)
-			if conn == nil {
-				conn = newTargetConn()
-			}
-			_, err = conn.Exec(context.Background(), cmd)
-			if err == nil {
-				continue outer
-			}
-			log.Warnf("Error while running [%s] attempt %d: %s", cmd, attempt, err)
-			time.Sleep(5 * time.Second)
-			conn.Close(context.Background())
-			conn = nil
-		}
-		if err != nil {
-			return fmt.Errorf("create ybvoyager schema on target: %w", err)
-		}
-	}
-	if conn != nil {
-		conn.Close(context.Background())
-	}
-	return nil
 }
 
 func importFileTasksToTableNames(tasks []*ImportFileTask) []string {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -90,7 +90,7 @@ var importDataCmd = &cobra.Command{
 
 func importDataCommandFn(cmd *cobra.Command, args []string) {
 	reportProgressInBytes = false
-	target.ImportMode = true
+	tconf.ImportMode = true
 	checkExportDataDoneFlag()
 	sourceDBType = ExtractMetaInfo(exportDir).SourceDBType
 	sqlname.SourceDBType = sourceDBType
@@ -123,9 +123,9 @@ func discoverFilesToImport() []*ImportFileTask {
 
 func applyTableListFilter(importFileTasks []*ImportFileTask) []*ImportFileTask {
 	result := []*ImportFileTask{}
-	includeList := utils.CsvStringToSlice(target.TableList)
+	includeList := utils.CsvStringToSlice(tconf.TableList)
 	log.Infof("includeList: %v", includeList)
-	excludeList := utils.CsvStringToSlice(target.ExcludeTableList)
+	excludeList := utils.CsvStringToSlice(tconf.ExcludeTableList)
 	log.Infof("excludeList: %v", excludeList)
 	for _, task := range importFileTasks {
 		if len(includeList) > 0 && !slices.Contains(includeList, task.TableName) {
@@ -141,17 +141,17 @@ func applyTableListFilter(importFileTasks []*ImportFileTask) []*ImportFileTask {
 	return result
 }
 
-func getYBServers() []*tgtdb.Target {
-	var targets []*tgtdb.Target
+func getYBServers() []*tgtdb.TargetConf {
+	var tconfs []*tgtdb.TargetConf
 
 	if targetEndpoints != "" {
 		msg := fmt.Sprintf("given yb-servers for import data: %q\n", targetEndpoints)
-		utils.PrintIfTrue(msg, target.VerboseMode)
+		utils.PrintIfTrue(msg, tconf.VerboseMode)
 		log.Infof(msg)
 
 		ybServers := utils.CsvStringToSlice(targetEndpoints)
 		for _, ybServer := range ybServers {
-			clone := target.Clone()
+			clone := tconf.Clone()
 
 			if strings.Contains(ybServer, ":") {
 				clone.Host = strings.Split(ybServer, ":")[0]
@@ -166,12 +166,12 @@ func getYBServers() []*tgtdb.Target {
 			}
 
 			clone.Uri = getCloneConnectionUri(clone)
-			log.Infof("using yb server for import data: %+v", tgtdb.GetRedactedTarget(clone))
-			targets = append(targets, clone)
+			log.Infof("using yb server for import data: %+v", tgtdb.GetRedactedTargetConf(clone))
+			tconfs = append(tconfs, clone)
 		}
 	} else {
 		loadBalancerUsed = true
-		url := target.GetConnectionUri()
+		url := tconf.GetConnectionUri()
 		conn, err := pgx.Connect(context.Background(), url)
 		if err != nil {
 			utils.ErrExit("Unable to connect to database: %v", err)
@@ -186,7 +186,7 @@ func getYBServers() []*tgtdb.Target {
 
 		var hostPorts []string
 		for rows.Next() {
-			clone := target.Clone()
+			clone := tconf.Clone()
 			var host, nodeType, cloud, region, zone, public_ip string
 			var port, num_conns int
 			if err := rows.Scan(&host, &port, &num_conns,
@@ -221,7 +221,7 @@ func getYBServers() []*tgtdb.Target {
 
 			clone.Port = port
 			clone.Uri = getCloneConnectionUri(clone)
-			targets = append(targets, clone)
+			tconfs = append(tconfs, clone)
 
 			hostPorts = append(hostPorts, fmt.Sprintf("%s:%v", host, port))
 		}
@@ -231,25 +231,25 @@ func getYBServers() []*tgtdb.Target {
 	if loadBalancerUsed { // if load balancer is used no need to check direct connectivity
 		utils.PrintAndLog(LB_WARN_MSG)
 		if parallelism == -1 {
-			parallelism = 2 * len(targets)
+			parallelism = 2 * len(tconfs)
 			utils.PrintAndLog("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", parallelism)
 		}
-		targets = []*tgtdb.Target{&target}
+		tconfs = []*tgtdb.TargetConf{&tconf}
 	} else {
-		targets = testAndFilterYbServers(targets)
+		tconfs = testAndFilterYbServers(tconfs)
 	}
-	return targets
+	return tconfs
 }
 
-func fetchDefaultParllelJobs(targets []*tgtdb.Target) int {
+func fetchDefaultParllelJobs(tconfs []*tgtdb.TargetConf) int {
 	totalCores := 0
 	targetCores := 0
-	for _, target := range targets {
-		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs([]string{target.Uri})[0])
-		conn, err := pgx.Connect(context.Background(), target.Uri)
+	for _, tconf := range tconfs {
+		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs([]string{tconf.Uri})[0])
+		conn, err := pgx.Connect(context.Background(), tconf.Uri)
 		if err != nil {
 			log.Warnf("Unable to reach target while querying cores: %v", err)
-			return len(targets) * 2
+			return len(tconfs) * 2
 		}
 		defer conn.Close(context.Background())
 
@@ -257,20 +257,20 @@ func fetchDefaultParllelJobs(targets []*tgtdb.Target) int {
 		_, err = conn.Exec(context.Background(), cmd)
 		if err != nil {
 			log.Warnf("Unable to create tables on target DB: %v", err)
-			return len(targets) * 2
+			return len(tconfs) * 2
 		}
 
 		cmd = "COPY yb_voyager_cores(num_cores) FROM PROGRAM 'grep processor /proc/cpuinfo|wc -l';"
 		_, err = conn.Exec(context.Background(), cmd)
 		if err != nil {
-			log.Warnf("Error while running query %s on host %s: %v", cmd, utils.GetRedactedURLs([]string{target.Uri}), err)
-			return len(targets) * 2
+			log.Warnf("Error while running query %s on host %s: %v", cmd, utils.GetRedactedURLs([]string{tconf.Uri}), err)
+			return len(tconfs) * 2
 		}
 
 		cmd = "SELECT num_cores FROM yb_voyager_cores;"
 		if err = conn.QueryRow(context.Background(), cmd).Scan(&targetCores); err != nil {
 			log.Warnf("Error while running query %s: %v", cmd, err)
-			return len(targets) * 2
+			return len(tconfs) * 2
 		}
 		totalCores += targetCores
 	}
@@ -281,16 +281,16 @@ func fetchDefaultParllelJobs(targets []*tgtdb.Target) int {
 }
 
 // this function will check the reachability to each of the nodes and returns list of ones which are reachable
-func testAndFilterYbServers(targets []*tgtdb.Target) []*tgtdb.Target {
-	var availableTargets []*tgtdb.Target
+func testAndFilterYbServers(tconfs []*tgtdb.TargetConf) []*tgtdb.TargetConf {
+	var availableTargets []*tgtdb.TargetConf
 
-	for _, target := range targets {
-		log.Infof("testing server: %s\n", spew.Sdump(tgtdb.GetRedactedTarget(target)))
-		conn, err := pgx.Connect(context.Background(), target.GetConnectionUri())
+	for _, tconf := range tconfs {
+		log.Infof("testing server: %s\n", spew.Sdump(tgtdb.GetRedactedTargetConf(tconf)))
+		conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
 		if err != nil {
-			utils.PrintAndLog("unable to use yb-server %q: %v", target.Host, err)
+			utils.PrintAndLog("unable to use yb-server %q: %v", tconf.Host, err)
 		} else {
-			availableTargets = append(availableTargets, target)
+			availableTargets = append(availableTargets, tconf)
 			conn.Close(context.Background())
 		}
 	}
@@ -309,7 +309,7 @@ func isSeedTargetHost(names ...string) bool {
 		}
 	}
 
-	seedHostIPs := utils.LookupIP(target.Host)
+	seedHostIPs := utils.LookupIP(tconf.Host)
 	for _, seedHostIP := range seedHostIPs {
 		if slices.Contains(allIPs, seedHostIP) {
 			log.Infof("Target.Host=%s matched with one of ips in %v\n", seedHostIP, allIPs)
@@ -319,7 +319,7 @@ func isSeedTargetHost(names ...string) bool {
 	return false
 }
 
-func getCloneConnectionUri(clone *tgtdb.Target) string {
+func getCloneConnectionUri(clone *tgtdb.TargetConf) string {
 	var cloneConnectionUri string
 	if clone.Uri == "" {
 		//fallback to constructing the URI from individual parameters. If URI was not set for target, then its other necessary parameters must be non-empty (or default values)
@@ -337,30 +337,30 @@ func getCloneConnectionUri(clone *tgtdb.Target) string {
 }
 
 func importData(importFileTasks []*ImportFileTask) {
-	utils.PrintAndLog("import of data in %q database started", target.DBName)
-	err := target.DB().Connect()
+	utils.PrintAndLog("import of data in %q database started", tconf.DBName)
+	err := tconf.DB().Connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to the target DB: %s", err)
 	}
-	defer target.DB().Disconnect()
+	defer tconf.DB().Disconnect()
 
-	target.Schema = strings.ToLower(target.Schema)
-	targetDBVersion := target.DB().GetVersion()
+	tconf.Schema = strings.ToLower(tconf.Schema)
+	targetDBVersion := tconf.DB().GetVersion()
 	fmt.Printf("Target YugabyteDB version: %s\n", targetDBVersion)
 
 	payload := callhome.GetPayload(exportDir)
 	payload.TargetDBVersion = targetDBVersion
-	targets := getYBServers()
-	payload.NodeCount = len(targets)
+	tconfs := getYBServers()
+	payload.NodeCount = len(tconfs)
 
 	var targetUriList []string
-	for _, t := range targets {
-		targetUriList = append(targetUriList, t.Uri)
+	for _, tconf := range tconfs {
+		targetUriList = append(targetUriList, tconf.Uri)
 	}
 	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
 
 	if parallelism == -1 {
-		parallelism = fetchDefaultParllelJobs(targets)
+		parallelism = fetchDefaultParllelJobs(tconfs)
 		utils.PrintAndLog("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", parallelism)
 	}
 
@@ -377,7 +377,7 @@ func importData(importFileTasks []*ImportFileTask) {
 
 	log.Infof("parallelism=%v", parallelism)
 	payload.ParallelJobs = parallelism
-	if target.VerboseMode {
+	if tconf.VerboseMode {
 		fmt.Printf("Number of parallel imports jobs at a time: %d\n", parallelism)
 	}
 
@@ -423,7 +423,7 @@ func importData(importFileTasks []*ImportFileTask) {
 
 	if liveMigration {
 		fmt.Println("streaming changes to target DB...")
-		targetSchema := target.Schema
+		targetSchema := tconf.Schema
 		if sourceDBType == POSTGRESQL {
 			targetSchema = ""
 		}
@@ -826,7 +826,7 @@ func importBatch(conn *pgx.Conn, batch *Batch, copyCmd string) (rowsAffected int
 }
 
 func newTargetConn() *pgx.Conn {
-	conn, err := pgx.Connect(context.Background(), target.GetConnectionUri())
+	conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
 	if err != nil {
 		utils.WaitChannel <- 1
 		<-utils.WaitChannel
@@ -838,24 +838,24 @@ func newTargetConn() *pgx.Conn {
 }
 
 func setTargetSchema(conn *pgx.Conn) {
-	if sourceDBType == POSTGRESQL || target.Schema == YUGABYTEDB_DEFAULT_SCHEMA {
+	if sourceDBType == POSTGRESQL || tconf.Schema == YUGABYTEDB_DEFAULT_SCHEMA {
 		// For PG, schema name is already included in the object name.
 		// No need to set schema if importing in the default schema.
 		return
 	}
-	checkSchemaExistsQuery := fmt.Sprintf("SELECT count(schema_name) FROM information_schema.schemata WHERE schema_name = '%s'", target.Schema)
+	checkSchemaExistsQuery := fmt.Sprintf("SELECT count(schema_name) FROM information_schema.schemata WHERE schema_name = '%s'", tconf.Schema)
 	var cntSchemaName int
 
 	if err := conn.QueryRow(context.Background(), checkSchemaExistsQuery).Scan(&cntSchemaName); err != nil {
-		utils.ErrExit("run query %q on target %q to check schema exists: %s", checkSchemaExistsQuery, target.Host, err)
+		utils.ErrExit("run query %q on target %q to check schema exists: %s", checkSchemaExistsQuery, tconf.Host, err)
 	} else if cntSchemaName == 0 {
-		utils.ErrExit("schema '%s' does not exist in target", target.Schema)
+		utils.ErrExit("schema '%s' does not exist in target", tconf.Schema)
 	}
 
-	setSchemaQuery := fmt.Sprintf("SET SCHEMA '%s'", target.Schema)
+	setSchemaQuery := fmt.Sprintf("SET SCHEMA '%s'", tconf.Schema)
 	_, err := conn.Exec(context.Background(), setSchemaQuery)
 	if err != nil {
-		utils.ErrExit("run query %q on target %q: %s", setSchemaQuery, target.Host, err)
+		utils.ErrExit("run query %q on target %q: %s", setSchemaQuery, tconf.Host, err)
 	}
 
 	if sourceDBType == ORACLE && enableOrafce {
@@ -878,7 +878,7 @@ func dropIdx(conn *pgx.Conn, idxName string) {
 }
 
 func executeSqlFile(file string, objType string, skipFn func(string, string) bool) {
-	log.Infof("Execute SQL file %q on target %q", file, target.Host)
+	log.Infof("Execute SQL file %q on target %q", file, tconf.Host)
 	conn := newTargetConn()
 	defer func() {
 		if conn != nil {
@@ -926,7 +926,7 @@ func getIndexName(sqlQuery string, indexName string) (string, error) {
 
 func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string) error {
 	var err error
-	log.Infof("On %s run query:\n%s\n", target.Host, sqlInfo.formattedStmt)
+	log.Infof("On %s run query:\n%s\n", tconf.Host, sqlInfo.formattedStmt)
 	for retryCount := 0; retryCount <= DDL_MAX_RETRY_COUNT; retryCount++ {
 		if retryCount > 0 { // Not the first iteration.
 			log.Infof("Sleep for 5 seconds before retrying for %dth time", retryCount)
@@ -967,7 +967,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 			// pg_dump generates `CREATE SCHEMA public;` in the schemas.sql. Because the `public`
 			// schema already exists on the target YB db, the create schema statement fails with
 			// "already exists" error. Ignore the error.
-			if target.IgnoreIfExists || strings.EqualFold(strings.Trim(sqlInfo.stmt, " \n"), "CREATE SCHEMA public;") {
+			if tconf.IgnoreIfExists || strings.EqualFold(strings.Trim(sqlInfo.stmt, " \n"), "CREATE SCHEMA public;") {
 				err = nil
 			}
 		}
@@ -979,7 +979,7 @@ func executeSqlStmtWithRetries(conn **pgx.Conn, sqlInfo sqlInfo, objType string)
 		} else {
 			utils.PrintSqlStmtIfDDL(sqlInfo.stmt, utils.GetObjectFileName(filepath.Join(exportDir, "schema"), objType))
 			color.Red(fmt.Sprintf("%s\n", err.Error()))
-			if target.ContinueOnError {
+			if tconf.ContinueOnError {
 				log.Infof("appending stmt to failedSqlStmts list: %s\n", utils.GetSqlStmtToPrint(sqlInfo.stmt))
 				errString := "/*\n" + err.Error() + "\n*/\n"
 				failedSqlStmts = append(failedSqlStmts, errString+sqlInfo.formattedStmt)
@@ -996,7 +996,7 @@ func getTargetSchemaName(tableName string) string {
 	if len(parts) == 2 {
 		return parts[0]
 	}
-	return target.Schema // default set to "public"
+	return tconf.Schema // default set to "public"
 }
 
 func findCopyCommandForDebeziumExportedFiles(tableName, dataFilePath string) (string, error) {
@@ -1215,7 +1215,7 @@ func getYBSessionInitScript() []string {
 }
 
 func checkSessionVariableSupport(sqlStmt string) bool {
-	conn, err := pgx.Connect(context.Background(), target.GetConnectionUri())
+	conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
 	if err != nil {
 		utils.ErrExit("error while creating connection for checking session parameter(%q) support: %v", sqlStmt, err)
 	}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -393,7 +393,7 @@ func submitBatch(batch *Batch, updateProgressFn func(int64)) {
 		// There are `poolSize` number of competing go-routines trying to invoke COPY.
 		// But the `connPool` will allow only `parallelism` number of connections to be
 		// used at a time. Thus limiting the number of concurrent COPYs to `parallelism`.
-		doOneImport(batch)
+		importBatch(batch)
 		if reportProgressInBytes {
 			updateProgressFn(batch.ByteCount)
 		} else {
@@ -411,7 +411,7 @@ func executePostImportDataSqls() {
 	}
 }
 
-func doOneImport(batch *Batch) {
+func importBatch(batch *Batch) {
 	err := batch.MarkPending()
 	if err != nil {
 		utils.ErrExit("marking batch %d as pending: %s", batch.Number, err)

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -159,7 +159,7 @@ func setImportTableListFlag() {
 	for _, task := range importFileTasks {
 		tableList[task.TableName] = true
 	}
-	target.TableList = strings.Join(maps.Keys(tableList), ",")
+	tconf.TableList = strings.Join(maps.Keys(tableList), ",")
 }
 
 func prepareImportFileTasks() []*ImportFileTask {

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -77,6 +77,7 @@ func prepareForImportDataCmd() {
 		Delimiter:    delimiter,
 		HasHeader:    hasHeader,
 		ExportDir:    exportDir,
+		NullString:   nullString,
 	}
 	if quoteChar != "" {
 		quoteCharBytes := []byte(quoteChar)

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -28,7 +28,12 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"golang.org/x/exp/slices"
+)
+
+const (
+	BATCH_METADATA_TABLE_NAME = tgtdb.BATCH_METADATA_TABLE_NAME
 )
 
 /*

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -155,7 +155,7 @@ func (s *ImportDataState) Recover(filePath, tableName string) ([]*Batch, int64, 
 	return pendingBatches, lastBatchNumber, lastOffset, fileFullySplit, nil
 }
 
-func (s *ImportDataState) Clean(filePath string, tableName string, conn *pgx.Conn) error {
+func (s *ImportDataState) Clean(filePath string, tableName string) error {
 	log.Infof("Cleaning import data state for table %q.", tableName)
 	fileStateDir := s.getFileStateDir(filePath, tableName)
 	log.Infof("Removing %q.", fileStateDir)

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -48,7 +48,10 @@ type ImportDataState struct {
 }
 
 func NewImportDataState(exportDir string) *ImportDataState {
-	return &ImportDataState{exportDir: exportDir, stateDir: filepath.Join(exportDir, "metainfo", "import_data_state")}
+	return &ImportDataState{
+		exportDir: exportDir,
+		stateDir:  filepath.Join(exportDir, "metainfo", "import_data_state"),
+	}
 }
 
 func (s *ImportDataState) PrepareForFileImport(filePath, tableName string) error {

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -519,27 +519,47 @@ func (batch *Batch) MarkDone() error {
 	return nil
 }
 
-func (batch *Batch) GetQueryIsBatchAlreadyImported() string {
+func (batch *Batch) GetQueryIsBatchAlreadyImported(TargetDBType string) string {
 	schemaName := getTargetSchemaName(batch.TableName)
-	query := fmt.Sprintf(
-		"SELECT rows_imported FROM %s "+
-			"WHERE data_file_name = '%s' AND batch_number = %d AND schema_name = '%s' AND table_name = '%s';",
-		BATCH_METADATA_TABLE_NAME, batch.BaseFilePath, batch.Number, schemaName, batch.TableName)
+	var query string
+	if TargetDBType == "oracle" {
+		query = fmt.Sprintf(
+			"SELECT rows_imported FROM %s "+
+				"WHERE data_file_name = '%s' AND batch_number = %d AND schema_name = '%s' AND table_name = '%s'",
+			BATCH_METADATA_TABLE_NAME, batch.BaseFilePath, batch.Number, schemaName, batch.TableName)
+	} else {
+		query = fmt.Sprintf(
+			"SELECT rows_imported FROM %s "+
+				"WHERE data_file_name = '%s' AND batch_number = %d AND schema_name = '%s' AND table_name = '%s';",
+			BATCH_METADATA_TABLE_NAME, batch.BaseFilePath, batch.Number, schemaName, batch.TableName)
+	}
 	return query
 }
 
-func (batch *Batch) GetCommandToRecordEntryInDB(rowsAffected int64) string {
+func (batch *Batch) GetCommandToRecordEntryInDB(TargetDBType string, rowsAffected int64) string {
 	// Record an entry in ${BATCH_METADATA_TABLE_NAME}, that the split is imported.
 	schemaName := getTargetSchemaName(batch.TableName)
-	cmd := fmt.Sprintf(
-		`INSERT INTO %s (data_file_name, batch_number, schema_name, table_name, rows_imported)
-		VALUES ('%s', %d, '%s', '%s', %v);`,
-		BATCH_METADATA_TABLE_NAME, batch.BaseFilePath, batch.Number, schemaName, batch.TableName, rowsAffected)
+	var cmd string
+	if TargetDBType == "oracle" {
+		cmd = fmt.Sprintf(
+			`INSERT INTO %s (data_file_name, batch_number, schema_name, table_name, rows_imported)
+			VALUES ('%s', %d, '%s', '%s', %v)`,
+			BATCH_METADATA_TABLE_NAME, batch.BaseFilePath, batch.Number, schemaName, batch.TableName, rowsAffected)
+	} else {
+		cmd = fmt.Sprintf(
+			`INSERT INTO %s (data_file_name, batch_number, schema_name, table_name, rows_imported)
+			VALUES ('%s', %d, '%s', '%s', %v);`,
+			BATCH_METADATA_TABLE_NAME, batch.BaseFilePath, batch.Number, schemaName, batch.TableName, rowsAffected)
+	}
 	return cmd
 }
 
 func (batch *Batch) GetFilePath() string {
 	return batch.FilePath
+}
+
+func (batch *Batch) GetTableName() string {
+	return batch.TableName
 }
 
 func (batch *Batch) getInProgressFilePath() string {

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -164,16 +164,10 @@ func (s *ImportDataState) Clean(filePath string, tableName string, conn *pgx.Con
 		return fmt.Errorf("error while removing %q: %w", fileStateDir, err)
 	}
 
-	// Delete all entries from ${BATCH_METADATA_TABLE_NAME} for this table.
-	schemaName := getTargetSchemaName(tableName)
-	cmd := fmt.Sprintf(
-		`DELETE FROM %s WHERE data_file_name = '%s' AND schema_name = '%s' AND table_name = '%s'`,
-		BATCH_METADATA_TABLE_NAME, filePath, schemaName, tableName)
-	res, err := conn.Exec(context.Background(), cmd)
+	err = tdb.CleanFileImportState(filePath, tableName)
 	if err != nil {
-		return fmt.Errorf("remove %q related entries from %s: %w", tableName, BATCH_METADATA_TABLE_NAME, err)
+		return fmt.Errorf("error while cleaning file import state for %q: %w", tableName, err)
 	}
-	log.Infof("query: [%s] => rows affected %v", cmd, res.RowsAffected())
 	return nil
 }
 

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -62,11 +62,11 @@ var flagRefreshMViews bool
 
 func importSchema() {
 	tdb = tgtdb.NewTargetDB(&tconf)
-	err := tdb.Connect()
+	err := tdb.Init()
 	if err != nil {
-		utils.ErrExit("Failed to connect to target YB cluster: %s", err)
+		utils.ErrExit("Failed to initialize the target DB: %s", err)
 	}
-	defer tdb.Disconnect()
+	defer tdb.Finalize()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
 	conn := tdb.Conn()

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -61,6 +61,8 @@ var importObjectsInStraightOrder bool
 var flagRefreshMViews bool
 
 func importSchema() {
+	tconf.Schema = strings.ToLower(tconf.Schema)
+
 	tdb = tgtdb.NewTargetDB(&tconf)
 	err := tdb.Init()
 	if err != nil {
@@ -68,9 +70,12 @@ func importSchema() {
 	}
 	defer tdb.Finalize()
 
-	tconf.Schema = strings.ToLower(tconf.Schema)
-	conn := tdb.Conn()
-	targetDBVersion := tdb.GetVersion()
+	ybdb, ok := tdb.(*tgtdb.TargetYugabyteDB)
+	if !ok {
+		utils.ErrExit("The target DB must be YugabyteDB")
+	}
+	conn := ybdb.Conn()
+	targetDBVersion := ybdb.GetVersion()
 	utils.PrintAndLog("YugabyteDB version: %s\n", targetDBVersion)
 
 	payload := callhome.GetPayload(exportDir)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -60,15 +61,16 @@ var importObjectsInStraightOrder bool
 var flagRefreshMViews bool
 
 func importSchema() {
-	err := tconf.DB().Connect()
+	tdb = tgtdb.NewTargetDB(&tconf)
+	err := tdb.Connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to target YB cluster: %s", err)
 	}
-	defer tconf.DB().Disconnect()
+	defer tdb.Disconnect()
 
 	tconf.Schema = strings.ToLower(tconf.Schema)
-	conn := tconf.DB().Conn()
-	targetDBVersion := tconf.DB().GetVersion()
+	conn := tdb.Conn()
+	targetDBVersion := tdb.GetVersion()
 	utils.PrintAndLog("YugabyteDB version: %s\n", targetDBVersion)
 
 	payload := callhome.GetPayload(exportDir)

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -118,12 +118,12 @@ func ExtractMetaInfo(exportDir string) utils.ExportMetaInfo {
 
 func applySchemaObjectFilterFlags(importObjectOrderList []string) []string {
 	var finalImportObjectList []string
-	excludeObjectList := utils.CsvStringToSlice(target.ExcludeImportObjects)
+	excludeObjectList := utils.CsvStringToSlice(tconf.ExcludeImportObjects)
 	for i, item := range excludeObjectList {
 		excludeObjectList[i] = strings.ToUpper(item)
 	}
-	if target.ImportObjects != "" {
-		includeObjectList := utils.CsvStringToSlice(target.ImportObjects)
+	if tconf.ImportObjects != "" {
+		includeObjectList := utils.CsvStringToSlice(tconf.ImportObjects)
 		for i, item := range includeObjectList {
 			includeObjectList[i] = strings.ToUpper(item)
 		}

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -16,96 +16,18 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
-type Event struct {
-	Op         string            `json:"op"`
-	SchemaName string            `json:"schema_name"`
-	TableName  string            `json:"table_name"`
-	Key        map[string]string `json:"key"`
-	Fields     map[string]string `json:"fields"`
-}
-
-func (e *Event) GetSQLStmt(targetSchema string) string {
-	switch e.Op {
-	case "c":
-		return e.getInsertStmt(targetSchema)
-	case "u":
-		return e.getUpdateStmt(targetSchema)
-	case "d":
-		return e.getDeleteStmt(targetSchema)
-	default:
-		panic("unknown op: " + e.Op)
-	}
-}
-
-const insertTemplate = "INSERT INTO %s (%s) VALUES (%s);"
-const updateTemplate = "UPDATE %s SET %s WHERE %s;"
-const deleteTemplate = "DELETE FROM %s WHERE %s;"
-
-func (event *Event) getInsertStmt(targetSchema string) string {
-	tableName := event.SchemaName + "." + event.TableName
-	if targetSchema != "" {
-		tableName = targetSchema + "." + event.TableName
-	}
-	columnList := make([]string, 0, len(event.Fields))
-	valueList := make([]string, 0, len(event.Fields))
-	for column, value := range event.Fields {
-		columnList = append(columnList, column)
-		valueList = append(valueList, value)
-	}
-	columns := strings.Join(columnList, ", ")
-	values := strings.Join(valueList, ", ")
-	stmt := fmt.Sprintf(insertTemplate, tableName, columns, values)
-	return stmt
-}
-
-func (event *Event) getUpdateStmt(targetSchema string) string {
-	tableName := event.SchemaName + "." + event.TableName
-	if targetSchema != "" {
-		tableName = targetSchema + "." + event.TableName
-	}
-	var setClauses []string
-	for column, value := range event.Fields {
-		setClauses = append(setClauses, fmt.Sprintf("%s = %s", column, value))
-	}
-	setClause := strings.Join(setClauses, ", ")
-	var whereClauses []string
-	for column, value := range event.Key {
-		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
-	}
-	whereClause := strings.Join(whereClauses, " AND ")
-	return fmt.Sprintf(updateTemplate, tableName, setClause, whereClause)
-}
-
-func (event *Event) getDeleteStmt(targetSchema string) string {
-	tableName := event.SchemaName + "." + event.TableName
-	if targetSchema != "" {
-		tableName = targetSchema + "." + event.TableName
-	}
-	var whereClauses []string
-	for column, value := range event.Key {
-		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
-	}
-	whereClause := strings.Join(whereClauses, " AND ")
-	return fmt.Sprintf(deleteTemplate, tableName, whereClause)
-}
-
-//==================================================================================
-
-func streamChanges(connPool *tgtdb.ConnectionPool, targetSchema string) error {
+func streamChanges() error {
 	queueFilePath := filepath.Join(exportDir, "data", "queue.json")
 	log.Infof("Streaming changes from %s", queueFilePath)
 	file, err := os.OpenFile(queueFilePath, os.O_CREATE, 0640)
@@ -119,13 +41,13 @@ func streamChanges(connPool *tgtdb.ConnectionPool, targetSchema string) error {
 	log.Infof("Waiting for changes in %s", queueFilePath)
 	// TODO: Batch the changes.
 	for dec.More() {
-		var event Event
+		var event tgtdb.Event
 		err := dec.Decode(&event)
 		if err != nil {
 			return fmt.Errorf("error decoding change: %v", err)
 		}
 
-		err = handleEvent(connPool, &event, targetSchema)
+		err = handleEvent(&event)
 		if err != nil {
 			return fmt.Errorf("error handling event: %v", err)
 		}
@@ -133,24 +55,14 @@ func streamChanges(connPool *tgtdb.ConnectionPool, targetSchema string) error {
 	return nil
 }
 
-func handleEvent(connPool *tgtdb.ConnectionPool, event *Event, targetSchema string) error {
+func handleEvent(event *tgtdb.Event) error {
 	log.Debugf("Handling event: %v", event)
-	stmt := event.GetSQLStmt(targetSchema)
-	log.Debug(stmt)
-	err := connPool.WithConn(func(conn *pgx.Conn) (bool, error) {
-		tag, err := conn.Exec(context.Background(), stmt)
-		if err != nil {
-			log.Errorf("Error executing stmt: %v", err)
-		}
-		log.Debugf("Executed stmt [ %s ]: rows affected => %v", stmt, tag.RowsAffected())
-		return false, err
-	})
-	// Idempotency considerations:
-	// Note: Assuming PK column value is not changed via UPDATEs
-	// INSERT: The connPool sets `yb_enable_upsert_mode to true`. Hece the insert will be
-	// successful even if the row already exists.
-	// DELETE does NOT fail if the row does not exist. Rows affected will be 0.
-	// UPDATE statement does not fail if the row does not exist. Rows affected will be 0.
 
-	return err
+	// TODO: Convert values in the event to make it suitable for target DB.
+	batch := []*tgtdb.Event{event}
+	err := tdb.ExecuteBatch(batch)
+	if err != nil {
+		return fmt.Errorf("error executing batch: %v", err)
+	}
+	return nil
 }

--- a/yb-voyager/src/datafile/descriptor.go
+++ b/yb-voyager/src/datafile/descriptor.go
@@ -48,13 +48,14 @@ type FileEntry struct {
 }
 
 type Descriptor struct {
-	FileFormat   string       `json:"FileFormat"`
-	Delimiter    string       `json:"Delimiter"`
-	HasHeader    bool         `json:"HasHeader"`
-	ExportDir    string       `json:"-"`
-	QuoteChar    byte         `json:"QuoteChar,omitempty"`
-	EscapeChar   byte         `json:"EscapeChar,omitempty"`
-	DataFileList []*FileEntry `json:"FileList"`
+	FileFormat                 string              `json:"FileFormat"`
+	Delimiter                  string              `json:"Delimiter"`
+	HasHeader                  bool                `json:"HasHeader"`
+	ExportDir                  string              `json:"-"`
+	QuoteChar                  byte                `json:"QuoteChar,omitempty"`
+	EscapeChar                 byte                `json:"EscapeChar,omitempty"`
+	DataFileList               []*FileEntry        `json:"FileList"`
+	TableNameToExportedColumns map[string][]string `json:"TableNameToExportedColumns"`
 }
 
 func OpenDescriptor(exportDir string) *Descriptor {

--- a/yb-voyager/src/datafile/descriptor.go
+++ b/yb-voyager/src/datafile/descriptor.go
@@ -54,6 +54,7 @@ type Descriptor struct {
 	ExportDir                  string              `json:"-"`
 	QuoteChar                  byte                `json:"QuoteChar,omitempty"`
 	EscapeChar                 byte                `json:"EscapeChar,omitempty"`
+	NullString                 string              `json:"NullString,omitempty"`
 	DataFileList               []*FileEntry        `json:"FileList"`
 	TableNameToExportedColumns map[string][]string `json:"TableNameToExportedColumns"`
 }

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -171,6 +171,7 @@ func (ms *MySQL) ExportDataPostProcessing(exportDir string, tablesProgressMetada
 		Delimiter:                  "\t",
 		HasHeader:                  false,
 		ExportDir:                  exportDir,
+		NullString:                 `\N`,
 		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
 		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -167,11 +167,12 @@ func (ms *MySQL) ExportData(ctx context.Context, exportDir string, tableList []*
 func (ms *MySQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	renameDataFilesForReservedWords(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileFormat:   datafile.SQL,
-		Delimiter:    "\t",
-		HasHeader:    false,
-		ExportDir:    exportDir,
-		DataFileList: getExportedDataFileList(tablesProgressMetadata),
+		FileFormat:                 datafile.SQL,
+		Delimiter:                  "\t",
+		HasHeader:                  false,
+		ExportDir:                  exportDir,
+		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
+		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 	dfd.Save()
 }

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -180,6 +180,7 @@ func (ora *Oracle) ExportDataPostProcessing(exportDir string, tablesProgressMeta
 		Delimiter:                  "\t",
 		HasHeader:                  false,
 		ExportDir:                  exportDir,
+		NullString:                 `\N`,
 		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 	dfd.Save()

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -175,11 +175,12 @@ func (ora *Oracle) ExportData(ctx context.Context, exportDir string, tableList [
 func (ora *Oracle) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	renameDataFilesForReservedWords(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileFormat:   datafile.SQL,
-		DataFileList: getExportedDataFileList(tablesProgressMetadata),
-		Delimiter:    "\t",
-		HasHeader:    false,
-		ExportDir:    exportDir,
+		FileFormat:                 datafile.SQL,
+		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
+		Delimiter:                  "\t",
+		HasHeader:                  false,
+		ExportDir:                  exportDir,
+		TableNameToExportedColumns: getOra2pgExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 	dfd.Save()
 

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -251,16 +251,12 @@ func (pg *PostgreSQL) getExportedColumnsListForTable(exportDir, tableName string
 		re = regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]+\((.*)\) FROM STDIN`, tableName))
 	}
 	tocFilePath := filepath.Join(exportDir, "data", "toc.dat")
-	err := utils.ForEachLineInFile(tocFilePath, func(line string) bool {
-		matches := re.FindStringSubmatch(line)
-		if len(matches) > 0 {
-			columnsList = strings.Split(matches[1], ",")
-			for i, column := range columnsList {
-				columnsList[i] = strings.TrimSpace(column)
-			}
-			return false // stop reading file
+	err := utils.ForEachMatchingLineInFile(tocFilePath, re, func(matches []string) bool {
+		columnsList = strings.Split(matches[1], ",")
+		for i, column := range columnsList {
+			columnsList[i] = strings.TrimSpace(column)
 		}
-		return true
+		return false // stop reading file
 	})
 	if err != nil {
 		utils.ErrExit("error in reading toc file: %v\n", err)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v4"
@@ -217,13 +219,54 @@ func (pg *PostgreSQL) ExportData(ctx context.Context, exportDir string, tableLis
 func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
 	renameDataFiles(tablesProgressMetadata)
 	dfd := datafile.Descriptor{
-		FileFormat:   datafile.TEXT,
-		DataFileList: getExportedDataFileList(tablesProgressMetadata),
-		Delimiter:    "\t",
-		HasHeader:    false,
-		ExportDir:    exportDir,
+		FileFormat:                 datafile.TEXT,
+		DataFileList:               getExportedDataFileList(tablesProgressMetadata),
+		Delimiter:                  "\t",
+		HasHeader:                  false,
+		ExportDir:                  exportDir,
+		TableNameToExportedColumns: pg.getExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
+
 	dfd.Save()
+}
+
+func (pg *PostgreSQL) getExportedColumnsMap(
+	exportDir string, tablesMetadata map[string]*utils.TableProgressMetadata) map[string][]string {
+
+	result := make(map[string][]string)
+	for _, tableMetadata := range tablesMetadata {
+		tableName := strings.TrimSuffix(filepath.Base(tableMetadata.FinalFilePath), "_data.sql")
+		result[tableName] = pg.getExportedColumnsListForTable(exportDir, tableName)
+	}
+	return result
+}
+
+func (pg *PostgreSQL) getExportedColumnsListForTable(exportDir, tableName string) []string {
+	var columnsList []string
+	var re *regexp.Regexp
+	if len(strings.Split(tableName, ".")) == 1 {
+		// happens only when table is in public schema, use public schema with table name for regexp
+		re = regexp.MustCompile(fmt.Sprintf(`(?i)COPY public.%s[\s]+\((.*)\) FROM STDIN`, tableName))
+	} else {
+		re = regexp.MustCompile(fmt.Sprintf(`(?i)COPY %s[\s]+\((.*)\) FROM STDIN`, tableName))
+	}
+	tocFilePath := filepath.Join(exportDir, "data", "toc.dat")
+	err := utils.ForEachLineInFile(tocFilePath, func(line string) bool {
+		matches := re.FindStringSubmatch(line)
+		if len(matches) > 0 {
+			columnsList = strings.Split(matches[1], ",")
+			for i, column := range columnsList {
+				columnsList[i] = strings.TrimSpace(column)
+			}
+			return false // stop reading file
+		}
+		return true
+	})
+	if err != nil {
+		utils.ErrExit("error in reading toc file: %v\n", err)
+	}
+	log.Infof("columns list for table %s: %v", tableName, columnsList)
+	return columnsList
 }
 
 // Given a PG command name ("pg_dump", "pg_restore"), find absolute path of

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -224,6 +224,7 @@ func (pg *PostgreSQL) ExportDataPostProcessing(exportDir string, tablesProgressM
 		Delimiter:                  "\t",
 		HasHeader:                  false,
 		ExportDir:                  exportDir,
+		NullString:                 `\N`,
 		TableNameToExportedColumns: pg.getExportedColumnsMap(exportDir, tablesProgressMetadata),
 	}
 

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -1,0 +1,79 @@
+package tgtdb
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Event struct {
+	Op         string            `json:"op"`
+	SchemaName string            `json:"schema_name"`
+	TableName  string            `json:"table_name"`
+	Key        map[string]string `json:"key"`
+	Fields     map[string]string `json:"fields"`
+}
+
+func (e *Event) GetSQLStmt(targetSchema string) string {
+	switch e.Op {
+	case "c":
+		return e.getInsertStmt(targetSchema)
+	case "u":
+		return e.getUpdateStmt(targetSchema)
+	case "d":
+		return e.getDeleteStmt(targetSchema)
+	default:
+		panic("unknown op: " + e.Op)
+	}
+}
+
+const insertTemplate = "INSERT INTO %s (%s) VALUES (%s);"
+const updateTemplate = "UPDATE %s SET %s WHERE %s;"
+const deleteTemplate = "DELETE FROM %s WHERE %s;"
+
+func (event *Event) getInsertStmt(targetSchema string) string {
+	tableName := event.SchemaName + "." + event.TableName
+	if targetSchema != "" {
+		tableName = targetSchema + "." + event.TableName
+	}
+	columnList := make([]string, 0, len(event.Fields))
+	valueList := make([]string, 0, len(event.Fields))
+	for column, value := range event.Fields {
+		columnList = append(columnList, column)
+		valueList = append(valueList, value)
+	}
+	columns := strings.Join(columnList, ", ")
+	values := strings.Join(valueList, ", ")
+	stmt := fmt.Sprintf(insertTemplate, tableName, columns, values)
+	return stmt
+}
+
+func (event *Event) getUpdateStmt(targetSchema string) string {
+	tableName := event.SchemaName + "." + event.TableName
+	if targetSchema != "" {
+		tableName = targetSchema + "." + event.TableName
+	}
+	var setClauses []string
+	for column, value := range event.Fields {
+		setClauses = append(setClauses, fmt.Sprintf("%s = %s", column, value))
+	}
+	setClause := strings.Join(setClauses, ", ")
+	var whereClauses []string
+	for column, value := range event.Key {
+		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
+	}
+	whereClause := strings.Join(whereClauses, " AND ")
+	return fmt.Sprintf(updateTemplate, tableName, setClause, whereClause)
+}
+
+func (event *Event) getDeleteStmt(targetSchema string) string {
+	tableName := event.SchemaName + "." + event.TableName
+	if targetSchema != "" {
+		tableName = targetSchema + "." + event.TableName
+	}
+	var whereClauses []string
+	for column, value := range event.Key {
+		whereClauses = append(whereClauses, fmt.Sprintf("%s = %s", column, value))
+	}
+	whereClause := strings.Join(whereClauses, " AND ")
+	return fmt.Sprintf(deleteTemplate, tableName, whereClause)
+}

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -16,9 +16,15 @@ limitations under the License.
 package tgtdb
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -29,7 +35,7 @@ import (
 
 type TargetOracleDB struct {
 	sync.Mutex
-	tconf    *TargetConf // Target conf needs to be implemented for Oracle
+	tconf    *TargetConf
 	conn_    *sql.DB
 	connPool *ConnectionPool // Connection pool needs to be implemented for Oracle
 }
@@ -40,6 +46,11 @@ func newTargetOracleDB(tconf *TargetConf) TargetDB {
 
 func (db *TargetOracleDB) connect() error {
 	conn, err := sql.Open("godror", db.getConnectionUri(db.tconf))
+	setTargetSchemaConn, err := conn.Conn(context.Background())
+	if err != nil {
+		return fmt.Errorf("get connection from target db: %w", err)
+	}
+	db.setTargetSchema(setTargetSchemaConn)
 	db.conn_ = conn
 	return err
 }
@@ -97,18 +108,17 @@ func (db *TargetOracleDB) getTargetSchemaName(tableName string) string {
 }
 
 func (db *TargetOracleDB) CleanFileImportState(filePath, tableName string) error {
-	// // Delete all entries from ${BATCH_METADATA_TABLE_NAME} for the given file.
-	// schemaName := db.getTargetSchemaName(tableName)
-	// cmd := fmt.Sprintf(
-	// 	`DELETE FROM %s WHERE data_file_name = '%s' AND schema_name = '%s' AND table_name = '%s';`,
-	// 	BATCH_METADATA_TABLE_NAME, filePath, schemaName, tableName)
-	// res, err := db.conn_.ExecContext(context.Background(), cmd)
-	// if err != nil {
-	// 	return fmt.Errorf("remove %q related entries from %s: %w", tableName, BATCH_METADATA_TABLE_NAME, err)
-	// }
-	// rowsAffected, _ := res.RowsAffected()
-	// log.Infof("query: [%s] => rows affected %v", cmd, rowsAffected)
-	// return nil
+	// Delete all entries from ${BATCH_METADATA_TABLE_NAME} for the given file.
+	schemaName := db.getTargetSchemaName(tableName)
+	cmd := fmt.Sprintf(
+		`DELETE FROM %s WHERE data_file_name = '%s' AND schema_name = '%s' AND table_name = '%s'`,
+		BATCH_METADATA_TABLE_NAME, filePath, schemaName, tableName)
+	res, err := db.conn_.ExecContext(context.Background(), cmd)
+	if err != nil {
+		return fmt.Errorf("remove %q related entries from %s: %w", tableName, BATCH_METADATA_TABLE_NAME, err)
+	}
+	rowsAffected, _ := res.RowsAffected()
+	log.Infof("query: [%s] => rows affected %v", cmd, rowsAffected)
 	return nil
 }
 
@@ -124,70 +134,86 @@ func (db *TargetOracleDB) GetVersion() string {
 }
 
 func (db *TargetOracleDB) CreateVoyagerSchema() error {
-	// 	createUserQuery := fmt.Sprintf("CREATE USER %s IDENTIFIED BY password;", BATCH_METADATA_TABLE_SCHEMA)
-	// 	grantQuery := fmt.Sprintf("GRANT CONNECT, RESOURCE TO %s;", BATCH_METADATA_TABLE_SCHEMA)
-	// 	alterQuery := fmt.Sprintf("ALTER USER %s QUOTA UNLIMITED ON USERS;", BATCH_METADATA_TABLE_SCHEMA)
+	createUserQuery := fmt.Sprintf(`BEGIN
+    DECLARE
+        user_exists NUMBER;
+    BEGIN
+        SELECT COUNT(*) INTO user_exists FROM all_users WHERE username = UPPER('%s');
+        IF user_exists = 0 THEN
+            EXECUTE IMMEDIATE 'CREATE USER %s IDENTIFIED BY "password"';
+        END IF;
+    END;
+END;`, BATCH_METADATA_TABLE_SCHEMA, BATCH_METADATA_TABLE_SCHEMA)
+	grantQuery := fmt.Sprintf(`GRANT CONNECT, RESOURCE TO %s`, BATCH_METADATA_TABLE_SCHEMA)
+	alterQuery := fmt.Sprintf(`ALTER USER %s QUOTA UNLIMITED ON USERS`, BATCH_METADATA_TABLE_SCHEMA)
+	createTableQuery := fmt.Sprintf(`BEGIN
+		EXECUTE IMMEDIATE 'CREATE TABLE %s (
+			data_file_name VARCHAR2(250),
+			batch_number NUMBER(10),
+			schema_name VARCHAR2(250),
+			table_name VARCHAR2(250),
+			rows_imported NUMBER(19),
+			PRIMARY KEY (data_file_name, batch_number, schema_name, table_name)
+		)';
+	EXCEPTION
+		WHEN OTHERS THEN
+			IF SQLCODE != -955 THEN
+				RAISE;
+			END IF;
+	END;`, BATCH_METADATA_TABLE_NAME)
 
-	// 	cmds := []string{
-	// 		createUserQuery,
-	// 		grantQuery,
-	// 		alterQuery,
-	// 		fmt.Sprintf(`CREATE TABLE %s (
-	// 			data_file_name VARCHAR2(250),
-	// 			batch_number NUMBER(10),
-	// 			schema_name VARCHAR2(250),
-	// 			table_name VARCHAR2(250),
-	// 			rows_imported NUMBER(19),
-	// 			PRIMARY KEY (data_file_name, batch_number, schema_name, table_name)
-	// 		);`, BATCH_METADATA_TABLE_NAME),
-	// 	}
+	cmds := []string{
+		createUserQuery,
+		grantQuery,
+		alterQuery,
+		createTableQuery,
+	}
 
-	// 	maxAttempts := 12
-	// 	var err error
+	maxAttempts := 12
+	var err error
 
-	// outer:
-	// 	for _, cmd := range cmds {
-	// 		for attempt := 1; attempt <= maxAttempts; attempt++ {
-	// 			log.Infof("Executing on target: [%s]", cmd)
-	// 			conn := db.GetConnection()
-	// 			_, err = conn.ExecContext(context.Background(), cmd)
-	// 			if err == nil {
-	// 				// No error. Move on to the next command.
-	// 				continue outer
-	// 			}
-	// 			log.Warnf("Error while running [%s] attempt %d: %s", cmd, attempt, err)
-	// 			time.Sleep(5 * time.Second)
-	// 			err = db.reconnect()
-	// 			if err != nil {
-	// 				break
-	// 			}
-	// 		}
-	// 		if err != nil {
-	// 			return fmt.Errorf("create ybvoyager schema on target: %w", err)
-	// 		}
-	// 	}
+outer:
+	for _, cmd := range cmds {
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			log.Infof("Executing on target: [%s]", cmd)
+			conn := db.GetConnection()
+			_, err = conn.ExecContext(context.Background(), cmd)
+			if err == nil {
+				// No error. Move on to the next command.
+				continue outer
+			}
+			log.Warnf("Error while running [%s] attempt %d: %s", cmd, attempt, err)
+			time.Sleep(5 * time.Second)
+			err2 := db.reconnect()
+			if err2 != nil {
+				break
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("create ybvoyager schema on target: %w", err)
+		}
+	}
 	return nil
 }
 
 func (db *TargetOracleDB) GetNonEmptyTables(tables []string) []string {
-	// result := []string{}
+	result := []string{}
 
-	// for _, table := range tables {
-	// 	log.Infof("Checking if table %s is empty", table)
-	// 	tmp := false
-	// 	stmt := fmt.Sprintf("SELECT 1 FROM %s WHERE ROWNUM <= 1", table)
-	// 	err := db.conn_.QueryRow(stmt).Scan(&tmp)
-	// 	if err != nil {
-	// 		log.Errorf("Failed to check if table %s is empty: %v", table, err)
-	// 		continue
-	// 	}
-	// 	if tmp {
-	// 		result = append(result, table)
-	// 	}
-	// }
+	for _, table := range tables {
+		log.Infof("Checking if table %s is empty", table)
+		tmp := false
+		stmt := fmt.Sprintf("SELECT 1 FROM %s WHERE ROWNUM <= 1", table)
+		err := db.conn_.QueryRow(stmt).Scan(&tmp)
+		if err != nil {
+			log.Errorf("Failed to check if table %s is empty: %v", table, err)
+			continue
+		}
+		if tmp {
+			result = append(result, table)
+		}
+	}
 
-	// return result
-	return nil
+	return result
 }
 
 func (db *TargetOracleDB) IsNonRetryableCopyError(err error) bool {
@@ -195,15 +221,14 @@ func (db *TargetOracleDB) IsNonRetryableCopyError(err error) bool {
 }
 
 func (db *TargetOracleDB) ImportBatch(batch Batch, args *ImportBatchArgs, exportDir string) (int64, error) {
-	// var rowsAffected int64
-	// var err error
-	// copyFn := func(conn *sql.Conn) (bool, error) {
-	// 	rowsAffected, err = db.importBatch(conn, batch, args, exportDir)
-	// 	return false, err
-	// }
-	// err = db.WithConn(copyFn)
-	// return rowsAffected, err
-	return 0, nil
+	var rowsAffected int64
+	var err error
+	copyFn := func(conn *sql.Conn) (bool, error) {
+		rowsAffected, err = db.importBatch(conn, batch, args, exportDir)
+		return false, err
+	}
+	err = db.WithConn(copyFn)
+	return rowsAffected, err
 }
 
 func (db *TargetOracleDB) WithConn(fn func(*sql.Conn) (bool, error)) error {
@@ -231,99 +256,214 @@ func (db *TargetOracleDB) WithConn(fn func(*sql.Conn) (bool, error)) error {
 }
 
 func (db *TargetOracleDB) importBatch(conn *sql.Conn, batch Batch, args *ImportBatchArgs, exportDir string) (rowsAffected int64, err error) {
-	// var file *os.File
-	// file, err = batch.Open()
-	// if err != nil {
-	// 	return 0, fmt.Errorf("open batch file %q: %w", batch.GetFilePath(), err)
-	// }
-	// defer file.Close()
+	var file *os.File
+	file, err = batch.Open()
+	if err != nil {
+		return 0, fmt.Errorf("open batch file %q: %w", batch.GetFilePath(), err)
+	}
+	defer file.Close()
 
-	// //setting the schema so that the table is created in the correct schema
-	// db.setTargetSchema(conn)
+	//setting the schema so that the table is created in the correct schema
+	db.setTargetSchema(conn)
 
-	// ctx := context.Background()
-	// var tx *sql.Tx
-	// tx, err = conn.BeginTx(ctx, &sql.TxOptions{})
-	// if err != nil {
-	// 	return 0, fmt.Errorf("begin transaction: %w", err)
-	// }
-	// defer func() {
-	// 	var err2 error
-	// 	if err != nil {
-	// 		err2 = tx.Rollback(ctx)
-	// 		if err2 != nil {
-	// 			rowsAffected = 0
-	// 			err = fmt.Errorf("rollback transaction: %w (while processing %s)", err2, err)
-	// 		}
-	// 	} else {
-	// 		err2 = tx.Commit(ctx)
-	// 		if err2 != nil {
-	// 			rowsAffected = 0
-	// 			err = fmt.Errorf("commit transaction: %w", err2)
-	// 		}
-	// 	}
-	// }()
+	ctx := context.Background()
+	var tx *sql.Tx
+	tx, err = conn.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		var err2 error
+		if err != nil {
+			err2 = tx.Rollback()
+			if err2 != nil {
+				rowsAffected = 0
+				err = fmt.Errorf("rollback transaction: %w (while processing %s)", err2, err)
+			}
+		} else {
+			err2 = tx.Commit()
+			if err2 != nil {
+				rowsAffected = 0
+				err = fmt.Errorf("commit transaction: %w", err2)
+			}
+		}
+	}()
 
-	// // Check if split is already imported
-	// var alreadyImported bool
-	// alreadyImported, rowsAffected, err = db.isBatchAlreadyImported(tx, batch)
-	// if err != nil {
-	// 	return 0, err
-	// }
-	// if alreadyImported {
-	// 	return rowsAffected, nil
-	// }
+	// Check if split is already imported
+	var alreadyImported bool
+	alreadyImported, rowsAffected, err = db.isBatchAlreadyImported(tx, batch)
+	if err != nil {
+		return 0, err
+	}
+	if alreadyImported {
+		return rowsAffected, nil
+	}
 
-	// // Import the split using sqldr
-	// sqlldrControlFile := args.GetSqlLdrControlFile()
-	// // Create sqlldr control file at export-dir/sqlldr
-	// // Create folder if it does not exist
-	// if _, err := os.Stat(fmt.Sprintf("%s/sqlldr", exportDir)); os.IsNotExist(err) {
-	// 	os.Mkdir(fmt.Sprintf("%s/sqlldr", exportDir), 0755)
-	// }
-	// sqlldrControlFilePath := fmt.Sprintf("%s/sqlldr/%s.ctl", exportDir, batch.GetBatchId())
-	return 0, nil
+	// fmt.Printf("Importing table path: %s \n", batch.GetFilePath())
+	filePath := batch.GetFilePath()
+	pathElements := strings.Split(filePath, "/")
+	batchName := pathElements[len(pathElements)-1]
+	tableName := batch.GetTableName()
+
+	// Import the split using sqldr
+	sqlldrControlFileContent := args.GetSqlLdrControlFile(db.tconf.Schema)
+	// Create sqlldr control file at export-dir/sqlldr
+	// Create folder if it does not exist
+	if _, err := os.Stat(fmt.Sprintf("%s/sqlldr", exportDir)); os.IsNotExist(err) {
+		os.Mkdir(fmt.Sprintf("%s/sqlldr", exportDir), 0755)
+	}
+	sqlldrControlFileName := fmt.Sprintf("%s-%s.ctl", tableName, batchName)
+	sqlldrControlFilePath := fmt.Sprintf("%s/sqlldr/%s", exportDir, sqlldrControlFileName)
+	sqlldrControlFile, err := os.Create(sqlldrControlFilePath)
+	if err != nil {
+		return 0, fmt.Errorf("create sqlldr control file %q: %w", sqlldrControlFilePath, err)
+	}
+	defer sqlldrControlFile.Close()
+	_, err = sqlldrControlFile.WriteString(sqlldrControlFileContent)
+	if err != nil {
+		return 0, fmt.Errorf("write sqlldr control file %q: %w", sqlldrControlFilePath, err)
+	}
+	// Create log file
+	sqlldrLogFileName := fmt.Sprintf("%s-%s.log", tableName, batchName)
+	sqlldrLogFilePath := fmt.Sprintf("%s/sqlldr/%s", exportDir, sqlldrLogFileName)
+	sqlldrLogFile, err := os.Create(sqlldrLogFilePath)
+	if err != nil {
+		return 0, fmt.Errorf("create sqlldr log file %q: %w", sqlldrLogFilePath, err)
+	}
+	sqlldrLogFile.Close()
+
+	// Run sqlldr
+	// fmt.Println("Running sqlldr for file: ", sqlldrControlFilePath)
+	// Extract the values from the connection string
+	connectionString := db.getConnectionUri(db.tconf)
+	user := getValue(connectionString, "user")
+	password := getValue(connectionString, "password")
+	connectString := getValue(connectionString, "connectString")
+
+	// Format the Oracle connection string
+	oracleConnectionString := fmt.Sprintf("%s/%s@\"%s\"", user, password, connectString)
+	// Extract the values from the connection string
+	sqlldrArgs := fmt.Sprintf("userid=%s control=%s log=%s DIRECT=TRUE PARALLEL=TRUE", oracleConnectionString, sqlldrControlFilePath, sqlldrLogFilePath)
+	// fmt.Println("Args: ", sqlldrArgs)
+
+	cmd := exec.Command("sqlldr", sqlldrArgs)
+	var outbuf bytes.Buffer
+	var errbuf bytes.Buffer
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+	// fmt.Printf("cmd: %v\n", cmd)
+	err = cmd.Run()
+	log.Infof("sqlldr output: %s", outbuf.String())
+	log.Errorf("sqlldr error: %s", errbuf.String())
+	var err2 error
+	rowsAffected, err2 = getRowsAffected(sqlldrLogFilePath)
+	if err2 != nil {
+		err2 = fmt.Errorf("error parsing log file: %v", err)
+		return 0, err2
+	}
+	if err != nil {
+		// fmt.Printf("Error running sqlldr: %v\n", err)
+		return rowsAffected, fmt.Errorf("run sqlldr: %w", err)
+	}
+
+	// Insert the split metadata into ${BATCH_METADATA_TABLE_NAME}
+	err = db.recordEntryInDB(tx, batch, rowsAffected)
+	if err != nil {
+		err = fmt.Errorf("record entry in DB for batch %q: %w", batch.GetFilePath(), err)
+	}
+
+	return rowsAffected, err
+}
+
+func (db *TargetOracleDB) recordEntryInDB(tx *sql.Tx, batch Batch, rowsAffected int64) error {
+	cmd := batch.GetCommandToRecordEntryInDB(db.tconf.TargetDBType, rowsAffected)
+	_, err := tx.ExecContext(context.Background(), cmd)
+	if err != nil {
+		fmt.Printf("Error running query: %v\n", err)
+		return fmt.Errorf("insert into %s: %w", BATCH_METADATA_TABLE_NAME, err)
+	}
+	return nil
+}
+
+func getRowsAffected(logFilePath string) (int64, error) {
+	// Open the log file
+	logFile, err := os.Open(logFilePath)
+	if err != nil {
+		return 0, err
+	}
+	defer logFile.Close()
+
+	// Create a regular expression to match the rows affected information
+	re := regexp.MustCompile(`(\d+) Rows successfully loaded.`)
+
+	// Read the log file line by line
+	scanner := bufio.NewScanner(logFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Check if the line matches the regular expression
+		if matches := re.FindStringSubmatch(line); len(matches) > 1 {
+			// Extract the number of rows affected from the regular expression match
+			rowsAffected, err := strconv.ParseInt(matches[1], 10, 64)
+			if err != nil {
+				return 0, err
+			}
+			return rowsAffected, nil
+		}
+	}
+
+	// If no match found, return an error
+	return 0, fmt.Errorf("Rows affected not found in the log file")
+}
+
+func getValue(connectionString, key string) string {
+	startIndex := strings.Index(connectionString, key)
+	if startIndex == -1 {
+		return ""
+	}
+
+	startIndex += len(key) + 2 // Move to the starting quote
+	endIndex := strings.Index(connectionString[startIndex:], "\"")
+
+	return connectionString[startIndex : startIndex+endIndex]
 }
 
 func (db *TargetOracleDB) isBatchAlreadyImported(tx *sql.Tx, batch Batch) (bool, int64, error) {
-	// var rowsImported int64
-	// query := batch.GetQueryIsBatchAlreadyImported()
-	// err := tx.QueryRowContext(context.Background(), query).Scan(&rowsImported)
-	// if err == nil {
-	// 	log.Infof("%v rows from %q are already imported", rowsImported, batch.GetFilePath())
-	// 	return true, rowsImported, nil
-	// }
-	// if err == sql.ErrNoRows {
-	// 	log.Infof("%q is not imported yet", batch.GetFilePath())
-	// 	return false, 0, nil
-	// }
-	// return false, 0, fmt.Errorf("check if %s is already imported: %w", batch.GetFilePath(), err)
-	return false, 0, nil
+	var rowsImported int64
+	query := batch.GetQueryIsBatchAlreadyImported(db.tconf.TargetDBType)
+	err := tx.QueryRowContext(context.Background(), query).Scan(&rowsImported)
+	if err == nil {
+		log.Infof("%v rows from %q are already imported", rowsImported, batch.GetFilePath())
+		return true, rowsImported, nil
+	}
+	if err == sql.ErrNoRows {
+		log.Infof("%q is not imported yet", batch.GetFilePath())
+		return false, 0, nil
+	}
+	return false, 0, fmt.Errorf("check if %s is already imported: %w", batch.GetFilePath(), err)
 }
 
 func (db *TargetOracleDB) setTargetSchema(conn *sql.Conn) {
-	// // Set the target schema.
-	// checkSchemaExistsQuery := fmt.Sprintf(
-	// 	"SELECT 1 FROM ALL_USERS WHERE USERNAME = '%s'",
-	// 	db.tconf.Schema)
-	// var cntSchemaName int
+	// Set the target schema.
+	checkSchemaExistsQuery := fmt.Sprintf(
+		"SELECT 1 FROM ALL_USERS WHERE USERNAME = '%s'",
+		strings.ToUpper(db.tconf.Schema))
+	var cntSchemaName int
 
-	// if err := conn.QueryRowContext(context.Background(), checkSchemaExistsQuery).Scan(&cntSchemaName); err != nil {
-	// 	utils.ErrExit("run query %q on target %q to check schema exists: %s", checkSchemaExistsQuery, db.tconf.Host, err)
-	// } else if cntSchemaName == 0 {
-	// 	utils.ErrExit("schema '%s' does not exist in target", db.tconf.Schema)
-	// }
+	if err := conn.QueryRowContext(context.Background(), checkSchemaExistsQuery).Scan(&cntSchemaName); err != nil {
+		utils.ErrExit("run query %q on target %q to check schema exists: %s", checkSchemaExistsQuery, db.tconf.Host, err)
+	} else if cntSchemaName == 0 {
+		utils.ErrExit("schema '%s' does not exist in target", db.tconf.Schema)
+	}
 
-	// setSchemaQuery := fmt.Sprintf("ALTER SESSION SET CURRENT_SCHEMA = %s", db.tconf.Schema)
-	// _, err := conn.ExecContext(context.Background(), setSchemaQuery)
-	// if err != nil {
-	// 	utils.ErrExit("run query %q on target %q to set schema: %s", setSchemaQuery, db.tconf.Host, err)
-	// }
-	fmt.Printf("setTargetSchema() not implemented")
+	setSchemaQuery := fmt.Sprintf("ALTER SESSION SET CURRENT_SCHEMA = %s", db.tconf.Schema)
+	_, err := conn.ExecContext(context.Background(), setSchemaQuery)
+	if err != nil {
+		utils.ErrExit("run query %q on target %q to set schema: %s", setSchemaQuery, db.tconf.Host, err)
+	}
 }
 
 func (db *TargetOracleDB) IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error) {
-	return nil, nil
+	return columns, nil
 }
 
 func (db *TargetOracleDB) ExecuteBatch(batch []*Event) error {

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -1,0 +1,356 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tgtdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+)
+
+type TargetOracleDB struct {
+	sync.Mutex
+	tconf    *TargetConf // Target conf needs to be implemented for Oracle
+	conn_    *sql.DB
+	connPool *ConnectionPool // Connection pool needs to be implemented for Oracle
+}
+
+func newTargetOracleDB(tconf *TargetConf) TargetDB {
+	return &TargetOracleDB{tconf: tconf}
+}
+
+func (db *TargetOracleDB) connect() error {
+	conn, err := sql.Open("godror", db.getConnectionUri(db.tconf))
+	db.conn_ = conn
+	return err
+}
+
+func (db *TargetOracleDB) disconnect() {
+	if db.conn_ != nil {
+		log.Infof("No connection to the target database to close")
+	}
+
+	err := db.conn_.Close()
+	if err != nil {
+		log.Errorf("Failed to close connection to the target database: %v", err)
+	}
+}
+
+func (db *TargetOracleDB) reconnect() error {
+	db.Mutex.Lock()
+	defer db.Mutex.Unlock()
+
+	var err error
+	db.disconnect()
+	for attempt := 1; attempt < 5; attempt++ {
+		err = db.connect()
+		if err == nil {
+			return nil
+		}
+		log.Infof("Failed to reconnect to the target database: %s", err)
+		time.Sleep(time.Duration(attempt*2) * time.Second)
+		// Retry.
+	}
+	return fmt.Errorf("reconnect to target db: %w", err)
+}
+
+func (db *TargetOracleDB) GetConnection() *sql.DB {
+	if db.conn_ == nil {
+		utils.ErrExit("Called target db GetConnection() before Init()")
+	}
+	return db.conn_
+}
+
+func (db *TargetOracleDB) Init() error {
+	return db.connect()
+}
+
+func (db *TargetOracleDB) Finalize() {
+	db.disconnect()
+}
+
+func (db *TargetOracleDB) getTargetSchemaName(tableName string) string {
+	parts := strings.Split(tableName, ".")
+	if len(parts) == 2 {
+		return parts[0]
+	}
+	return db.tconf.Schema // default set to "public"
+}
+
+func (db *TargetOracleDB) CleanFileImportState(filePath, tableName string) error {
+	// // Delete all entries from ${BATCH_METADATA_TABLE_NAME} for the given file.
+	// schemaName := db.getTargetSchemaName(tableName)
+	// cmd := fmt.Sprintf(
+	// 	`DELETE FROM %s WHERE data_file_name = '%s' AND schema_name = '%s' AND table_name = '%s';`,
+	// 	BATCH_METADATA_TABLE_NAME, filePath, schemaName, tableName)
+	// res, err := db.conn_.ExecContext(context.Background(), cmd)
+	// if err != nil {
+	// 	return fmt.Errorf("remove %q related entries from %s: %w", tableName, BATCH_METADATA_TABLE_NAME, err)
+	// }
+	// rowsAffected, _ := res.RowsAffected()
+	// log.Infof("query: [%s] => rows affected %v", cmd, rowsAffected)
+	// return nil
+	return nil
+}
+
+func (db *TargetOracleDB) GetVersion() string {
+	var version string
+	query := "SELECT BANNER FROM V$VERSION"
+	// query sample output: Oracle Database 19c Enterprise Edition Release 19.0.0.0.0 - Production
+	err := db.conn_.QueryRow(query).Scan(&version)
+	if err != nil {
+		utils.ErrExit("run query %q on source: %s", query, err)
+	}
+	return version
+}
+
+func (db *TargetOracleDB) CreateVoyagerSchema() error {
+	// 	createUserQuery := fmt.Sprintf("CREATE USER %s IDENTIFIED BY password;", BATCH_METADATA_TABLE_SCHEMA)
+	// 	grantQuery := fmt.Sprintf("GRANT CONNECT, RESOURCE TO %s;", BATCH_METADATA_TABLE_SCHEMA)
+	// 	alterQuery := fmt.Sprintf("ALTER USER %s QUOTA UNLIMITED ON USERS;", BATCH_METADATA_TABLE_SCHEMA)
+
+	// 	cmds := []string{
+	// 		createUserQuery,
+	// 		grantQuery,
+	// 		alterQuery,
+	// 		fmt.Sprintf(`CREATE TABLE %s (
+	// 			data_file_name VARCHAR2(250),
+	// 			batch_number NUMBER(10),
+	// 			schema_name VARCHAR2(250),
+	// 			table_name VARCHAR2(250),
+	// 			rows_imported NUMBER(19),
+	// 			PRIMARY KEY (data_file_name, batch_number, schema_name, table_name)
+	// 		);`, BATCH_METADATA_TABLE_NAME),
+	// 	}
+
+	// 	maxAttempts := 12
+	// 	var err error
+
+	// outer:
+	// 	for _, cmd := range cmds {
+	// 		for attempt := 1; attempt <= maxAttempts; attempt++ {
+	// 			log.Infof("Executing on target: [%s]", cmd)
+	// 			conn := db.GetConnection()
+	// 			_, err = conn.ExecContext(context.Background(), cmd)
+	// 			if err == nil {
+	// 				// No error. Move on to the next command.
+	// 				continue outer
+	// 			}
+	// 			log.Warnf("Error while running [%s] attempt %d: %s", cmd, attempt, err)
+	// 			time.Sleep(5 * time.Second)
+	// 			err = db.reconnect()
+	// 			if err != nil {
+	// 				break
+	// 			}
+	// 		}
+	// 		if err != nil {
+	// 			return fmt.Errorf("create ybvoyager schema on target: %w", err)
+	// 		}
+	// 	}
+	return nil
+}
+
+func (db *TargetOracleDB) GetNonEmptyTables(tables []string) []string {
+	// result := []string{}
+
+	// for _, table := range tables {
+	// 	log.Infof("Checking if table %s is empty", table)
+	// 	tmp := false
+	// 	stmt := fmt.Sprintf("SELECT 1 FROM %s WHERE ROWNUM <= 1", table)
+	// 	err := db.conn_.QueryRow(stmt).Scan(&tmp)
+	// 	if err != nil {
+	// 		log.Errorf("Failed to check if table %s is empty: %v", table, err)
+	// 		continue
+	// 	}
+	// 	if tmp {
+	// 		result = append(result, table)
+	// 	}
+	// }
+
+	// return result
+	return nil
+}
+
+func (db *TargetOracleDB) IsNonRetryableCopyError(err error) bool {
+	return false
+}
+
+func (db *TargetOracleDB) ImportBatch(batch Batch, args *ImportBatchArgs, exportDir string) (int64, error) {
+	// var rowsAffected int64
+	// var err error
+	// copyFn := func(conn *sql.Conn) (bool, error) {
+	// 	rowsAffected, err = db.importBatch(conn, batch, args, exportDir)
+	// 	return false, err
+	// }
+	// err = db.WithConn(copyFn)
+	// return rowsAffected, err
+	return 0, nil
+}
+
+func (db *TargetOracleDB) WithConn(fn func(*sql.Conn) (bool, error)) error {
+	var err error
+	if db.conn_ == nil {
+		err = db.reconnect()
+		if err != nil {
+			return err
+		}
+	}
+	retry := true
+	for retry {
+		conn, err := db.conn_.Conn(context.Background())
+		if err != nil {
+			return fmt.Errorf("get connection from target db: %w", err)
+		}
+		retry, err = fn(conn)
+		if err != nil {
+			// On err, drop the connection.
+			conn.Close()
+		}
+	}
+
+	return err
+}
+
+func (db *TargetOracleDB) importBatch(conn *sql.Conn, batch Batch, args *ImportBatchArgs, exportDir string) (rowsAffected int64, err error) {
+	// var file *os.File
+	// file, err = batch.Open()
+	// if err != nil {
+	// 	return 0, fmt.Errorf("open batch file %q: %w", batch.GetFilePath(), err)
+	// }
+	// defer file.Close()
+
+	// //setting the schema so that the table is created in the correct schema
+	// db.setTargetSchema(conn)
+
+	// ctx := context.Background()
+	// var tx *sql.Tx
+	// tx, err = conn.BeginTx(ctx, &sql.TxOptions{})
+	// if err != nil {
+	// 	return 0, fmt.Errorf("begin transaction: %w", err)
+	// }
+	// defer func() {
+	// 	var err2 error
+	// 	if err != nil {
+	// 		err2 = tx.Rollback(ctx)
+	// 		if err2 != nil {
+	// 			rowsAffected = 0
+	// 			err = fmt.Errorf("rollback transaction: %w (while processing %s)", err2, err)
+	// 		}
+	// 	} else {
+	// 		err2 = tx.Commit(ctx)
+	// 		if err2 != nil {
+	// 			rowsAffected = 0
+	// 			err = fmt.Errorf("commit transaction: %w", err2)
+	// 		}
+	// 	}
+	// }()
+
+	// // Check if split is already imported
+	// var alreadyImported bool
+	// alreadyImported, rowsAffected, err = db.isBatchAlreadyImported(tx, batch)
+	// if err != nil {
+	// 	return 0, err
+	// }
+	// if alreadyImported {
+	// 	return rowsAffected, nil
+	// }
+
+	// // Import the split using sqldr
+	// sqlldrControlFile := args.GetSqlLdrControlFile()
+	// // Create sqlldr control file at export-dir/sqlldr
+	// // Create folder if it does not exist
+	// if _, err := os.Stat(fmt.Sprintf("%s/sqlldr", exportDir)); os.IsNotExist(err) {
+	// 	os.Mkdir(fmt.Sprintf("%s/sqlldr", exportDir), 0755)
+	// }
+	// sqlldrControlFilePath := fmt.Sprintf("%s/sqlldr/%s.ctl", exportDir, batch.GetBatchId())
+	return 0, nil
+}
+
+func (db *TargetOracleDB) isBatchAlreadyImported(tx *sql.Tx, batch Batch) (bool, int64, error) {
+	// var rowsImported int64
+	// query := batch.GetQueryIsBatchAlreadyImported()
+	// err := tx.QueryRowContext(context.Background(), query).Scan(&rowsImported)
+	// if err == nil {
+	// 	log.Infof("%v rows from %q are already imported", rowsImported, batch.GetFilePath())
+	// 	return true, rowsImported, nil
+	// }
+	// if err == sql.ErrNoRows {
+	// 	log.Infof("%q is not imported yet", batch.GetFilePath())
+	// 	return false, 0, nil
+	// }
+	// return false, 0, fmt.Errorf("check if %s is already imported: %w", batch.GetFilePath(), err)
+	return false, 0, nil
+}
+
+func (db *TargetOracleDB) setTargetSchema(conn *sql.Conn) {
+	// // Set the target schema.
+	// checkSchemaExistsQuery := fmt.Sprintf(
+	// 	"SELECT 1 FROM ALL_USERS WHERE USERNAME = '%s'",
+	// 	db.tconf.Schema)
+	// var cntSchemaName int
+
+	// if err := conn.QueryRowContext(context.Background(), checkSchemaExistsQuery).Scan(&cntSchemaName); err != nil {
+	// 	utils.ErrExit("run query %q on target %q to check schema exists: %s", checkSchemaExistsQuery, db.tconf.Host, err)
+	// } else if cntSchemaName == 0 {
+	// 	utils.ErrExit("schema '%s' does not exist in target", db.tconf.Schema)
+	// }
+
+	// setSchemaQuery := fmt.Sprintf("ALTER SESSION SET CURRENT_SCHEMA = %s", db.tconf.Schema)
+	// _, err := conn.ExecContext(context.Background(), setSchemaQuery)
+	// if err != nil {
+	// 	utils.ErrExit("run query %q on target %q to set schema: %s", setSchemaQuery, db.tconf.Host, err)
+	// }
+	fmt.Printf("setTargetSchema() not implemented")
+}
+
+func (db *TargetOracleDB) IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error) {
+	return nil, nil
+}
+
+func (db *TargetOracleDB) ExecuteBatch(batch []*Event) error {
+	return nil
+}
+
+func (db *TargetOracleDB) InitConnPool() error {
+	return nil
+}
+
+func (db *TargetOracleDB) getConnectionUri(tconf *TargetConf) string {
+	if tconf.Uri != "" {
+		return tconf.Uri
+	}
+
+	switch true {
+	case tconf.DBSid != "":
+		tconf.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SID=%s)))"`,
+			tconf.User, tconf.Password, tconf.Host, tconf.Port, tconf.DBSid)
+
+	case tconf.TNSAlias != "":
+		tconf.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, tconf.User, tconf.Password, tconf.TNSAlias)
+
+	case tconf.DBName != "":
+		tconf.Uri = fmt.Sprintf(`user="%s" password="%s" connectString="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))(CONNECT_DATA=(SERVICE_NAME=%s)))"`,
+			tconf.User, tconf.Password, tconf.Host, tconf.Port, tconf.DBName)
+	}
+
+	return tconf.Uri
+}

--- a/yb-voyager/src/tgtdb/target.go
+++ b/yb-voyager/src/tgtdb/target.go
@@ -22,7 +22,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
-type Target struct {
+type TargetConf struct {
 	Host                 string
 	Port                 int
 	User                 string
@@ -49,20 +49,20 @@ type Target struct {
 	db *TargetDB
 }
 
-func (t *Target) Clone() *Target {
+func (t *TargetConf) Clone() *TargetConf {
 	clone := *t
 	clone.db = nil
 	return &clone
 }
 
-func (t *Target) DB() *TargetDB {
+func (t *TargetConf) DB() *TargetDB {
 	if t.db == nil {
 		t.db = newTargetDB(t)
 	}
 	return t.db
 }
 
-func (t *Target) GetConnectionUri() string {
+func (t *TargetConf) GetConnectionUri() string {
 	if t.Uri == "" {
 		hostAndPort := fmt.Sprintf("%s:%d", t.Host, t.Port)
 		targetUrl := &url.URL{
@@ -80,7 +80,7 @@ func (t *Target) GetConnectionUri() string {
 }
 
 // this function is only triggered when t.Uri==""
-func generateSSLQueryStringIfNotExists(t *Target) string {
+func generateSSLQueryStringIfNotExists(t *TargetConf) string {
 	SSLQueryString := ""
 	if t.SSLMode == "" {
 		t.SSLMode = "prefer"
@@ -113,9 +113,9 @@ func generateSSLQueryStringIfNotExists(t *Target) string {
 	return SSLQueryString
 }
 
-func GetRedactedTarget(t *Target) *Target {
-	redactedTarget := *t
-	redactedTarget.Uri = utils.GetRedactedURLs([]string{t.Uri})[0]
-	redactedTarget.Password = "XXX"
-	return &redactedTarget
+func GetRedactedTargetConf(t *TargetConf) *TargetConf {
+	redacted := *t
+	redacted.Uri = utils.GetRedactedURLs([]string{t.Uri})[0]
+	redacted.Password = "XXX"
+	return &redacted
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -1,18 +1,9 @@
 package tgtdb
 
-// Not used yet.
-type ImportBatchArgs struct {
-	TableName string
-	Columns   []string
-	Format    *string
-	Header    *bool
-	Delimiter *rune
-	Quote     *rune
-	Escape    *rune
-	Null      *string
-
-	RowsPerTransaction int
-}
+import (
+	"fmt"
+	"strings"
+)
 
 type TargetDB interface {
 	Init() error
@@ -23,12 +14,54 @@ type TargetDB interface {
 	CreateVoyagerSchema() error
 	GetNonEmptyTables(tableNames []string) []string
 	IsNonRetryableCopyError(err error) bool
-	// TODO: Replace `copyCommand` with `*ImportBatchArgs`.
-	ImportBatch(batch Batch, copyCommand string) (int64, error)
+	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
 	// TODO: ConnPool() is a temporary method. It should eventually be removed.
 	ConnPool() *ConnectionPool
 }
 
 func NewTargetDB(tconf *TargetConf) TargetDB {
 	return newTargetYugabyteDB(tconf)
+}
+
+type ImportBatchArgs struct {
+	FilePath  string
+	TableName string
+	Columns   []string
+
+	FileFormat string
+	HasHeader  bool
+	Delimiter  string
+	QuoteChar  byte
+	EscapeChar byte
+	NullString string
+
+	RowsPerTransaction int
+}
+
+func (args *ImportBatchArgs) GetYBCopyStatement() string {
+	columns := ""
+	if len(args.Columns) > 0 {
+		columns = fmt.Sprintf("(%s)", strings.Join(args.Columns, ", "))
+	}
+	options := []string{
+		fmt.Sprintf("FORMAT '%s'", args.FileFormat),
+		fmt.Sprintf("ROWS_PER_TRANSACTION %v", args.RowsPerTransaction),
+	}
+	if args.HasHeader {
+		options = append(options, "HEADER")
+	}
+	if args.Delimiter != "" {
+		options = append(options, fmt.Sprintf("DELIMITER E'%c'", []rune(args.Delimiter)[0]))
+	}
+	if args.QuoteChar != 0 {
+		// TODO: confirm if the following cast to string is correct.
+		options = append(options, fmt.Sprintf("QUOTE E'%s'", string(args.QuoteChar)))
+	}
+	if args.EscapeChar != 0 {
+		options = append(options, fmt.Sprintf("ESCAPE E'%s'", string(args.EscapeChar)))
+	}
+	if args.NullString != "" {
+		options = append(options, fmt.Sprintf("NULL '%s'", args.NullString))
+	}
+	return fmt.Sprintf(`COPY %s %s FROM STDIN WITH (%s)`, args.TableName, columns, strings.Join(options, ", "))
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -16,8 +16,7 @@ type TargetDB interface {
 	IsNonRetryableCopyError(err error) bool
 	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
 	IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error)
-	// TODO: ConnPool() is a temporary method. It should eventually be removed.
-	ConnPool() *ConnectionPool
+	ExecuteBatch(batch []*Event) error
 }
 
 func NewTargetDB(tconf *TargetConf) TargetDB {

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -14,12 +14,22 @@ type TargetDB interface {
 	CreateVoyagerSchema() error
 	GetNonEmptyTables(tableNames []string) []string
 	IsNonRetryableCopyError(err error) bool
-	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
+	ImportBatch(batch Batch, args *ImportBatchArgs, exportDir string) (int64, error)
 	IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error)
 	ExecuteBatch(batch []*Event) error
 }
 
+const (
+	ORACLE     = "oracle"
+	MYSQL      = "mysql"
+	POSTGRESQL = "postgresql"
+	YUGABYTEDB = "yugabytedb"
+)
+
 func NewTargetDB(tconf *TargetConf) TargetDB {
+	if tconf.TargetDBType == "oracle" {
+		return newTargetOracleDB(tconf)
+	}
 	return newTargetYugabyteDB(tconf)
 }
 
@@ -71,4 +81,12 @@ func (args *ImportBatchArgs) GetYBCopyStatement() string {
 		options = append(options, fmt.Sprintf("NULL '%s'", args.NullString))
 	}
 	return fmt.Sprintf(`COPY %s %s FROM STDIN WITH (%s)`, args.TableName, columns, strings.Join(options, ", "))
+}
+
+func (args *ImportBatchArgs) GetSqlLdrControlFile() string {
+	var columns string
+	if len(args.Columns) > 0 {
+		columns = fmt.Sprintf("(%s)", strings.Join(args.Columns, ", "))
+	}
+	return fmt.Sprintf("LOAD DATA\nINFILE '%s'\nAPPEND\nINTO TABLE %s\nFIELDS TERMINATED BY '\t'\n%s", args.FilePath, args.TableName, columns)
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -15,6 +15,7 @@ type TargetDB interface {
 	GetNonEmptyTables(tableNames []string) []string
 	IsNonRetryableCopyError(err error) bool
 	ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error)
+	IfRequiredQuoteColumnNames(tableName string, columns []string) ([]string, error)
 	// TODO: ConnPool() is a temporary method. It should eventually be removed.
 	ConnPool() *ConnectionPool
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -1,0 +1,6 @@
+package tgtdb
+
+// TODO Define a Target interface and make TargetYugabyteDB implement it.
+func NewTargetDB(tconf *TargetConf) *TargetYugabyteDB {
+	return newTargetYugabyteDB(tconf)
+}

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -54,11 +54,18 @@ func (args *ImportBatchArgs) GetYBCopyStatement() string {
 		options = append(options, fmt.Sprintf("DELIMITER E'%c'", []rune(args.Delimiter)[0]))
 	}
 	if args.QuoteChar != 0 {
-		// TODO: confirm if the following cast to string is correct.
-		options = append(options, fmt.Sprintf("QUOTE E'%s'", string(args.QuoteChar)))
+		quoteChar := string(args.QuoteChar)
+		if quoteChar == `'` || quoteChar == `\` {
+			quoteChar = `\` + quoteChar
+		}
+		options = append(options, fmt.Sprintf("QUOTE E'%s'", quoteChar))
 	}
 	if args.EscapeChar != 0 {
-		options = append(options, fmt.Sprintf("ESCAPE E'%s'", string(args.EscapeChar)))
+		escapeChar := string(args.EscapeChar)
+		if escapeChar == `'` || escapeChar == `\` {
+			escapeChar = `\` + escapeChar
+		}
+		options = append(options, fmt.Sprintf("ESCAPE E'%s'", escapeChar))
 	}
 	if args.NullString != "" {
 		options = append(options, fmt.Sprintf("NULL '%s'", args.NullString))

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -1,6 +1,34 @@
 package tgtdb
 
-// TODO Define a Target interface and make TargetYugabyteDB implement it.
-func NewTargetDB(tconf *TargetConf) *TargetYugabyteDB {
+// Not used yet.
+type ImportBatchArgs struct {
+	TableName string
+	Columns   []string
+	Format    *string
+	Header    *bool
+	Delimiter *rune
+	Quote     *rune
+	Escape    *rune
+	Null      *string
+
+	RowsPerTransaction int
+}
+
+type TargetDB interface {
+	Init() error
+	Finalize()
+	InitConnPool() error
+	CleanFileImportState(filePath, tableName string) error
+	GetVersion() string
+	CreateVoyagerSchema() error
+	GetNonEmptyTables(tableNames []string) []string
+	IsNonRetryableCopyError(err error) bool
+	// TODO: Replace `copyCommand` with `*ImportBatchArgs`.
+	ImportBatch(batch Batch, copyCommand string) (int64, error)
+	// TODO: ConnPool() is a temporary method. It should eventually be removed.
+	ConnPool() *ConnectionPool
+}
+
+func NewTargetDB(tconf *TargetConf) TargetDB {
 	return newTargetYugabyteDB(tconf)
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -83,10 +83,10 @@ func (args *ImportBatchArgs) GetYBCopyStatement() string {
 	return fmt.Sprintf(`COPY %s %s FROM STDIN WITH (%s)`, args.TableName, columns, strings.Join(options, ", "))
 }
 
-func (args *ImportBatchArgs) GetSqlLdrControlFile() string {
+func (args *ImportBatchArgs) GetSqlLdrControlFile(schema string) string {
 	var columns string
 	if len(args.Columns) > 0 {
 		columns = fmt.Sprintf("(%s)", strings.Join(args.Columns, ", "))
 	}
-	return fmt.Sprintf("LOAD DATA\nINFILE '%s'\nAPPEND\nINTO TABLE %s\nFIELDS TERMINATED BY '\t'\n%s", args.FilePath, args.TableName, columns)
+	return fmt.Sprintf("LOAD DATA\nINFILE '%s'\nAPPEND\nINTO TABLE %s\nREENABLE DISABLED_CONSTRAINTS\nFIELDS TERMINATED BY '\\t'\n%s", args.FilePath, schema+"."+args.TableName, columns)
 }

--- a/yb-voyager/src/tgtdb/tconf.go
+++ b/yb-voyager/src/tgtdb/tconf.go
@@ -45,21 +45,11 @@ type TargetConf struct {
 	ImportObjects        string
 	ExcludeImportObjects string
 	dbVersion            string
-
-	db *TargetDB
 }
 
 func (t *TargetConf) Clone() *TargetConf {
 	clone := *t
-	clone.db = nil
 	return &clone
-}
-
-func (t *TargetConf) DB() *TargetDB {
-	if t.db == nil {
-		t.db = newTargetDB(t)
-	}
-	return t.db
 }
 
 func (t *TargetConf) GetConnectionUri() string {

--- a/yb-voyager/src/tgtdb/tconf.go
+++ b/yb-voyager/src/tgtdb/tconf.go
@@ -23,6 +23,7 @@ import (
 )
 
 type TargetConf struct {
+	TargetDBType         string
 	Host                 string
 	Port                 int
 	User                 string
@@ -35,6 +36,9 @@ type TargetConf struct {
 	SSLRootCert          string
 	SSLCRL               string
 	SSLQueryString       string
+	DBSid                string
+	TNSAlias             string
+	OracleHome           string
 	Uri                  string
 	ContinueOnError      bool
 	IgnoreIfExists       bool

--- a/yb-voyager/src/tgtdb/tconf.go
+++ b/yb-voyager/src/tgtdb/tconf.go
@@ -45,6 +45,12 @@ type TargetConf struct {
 	ImportObjects        string
 	ExcludeImportObjects string
 	dbVersion            string
+
+	TargetEndpoints            string
+	UsePublicIP                bool
+	EnableUpsert               bool
+	DisableTransactionalWrites bool
+	Parallelism                int
 }
 
 func (t *TargetConf) Clone() *TargetConf {

--- a/yb-voyager/src/tgtdb/yb.go
+++ b/yb-voyager/src/tgtdb/yb.go
@@ -161,11 +161,12 @@ func (yb *TargetYugabyteDB) InitConnPool() error {
 // try to use the similar table created by the voyager 1.3 and earlier.
 // Voyager 1.4 uses import data state format that is incompatible from
 // the earlier versions.
-const BATCH_METADATA_TABLE_NAME = "ybvoyager_metadata.ybvoyager_import_data_batches_metainfo_v2"
+const BATCH_METADATA_TABLE_SCHEMA = "ybvoyager_metadata"
+const BATCH_METADATA_TABLE_NAME = BATCH_METADATA_TABLE_SCHEMA + "." + "ybvoyager_import_data_batches_metainfo_v2"
 
 func (yb *TargetYugabyteDB) CreateVoyagerSchema() error {
 	cmds := []string{
-		"CREATE SCHEMA IF NOT EXISTS ybvoyager_metadata",
+		fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, BATCH_METADATA_TABLE_SCHEMA),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			data_file_name VARCHAR(250),
 			batch_number INT,
@@ -243,7 +244,7 @@ type Batch interface {
 	GetCommandToRecordEntryInDB(rowsAffected int64) string
 }
 
-func (yb *TargetYugabyteDB) ImportBatch(batch Batch, args *ImportBatchArgs) (int64, error) {
+func (yb *TargetYugabyteDB) ImportBatch(batch Batch, args *ImportBatchArgs, exportDir string) (int64, error) {
 	var rowsAffected int64
 	var err error
 	copyFn := func(conn *pgx.Conn) (bool, error) {

--- a/yb-voyager/src/tgtdb/yb.go
+++ b/yb-voyager/src/tgtdb/yb.go
@@ -16,20 +16,28 @@ limitations under the License.
 package tgtdb
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 type TargetYugabyteDB struct {
 	sync.Mutex
-	tconf *TargetConf
-	conn  *pgx.Conn
+	tconf    *TargetConf
+	conn     *pgx.Conn
+	connPool *ConnectionPool
 }
 
 func newTargetYugabyteDB(tconf *TargetConf) *TargetYugabyteDB {
@@ -100,4 +108,314 @@ func (yb *TargetYugabyteDB) GetVersion() string {
 		utils.ErrExit("get target db version: %s", err)
 	}
 	return yb.tconf.dbVersion
+}
+
+func (yb *TargetYugabyteDB) InitConnPool() error {
+	tconfs := yb.getYBServers()
+	var targetUriList []string
+	for _, tconf := range tconfs {
+		targetUriList = append(targetUriList, tconf.Uri)
+	}
+	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
+
+	if yb.tconf.Parallelism == -1 {
+		yb.tconf.Parallelism = fetchDefaultParllelJobs(tconfs)
+		utils.PrintAndLog("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", yb.tconf.Parallelism)
+	} else {
+		utils.PrintAndLog("Using %d parallel jobs", yb.tconf.Parallelism)
+	}
+
+	params := &ConnectionParams{
+		NumConnections:    yb.tconf.Parallelism,
+		ConnUriList:       targetUriList,
+		SessionInitScript: getYBSessionInitScript(yb.tconf),
+	}
+	yb.connPool = NewConnectionPool(params)
+	return nil
+}
+
+// TODO Do not export this method. This is temporary--until we refactor all target db access.
+func (yb *TargetYugabyteDB) ConnPool() *ConnectionPool {
+	return yb.connPool
+}
+
+const (
+	LB_WARN_MSG = "--target-db-host is a load balancer IP which will be used to create connections for data import.\n" +
+		"\t To control the parallelism and servers used, refer to help for --parallel-jobs and --target-endpoints flags.\n"
+
+	GET_YB_SERVERS_QUERY = "SELECT host, port, num_connections, node_type, cloud, region, zone, public_ip FROM yb_servers()"
+)
+
+func (yb *TargetYugabyteDB) getYBServers() []*TargetConf {
+	var tconfs []*TargetConf
+	var loadBalancerUsed bool
+
+	tconf := yb.tconf
+
+	if tconf.TargetEndpoints != "" {
+		msg := fmt.Sprintf("given yb-servers for import data: %q\n", tconf.TargetEndpoints)
+		utils.PrintIfTrue(msg, tconf.VerboseMode)
+		log.Infof(msg)
+
+		ybServers := utils.CsvStringToSlice(tconf.TargetEndpoints)
+		for _, ybServer := range ybServers {
+			clone := tconf.Clone()
+
+			if strings.Contains(ybServer, ":") {
+				clone.Host = strings.Split(ybServer, ":")[0]
+				var err error
+				clone.Port, err = strconv.Atoi(strings.Split(ybServer, ":")[1])
+
+				if err != nil {
+					utils.ErrExit("error in parsing useYbServers flag: %v", err)
+				}
+			} else {
+				clone.Host = ybServer
+			}
+
+			clone.Uri = getCloneConnectionUri(clone)
+			log.Infof("using yb server for import data: %+v", GetRedactedTargetConf(clone))
+			tconfs = append(tconfs, clone)
+		}
+	} else {
+		loadBalancerUsed = true
+		url := tconf.GetConnectionUri()
+		conn, err := pgx.Connect(context.Background(), url)
+		if err != nil {
+			utils.ErrExit("Unable to connect to database: %v", err)
+		}
+		defer conn.Close(context.Background())
+
+		rows, err := conn.Query(context.Background(), GET_YB_SERVERS_QUERY)
+		if err != nil {
+			utils.ErrExit("error in query rows from yb_servers(): %v", err)
+		}
+		defer rows.Close()
+
+		var hostPorts []string
+		for rows.Next() {
+			clone := tconf.Clone()
+			var host, nodeType, cloud, region, zone, public_ip string
+			var port, num_conns int
+			if err := rows.Scan(&host, &port, &num_conns,
+				&nodeType, &cloud, &region, &zone, &public_ip); err != nil {
+				utils.ErrExit("error in scanning rows of yb_servers(): %v", err)
+			}
+
+			// check if given host is one of the server in cluster
+			if loadBalancerUsed {
+				if isSeedTargetHost(tconf, host, public_ip) {
+					loadBalancerUsed = false
+				}
+			}
+
+			if tconf.UsePublicIP {
+				if public_ip != "" {
+					clone.Host = public_ip
+				} else {
+					var msg string
+					if host == "" {
+						msg = fmt.Sprintf("public ip is not available for host: %s."+
+							"Refer to help for more details for how to enable public ip.", host)
+					} else {
+						msg = fmt.Sprintf("public ip is not available for host: %s but private ip are available. "+
+							"Either refer to help for how to enable public ip or remove --use-public-up flag and restart the import", host)
+					}
+					utils.ErrExit(msg)
+				}
+			} else {
+				clone.Host = host
+			}
+
+			clone.Port = port
+			clone.Uri = getCloneConnectionUri(clone)
+			tconfs = append(tconfs, clone)
+
+			hostPorts = append(hostPorts, fmt.Sprintf("%s:%v", host, port))
+		}
+		log.Infof("Target DB nodes: %s", strings.Join(hostPorts, ","))
+	}
+
+	if loadBalancerUsed { // if load balancer is used no need to check direct connectivity
+		utils.PrintAndLog(LB_WARN_MSG)
+		tconfs = []*TargetConf{tconf}
+	} else {
+		tconfs = testAndFilterYbServers(tconfs)
+	}
+	return tconfs
+}
+
+func getCloneConnectionUri(clone *TargetConf) string {
+	var cloneConnectionUri string
+	if clone.Uri == "" {
+		//fallback to constructing the URI from individual parameters. If URI was not set for target, then its other necessary parameters must be non-empty (or default values)
+		cloneConnectionUri = clone.GetConnectionUri()
+	} else {
+		targetConnectionUri, err := url.Parse(clone.Uri)
+		if err == nil {
+			targetConnectionUri.Host = fmt.Sprintf("%s:%d", clone.Host, clone.Port)
+			cloneConnectionUri = fmt.Sprint(targetConnectionUri)
+		} else {
+			panic(err)
+		}
+	}
+	return cloneConnectionUri
+}
+
+func isSeedTargetHost(tconf *TargetConf, names ...string) bool {
+	var allIPs []string
+	for _, name := range names {
+		if name != "" {
+			allIPs = append(allIPs, utils.LookupIP(name)...)
+		}
+	}
+
+	seedHostIPs := utils.LookupIP(tconf.Host)
+	for _, seedHostIP := range seedHostIPs {
+		if slices.Contains(allIPs, seedHostIP) {
+			log.Infof("Target.Host=%s matched with one of ips in %v\n", seedHostIP, allIPs)
+			return true
+		}
+	}
+	return false
+}
+
+// this function will check the reachability to each of the nodes and returns list of ones which are reachable
+func testAndFilterYbServers(tconfs []*TargetConf) []*TargetConf {
+	var availableTargets []*TargetConf
+
+	for _, tconf := range tconfs {
+		log.Infof("testing server: %s\n", spew.Sdump(GetRedactedTargetConf(tconf)))
+		conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
+		if err != nil {
+			utils.PrintAndLog("unable to use yb-server %q: %v", tconf.Host, err)
+		} else {
+			availableTargets = append(availableTargets, tconf)
+			conn.Close(context.Background())
+		}
+	}
+
+	if len(availableTargets) == 0 {
+		utils.ErrExit("no yb servers available for data import")
+	}
+	return availableTargets
+}
+
+func fetchDefaultParllelJobs(tconfs []*TargetConf) int {
+	totalCores := 0
+	targetCores := 0
+	for _, tconf := range tconfs {
+		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs([]string{tconf.Uri})[0])
+		conn, err := pgx.Connect(context.Background(), tconf.Uri)
+		if err != nil {
+			log.Warnf("Unable to reach target while querying cores: %v", err)
+			return len(tconfs) * 2
+		}
+		defer conn.Close(context.Background())
+
+		cmd := "CREATE TEMP TABLE yb_voyager_cores(num_cores int);"
+		_, err = conn.Exec(context.Background(), cmd)
+		if err != nil {
+			log.Warnf("Unable to create tables on target DB: %v", err)
+			return len(tconfs) * 2
+		}
+
+		cmd = "COPY yb_voyager_cores(num_cores) FROM PROGRAM 'grep processor /proc/cpuinfo|wc -l';"
+		_, err = conn.Exec(context.Background(), cmd)
+		if err != nil {
+			log.Warnf("Error while running query %s on host %s: %v", cmd, utils.GetRedactedURLs([]string{tconf.Uri}), err)
+			return len(tconfs) * 2
+		}
+
+		cmd = "SELECT num_cores FROM yb_voyager_cores;"
+		if err = conn.QueryRow(context.Background(), cmd).Scan(&targetCores); err != nil {
+			log.Warnf("Error while running query %s: %v", cmd, err)
+			return len(tconfs) * 2
+		}
+		totalCores += targetCores
+	}
+	if totalCores == 0 { //if target is running on MacOS, we are unable to determine totalCores
+		return 3
+	}
+	return totalCores / 2
+}
+
+// import session parameters
+const (
+	SET_CLIENT_ENCODING_TO_UTF8           = "SET client_encoding TO 'UTF8'"
+	SET_SESSION_REPLICATE_ROLE_TO_REPLICA = "SET session_replication_role TO replica" //Disable triggers or fkeys constraint checks.
+	SET_YB_ENABLE_UPSERT_MODE             = "SET yb_enable_upsert_mode to true"
+	SET_YB_DISABLE_TRANSACTIONAL_WRITES   = "SET yb_disable_transactional_writes to true" // Disable transactions to improve ingestion throughput.
+)
+
+func getYBSessionInitScript(tconf *TargetConf) []string {
+	var sessionVars []string
+	if checkSessionVariableSupport(tconf, SET_CLIENT_ENCODING_TO_UTF8) {
+		sessionVars = append(sessionVars, SET_CLIENT_ENCODING_TO_UTF8)
+	}
+	if checkSessionVariableSupport(tconf, SET_SESSION_REPLICATE_ROLE_TO_REPLICA) {
+		sessionVars = append(sessionVars, SET_SESSION_REPLICATE_ROLE_TO_REPLICA)
+	}
+
+	if tconf.EnableUpsert {
+		// upsert_mode parameters was introduced later than yb_disable_transactional writes in yb releases
+		// hence if upsert_mode is supported then its safe to assume yb_disable_transactional_writes is already there
+		if checkSessionVariableSupport(tconf, SET_YB_ENABLE_UPSERT_MODE) {
+			sessionVars = append(sessionVars, SET_YB_ENABLE_UPSERT_MODE)
+			// 	SET_YB_DISABLE_TRANSACTIONAL_WRITES is used only with & if upsert_mode is supported
+			if tconf.DisableTransactionalWrites {
+				if checkSessionVariableSupport(tconf, SET_YB_DISABLE_TRANSACTIONAL_WRITES) {
+					sessionVars = append(sessionVars, SET_YB_DISABLE_TRANSACTIONAL_WRITES)
+				} else {
+					tconf.DisableTransactionalWrites = false
+				}
+			}
+		} else {
+			log.Infof("Falling back to transactional inserts of batches during data import")
+		}
+	}
+
+	sessionVarsPath := "/etc/yb-voyager/ybSessionVariables.sql"
+	if !utils.FileOrFolderExists(sessionVarsPath) {
+		log.Infof("YBSessionInitScript: %v\n", sessionVars)
+		return sessionVars
+	}
+
+	varsFile, err := os.Open(sessionVarsPath)
+	if err != nil {
+		utils.PrintAndLog("Unable to open %s : %v. Using default values.", sessionVarsPath, err)
+		log.Infof("YBSessionInitScript: %v\n", sessionVars)
+		return sessionVars
+	}
+	defer varsFile.Close()
+	fileScanner := bufio.NewScanner(varsFile)
+
+	var curLine string
+	for fileScanner.Scan() {
+		curLine = strings.TrimSpace(fileScanner.Text())
+		if curLine != "" && checkSessionVariableSupport(tconf, curLine) {
+			sessionVars = append(sessionVars, curLine)
+		}
+	}
+	log.Infof("YBSessionInitScript: %v\n", sessionVars)
+	return sessionVars
+}
+
+func checkSessionVariableSupport(tconf *TargetConf, sqlStmt string) bool {
+	conn, err := pgx.Connect(context.Background(), tconf.GetConnectionUri())
+	if err != nil {
+		utils.ErrExit("error while creating connection for checking session parameter(%q) support: %v", sqlStmt, err)
+	}
+	defer conn.Close(context.Background())
+
+	_, err = conn.Exec(context.Background(), sqlStmt)
+	if err != nil {
+		if !strings.Contains(err.Error(), "unrecognized configuration parameter") {
+			utils.ErrExit("error while executing sqlStatement=%q: %v", sqlStmt, err)
+		} else {
+			log.Warnf("Warning: %q is not supported: %v", sqlStmt, err)
+		}
+	}
+
+	return err == nil
 }

--- a/yb-voyager/src/tgtdb/yb.go
+++ b/yb-voyager/src/tgtdb/yb.go
@@ -36,6 +36,14 @@ func newTargetYugabyteDB(tconf *TargetConf) *TargetYugabyteDB {
 	return &TargetYugabyteDB{tconf: tconf}
 }
 
+func (yb *TargetYugabyteDB) Init() error {
+	return yb.connect()
+}
+
+func (yb *TargetYugabyteDB) Finalize() {
+	yb.disconnect()
+}
+
 // TODO We should not export `Conn`. This is temporary--until we refactor all target db access.
 func (yb *TargetYugabyteDB) Conn() *pgx.Conn {
 	if yb.conn == nil {
@@ -44,7 +52,7 @@ func (yb *TargetYugabyteDB) Conn() *pgx.Conn {
 	return yb.conn
 }
 
-func (yb *TargetYugabyteDB) Connect() error {
+func (yb *TargetYugabyteDB) connect() error {
 	if yb.conn != nil {
 		// Already connected.
 		return nil
@@ -60,7 +68,7 @@ func (yb *TargetYugabyteDB) Connect() error {
 	return nil
 }
 
-func (yb *TargetYugabyteDB) Disconnect() {
+func (yb *TargetYugabyteDB) disconnect() {
 	if yb.conn == nil {
 		log.Infof("No connection to the target database to close")
 	}
@@ -72,7 +80,7 @@ func (yb *TargetYugabyteDB) Disconnect() {
 }
 
 func (yb *TargetYugabyteDB) EnsureConnected() {
-	err := yb.Connect()
+	err := yb.connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to the target DB: %s", err)
 	}

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -378,6 +379,16 @@ func GenerateRandomString(length int) string {
 		buf[i], buf[j] = buf[j], buf[i]
 	})
 	return string(buf)
+}
+
+func ForEachMatchingLineInFile(filePath string, re *regexp.Regexp, callback func(matches []string) bool) error {
+	return ForEachLineInFile(filePath, func(line string) bool {
+		matches := re.FindStringSubmatch(line)
+		if len(matches) > 0 {
+			return callback(matches)
+		}
+		return true // Continue with next line.
+	})
 }
 
 func ForEachLineInFile(filePath string, callback func(line string) bool) error {

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -379,3 +379,24 @@ func GenerateRandomString(length int) string {
 	})
 	return string(buf)
 }
+
+func ForEachLineInFile(filePath string, callback func(line string) bool) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("error opening file %s: %v", filePath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		cont := callback(scanner.Text())
+		if !cont {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading file %s: %v", filePath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Currently these functions are not implemented in `oracle.go`:
```
IfRequiredQuoteColumnNames()
ExecuteBatch()
InitConnPool()
```
I have also commented out `executePostImportDataSqls()` from importData.go as it is implemented using pgx.