### PR TITLE
Bug fix  [import data file] with --start-clean resetting the metaDB tables in cleanImportState() only in live migration (#1074)

### DIFF
--- a/migtests/tests/import-file/run-import-file-test
+++ b/migtests/tests/import-file/run-import-file-test
@@ -45,7 +45,7 @@ main() {
 	export CSV_READER_MAX_BUFFER_SIZE_BYTES=300
 	step "Import data file: FY2021_Survey.csv -> survey"
 	import_data_file --data-dir ${TEST_DIR} --format csv --delimiter ',' \
-		--file-table-map "FY2021_Survey.csv:survey" --has-header
+		--file-table-map "FY2021_Survey.csv:survey" --has-header --start-clean
 
 	step "Import data file: SMSA.txt -> smsa"
 	import_data_file --data-dir ${TEST_DIR} --format text --delimiter '\t' \

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -553,14 +553,16 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 		}
 	}
 
-	// clearing state from metaDB based on importerRole
-	err := metaDB.ResetQueueSegmentMeta(importerRole)
-	if err != nil {
-		utils.ErrExit("failed to reset queue segment meta: %s", err)
-	}
-	err = metaDB.DeleteJsonObject(identityColumnsMetaDBKey)
-	if err != nil {
-		utils.ErrExit("failed to reset identity columns meta: %s", err)
+	if changeStreamingIsEnabled(importType) { 
+		// clearing state from metaDB based on importerRole
+		err := metaDB.ResetQueueSegmentMeta(importerRole)
+		if err != nil {
+			utils.ErrExit("failed to reset queue segment meta: %s", err)
+		}
+		err = metaDB.DeleteJsonObject(identityColumnsMetaDBKey)
+		if err != nil {
+			utils.ErrExit("failed to reset identity columns meta: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
…

* Bug fix  [import data file] with --start-clean resetting the metaDB tables of live migration in cleanImportState() only in live migration
* automation case