### PR TITLE
Implemented yb-voyager end migration command

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -567,11 +567,11 @@ func getPassword(cmd *cobra.Command, cliArgName, envVarName string) (string, err
 	if os.Getenv(envVarName) != "" {
 		return os.Getenv(envVarName), nil
 	}
-	fmt.Printf("Password to connect to %s (In addition, you can also set the password using the environment variable `%s`): ", strings.TrimSuffix(cliArgName, "-password"), envVarName)
+	fmt.Printf("Password to connect to %s (In addition, you can also set the password using the environment variable `%s`): ",
+		strings.TrimSuffix(cliArgName, "-password"), envVarName)
 	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
-		utils.ErrExit("read password: %v", err)
-		return "", err
+		return "", fmt.Errorf("read password: %w", err)
 	}
 	fmt.Print("\n")
 	return string(bytePassword), nil

--- a/yb-voyager/cmd/endCommand.go
+++ b/yb-voyager/cmd/endCommand.go
@@ -6,8 +6,8 @@ import (
 
 var endCmd = &cobra.Command{
 	Use:   "end",
-	Short: "This command will mark the end of the migration",
-	Long:  `This command will mark the end of the migration`,
+	Short: "Parent of the command that ends the migration and clears all the migration state.",
+	Long:  `Parent of the command that ends the migration and clears all the migration state.`,
 }
 
 func init() {

--- a/yb-voyager/cmd/endCommand.go
+++ b/yb-voyager/cmd/endCommand.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var endCmd = &cobra.Command{
+	Use:   "end",
+	Short: "This command will mark the end of the migration",
+	Long:  `This command will mark the end of the migration`,
+}
+
+func init() {
+	rootCmd.AddCommand(endCmd)
+}

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -185,7 +185,7 @@ func saveMigrationReportsFn() {
 	}
 	log.Infof("saving up migration reports to %s", backupDir)
 	// TODO: what if there is report.txt generated from analyze-schema step
-	err := os.Rename(filepath.Join(exportDir, "reports"), filepath.Join(backupDir, "reports-backup"))
+	err := os.Rename(filepath.Join(exportDir, "reports"), filepath.Join(backupDir, "reports"))
 	if err != nil {
 		utils.ErrExit("end migration: moving migration reports: %v", err)
 	}

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -122,11 +122,22 @@ func saveMigrationReportsFn() {
 	if !saveMigrationReports {
 		return
 	}
+
+	// TODO: what if there is no report.txt generated from analyze-schema step
 	utils.PrintAndLog("saving schema analysis report")
-	// TODO: what if there is report.txt generated from analyze-schema step
-	err := os.Rename(filepath.Join(exportDir, "reports"), filepath.Join(backupDir, "reports"))
+	files, err := os.ReadDir(filepath.Join(exportDir, "reports"))
 	if err != nil {
-		utils.ErrExit("end migration: moving migration reports: %v", err)
+		utils.ErrExit("end migration: reading reports directory: %v", err)
+	}
+	for _, file := range files {
+		if file.IsDir() || !strings.HasPrefix(file.Name(), "report.") {
+			continue
+		}
+
+		err = os.Rename(filepath.Join(exportDir, "reports", file.Name()), filepath.Join(backupDir, "reports", file.Name()))
+		if err != nil {
+			utils.ErrExit("end migration: moving migration reports: %v", err)
+		}
 	}
 
 	utils.PrintAndLog("saving data export reports...")
@@ -167,6 +178,7 @@ func backupLogFilesFn() {
 		return
 	}
 	utils.PrintAndLog("backing up log files")
+	// TODO: in case of failures when cmd is executed again, even if logs were backed up, new log file for end migration will come up
 	err := os.Rename(filepath.Join(exportDir, "logs"), filepath.Join(backupDir, "logs"))
 	if err != nil {
 		utils.ErrExit("end migration: moving log files: %v", err)

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -213,22 +213,11 @@ func backupLogFilesFn() {
 	}
 
 	utils.PrintAndLog("backing up log files")
-	files, err := os.ReadDir(filepath.Join(exportDir, "logs"))
+	cmdStr := fmt.Sprintf("mv %s/logs/*.log %s", exportDir, backupLogDir)
+	cmd := exec.Command("bash", "-c", cmdStr)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		utils.ErrExit("end migration: reading logs directory: %v", err)
-	}
-
-	for _, file := range files {
-		if file.IsDir() || !strings.HasSuffix(file.Name(), ".log") {
-			continue
-		}
-
-		logFilePath := filepath.Join(exportDir, "logs", file.Name())
-		backupFilePath := filepath.Join(backupDir, "logs", file.Name())
-		err = os.Rename(logFilePath, backupFilePath)
-		if err != nil {
-			utils.ErrExit("end migration: moving log files: %v", err)
-		}
+		utils.ErrExit("end migration: moving log files: %s: %v", string(output), err)
 	}
 }
 

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -322,7 +322,7 @@ func deleteCDCStreamIDForEndMigration(tconf *tgtdb.TargetConf) {
 		User:           tconf.User,
 		Password:       tconf.Password,
 		DBName:         tconf.DBName,
-		Schema:      tconf.Schema,
+		Schema:         tconf.Schema,
 		SSLMode:        tconf.SSLMode,
 		SSLCertPath:    tconf.SSLCertPath,
 		SSLKey:         tconf.SSLKey,
@@ -444,6 +444,7 @@ func checkIfEndCommandCanBePerformed(msr *metadb.MigrationStatusRecord) {
 	if len(matches) > 0 {
 		var ongoingCmds []string
 		for _, match := range matches {
+			match = filepath.Base(match)
 			match = strings.TrimPrefix(match, ".")
 			match = strings.TrimSuffix(match, "Lockfile.lck")
 			if match == "end-migration" {

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -63,7 +63,7 @@ func endMigrationCommandFn(cmd *cobra.Command, args []string) {
 	checkIfEndCommandCanBePerformed(msr)
 
 	// backing up the state from the export directory
-	backupSchemaFilesFn(msr)
+	backupSchemaFilesFn()
 	backupDataFilesFn()
 	backupLogFilesFn()
 	saveMigrationReportsFn()
@@ -78,8 +78,8 @@ func endMigrationCommandFn(cmd *cobra.Command, args []string) {
 	utils.PrintAndLog("Migration ended successfully")
 }
 
-func backupSchemaFilesFn(msr *metadb.MigrationStatusRecord) {
-	if !backupSchemaFiles {
+func backupSchemaFilesFn() {
+	if !bool(backupSchemaFiles) || !utils.FileOrFolderExists(filepath.Join(exportDir, "schema")) {
 		return
 	}
 

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -1,0 +1,338 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/dustin/go-humanize"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+)
+
+var (
+	backupSchemaFiles    utils.BoolStr
+	backupDataFiles      utils.BoolStr
+	backupMigrationFiles utils.BoolStr
+	backupLogFiles       utils.BoolStr
+	backupDir            string
+)
+
+var endMigrationCmd = &cobra.Command{
+	Use:   "migration",
+	Short: "End the current migration and cleanup all metadata stored in databases(Target, FF and FB) and export-dir",
+	Long:  "End the current migration and cleanup all metadata stored in databases(Target, FF and FB) and export-dir",
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		err := validateEndMigrationFlags(cmd)
+		if err != nil {
+			utils.ErrExit(err.Error())
+		}
+	},
+
+	Run: endMigrationCommandFn,
+}
+
+func endMigrationCommandFn(cmd *cobra.Command, args []string) {
+	if utils.AskPrompt("Migration can't be resumed or continued after this.", "Are you sure you want to end the migration") {
+		log.Info("ending the migration")
+	} else {
+		log.Info("Aborting the end migration command")
+		return
+	}
+
+	checkIfEndCommandCanBePerformed()
+
+	msr, err := metaDB.GetMigrationStatusRecord()
+	if err != nil {
+		utils.ErrExit("end migration: getting migration status record: %v", err)
+	} else if msr == nil {
+		utils.ErrExit("end migration: migration status record not found. Is the migration initialized?")
+	}
+
+	// cleaning only the migration state wherever and  whatever required
+	cleanupSourceDB(msr)
+	cleanupTargetDB(msr)
+	cleanupFallForwardDB(msr)
+	cleanupFallBackDB(msr)
+
+	// backing up the state from the export directory
+	retrieveMigrationUUID()
+	backupSchemaFilesFn(msr)
+	backupDataFilesFn()
+	backupMigrationReportsFn()
+	backupLogFilesFn()
+
+	utils.CleanDir(exportDir)
+	utils.PrintAndLog("Migration ended successfully")
+}
+
+func backupSchemaFilesFn(msr *metadb.MigrationStatusRecord) {
+	if !bool(backupSchemaFiles) || !msr.ExportSchemaDone {
+		return
+	}
+
+	log.Infof("backing up schema files to %s", backupDir)
+	err := os.MkdirAll(filepath.Join(backupDir, "schema-backup"), 0755)
+	if err != nil {
+		utils.ErrExit("end migration: creating schema backup directory: %v", err)
+	}
+
+	cmd := exec.Command("mv", filepath.Join(exportDir, "schema"), filepath.Join(backupDir, "schema-backup"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		utils.ErrExit("end migration: moving schema files: %s:\n%v", string(output), err)
+	}
+}
+
+func backupDataFilesFn() {
+	if !bool(backupDataFiles) {
+		return
+	}
+
+	log.Infof("backing up sql data files to %s", backupDir)
+	err := os.MkdirAll(filepath.Join(backupDir, "data-backup"), 0755)
+	if err != nil {
+		utils.ErrExit("end migration: creating data backup directory: %v", err)
+	}
+
+	files, err := os.ReadDir(filepath.Join(exportDir, "data"))
+	if err != nil {
+		utils.ErrExit("end migration: reading data directory: %v", err)
+	}
+	for _, file := range files {
+		if file.IsDir() || !strings.HasPrefix(file.Name(), ".sql") {
+			continue
+		}
+
+		err = os.Rename(filepath.Join(exportDir, "data", file.Name()), filepath.Join(backupDir, "data-backup", file.Name()))
+		if err != nil {
+			utils.ErrExit("end migration: moving data files: %v", err)
+		}
+	}
+}
+
+func backupMigrationReportsFn() {
+	if !bool(backupMigrationFiles) {
+		return
+	}
+	log.Infof("backing up migration reports to %s", backupDir)
+	err := os.MkdirAll(filepath.Join(backupDir, "reports-backup"), 0755)
+	if err != nil {
+		utils.ErrExit("end migration: creating reports backup directory: %v", err)
+	}
+
+	err = os.Rename(filepath.Join(exportDir, "reports"), filepath.Join(backupDir, "reports-backup"))
+	if err != nil {
+		utils.ErrExit("end migration: moving migration reports: %v", err)
+	}
+
+	utils.PrintAndLog("backing up export data status report...")
+	file, err := os.Create(filepath.Join(backupDir, "reports", "export_data_status.txt"))
+	if err != nil {
+		utils.ErrExit("end migration: creating export data status report: %v", err)
+	}
+	originalStdout := os.Stdout
+	os.Stdout = file
+	exportDataStatusCmd.Run(exportDataStatusCmd, nil)
+	os.Stdout = originalStdout
+	file.Close()
+
+	utils.PrintAndLog("backing up export data status report...")
+	file, err = os.Create(filepath.Join(backupDir, "reports", "import_data_status.txt"))
+	if err != nil {
+		utils.ErrExit("end migration: creating import data status report: %v", err)
+	}
+	originalStdout = os.Stdout
+	os.Stdout = file
+	importDataStatusCmd.Run(importDataStatusCmd, nil)
+	os.Stdout = originalStdout
+	file.Close()
+}
+
+func backupLogFilesFn() {
+	if !bool(backupLogFiles) {
+		return
+	}
+	log.Infof("backing up log files to %s", backupDir)
+	// err := os.MkdirAll(filepath.Join(backupDir, "logs-backup"), 0755)
+	// if err != nil {
+	// 	utils.ErrExit("end migration: creating logs backup directory: %v", err)
+	// }
+
+	err := os.Rename(filepath.Join(exportDir, "logs"), filepath.Join(backupDir, "logs-backup"))
+	if err != nil {
+		utils.ErrExit("end migration: moving log files: %v", err)
+	}
+}
+
+func cleanupSourceDB(msr *metadb.MigrationStatusRecord) {
+	source := msr.SourceDBConf
+	if source == nil {
+		log.Infof("source db conf is not set. skipping cleanup")
+		return
+	}
+	err := source.DB().Connect()
+	if err != nil {
+		utils.ErrExit("end migration: connecting to source db: %v", err)
+	}
+	defer source.DB().Disconnect()
+	source.DB().ClearMigrationState(migrationUUID, exportDir)
+
+	err = dbzm.NewYugabyteDBCDCClient(exportDir, "", source.SSLRootCert, source.DBName, strings.Split(source.TableList, ",")[0], metaDB).DeleteStreamID()
+	if err != nil {
+		utils.ErrExit("end migration: deleting yugabytedb cdc stream id: %v", err)
+	}
+}
+
+func cleanupTargetDB(msr *metadb.MigrationStatusRecord) {
+	if msr.TargetDBConf == nil {
+		log.Infof("target db conf is not set. skipping cleanup")
+		return
+	}
+	tdb := tgtdb.NewTargetDB(msr.TargetDBConf)
+	err := tdb.Init()
+	if err != nil {
+		utils.ErrExit("end migration: initializing target db: %v", err)
+	}
+	defer tdb.Finalize()
+	tdb.ClearMigrationState(migrationUUID, exportDir)
+}
+
+func cleanupFallForwardDB(msr *metadb.MigrationStatusRecord) {
+	if msr.FallForwardEnabled {
+		ffdb := tgtdb.NewTargetDB(msr.FallForwardDBConf)
+		err := ffdb.Init()
+		if err != nil {
+			utils.ErrExit("end migration: initializing fallforward db: %v", err)
+		}
+		defer ffdb.Finalize()
+		ffdb.ClearMigrationState(migrationUUID, exportDir)
+	}
+}
+
+func cleanupFallBackDB(msr *metadb.MigrationStatusRecord) {
+	if msr.FallbackEnabled {
+		fbdb := tgtdb.NewTargetDB(msr.SourceDBAsTargetConf)
+		err := fbdb.Init()
+		if err != nil {
+			utils.ErrExit("end migration: initializing fallback db: %v", err)
+		}
+		defer fbdb.Finalize()
+		fbdb.ClearMigrationState(migrationUUID, exportDir)
+	}
+}
+
+func validateEndMigrationFlags(cmd *cobra.Command) error {
+	flags := []string{"backup-schema-files", "backup-data-files", "backup-migration-reports", "backup-log-files"}
+	for _, flag := range flags {
+		if cmd.Flag(flag).Value.String() == "true" && !cmd.Flag("backup-dir").Changed {
+			return fmt.Errorf("flag %s requires --backup-dir flag to be set", flag)
+		}
+	}
+	return nil
+}
+
+func checkIfEndCommandCanBePerformed() {
+	// check if any ongoing voyager command
+	matches, err := filepath.Glob(filepath.Join(exportDir, ".*.lck"))
+	if err != nil {
+		utils.ErrExit("end migration: checking for ongoing voyager commands: %v", err)
+	}
+	if len(matches) > 0 {
+		var ongoingCmds []string
+		for _, match := range matches {
+			match = strings.TrimPrefix(match, ".")
+			match = strings.TrimSuffix(match, "Lockfile.lck")
+			if match == "end-migration" {
+				continue
+			}
+			ongoingCmds = append(ongoingCmds, match)
+		}
+		if len(ongoingCmds) > 0 &&
+			!utils.AskPrompt(fmt.Sprintf("found ongoing voyager commands: %s. Do you want to continue", strings.Join(ongoingCmds, ", "))) {
+			utils.ErrExit("aborting the end migration command")
+		}
+	} else {
+		log.Infof("no ongoing voyager commands found")
+	}
+
+	if backupDataFiles {
+		// verify that the size of backup-data dir to be greater the export-dir/data dir
+		exportDirDataSize, err := calculateDirSizeWithPattern(exportDir, "data/*.sql")
+		if err != nil {
+			utils.ErrExit("end migration: calculating export dir data size: %v", err)
+		}
+
+		backupDirSize, err := getFreeDiskSpace(backupDir)
+		if err != nil {
+			utils.ErrExit("end migration: calculating backup dir size: %v", err)
+		}
+
+		if exportDirDataSize >= int64(backupDirSize) {
+			utils.ErrExit(`end migration: backup directory free space is less than the export directory data size.
+			Please provide a backup directory with more free space than the export directory data size(%s).`, humanize.Bytes(uint64(exportDirDataSize)))
+
+		}
+	}
+
+	// TODO: more checks like if the migration is in progress or not
+}
+
+func calculateDirSizeWithPattern(dirPath string, filePattern string) (int64, error) {
+	var size int64
+
+	fileMatches, err := filepath.Glob(filepath.Join(dirPath, filePattern))
+	if err != nil {
+		return 0, err
+	}
+
+	for _, filePath := range fileMatches {
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			return 0, err
+		}
+
+		if !fileInfo.IsDir() {
+			size += fileInfo.Size()
+		}
+	}
+
+	return size, nil
+}
+
+func getFreeDiskSpace(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	// calculate the free space in bytes
+	freeSpace := stat.Bfree * uint64(stat.Bsize)
+	return freeSpace, nil
+}
+
+func init() {
+	endCmd.AddCommand(endMigrationCmd)
+
+	BoolVar(endMigrationCmd.Flags(), &backupSchemaFiles, "backup-schema-files", false, "backup migration schema files")
+	BoolVar(endMigrationCmd.Flags(), &backupDataFiles, "backup-data-files", false, "backup migration data files")
+	// Name of flag: backup-migration-reports or save-migration-reports
+	BoolVar(endMigrationCmd.Flags(), &backupMigrationFiles, "backup-migration-reports", false, "backup migration reports")
+	BoolVar(endMigrationCmd.Flags(), &backupLogFiles, "backup-log-files", false, "backup migration log files")
+	endMigrationCmd.Flags().StringVar(&backupDir, "backup-dir", "", "backup directory")
+	endMigrationCmd.Flags().StringVarP(&exportDir, "export-dir", "e", "",
+		"export directory is the workspace used to keep the exported schema, data, state, and logs")
+
+	endMigrationCmd.MarkFlagRequired("backup-schema-files")
+	endMigrationCmd.MarkFlagRequired("backup-data-files")
+	endMigrationCmd.MarkFlagRequired("backup-migration-reports")
+	endMigrationCmd.MarkFlagRequired("backup-log-files")
+	endMigrationCmd.MarkFlagRequired("export-dir")
+}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -132,7 +132,7 @@ func startFallforwardSynchronizeIfRequired() {
 	}
 	msr, err := metaDB.GetMigrationStatusRecord()
 	if err != nil {
-		utils.ErrExit("could not fetch MigrationstatusRecord: %w", err)
+		utils.ErrExit("could not fetch MigrationStatusRecord: %w", err)
 	}
 	if !msr.FallForwardEnabled && !msr.FallbackEnabled {
 		utils.PrintAndLog("No fall-forward/back enabled. Exiting.")

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -424,7 +424,7 @@ func importData(importFileTasks []*ImportFileTask) {
 			utils.PrintAndLog("All the tables are already imported, nothing left to import\n")
 		} else {
 			utils.PrintAndLog("Tables to import: %v", importFileTasksToTableNames(pendingTasks))
-			prepareTableToColumns(pendingTasks)                                                  //prepare the tableToColumns map
+			prepareTableToColumns(pendingTasks) //prepare the tableToColumns map
 			poolSize := tconf.Parallelism * 2
 			progressReporter := NewImportDataProgressReporter(bool(disablePb))
 			for _, task := range pendingTasks {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -49,7 +49,6 @@ var importSchemaCmd = &cobra.Command{
 		if err != nil {
 			utils.ErrExit("Error: %s", err.Error())
 		}
-
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -105,6 +105,8 @@ func shouldLock(cmd *cobra.Command) bool {
 		"yb-voyager fall-forward status",
 		"yb-voyager cutover initiate",
 		"yb-voyager fall-forward switchover",
+		"yb-voyager end",
+		"yb-voyager end migration",
 	}
 	return !slices.Contains(noLockNeededList, cmd.CommandPath())
 }

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.5
 	github.com/davecgh/go-spew v1.1.1
+	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/godror/godror v0.30.2
-	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/gosuri/uilive v0.0.4
 	github.com/gosuri/uitable v0.0.4
@@ -38,7 +38,6 @@ require (
 )
 
 require (
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/godror/godror v0.30.2
+	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/gosuri/uilive v0.0.4
 	github.com/gosuri/uitable v0.0.4
@@ -37,6 +38,7 @@ require (
 )
 
 require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
@@ -83,7 +85,6 @@ require (
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
-	github.com/gosuri/uilive v0.0.4
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -108,7 +109,7 @@ require (
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/subosito/gotenv v1.4.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -849,6 +849,8 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
@@ -344,4 +345,8 @@ func (ms *MySQL) GetServers() []string {
 
 func (ms *MySQL) GetPartitions(tableName *sqlname.SourceName) []*sqlname.SourceName {
 	panic("not implemented")
-} 
+}
+
+func (ms *MySQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
+	panic("ClearMigrationState() not implemented for MySQL yet")
+}

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -348,5 +348,6 @@ func (ms *MySQL) GetPartitions(tableName *sqlname.SourceName) []*sqlname.SourceN
 }
 
 func (ms *MySQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
-	panic("ClearMigrationState() not implemented for MySQL yet")
+	log.Infof("ClearMigrationState not implemented yet for MySQL")
+	return nil
 }

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 
@@ -447,4 +448,16 @@ func (ora *Oracle) GetServers() []string {
 
 func (ora *Oracle) GetPartitions(tableName *sqlname.SourceName) []*sqlname.SourceName {
 	panic("not implemented")
-} 
+}
+
+func (ora *Oracle) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
+	_, err := ora.db.Exec("DROP TABLE LOG_MINING_FLUSH")
+	if err != nil {
+		if strings.Contains(err.Error(), "ORA-00942") {
+			// Table does not exist, so nothing to drop
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -451,6 +451,8 @@ func (ora *Oracle) GetPartitions(tableName *sqlname.SourceName) []*sqlname.Sourc
 }
 
 func (ora *Oracle) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
+	log.Infof("Clearing migration state for migration %q", migrationUUID)
+	log.Infof("Dropping table LOG_MINING_FLUSH")
 	_, err := ora.db.Exec("DROP TABLE LOG_MINING_FLUSH")
 	if err != nil {
 		if strings.Contains(err.Error(), "ORA-00942") {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -453,13 +453,14 @@ func (ora *Oracle) GetPartitions(tableName *sqlname.SourceName) []*sqlname.Sourc
 func (ora *Oracle) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
 	log.Infof("Clearing migration state for migration %q", migrationUUID)
 	log.Infof("Dropping table LOG_MINING_FLUSH")
-	_, err := ora.db.Exec("DROP TABLE LOG_MINING_FLUSH")
+	logMiningFlushTableName := "LOG_MINING_FLUSH"
+	_, err := ora.db.Exec(fmt.Sprintf("DROP TABLE %s", logMiningFlushTableName))
 	if err != nil {
 		if strings.Contains(err.Error(), "ORA-00942") {
 			// Table does not exist, so nothing to drop
 			return nil
 		}
-		return err
+		return fmt.Errorf("drop table %s: %w", logMiningFlushTableName, err)
 	}
 	return nil
 }

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -504,5 +504,6 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 }
 
 func (pg *PostgreSQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
-	panic("ClearMigrationState() not implemented for PostgreSQL yet")
+	log.Infof("ClearMigrationState not implemented yet for PostgreSQL")
+	return nil
 }

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
 	"github.com/mcuadros/go-version"
 	log "github.com/sirupsen/logrus"
@@ -500,4 +501,8 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 		utils.ErrExit("Error in scanning for child partitions of table=%s: %v", tableName, rows.Err())
 	}
 	return partitions
-} 
+}
+
+func (pg *PostgreSQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
+	panic("ClearMigrationState() not implemented for PostgreSQL yet")
+}

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
@@ -46,6 +47,7 @@ type SourceDB interface {
 	GetAllSequences() []string
 	GetServers() []string
 	GetPartitions(table *sqlname.SourceName) []*sqlname.SourceName
+	ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error
 }
 
 func newSourceDB(source *Source) SourceDB {

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
 	log "github.com/sirupsen/logrus"
 
@@ -445,4 +446,8 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 		utils.ErrExit("Error in scanning for child partitions of table=%s: %v", tableName, rows.Err())
 	}
 	return partitions
+}
+
+func (yb *YugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
+	panic("ClearMigrationState() not implemented for YugabyteDB yet")
 }

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -449,5 +449,6 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 }
 
 func (yb *YugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
-	panic("ClearMigrationState() not implemented for YugabyteDB yet")
+	log.Infof("ClearMigrationState not implemented yet for YugabyteDB")
+	return nil
 }

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -754,7 +754,8 @@ func (tdb *TargetOracleDB) ClearMigrationState(migrationUUID uuid.UUID, exportDi
 		}
 	}
 
-	// manually delete the USER in case of Oracle
+	// ask to manually delete the USER in case of FF or FB
+	// TODO: check and inform user if there is another migrationUUID data in metadata schema tables before cleaning up the schema
 	utils.PrintAndLog(`Please manually delete the user '%s' from the '%s' host using the following SQL statement:
 		DROP USER %s CASCADE`, tdb.tconf.Schema, tdb.tconf.Host, tdb.tconf.Schema)
 	return nil

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -732,8 +732,8 @@ func (tdb *TargetOracleDB) ClearMigrationState(migrationUUID uuid.UUID, exportDi
 			log.Infof("table %s does not exist, nothing to clear for migration state", table)
 			continue
 		}
-		query := fmt.Sprintf("DELETE FROM %s WHERE migration_uuid = '%s", table, migrationUUID)
-		_, err := tdb.conn.ExecContext(context.Background(), query, migrationUUID)
+		query := fmt.Sprintf("DELETE FROM %s WHERE migration_uuid = '%s'", table, migrationUUID)
+		_, err := tdb.conn.ExecContext(context.Background(), query)
 		if err != nil {
 			log.Errorf("error cleaning up table %s: %v", table, err)
 			return fmt.Errorf("error cleaning up table %s: %w", table, err)
@@ -742,7 +742,7 @@ func (tdb *TargetOracleDB) ClearMigrationState(migrationUUID uuid.UUID, exportDi
 
 	// ask to manually delete the USER in case of FF or FB
 	// TODO: check and inform user if there is another migrationUUID data in metadata schema tables before cleaning up the schema
-	utils.PrintAndLog(`Please manually delete the user '%s' from the '%s' host using the following SQL statement:
-		DROP USER %s CASCADE`, tdb.tconf.Schema, tdb.tconf.Host, tdb.tconf.Schema)
+	utils.PrintAndLog(`Please manually delete the user '%s' from the '%s' host using the following SQL statement(after making sure no other migration is IN-PROGRESS):
+DROP USER %s CASCADE`, tdb.tconf.Schema, tdb.tconf.Host, tdb.tconf.Schema)
 	return nil
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -46,6 +46,7 @@ type TargetDB interface {
 	DisableGeneratedAlwaysAsIdentityColumns(tableColumnsMap map[string][]string) error
 	EnableGeneratedAlwaysAsIdentityColumns(tableColumnsMap map[string][]string) error
 	EnableGeneratedByDefaultAsIdentityColumns(tableColumnsMap map[string][]string) error
+	ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error
 
 	// NOTE: The following four methods should not be used for arbitrary query
 	// execution on TargetDB. The should be only used from higher level

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1091,7 +1091,8 @@ func (yb *TargetYugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportD
 	nonEmptyTables := yb.GetNonEmptyTables(tables)
 	if len(nonEmptyTables) != 0 {
 		log.Infof("tables %v are not empty in schema %s", nonEmptyTables, schema)
-		utils.PrintAndLog("removed the current migration state from the target DB. "+"But could not remove the schema %s as it is not empty", schema)
+		utils.PrintAndLog("removed the current migration state from the target DB. "+
+			"But could not remove the schema %s as it still contains state of other migrations in '%s' database", schema, yb.tconf.DBName)
 		return nil
 	}
 	log.Infof("dropping schema %s", schema)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1093,7 +1093,7 @@ func (yb *TargetYugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportD
 			"But could not remove the schema %s as it still contains state of other migrations in '%s' database", schema, yb.tconf.DBName)
 		return nil
 	}
-	log.Infof("dropping schema %s", schema)
+	utils.PrintAndLog("dropping schema %s", schema)
 	query := fmt.Sprintf("DROP SCHEMA %s CASCADE", schema)
 	_, err := yb.conn_.Exec(context.Background(), query)
 	if err != nil {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -305,7 +305,7 @@ func (yb *TargetYugabyteDB) GetNonEmptyTables(tables []string) []string {
 	result := []string{}
 
 	for _, table := range tables {
-		log.Infof("Checking if table %q is empty.", table)
+		log.Infof("checking if table %q is empty.", table)
 		tmp := false
 		stmt := fmt.Sprintf("SELECT TRUE FROM %s LIMIT 1;", table)
 		err := yb.Conn().QueryRow(context.Background(), stmt).Scan(&tmp)
@@ -1104,7 +1104,7 @@ func (yb *TargetYugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportD
 		if !yb.isTableExists(table) {
 			continue
 		}
-		query := fmt.Sprintf("DELETE FROM %s WHERE migration_uuid = '%s", table, migrationUUID)
+		query := fmt.Sprintf("DELETE FROM %s WHERE migration_uuid = '%s'", table, migrationUUID)
 		_, err := yb.Exec(query)
 		if err != nil {
 			log.Errorf("error cleaning up table %s for migrationUUID=%s: %v", table, migrationUUID, err)
@@ -1116,8 +1116,9 @@ func (yb *TargetYugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportD
 	if len(nonEmptyTables) != 0 {
 		log.Infof("tables %v are not empty in schema %s", nonEmptyTables, schema)
 		utils.PrintAndLog("removed the current migration state from the target DB. "+"But could not remove the schema %s as it is not empty", schema)
+		return nil
 	}
-
+	log.Infof("dropping schema %s", schema)
 	query := fmt.Sprintf("DROP SCHEMA %s CASCADE", schema)
 	_, err := yb.conn_.Exec(context.Background(), query)
 	if err != nil {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -235,19 +235,6 @@ func (yb *TargetYugabyteDB) CreateVoyagerSchema() error {
 			rows_imported BIGINT,
 			PRIMARY KEY (migration_uuid, data_file_name, batch_number, schema_name, table_name)
 		);`, BATCH_METADATA_TABLE_NAME),
-		fmt.Sprintf(`ALTER TABLE %s 
-			ADD COLUMN IF NOT EXISTS 
-			migration_uuid uuid`,
-			BATCH_METADATA_TABLE_NAME),
-		fmt.Sprintf(`ALTER TABLE %s 
-			DROP CONSTRAINT 
-			ybvoyager_import_data_batches_metainfo_v2_pkey;`,
-			BATCH_METADATA_TABLE_NAME),
-		fmt.Sprintf(`ALTER TABLE %s
-			ADD CONSTRAINT
-			ybvoyager_import_data_batches_metainfo_v2_pkey
-			PRIMARY KEY (migration_uuid, data_file_name, batch_number, schema_name, table_name);`,
-			BATCH_METADATA_TABLE_NAME),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			migration_uuid uuid,
 			channel_no INT,

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1044,25 +1044,23 @@ func (yb *TargetYugabyteDB) splitMaybeQualifiedTableName(tableName string) (stri
 
 func (yb *TargetYugabyteDB) isSchemaExists(schema string) bool {
 	query := fmt.Sprintf("SELECT true FROM information_schema.schemata WHERE schema_name = '%s'", schema)
-	rows, err := yb.Query(query)
-	if err != nil {
-		utils.ErrExit("error checking if schema %s exists: %v", schema, err)
-	}
-	defer rows.Close()
-
-	return rows.Next()
+	return yb.isQueryResultEmpty(query)
 }
 
 func (yb *TargetYugabyteDB) isTableExists(qualifiedTableName string) bool {
 	schema, table := yb.splitMaybeQualifiedTableName(qualifiedTableName)
 	query := fmt.Sprintf("SELECT true FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'", schema, table)
+	return yb.isQueryResultEmpty(query)
+}
+
+func (yb *TargetYugabyteDB) isQueryResultEmpty(query string) bool {
 	rows, err := yb.Query(query)
 	if err != nil {
-		utils.ErrExit("error checking if table %s exists: %v", qualifiedTableName, err)
+		utils.ErrExit("error checking if query %s is empty: %v", query, err)
 	}
 	defer rows.Close()
 
-	return rows.Next()
+	return !rows.Next()
 }
 
 func (yb *TargetYugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {

--- a/yb-voyager/src/utils/boolStr_type.go
+++ b/yb-voyager/src/utils/boolStr_type.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"strings"
-
 )
 
 //Handling Bool flags with an explicit type
@@ -33,4 +32,3 @@ func (b *BoolStr) String() string {
 	}
 	return "false"
 }
-


### PR DESCRIPTION
This is how the UI looks like:

1. End migration for live migration with fall-back
```
[centos@ip-10-9-2-160 oracle-dbzmtest-migration]$  yb-voyager end migration --backup-dir /home/centos/dev-server-ssinghal/home/centos/backup-migs2 --export-dir . --backup-schema-files true --save-migration-reports true --backup-data-files true --backup-log-files true
Migration can't be resumed or continued after this. Are you sure you want to end the migration? [Y/N]: y
migrationID: 615db48d-2935-4b1e-92de-f3cbd51623aa
found other ongoing voyager commands: export-data, export-schema, import-data. Do you want to continue with end migration command? [Y/N]: y
backing up schema files
backing up snapshot sql data files
saving schema analysis report
saving data export reports...
saving data import reports...
Password to connect to target DB (In addition, you can also set the password using the environment variable 'TARGET_DB_PASSWORD'):
Password to connect to fall-back DB (In addition, you can also set the password using the environment variable 'SOURCE_DB_PASSWORD'):
cleaning up voyager state from source db...
cleaning up voyager state from target db...
cleaning up voyager state from fallback db...
Please manually delete the user 'DBZMTEST' from the 'ssinghal-dms-oracle.cbtcvpszcgdq.us-west-2.rds.amazonaws.com' host using the following SQL statement(after making sure no other migration is IN-PROGRESS):
DROP USER DBZMTEST CASCADE
backing up log files
cleaning up export dir...
Migration ended successfully
```

2. End migration for live migration with fall forward
```
[centos@ip-10-9-2-160 oracle-dbzmtest-migration]$  yb-voyager end migration --backup-dir /home/centos/dev-server-ssinghal/home/centos/backup-migs2 --export-dir . --backup-schema-files true --save-migration-reports true --backup-data-files true --backup-log-files true
Migration can't be resumed or continued after this. Are you sure you want to end the migration? [Y/N]: y
migrationID: ab3731f2-ede1-4580-a2b8-c887aba9016f
found other ongoing voyager commands: fall-forward-setup, fall-forward-synchronize, import-data. Do you want to continue with end migration command? [Y/N]: y
backing up schema files
backing up snapshot sql data files
saving schema analysis report
saving data export reports...
saving data import reports...
Password to connect to target DB (In addition, you can also set the password using the environment variable 'TARGET_DB_PASSWORD'):
Password to connect to fall-forward DB (In addition, you can also set the password using the environment variable 'FF_DB_PASSWORD'):
cleaning up voyager state from source db...
Password to connect to 'admin' user of source DB (In addition, you can also set the password using the environment variable 'SOURCE_DB_PASSWORD'):
cleaning up voyager state from target db...
Deleting YugabyteDB CDC stream id
Deleted YugabyteDB CDC stream-id: d9e758ad511c4609a7318e5c4a067aa2
cleaning up voyager state from fall-forward db...
Please manually delete the user 'SAKILA_DEMO' from the 'ssinghal-dms-oracle.cbtcvpszcgdq.us-west-2.rds.amazonaws.com' host using the following SQL statement(after making sure no other migration is IN-PROGRESS):
DROP USER SAKILA_DEMO CASCADE
backing up log files
cleaning up export dir...
Migration ended successfully
```