### PR TITLE
Bug Fix: Nil pointer dereference error due to assigning string value to null string pointer

### DIFF
--- a/yb-voyager/src/dbzm/valueConverter.go
+++ b/yb-voyager/src/dbzm/valueConverter.go
@@ -22,6 +22,8 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 )
 
+var NULL_STRING string = "NULL"
+
 type ValueConverter interface {
 	ConvertRow(tableName string, columnNames []string, row string) (string, error)
 	ConvertEvent(ev *tgtdb.Event, table string) error
@@ -120,8 +122,7 @@ func (conv *DebeziumValueConverter) ConvertEvent(ev *tgtdb.Event, table string) 
 func (conv *DebeziumValueConverter) convertMap(tableName string, m map[string]*string) error {
 	for column, value := range m {
 		if value == nil {
-			m[column] = new(string)
-			*m[column] = "NULL"
+			m[column] = &NULL_STRING
 			continue
 		}
 		columnValue := *value

--- a/yb-voyager/src/dbzm/valueConverter.go
+++ b/yb-voyager/src/dbzm/valueConverter.go
@@ -120,6 +120,7 @@ func (conv *DebeziumValueConverter) ConvertEvent(ev *tgtdb.Event, table string) 
 func (conv *DebeziumValueConverter) convertMap(tableName string, m map[string]*string) error {
 	for column, value := range m {
 		if value == nil {
+			m[column] = new(string)
 			*m[column] = "NULL"
 			continue
 		}


### PR DESCRIPTION
error message
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xa5dbbb]

goroutine 1 [running]:
github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm.(*DebeziumValueConverter).convertMap(0xc000013800, {0xc000478f38, 0x8}, 0x7f1a8442e408?)
	/home/centos/dev-server-ssinghal/home/centos/code/yb-voyager/yb-voyager/src/dbzm/valueConverter.go:123 +0xdb
github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm.(*DebeziumValueConverter).ConvertEvent(0x45b056?, 0xc000434180, {0xc000478f38, 0x8})
```