### PR TITLE
Data transformation fix: Local->UTC

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -89,6 +89,7 @@ func exportDataCommandFn(cmd *cobra.Command, args []string) {
 		exporterRole = SOURCE_DB_EXPORTER_ROLE
 	}
 
+	CreateMigrationProjectIfNotExists(source.DBType, exportDir)
 	err = retrieveMigrationUUID(exportDir)
 	if err != nil {
 		utils.ErrExit("failed to get migration UUID: %w", err)
@@ -118,8 +119,6 @@ func exportData() bool {
 	defer source.DB().Disconnect()
 	checkSourceDBCharset()
 	source.DB().CheckRequiredToolsAreInstalled()
-
-	CreateMigrationProjectIfNotExists(source.DBType, exportDir)
 
 	metaDB, err = NewMetaDB(exportDir)
 	if err != nil {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -80,11 +80,12 @@ var ybValueConverterSuite = map[string]ConverterFn{
 		}
 		epochSeconds := epochMicroSecs / 1000000
 		epochNanos := (epochMicroSecs % 1000000) * 1000
-		microTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano)) //TODO: check if proper format for Micro can work
-		if err != nil {
-			return columnValue, err
-		}
-		timestamp := strings.TrimSuffix(microTimeStamp.String(), " +0000 UTC")
+		timestamp := time.Unix(epochSeconds, epochNanos).UTC().Format("2006-01-02T15:04:05.999999")
+		// microTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano)) //TODO: check if proper format for Micro can work
+		// if err != nil {
+		// 	return columnValue, err
+		// }
+		// timestamp := strings.TrimSuffix(microTimeStamp.String(), " +0000 UTC")
 		if formatIfRequired {
 			timestamp = fmt.Sprintf("'%s'", timestamp)
 		}
@@ -97,11 +98,12 @@ var ybValueConverterSuite = map[string]ConverterFn{
 		}
 		epochSeconds := epochNanoSecs / 1000000000
 		epochNanos := epochNanoSecs % 1000000000
-		nanoTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano))
-		if err != nil {
-			return columnValue, err
-		}
-		timestamp := strings.TrimSuffix(nanoTimeStamp.String(), " +0000 UTC")
+		timestamp := time.Unix(epochSeconds, epochNanos).UTC().Format("2006-01-02T15:04:05.999999999")
+		// nanoTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano))
+		// if err != nil {
+		// 	return columnValue, err
+		// }
+		// timestamp := strings.TrimSuffix(nanoTimeStamp.String(), " +0000 UTC")
 		if formatIfRequired {
 			timestamp = fmt.Sprintf("'%s'", timestamp)
 		}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -81,11 +81,6 @@ var ybValueConverterSuite = map[string]ConverterFn{
 		epochSeconds := epochMicroSecs / 1000000
 		epochNanos := (epochMicroSecs % 1000000) * 1000
 		timestamp := time.Unix(epochSeconds, epochNanos).UTC().Format("2006-01-02T15:04:05.999999")
-		// microTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano)) //TODO: check if proper format for Micro can work
-		// if err != nil {
-		// 	return columnValue, err
-		// }
-		// timestamp := strings.TrimSuffix(microTimeStamp.String(), " +0000 UTC")
 		if formatIfRequired {
 			timestamp = fmt.Sprintf("'%s'", timestamp)
 		}
@@ -99,11 +94,6 @@ var ybValueConverterSuite = map[string]ConverterFn{
 		epochSeconds := epochNanoSecs / 1000000000
 		epochNanos := epochNanoSecs % 1000000000
 		timestamp := time.Unix(epochSeconds, epochNanos).UTC().Format("2006-01-02T15:04:05.999999999")
-		// nanoTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano))
-		// if err != nil {
-		// 	return columnValue, err
-		// }
-		// timestamp := strings.TrimSuffix(nanoTimeStamp.String(), " +0000 UTC")
 		if formatIfRequired {
 			timestamp = fmt.Sprintf("'%s'", timestamp)
 		}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -67,7 +67,7 @@ var ybValueConverterSuite = map[string]ConverterFn{
 			return columnValue, fmt.Errorf("parsing epoch milliseconds: %v", err)
 		}
 		epochSecs := epochMilliSecs / 1000
-		timestamp := time.Unix(epochSecs, 0).Local().Format(time.DateTime)
+		timestamp := time.Unix(epochSecs, 0).UTC().Format(time.DateTime)
 		if formatIfRequired {
 			timestamp = fmt.Sprintf("'%s'", timestamp)
 		}
@@ -80,7 +80,7 @@ var ybValueConverterSuite = map[string]ConverterFn{
 		}
 		epochSeconds := epochMicroSecs / 1000000
 		epochNanos := (epochMicroSecs % 1000000) * 1000
-		microTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).Local().Format(time.RFC3339Nano)) //TODO: check if proper format for Micro can work
+		microTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano)) //TODO: check if proper format for Micro can work
 		if err != nil {
 			return columnValue, err
 		}
@@ -97,7 +97,7 @@ var ybValueConverterSuite = map[string]ConverterFn{
 		}
 		epochSeconds := epochNanoSecs / 1000000000
 		epochNanos := epochNanoSecs % 1000000000
-		nanoTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).Local().Format(time.RFC3339Nano))
+		nanoTimeStamp, err := time.Parse(time.RFC3339Nano, time.Unix(epochSeconds, epochNanos).UTC().Format(time.RFC3339Nano))
 		if err != nil {
 			return columnValue, err
 		}


### PR DESCRIPTION
Timestamp fields without timezone are represented by debezium as microseconds/nanoseconds since Unix Epoch (which is in UTC). Therefore, we need to tie the time calculation to UTC timezone. 

