### PR TITLE
Added a way to provide password directly through the env variables (SOURCE/TARGET_DB_PASSWORD)

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -262,6 +262,10 @@ func validateSourcePassword(cmd *cobra.Command) {
 	if cmd.Flags().Changed("source-db-password") {
 		return
 	}
+	if os.Getenv("SOURCE_DB_PASSWORD") != "" {
+		source.Password = os.Getenv("SOURCE_DB_PASSWORD")
+		return
+	}
 	fmt.Print("Password to connect to source:")
 	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"syscall"
 
@@ -193,6 +194,10 @@ func validateTargetSchemaFlag() {
 
 func validateTargetPassword(cmd *cobra.Command) {
 	if cmd.Flags().Changed("target-db-password") {
+		return
+	}
+	if os.Getenv("TARGET_DB_PASSWORD") != "" {
+		tconf.Password = os.Getenv("TARGET_DB_PASSWORD")
 		return
 	}
 	fmt.Print("Password to connect to target:")

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -68,7 +68,6 @@ quarkus.log.level=info
 
 var baseSrcConfigTemplate = `
 debezium.source.database.user=%s
-debezium.source.database.password=%s
 
 debezium.source.snapshot.mode=%s
 debezium.source.offset.storage.file.filename=%s
@@ -192,7 +191,6 @@ func (c *Config) String() string {
 	case "postgresql":
 		conf = fmt.Sprintf(postgresConfigTemplate,
 			c.Username,
-			c.Password,
 			c.SnapshotMode,
 			offsetFile,
 			strings.Join(c.TableList, ","),
@@ -214,7 +212,6 @@ func (c *Config) String() string {
 	case "oracle":
 		conf = fmt.Sprintf(oracleConfigTemplate,
 			c.Username,
-			c.Password,
 			c.SnapshotMode,
 			offsetFile,
 			strings.Join(c.TableList, ","),
@@ -235,7 +232,6 @@ func (c *Config) String() string {
 	case "mysql":
 		conf = fmt.Sprintf(mysqlConfigTemplate,
 			c.Username,
-			c.Password,
 			c.SnapshotMode,
 			offsetFile,
 			strings.Join(c.TableList, ","),

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -78,7 +78,8 @@ func (d *Debezium) Start() error {
 	if err != nil {
 		return err
 	}
-
+    os.Setenv("DEBEZIUM_SOURCE_DATABASE_PASSWORD", d.Config.Password)
+	defer os.Unsetenv("DEBEZIUM_SOURCE_DATABASE_PASSWORD")
 	log.Infof("starting debezium...")
 	d.cmd = exec.Command(filepath.Join(DEBEZIUM_DIST_DIR, "run.sh"), DEBEZIUM_CONF_FILEPATH)
 	d.cmd.Env = os.Environ()

--- a/yb-voyager/src/srcdb/data/sample-ora2pg.conf
+++ b/yb-voyager/src/srcdb/data/sample-ora2pg.conf
@@ -22,7 +22,6 @@ ORACLE_HOME	{{ .OracleHome }}
 # Set Oracle database connection (datasource, user, password)
 ORACLE_DSN	{{ .OracleDSN }}
 ORACLE_USER	{{ .OracleUser }}
-ORACLE_PWD	{{ .OraclePWD }}
 
 # Set this to 1 if you connect as simple user and can not extract things
 # from the DBA_... tables. It will use tables ALL_... This will not works

--- a/yb-voyager/src/srcdb/ora2pg_export_data.go
+++ b/yb-voyager/src/srcdb/ora2pg_export_data.go
@@ -60,6 +60,8 @@ func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir stri
 	exportDataCommandString := fmt.Sprintf("ora2pg -q -t COPY -P %d -o data.sql -b %s/data -c %s --no_header -T %s",
 		source.NumConnections, exportDir, configFilePath, tempDirPath)
 
+	os.Setenv("ORA2PG_PASSWD", source.Password)
+	defer os.Unsetenv("ORA2PG_PASSWD")
 	//Exporting all the tables in the schema
 	log.Infof("Executing command: %s", exportDataCommandString)
 	exportDataCommand := exec.CommandContext(ctx, "/bin/bash", "-c", exportDataCommandString)

--- a/yb-voyager/src/srcdb/ora2pg_extract_schema.go
+++ b/yb-voyager/src/srcdb/ora2pg_extract_schema.go
@@ -18,6 +18,7 @@ package srcdb
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -45,6 +46,9 @@ func ora2pgExtractSchema(source *Source, exportDir string) {
 
 		exportObjectFileName := utils.GetObjectFileName(schemaDirPath, exportObject)
 		exportObjectDirPath := utils.GetObjectDirPath(schemaDirPath, exportObject)
+		
+		os.Setenv("ORA2PG_PASSWD", source.Password)
+		defer os.Unsetenv("ORA2PG_PASSWD")
 
 		var exportSchemaObjectCommand *exec.Cmd
 		if source.DBType == "oracle" {

--- a/yb-voyager/src/srcdb/source.go
+++ b/yb-voyager/src/srcdb/source.go
@@ -199,7 +199,6 @@ type Ora2pgConfig struct {
 	OracleDSN        string
 	OracleUser       string
 	OracleHome       string
-	OraclePWD        string
 	Schema           string
 	ParallelTables   string
 	UseOrafce        string
@@ -234,7 +233,6 @@ func (source *Source) getDefaultOra2pgConfig() *Ora2pgConfig {
 	conf.OracleDSN = source.getSourceDSN()
 	conf.OracleUser = source.User
 	conf.ParallelTables = strconv.Itoa(source.NumConnections)
-	conf.OraclePWD = source.Password
 	conf.DisablePartition = "0"
 
 	conf.OracleHome = source.GetOracleHome()


### PR DESCRIPTION
This PR has two changes - 
1. obfuscating password from the conf files of ora2pg and debezium by using env variables provided by tools.
2. added a way of providing password to voyager using env variables `SOURCE_DB_PASSWORD`/`TARGET_DB_PASSWORD`