### PR TITLE
Bug fix: migration uuid being printed more than once on console

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -429,6 +429,9 @@ func initMetaDB() {
 
 // sets the global variable migrationUUID after retrieving it from MigrationStatusRecord
 func retrieveMigrationUUID() error {
+	if migrationUUID != uuid.Nil {
+		return nil
+	}
 	msr, err := metaDB.GetMigrationStatusRecord()
 	if err != nil {
 		return fmt.Errorf("retrieving migration status record: %w", err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -322,7 +322,7 @@ func applyTableListFilter(importFileTasks []*ImportFileTask) []*ImportFileTask {
 
 	for _, task := range importFileTasks {
 		table := standardizeCaseInsensitiveTableNames(task.TableName, defaultSourceSchema)
-		if len(includeList) > 0 && !slices.Contains(includeList,table) {
+		if len(includeList) > 0 && !slices.Contains(includeList, table) {
 			log.Infof("Skipping table %q (fileName: %s) as it is not in the include list", task.TableName, task.FilePath)
 			continue
 		}
@@ -437,7 +437,7 @@ func importData(importFileTasks []*ImportFileTask) {
 		}
 		time.Sleep(time.Second * 2)
 	}
-
+	utils.PrintAndLog("snapshot data import complete\n")
 	callhome.PackAndSendPayload(exportDir)
 	if !dbzm.IsDebeziumForDataExport(exportDir) {
 		executePostImportDataSqls()


### PR DESCRIPTION
- return if migrationUUID already present, instead of retrieving