### PR TITLE
Bug fixes in end migration command

### DIFF
--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -70,9 +70,9 @@ func endMigrationCommandFn(cmd *cobra.Command, args []string) {
 	checkIfEndCommandCanBePerformed(msr)
 
 	// backing up the state from the export directory
+	saveMigrationReportsFn(msr)
 	backupSchemaFilesFn()
 	backupDataFilesFn()
-	saveMigrationReportsFn(msr)
 
 	// cleaning only the migration state wherever and  whatever required
 	cleanupSourceDB(msr)

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -696,13 +696,15 @@ func (tdb *TargetOracleDB) splitMaybeQualifiedTableName(tableName string) (strin
 }
 
 func (tdb *TargetOracleDB) isSchemaExists(schema string) bool {
-	query := fmt.Sprintf("SELECT 1 FROM ALL_USERS WHERE USERNAME = '%s'", schema)
+	// TODO: handle case-sensitivity properly
+	query := fmt.Sprintf("SELECT 1 FROM ALL_USERS WHERE USERNAME = UPPER('%s')", schema)
 	return tdb.isQueryResultNonEmpty(query)
 }
 
 func (tdb *TargetOracleDB) isTableExists(qualifiedTableName string) bool {
 	schema, table := tdb.splitMaybeQualifiedTableName(qualifiedTableName)
-	query := fmt.Sprintf("SELECT 1 FROM ALL_TABLES WHERE TABLE_NAME = '%s' AND OWNER = '%s'", table, schema)
+	// TODO: handle case-sensitivity properly
+	query := fmt.Sprintf("SELECT 1 FROM ALL_TABLES WHERE TABLE_NAME = UPPER('%s') AND OWNER = UPPER('%s')", table, schema)
 	return tdb.isQueryResultNonEmpty(query)
 }
 
@@ -743,7 +745,7 @@ func (tdb *TargetOracleDB) ClearMigrationState(migrationUUID uuid.UUID, exportDi
 
 	// ask to manually delete the USER in case of FF or FB
 	// TODO: check and inform user if there is another migrationUUID data in metadata schema tables before cleaning up the schema
-	utils.PrintAndLog(`Please manually delete the user '%s' from the '%s' host using the following SQL statement(after making sure no other migration is IN-PROGRESS):
-DROP USER %s CASCADE`, tdb.tconf.Schema, tdb.tconf.Host, tdb.tconf.Schema)
+	utils.PrintAndLog(`Please manually delete the metadata schema '%s' from the '%s' host using the following SQL statement(after making sure no other migration is IN-PROGRESS):
+	DROP USER %s CASCADE`, schema, tdb.tconf.Host, schema)
 	return nil
 }


### PR DESCRIPTION
1. Bug Fix[DB-8841]: Export data report fails to backup for offline migration
- reason being we backedup and remove data files before saving the reports, moved saveMigrationReportsFn() before backing up data files
https://yugabyte.atlassian.net/browse/DB-8840

2. Bug fix: Oracle handling case-sensitivity for ClearMigrationState function
https://yugabyte.atlassian.net/browse/DB-8841