### PR TITLE
Added possible paths for pg_dump-args.ini

### DIFF
--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -150,7 +150,7 @@ ubuntu_main() {
 
 	install_golang linux
 	ubuntu_install_postgres
-	create_pg_dump_args_file
+	# create_pg_dump_args_file
 	if [ $ONLY_PG == "false" ] ; then
 		sudo apt-get -y install perl  1>&2
 		sudo apt-get -y install libdbi-perl 1>&2

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -150,7 +150,7 @@ ubuntu_main() {
 
 	install_golang linux
 	ubuntu_install_postgres
-	# create_pg_dump_args_file
+	create_pg_dump_args_file
 	if [ $ONLY_PG == "false" ] ; then
 		sudo apt-get -y install perl  1>&2
 		sudo apt-get -y install libdbi-perl 1>&2

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -40,8 +40,23 @@ var pgDumpArgs PgDumpArgs
 var pgDumpArgsFile string
 
 func getPgDumpArgsFromFile(sectionToRead string) string {
-	basePgDumpArgsFilePath := filepath.Join("/", "etc", "yb-voyager", "pg_dump-args.ini")
-	if utils.FileOrFolderExists(basePgDumpArgsFilePath) {
+	var basePgDumpArgsFilePath string
+	homebrewVoyagerDir := fmt.Sprintf("yb-voyager@%s", utils.YB_VOYAGER_VERSION)
+	possiblePaths := []string{
+		filepath.Join("/", "etc", "yb-voyager", "pg_dump-args.ini"),
+		filepath.Join("/", "opt", "homebrew", "Cellar", homebrewVoyagerDir, utils.YB_VOYAGER_VERSION, "etc", "yb-voyager", "pg_dump-args.ini"),
+		filepath.Join("/", "usr", "local", "Cellar", homebrewVoyagerDir, utils.YB_VOYAGER_VERSION, "etc", "yb-voyager", "pg_dump-args.ini"),
+	}
+
+	for _, path := range possiblePaths {
+		if utils.FileOrFolderExists(path) {
+			basePgDumpArgsFilePath = path
+			break
+		}
+	}
+	if basePgDumpArgsFilePath == "" {
+		utils.ErrExit("Could not find pg_dump-args.ini in any of %v.", possiblePaths)
+	} else {
 		log.Infof("Using base pg_dump arguments file: %s", basePgDumpArgsFilePath)
 		basePgDumpArgsFile, err := os.ReadFile(basePgDumpArgsFilePath)
 		if err != nil {

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -55,12 +55,14 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 		}
 	}
 
-	log.Infof("Using base pg_dump arguments file: %s", basePgDumpArgsFilePath)
-	basePgDumpArgsFile, err := os.ReadFile(basePgDumpArgsFilePath)
-	if err != nil {
-		utils.ErrExit("Error while reading pg_dump arguments file: %v", err)
+	if pgDumpArgsFile == "" {
+		log.Infof("Using base pg_dump arguments file: %s", basePgDumpArgsFilePath)
+		basePgDumpArgsFile, err := os.ReadFile(basePgDumpArgsFilePath)
+		if err != nil {
+			utils.ErrExit("Error while reading pg_dump arguments file: %v", err)
+		}
+		pgDumpArgsFile = string(basePgDumpArgsFile)
 	}
-	pgDumpArgsFile = string(basePgDumpArgsFile)
 
 	tmpl, err := template.New("pg_dump_args").Parse(string(pgDumpArgsFile))
 	if err != nil {

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -55,7 +55,9 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 		}
 	}
 
-	if pgDumpArgsFile == "" {
+	if basePgDumpArgsFilePath == "" {
+		log.Infof("Using embedded pg_dump arguments file")
+	} else {
 		log.Infof("Using base pg_dump arguments file: %s", basePgDumpArgsFilePath)
 		basePgDumpArgsFile, err := os.ReadFile(basePgDumpArgsFilePath)
 		if err != nil {

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -54,16 +54,13 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 			break
 		}
 	}
-	if basePgDumpArgsFilePath == "" {
-		utils.ErrExit("Could not find pg_dump-args.ini in any of %v.", possiblePaths)
-	} else {
-		log.Infof("Using base pg_dump arguments file: %s", basePgDumpArgsFilePath)
-		basePgDumpArgsFile, err := os.ReadFile(basePgDumpArgsFilePath)
-		if err != nil {
-			utils.ErrExit("Error while reading pg_dump arguments file: %v", err)
-		}
-		pgDumpArgsFile = string(basePgDumpArgsFile)
+
+	log.Infof("Using base pg_dump arguments file: %s", basePgDumpArgsFilePath)
+	basePgDumpArgsFile, err := os.ReadFile(basePgDumpArgsFilePath)
+	if err != nil {
+		utils.ErrExit("Error while reading pg_dump arguments file: %v", err)
 	}
+	pgDumpArgsFile = string(basePgDumpArgsFile)
 
 	tmpl, err := template.New("pg_dump_args").Parse(string(pgDumpArgsFile))
 	if err != nil {


### PR DESCRIPTION
In case of brew, we cannot install files directly into the `/etc/yb-voyager` folder due to permission issues. Hence, I install the `pg_dump-args.ini` file in `${HOMEBREW_PREFIX}/etc/yb-voyager`