### PR TITLE
Fixed Typos for "Materialised" in note and "Auto-migrated" in analyze-schema html report

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -857,7 +857,7 @@ func generateHTMLReport(Report utils.Report) string {
 	htmlstring += "<tr><th>" + strings.ToUpper(miginfo.SourceDBType) + " Version</th><td>" + Report.Summary.DBVersion + "</td></tr></table>"
 
 	//Summary of report
-	htmlstring += "<br><table width='100%' table-layout='fixed'><tr><th>Object</th><th>Total Count</th><th>Auto-Migrated</th><th>Invalid Count</th><th width='40%'>Object Names</th><th width='30%'>Details</th></tr>"
+	htmlstring += "<br><table width='100%' table-layout='fixed'><tr><th>Object</th><th>Total Count</th><th>Valid Count</th><th>Invalid Count</th><th width='40%'>Object Names</th><th width='30%'>Details</th></tr>"
 	for i := 0; i < len(Report.Summary.DBObjects); i++ {
 		if Report.Summary.DBObjects[i].TotalCount != 0 {
 			htmlstring += "<tr><th>" + Report.Summary.DBObjects[i].ObjectType + "</th><td style='text-align: center;'>" + strconv.Itoa(Report.Summary.DBObjects[i].TotalCount) + "</td><td style='text-align: center;'>" + strconv.Itoa(Report.Summary.DBObjects[i].TotalCount-Report.Summary.DBObjects[i].InvalidCount) + "</td><td style='text-align: center;'>" + strconv.Itoa(Report.Summary.DBObjects[i].InvalidCount) + "</td><td width='40%'>" + Report.Summary.DBObjects[i].ObjectNames + "</td><td width='30%'>" + Report.Summary.DBObjects[i].Details + "</td></tr>"

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -160,7 +160,7 @@ func importSchema() {
 			refreshMViews(conn)
 		}
 	} else {
-		utils.PrintAndLog("\nNOTE: Materialised Views are not populated by default. To populate them, pass --refresh-mviews while executing `import schema --post-import-data`.")
+		utils.PrintAndLog("\nNOTE: Materialized Views are not populated by default. To populate them, pass --refresh-mviews while executing `import schema --post-import-data`.")
 	}
 
 	callhome.PackAndSendPayload(exportDir)
@@ -234,7 +234,7 @@ func refreshMViews(conn *pgx.Conn) {
 		rows.Close()
 	}
 	if len(mviewsNotRefreshed) > 0 {
-		utils.PrintAndLog("\nNOTE: Following Materialised Views might not be refreshed - %v, Please verify and refresh them manually if required!", mviewsNotRefreshed)
+		utils.PrintAndLog("\nNOTE: Following Materialized Views might not be refreshed - %v, Please verify and refresh them manually if required!", mviewsNotRefreshed)
 	}
 }
 


### PR DESCRIPTION
Fixes - [DB-7587](https://yugabyte.atlassian.net/browse/DB-7587) and [DB-7963](https://yugabyte.atlassian.net/browse/DB-7963)