### PR TITLE
Implemented ExecuteBatch() for Oracle

### DIFF
--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -47,9 +47,9 @@ func (e *Event) GetSQLStmt(targetSchema string) string {
 	}
 }
 
-const insertTemplate = "INSERT INTO %s (%s) VALUES (%s);"
-const updateTemplate = "UPDATE %s SET %s WHERE %s;"
-const deleteTemplate = "DELETE FROM %s WHERE %s;"
+const insertTemplate = "INSERT INTO %s (%s) VALUES (%s)"
+const updateTemplate = "UPDATE %s SET %s WHERE %s"
+const deleteTemplate = "DELETE FROM %s WHERE %s"
 
 func (event *Event) getInsertStmt(targetSchema string) string {
 	tableName := event.SchemaName + "." + event.TableName

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -110,7 +110,7 @@ func (eb EventBatch) GetLastVsn() int64 {
 	return eb.Events[len(eb.Events)-1].Vsn
 }
 
-func (eb EventBatch) GetQueryToUpdateStateInDB(migrationUUID uuid.UUID) string {
+func (eb EventBatch) GetQueryToUpdateLastAppliedVSN(migrationUUID uuid.UUID) string {
 	return fmt.Sprintf(`UPDATE %s SET last_applied_vsn=%d where migration_uuid='%s' AND channel_no=%d`,
 		EVENT_CHANNELS_METADATA_TABLE_NAME, eb.GetLastVsn(), migrationUUID, eb.ChanNo)
 }

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -18,6 +18,8 @@ package tgtdb
 import (
 	"fmt"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 type Event struct {
@@ -106,6 +108,11 @@ type EventBatch struct {
 
 func (eb EventBatch) GetLastVsn() int64 {
 	return eb.Events[len(eb.Events)-1].Vsn
+}
+
+func (eb EventBatch) GetQueryToUpdateStateInDB(migrationUUID uuid.UUID) string {
+	return fmt.Sprintf(`UPDATE %s SET last_applied_vsn=%d where migration_uuid='%s' AND channel_no=%d`,
+		EVENT_CHANNELS_METADATA_TABLE_NAME, eb.GetLastVsn(), migrationUUID, eb.ChanNo)
 }
 
 type EventChannelMetaInfo struct {

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -102,10 +102,6 @@ func (tdb *TargetOracleDB) disconnect() {
 	tdb.conn = nil
 }
 
-func (tdb *TargetOracleDB) GetDebeziumValueConverterSuite() map[string]ConverterFn {
-	return oraValueConverterSuite
-}
-
 func (tdb *TargetOracleDB) reconnect() error {
 	tdb.Mutex.Lock()
 	defer tdb.Mutex.Unlock()
@@ -515,6 +511,10 @@ func (tdb *TargetOracleDB) InitConnPool() error {
 	tdb.oraDB.SetMaxIdleConns(tdb.tconf.Parallelism)
 	tdb.oraDB.SetMaxOpenConns(tdb.tconf.Parallelism)
 	return nil
+}
+
+func (tdb *TargetOracleDB) GetDebeziumValueConverterSuite() map[string]ConverterFn {
+	return oraValueConverterSuite
 }
 
 func (tdb *TargetOracleDB) getConnectionUri(tconf *TargetConf) string {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -678,18 +678,18 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch EventBat
 			log.Debug(stmt)
 			_, err := tx.Exec(context.Background(), stmt)
 			if err != nil {
-				log.Errorf("error executing stmt: %v", err)
-				return false, fmt.Errorf("error executing stmt %q: %w", stmt, err)
+				log.Errorf("error executing stmt for event with vsn(%d): %v", event.Vsn, err)
+				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %w", event.Vsn, err)
 			}
 		}
-		updateStateQuery := batch.GetQueryToUpdateStateInDB(migrationUUID)
-		res, err := tx.Exec(context.Background(), updateStateQuery)
+		updateVsnQuery := batch.GetQueryToUpdateLastAppliedVSN(migrationUUID)
+		res, err := tx.Exec(context.Background(), updateVsnQuery)
 		if err != nil || res.RowsAffected() == 0 {
 			log.Errorf("error executing stmt: %v, rowsAffected: %v", err, res.RowsAffected())
-			return false, fmt.Errorf("failed to update state on target db via query-%s: %w, rowsAffected: %v",
-				updateStateQuery, err, res.RowsAffected())
+			return false, fmt.Errorf("failed to update vsn on target db via query-%s: %w, rowsAffected: %v",
+				updateVsnQuery, err, res.RowsAffected())
 		}
-		log.Debugf("Updated event channel meta info with query = %s; rows Affected = %d", updateStateQuery, res.RowsAffected())
+		log.Debugf("Updated event channel meta info with query = %s; rows Affected = %d", updateVsnQuery, res.RowsAffected())
 		if err = tx.Commit(ctx); err != nil {
 			return false, fmt.Errorf("failed to commit transaction : %w", err)
 		}


### PR DESCRIPTION
- in case of Oracle, simply executing the statements one by one using transactions because transaction being faster in oracle as compared to YB