### PR TITLE
Finalize import stats only when --disable-pb is not set

### DIFF
--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -65,8 +65,9 @@ func streamChanges() error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize stats reporter: %w", err)
 	}
-	defer finalizeStats()
+
 	if !disablePb {
+		defer finalizeStats()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go updateExportedEventsStats(ctx)

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -67,11 +67,11 @@ func streamChanges() error {
 	}
 
 	if !disablePb {
-		defer finalizeStats()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go updateExportedEventsStats(ctx)
 		go statsReporter.ReportStats(ctx)
+		defer finalizeStats()
 	}
 
 	eventQueue = NewEventQueue(exportDir)


### PR DESCRIPTION
Bug when `--disable-pb` is used on the importer side and cutover happens `defer.finalizeStats()` will return a nil pointer exception as the stats table isn't initialized for this case. 