### PR TITLE
Bug fix for export data status while fetching event counts from metadb

### DIFF
--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -108,7 +108,18 @@ func getSnapshotExportStatusRow(tableStatus *dbzm.TableExportStatus) *exportTabl
 }
 
 func getSnapshotAndChangesExportStatusRow(tableStatus *dbzm.TableExportStatus) *exportTableMigStatusOutputRow {
-	eventCounter, err := metaDB.GetExportedEventsStatsForTable(tableStatus.SchemaName, tableStatus.TableName)
+	msr, err := metaDB.GetMigrationStatusRecord()
+	if err != nil {
+		utils.ErrExit("could not fetch migration status from meta DB: %w", err)
+	}
+	source = *msr.SourceDBConf
+	sourceSchemaCount := len(strings.Split(source.Schema, "|"))
+	schemaName := tableStatus.SchemaName
+	if sourceSchemaCount <= 1 {
+		schemaName = ""
+	}
+
+	eventCounter, err := metaDB.GetExportedEventsStatsForTable(schemaName, tableStatus.TableName)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		utils.ErrExit("could not fetch table stats from meta DB: %w", err)
 	}

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -290,7 +290,7 @@ func (ora *Oracle) FilterUnsupportedTables(tableList []*sqlname.SourceName, useD
 	}
 
 	for _, table := range tableList {
-		if !slices.Contains(unsupportedTableList, table) {
+		if !slices.Contains(unsupportedTableList, table) && table.ObjectName.MinQuoted != "LOG_MINING_FLUSH" {
 			filteredTableList = append(filteredTableList, table)
 		}
 	}


### PR DESCRIPTION
2. Removed `LOG_MINING_FLUSH` table from the list when it stays in one migration and comes up when we do start-clean