### PR TITLE
CLI HELP: minor formatting change

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1078,7 +1078,7 @@ func init() {
 	rootCmd.AddCommand(analyzeSchemaCmd)
 	registerCommonGlobalFlags(analyzeSchemaCmd)
 	analyzeSchemaCmd.PersistentFlags().StringVar(&outputFormat, "output-format", "txt",
-		"allowed report formats: html | txt | json | xml")
+		"format in which report will be generated: (html, txt, json, xml)")
 }
 
 func validateReportOutputFormat() {


### PR DESCRIPTION
The options are just better formatted within parantheses. 
before: 
`--output-format string       allowed report formats: html | txt | json | xml (default "txt")`
after:
`--output-format string       format in which report will be generated: (html, txt, json, xml) (default "txt")` 
Examples:
docker pull <img width="809" alt="image" src="https://github.com/yugabyte/yb-voyager/assets/6829754/086797fb-134f-46c5-9e34-84241f657f19">
