### PR TITLE
Bug fixes for UX of import report and --table-list

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -362,7 +362,11 @@ func displayImportedRowCountSnapshot(state *ImportDataState, tasks []*ImportFile
 		if i == 0 {
 			addHeader(uitable, "SCHEMA", "TABLE", "IMPORTED ROW COUNT")
 		}
-		uitable.AddRow(getTargetSchemaName(tableName), tableName, snapshotRowCount[tableName])
+		table := tableName
+		if len(strings.Split(tableName, ".")) == 2 {
+			table = strings.Split(tableName, ".")[1]
+		}
+		uitable.AddRow(getTargetSchemaName(tableName), table, snapshotRowCount[tableName])
 	}
 	fmt.Printf("\n")
 	fmt.Println(uitable)

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -336,7 +336,7 @@ func getDefaultSourceSchemaName() (string, bool) {
 		} else if slices.Contains(schemas, "public") {
 			return "public", false
 		} else {
-			return "", true 
+			return "", true
 		}
 	case ORACLE:
 		return source.Schema, false
@@ -385,7 +385,7 @@ func extractTableListFromString(fullTableList []*sqlname.SourceName, flagTableLi
 		utils.PrintAndLog("Unknown table names %v in the %s list", unknownTableNames, listName)
 		utils.ErrExit("Valid table names are %v", fullTableList)
 	}
-	return result
+	return lo.Uniq(result)
 }
 
 func checkSourceDBCharset() {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -557,7 +557,7 @@ func importFileTasksToTableNames(tasks []*ImportFileTask) []string {
 	for _, t := range tasks {
 		tableNames = append(tableNames, t.TableName)
 	}
-	return utils.Uniq(tableNames)
+	return lo.Uniq(tableNames)
 }
 
 func classifyTasks(state *ImportDataState, tasks []*ImportFileTask) (pendingTasks, completedTasks []*ImportFileTask, err error) {

--- a/yb-voyager/src/utils/sqlname/sqlname.go
+++ b/yb-voyager/src/utils/sqlname/sqlname.go
@@ -258,6 +258,7 @@ func IsCaseSensitive(s string, sourceDbType string) bool {
 	panic("invalid source db type")
 }
 
+
 var PgReservedKeywords = []string{"all", "analyse", "analyze", "and", "any", "array",
 	"as", "asc", "asymmetric", "both", "case", "cast", "check", "collate", "column",
 	"constraint", "create", "current_catalog", "current_date", "current_role",

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -339,18 +339,6 @@ func PrintSqlStmtIfDDL(stmt string, fileName string) {
 	}
 }
 
-func Uniq(slice []string) []string {
-	keys := make(map[string]bool)
-	var list []string
-	for _, entry := range slice {
-		if _, value := keys[entry]; !value {
-			keys[entry] = true
-			list = append(list, entry)
-		}
-	}
-	return list
-}
-
 func HumanReadableByteCount(bytes int64) string {
 	const unit = 1024
 	if bytes < unit {


### PR DESCRIPTION
1. fixes table name -  in case of multiple schemas with PG, import report should report unqualified tableName in 'TABLE'
2. display a unique list of table names for export data 