### PR TITLE
[#1002] yugabyted: Send visualization metadata and metrics to target yugabyteDB.

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -38,6 +38,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/visualizer"
 )
 
 func updateFilePaths(source *srcdb.Source, exportDir string, tablesProgressMetadata map[string]*utils.TableProgressMetadata) {
@@ -320,4 +321,121 @@ func nameContainsCapitalLetter(name string) bool {
 		}
 	}
 	return false
+}
+
+// Function to create and send the visualisation metadata
+func createAndSendVisualizerPayload(phase string, status string, payload string) {
+	defer utils.WaitGroup.Done()
+	if migrationUUID == uuid.Nil {
+		log.Warnf("MigrationUUID couldn't be retreived. Cannot send metadata for visualization")
+		return
+	}
+
+	currentTime := time.Now()
+	formattedTimestamp := currentTime.Format("2006-01-02 15:04:05")
+
+	invocationSequence, err := visualizerDB.GetInvocationSequence(migrationUUID,
+		visualizer.MIGRATION_PHASE_MAP[phase])
+
+	if err != nil {
+		log.Warnf("Cannot send metadata for visualization. %s", err)
+		return
+	}
+
+	var (
+		dbName string
+		schema string
+	)
+
+	if phase == "EXPORT SCHEMA" || phase == "EXPORT DATA" {
+		dbName = source.DBName
+		schema = source.Schema
+	}
+
+	if phase == "IMPORT SCHEMA" || phase == "IMPORT DATA" {
+		dbName = tconf.DBName
+		schema = tconf.Schema
+	}
+
+	visualizerDBPayload := visualizer.CreateVisualzerDBPayload(
+		migrationUUID,
+		visualizer.MIGRATION_PHASE_MAP[phase],
+		invocationSequence,
+		dbName,
+		schema,
+		payload,
+		status,
+		formattedTimestamp)
+
+	err = visualizerDB.SendVisualizerDBPayload(visualizerDBPayload)
+
+	if err != nil {
+		log.Warnf("Cannot send metadata for visualization. %s", err)
+	}
+}
+
+// Function to create and send table completion metrics for `EXPORT DATA` step
+func createAndSendVisualizerExportTableMetrics(tableNames []string) {
+	defer utils.WaitGroup.Done()
+	if migrationUUID == uuid.Nil {
+		log.Warnf("MigrationUUID couldn't be retreived. Cannot send metadata for visualization")
+		return
+	}
+
+	currentTime := time.Now()
+	formattedTimestamp := currentTime.Format("2006-01-02 15:04:05")
+
+	var visualizerTableMetricsList []visualizer.VisualizerTableMetrics
+	for _, tableName := range tableNames {
+		tableMetadata := tablesProgressMetadata[tableName]
+		visualizerTableMetrics := visualizer.CreateVisualzerDBTableMetrics(
+			migrationUUID,
+			tableName,
+			source.Schema,
+			visualizer.MIGRATION_PHASE_MAP["EXPORT DATA"],
+			tableMetadata.Status,
+			tableMetadata.CountLiveRows,
+			tableMetadata.CountTotalRows,
+			formattedTimestamp)
+		visualizerTableMetricsList = append(visualizerTableMetricsList, visualizerTableMetrics)
+	}
+
+	err := visualizerDB.SendVisualizerTableMetrics(visualizerTableMetricsList)
+
+	if err != nil {
+		log.Warnf("Cannot send metadata for visualization. %s", err)
+	}
+}
+
+// Function to create and send table completion metrics for `IMPORT DATA` step
+func createAndSendVisualizerImportTableMetrics(tableName string, countLiveRows int64,
+	countTotalRows int64, status int) {
+
+	defer utils.WaitGroup.Done()
+
+	if migrationUUID == uuid.Nil {
+		log.Warnf("MigrationUUID couldn't be retreived. Cannot send metadata for visualization")
+		return
+	}
+
+	currentTime := time.Now()
+	formattedTimestamp := currentTime.Format("2006-01-02 15:04:05")
+
+	var visualizerTableMetricsList []visualizer.VisualizerTableMetrics
+
+	visualizerTableMetricsList = append(visualizerTableMetricsList, visualizer.CreateVisualzerDBTableMetrics(
+		migrationUUID,
+		tableName,
+		tconf.Schema,
+		visualizer.MIGRATION_PHASE_MAP["IMPORT DATA"],
+		status,
+		countLiveRows,
+		countTotalRows,
+		formattedTimestamp))
+
+	err := visualizerDB.SendVisualizerTableMetrics(visualizerTableMetricsList)
+
+	if err != nil {
+		log.Warnf("Cannot send metadata for visualization. %s", err)
+	}
 }

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -83,6 +83,11 @@ func exportSchema() {
 	if err != nil {
 		utils.ErrExit("failed to get migration UUID: %w", err)
 	}
+
+	// Send 'IN PROGRESS' metadata for `EXPORT SCHEMA` step
+	utils.WaitGroup.Add(1)
+	go createAndSendVisualizerPayload("EXPORT SCHEMA", "IN PROGRESS", "")
+
 	source.DB().ExportSchema(exportDir)
 	utils.PrintAndLog("\nExported schema files created under directory: %s\n", filepath.Join(exportDir, "schema"))
 
@@ -106,6 +111,13 @@ func exportSchema() {
 	if err != nil {
 		utils.ErrExit("unable to save migration info: %s", err)
 	}
+
+	// Send 'COMPLETED' metadata for `EXPORT SCHEMA` step
+	utils.WaitGroup.Add(1)
+	go createAndSendVisualizerPayload("EXPORT SCHEMA", "COMPLETED", "")
+
+	// Wait till the visualisation metadata is sent
+	utils.WaitGroup.Wait()
 }
 
 func init() {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -22,11 +22,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nightlyone/lockfile"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/visualizer"
 )
 
 var (
@@ -35,6 +37,7 @@ var (
 	startClean    bool
 	lockFile      lockfile.Lockfile
 	migrationUUID uuid.UUID
+	visualizerDB  visualizer.VisualizerYugabyteDB
 )
 
 var rootCmd = &cobra.Command{
@@ -51,6 +54,10 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			}
 			InitLogging(exportDir, cmd.Use == "status")
 		}
+		err := visualizerDB.Init(exportDir)
+		if err != nil {
+			log.Warnf("Failed to initialize the target DB for visualization. %s", err)
+		}
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {
@@ -64,6 +71,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 		if exportDir != "" && utils.FileOrFolderExists(exportDir) && cmd.Use != "version" && cmd.Use != "status" {
 			unlockExportDir()
 		}
+		visualizerDB.Finalize()
 	},
 }
 

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -37,6 +37,7 @@ require (
 )
 
 require (
+	github.com/jackc/puddle v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -1344,6 +1344,7 @@ github.com/jackc/pgx/v4 v4.17.2/go.mod h1:lcxIZN44yMIrWI78a5CpucdD14hX0SBDbNRvjD
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=

--- a/yb-voyager/src/visualizer/table_metrics.go
+++ b/yb-voyager/src/visualizer/table_metrics.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package visualizer
+
+import "github.com/google/uuid"
+
+type VisualizerTableMetrics struct {
+	MigrationUUID       uuid.UUID `json:"migration_uuid"`
+	TableName           string    `json:"table_name"`
+	Schema              string    `json:"schema_name"`
+	MigrationPhase      int       `json:"migration_phase"`
+	Status              int       `json:"status"` //(0: NOT-STARTED, 1: IN-PROGRESS, 2: DONE, 3: COMPLETED)
+	CountLiveRows       int64     `json:"count_live_rows"`
+	CountTotalRows      int64     `json:"count_total_rows"`
+	InvocationTimestamp string    `json:"invocation_timestamp"`
+}
+
+var TABLE_STATUS_MAP = map[string]int{
+	"NOT STARTED": 0,
+	"IN PROGRESS": 1,
+	"DONE":        2,
+	"COMPLETED":   3,
+}
+
+// Create a table metrics struct
+func CreateVisualzerDBTableMetrics(mUUID uuid.UUID,
+	tableName string,
+	schema string,
+	phase int,
+	status int,
+	completedRows int64,
+	totalRows int64,
+	timestamp string) VisualizerTableMetrics {
+
+	return VisualizerTableMetrics{
+		MigrationUUID:       mUUID,
+		TableName:           tableName,
+		Schema:              schema,
+		MigrationPhase:      phase,
+		Status:              status,
+		CountLiveRows:       completedRows,
+		CountTotalRows:      totalRows,
+		InvocationTimestamp: timestamp,
+	}
+}

--- a/yb-voyager/src/visualizer/visualizer_db.go
+++ b/yb-voyager/src/visualizer/visualizer_db.go
@@ -1,0 +1,310 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package visualizer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+)
+
+type VisualizerYugabyteDB struct {
+	conn               *pgxpool.Pool
+	migrationDirectory string
+}
+
+// Initialize the target DB for visualisation metadata
+func (db *VisualizerYugabyteDB) Init(exportDir string) error {
+	err := db.connect()
+	if err != nil {
+		return err
+	}
+
+	err = db.createVoyagerSchema()
+	if err != nil {
+		return err
+	}
+
+	err = db.createYugabytedMetadataTable()
+	if err != nil {
+		return err
+	}
+
+	db.migrationDirectory = exportDir
+
+	return nil
+}
+
+// Destroy the connection
+func (db *VisualizerYugabyteDB) Finalize() {
+	db.disconnect()
+}
+
+func (db *VisualizerYugabyteDB) getConn() *pgxpool.Pool {
+	if db.conn == nil {
+		utils.ErrExit("Called TargetDB.Conn() before TargetDB.Connect()")
+	}
+	return db.conn
+}
+
+func (db *VisualizerYugabyteDB) reconnect() error {
+	var err error
+	db.disconnect()
+	for attempt := 1; attempt < 5; attempt++ {
+		err = db.connect()
+		if err == nil {
+			return nil
+		}
+		log.Infof("Failed to reconnect to the target database: %s", err)
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("reconnect to target db: %w", err)
+}
+
+func (db *VisualizerYugabyteDB) connect() error {
+	if db.conn != nil {
+		return nil
+	}
+	connectionUri := os.Getenv("TARGET_YBDB_CONN_URI")
+	if connectionUri == "" {
+		log.Warnf("Environment variable TARGET_YBDB_CONN_URI not set. " +
+			"Will not be able to visualize in yugabyted UI.")
+		return fmt.Errorf("connection uri string not set")
+	}
+
+	conn, err := pgxpool.Connect(context.Background(), connectionUri)
+	if err != nil {
+		return fmt.Errorf("connect to target db: %w", err)
+	}
+
+	db.conn = conn
+	return nil
+}
+
+func (db *VisualizerYugabyteDB) disconnect() {
+	if db.conn == nil {
+		return
+	}
+
+	db.conn.Close()
+	db.conn = nil
+}
+
+const BATCH_METADATA_TABLE_SCHEMA = "ybvoyager_visualizer"
+
+// Create the visualisation schema
+func (db *VisualizerYugabyteDB) createVoyagerSchema() error {
+	cmd := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, BATCH_METADATA_TABLE_SCHEMA)
+
+	err := db.executeCmdOnTarget(cmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const YUGABYTED_METADATA_TABLE_NAME = BATCH_METADATA_TABLE_SCHEMA + "." + "ybvoyager_visualizer_metadata"
+
+// Create visualisation metadata table
+func (db *VisualizerYugabyteDB) createYugabytedMetadataTable() error {
+	cmd := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			migration_uuid UUID,
+			migration_phase INT,
+			invocation_sequence INT,
+			migration_dir VARCHAR(250),
+			database_name VARCHAR(250),
+			schema_name VARCHAR(250),
+			payload TEXT,
+			status VARCHAR(30),
+			invocation_timestamp TIMESTAMPTZ,
+			PRIMARY KEY (migration_uuid, migration_phase, invocation_sequence)
+			);`, YUGABYTED_METADATA_TABLE_NAME)
+
+	err := db.executeCmdOnTarget(cmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const YUGABYTED_TABLE_METRICS_TABLE_NAME = BATCH_METADATA_TABLE_SCHEMA + "." + "ybvoyager_visualizer_table_metrics"
+
+// Create table metrics table
+func (db *VisualizerYugabyteDB) CreateYugabytedTableMetricsTable() error {
+	cmd := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			migration_uuid UUID,
+			table_name VARCHAR(250),
+			schema_name VARCHAR(250),
+			migration_phase INT,
+			status INT,
+			count_live_rows INT,
+			count_total_rows INT,
+			invocation_timestamp TIMESTAMPTZ,
+			PRIMARY KEY (migration_uuid, table_name, migration_phase, schema_name)
+			);`, YUGABYTED_TABLE_METRICS_TABLE_NAME)
+
+	err := db.executeCmdOnTarget(cmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Get the latest invocation sequence for a given migration_uuid and migration phase
+func (db *VisualizerYugabyteDB) GetInvocationSequence(mUUID uuid.UUID, phase int) (int, error) {
+	cmd := fmt.Sprintf(`SELECT MAX(invocation_sequence) AS latest_sequence 
+		FROM %s 
+		WHERE migration_uuid = '%s' AND migration_phase = %d`, YUGABYTED_METADATA_TABLE_NAME,
+		mUUID, phase)
+
+	log.Infof("Executing on target DB: [%s]", cmd)
+
+	var latestSequence *int
+	conn := db.getConn()
+	err := conn.QueryRow(context.Background(), cmd).Scan(&latestSequence)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return 1, nil
+		} else {
+			return 0, fmt.Errorf("couldn't get the latest sequence number: %w", err)
+		}
+	}
+
+	if latestSequence != nil {
+		return *latestSequence + 1, nil
+	} else {
+		return 1, nil
+	}
+}
+
+// Send visualisation metadata
+func (db *VisualizerYugabyteDB) SendVisualizerDBPayload(
+	visualizerDBPayload VisualizerDBPayload) error {
+	cmd := fmt.Sprintf("INSERT INTO %s ("+
+		"migration_uuid, "+
+		"migration_phase, "+
+		"invocation_sequence, "+
+		"migration_dir, "+
+		"database_name, "+
+		"schema_name, "+
+		"payload, "+
+		"status, "+
+		"invocation_timestamp"+
+		") VALUES ("+
+		"'%s', %d, %d, '%s', '%s', '%s', '%s', '%s', '%s'"+
+		")", YUGABYTED_METADATA_TABLE_NAME,
+		visualizerDBPayload.MigrationUUID,
+		visualizerDBPayload.MigrationPhase,
+		visualizerDBPayload.InvocationSequence,
+		db.migrationDirectory,
+		visualizerDBPayload.DatabaseName,
+		visualizerDBPayload.SchemaName,
+		visualizerDBPayload.Payload,
+		visualizerDBPayload.Status,
+		visualizerDBPayload.InvocationTimestamp)
+
+	err := db.executeCmdOnTarget(cmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Send Table metrics
+func (db *VisualizerYugabyteDB) SendVisualizerTableMetrics(
+	visualizerTableMetricsList []VisualizerTableMetrics) error {
+
+	cmd := fmt.Sprintf("INSERT INTO %s ("+
+		"migration_uuid, "+
+		"table_name, "+
+		"schema_name,"+
+		"migration_phase, "+
+		"status, "+
+		"count_live_rows, "+
+		"count_total_rows, "+
+		"invocation_timestamp"+
+		") VALUES ", YUGABYTED_TABLE_METRICS_TABLE_NAME)
+
+	var valuesList []string
+	for _, visualizerTableMetrics := range visualizerTableMetricsList {
+		value := fmt.Sprintf("('%s', '%s', '%s', %d, %d, %d, %d, '%s')",
+			visualizerTableMetrics.MigrationUUID,
+			visualizerTableMetrics.TableName,
+			visualizerTableMetrics.Schema,
+			visualizerTableMetrics.MigrationPhase,
+			visualizerTableMetrics.Status,
+			visualizerTableMetrics.CountLiveRows,
+			visualizerTableMetrics.CountTotalRows,
+			visualizerTableMetrics.InvocationTimestamp)
+
+		valuesList = append(valuesList, value)
+	}
+
+	cmd += strings.Join(valuesList, ",")
+
+	cmd += fmt.Sprintf(" ON CONFLICT (migration_uuid, table_name, schema_name, migration_phase) " +
+		"DO UPDATE " +
+		"SET " +
+		"status = EXCLUDED.status," +
+		"count_live_rows = EXCLUDED.count_live_rows," +
+		"count_total_rows = EXCLUDED.count_total_rows," +
+		"invocation_timestamp = EXCLUDED.invocation_timestamp;")
+
+	err := db.executeCmdOnTarget(cmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Function to execute any cmd on target DB.
+func (db *VisualizerYugabyteDB) executeCmdOnTarget(cmd string) error {
+	maxAttempts := 5
+	var err error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		log.Infof("Executing on target DB: [%s]", cmd)
+		conn := db.getConn()
+		_, err = conn.Exec(context.Background(), cmd)
+		if err == nil {
+			return nil
+		}
+		log.Warnf("Error while running [%s] attempt %d: %s", cmd, attempt, err)
+		time.Sleep(time.Second)
+		err2 := db.reconnect()
+		if err2 != nil {
+			log.Warnf("Failed to reconnect to the target database: %s", err2)
+			break
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("couldn't excute command %s on target db. error: %w", cmd, err)
+	}
+	return nil
+}

--- a/yb-voyager/src/visualizer/yugabyted_payload.go
+++ b/yb-voyager/src/visualizer/yugabyted_payload.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package visualizer
+
+import "github.com/google/uuid"
+
+type VisualizerDBPayload struct {
+	MigrationUUID       uuid.UUID `json:"migration_uuid"`
+	MigrationPhase      int       `json:"migration_phase"`
+	InvocationSequence  int       `json:"invocation_sequence"`
+	MigrationDirectory  string    `json:"migration_dir"`
+	DatabaseName        string    `json:"database_name"`
+	SchemaName          string    `json:"schema_name"`
+	Payload             string    `json:"payload"`
+	Status              string    `json:"status"`
+	InvocationTimestamp string    `json:"invocation_timestamp"`
+}
+
+var MIGRATION_PHASE_MAP = map[string]int{
+	"EXPORT SCHEMA":  0,
+	"ANALYZE SCHEMA": 1,
+	"EXPORT DATA":    2,
+	"IMPORT SCHEMA":  3,
+	"IMPORT DATA":    4,
+}
+
+// Create a visualisation metadata struct
+func CreateVisualzerDBPayload(mUUID uuid.UUID,
+	phase int,
+	invocationSequence int,
+	dbName string,
+	schema string,
+	visualizerPayload string,
+	status string,
+	timestamp string) VisualizerDBPayload {
+
+	return VisualizerDBPayload{
+		MigrationUUID:       mUUID,
+		MigrationPhase:      phase,
+		InvocationSequence:  invocationSequence,
+		DatabaseName:        dbName,
+		SchemaName:          schema,
+		Payload:             visualizerPayload,
+		Status:              status,
+		InvocationTimestamp: timestamp,
+	}
+}


### PR DESCRIPTION
Summary:

* Set the ENV variable `TARGET_YBDB_CONN_URI` before running any voyager command for visualisation in yugabyted-UI. Example: export TARGET_YBDB_CONN_URI=postgresql://yugabyte:yugabyte@10.150.1.230:5433
* For each of the following voyager steps, metadata is being sent to target DB in the ybvoyager_visualizer.ybvoyager_visualizer_metadata table:
   - EXPORT SCHEMA
   - ANALYZE SCHEMA
   - EXPORT DATA
   - IMPORT SCHEMA
   - IMPORT DATA
* For EXPORT DATA and IMPORT DATA steps, table completetion metrics are sent to the ybvoyager_visualizer.ybvoyager_visualizer_table_metrics.
* Table metrics are sent every 5 secs.

Test Plan: Manual Testing

Reviewers: nchandrappa, amit-yb, sanyamsinghal

Subscribers: gargsans-yb