### PR TITLE
Fixed a bug in import data file where default batchSize 20K not being set

### DIFF
--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -49,6 +49,7 @@ const (
 	TARGET_DB_IMPORTER_ROLE       = "target_db_importer"
 	SOURCE_DB_EXPORTER_ROLE       = "source_db_exporter"
 	TARGET_DB_EXPORTER_ROLE       = "target_db_exporter"
+	IMPORT_FILE_ROLE			  = "import_file"
 )
 
 var supportedSourceDBTypes = []string{ORACLE, MYSQL, POSTGRESQL, YUGABYTEDB}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -358,7 +358,9 @@ func importData(importFileTasks []*ImportFileTask) {
 	callhome.PackAndSendPayload(exportDir)
 	if !dbzm.IsDebeziumForDataExport(exportDir) {
 		executePostImportDataSqls()
-		displayImportedRowCountSnapshot(importFileTasks)
+		if !reportProgressInBytes { //shouldn't report in case import data file
+			displayImportedRowCountSnapshot(importFileTasks)
+		}
 	} else {
 		if changeStreamingIsEnabled(importType) {
 			displayImportedRowCountSnapshot(importFileTasks)

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -64,11 +64,13 @@ var importDataFileCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
+		importerRole = IMPORT_FILE_ROLE
 		metaDB, err = NewMetaDB(exportDir)
 		if err != nil {
 			utils.ErrExit("Failed to initialize meta db: %s", err)
 		}
 		reportProgressInBytes = true
+		validateBatchSizeFlag(batchSize)
 		checkImportDataFileFlags(cmd)
 		dataStore = datastore.NewDataStore(dataDir)
 		importFileTasks = prepareImportFileTasks()

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -223,6 +223,8 @@ func prepareImportDataStatusTable(isffDB bool, streamChanges bool) ([]*tableMigS
 	} else {
 		// Case of `import data file` command where row counts are not available.
 		// Use file sizes for progress reporting.
+		importerRole = IMPORT_FILE_ROLE
+		state = NewImportDataState(exportDir)
 		dataFileDescriptor, err = prepareDummyDescriptor(state)
 		if err != nil {
 			return nil, fmt.Errorf("prepare dummy descriptor: %w", err)


### PR DESCRIPTION
1. Fixed a bug in the `import data file` where the progress bar was kind of broken for the import data file, because the default batch size of 20K was not being set for the import data file command, and hence the splits were generating of 200MB size limit
2. Introduced a new `importerRole` as `import_file`.