### PR TITLE
[DB-8651] Bug fix: unlockExportDir() not being called for import/export data command in case of fall-forward/fall-back enabled

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -455,7 +455,7 @@ func startFallBackSetupIfRequired() {
 		return
 	}
 
-	unlockExportDir() // unlock export dir from export data cmd before starting fall-back setup cmd
+	unlockExportDir() // unlock export dir from export data cmd before switching current process to fall-back setup cmd
 	cmd := []string{"yb-voyager", "fall-back", "setup",
 		"--export-dir", exportDir,
 		fmt.Sprintf("--send-diagnostics=%t", callhome.SendDiagnostics),

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -455,6 +455,7 @@ func startFallBackSetupIfRequired() {
 		return
 	}
 
+	unlockExportDir() // unlock export dir from export data cmd before starting fall-back setup cmd
 	cmd := []string{"yb-voyager", "fall-back", "setup",
 		"--export-dir", exportDir,
 		fmt.Sprintf("--send-diagnostics=%t", callhome.SendDiagnostics),

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -153,6 +153,7 @@ func startFallforwardSynchronizeIfRequired() {
 		voyagerCmdPrefix = "fall-back"
 	}
 
+	unlockExportDir() // unlock export dir from import data cmd before starting ff/fb sync cmd
 	cmd := []string{"yb-voyager", voyagerCmdPrefix, "synchronize",
 		"--export-dir", exportDir,
 		"--table-list", strings.Join(unqualifiedTableList, ","),
@@ -424,7 +425,7 @@ func importData(importFileTasks []*ImportFileTask) {
 			utils.PrintAndLog("All the tables are already imported, nothing left to import\n")
 		} else {
 			utils.PrintAndLog("Tables to import: %v", importFileTasksToTableNames(pendingTasks))
-			prepareTableToColumns(pendingTasks)                                                  //prepare the tableToColumns map
+			prepareTableToColumns(pendingTasks) //prepare the tableToColumns map
 			poolSize := tconf.Parallelism * 2
 			progressReporter := NewImportDataProgressReporter(bool(disablePb))
 			for _, task := range pendingTasks {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -153,7 +153,7 @@ func startFallforwardSynchronizeIfRequired() {
 		voyagerCmdPrefix = "fall-back"
 	}
 
-	unlockExportDir() // unlock export dir from import data cmd before starting ff/fb sync cmd
+	unlockExportDir() // unlock export dir from import data cmd before switching current process to ff/fb sync cmd
 	cmd := []string{"yb-voyager", voyagerCmdPrefix, "synchronize",
 		"--export-dir", exportDir,
 		"--table-list", strings.Join(unqualifiedTableList, ","),


### PR DESCRIPTION
- calling unlockExportDir() manually before switching the process to fall-forward/fall-back sync/setup commands

This bug wa causing exportData and importData lockfile to be leftover even after everything is complete in case of fall-back and fall-forward, which this PR fixes.

Jira Ticket: https://yugabyte.atlassian.net/browse/DB-8651
