### PR TITLE
Fix in data-migration-report and misc UI fixes for new changed commands

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -373,7 +373,7 @@ end_migration() {
 	# setting env vars for passwords to be used for saving reports
 	export SOURCE_DB_PASSWORD=${SOURCE_DB_PASSWORD}
 	export TARGET_DB_PASSWORD=${TARGET_DB_PASSWORD}
-	export FF_DB_PASSWORD=${FF_DB_PASSWORD}
+	export SOURCE_REPLICA_DB_PASSWORD=${FF_DB_PASSWORD}
 
 	yb-voyager end migration --export-dir ${EXPORT_DIR} \
 	--backup-dir ${BACKUP_DIR} --backup-schema-files true \

--- a/yb-voyager/cmd/cutover.go
+++ b/yb-voyager/cmd/cutover.go
@@ -27,7 +27,7 @@ import (
 
 var cutoverCmd = &cobra.Command{
 	Use:   "cutover",
-	Short: "Prepare to point your application to a different database during live migration.",
+	Short: "Pointing your application to a different database during live migration.",
 	Long:  "",
 }
 

--- a/yb-voyager/cmd/cutover.go
+++ b/yb-voyager/cmd/cutover.go
@@ -27,7 +27,7 @@ import (
 
 var cutoverCmd = &cobra.Command{
 	Use:   "cutover",
-	Short: "Pointing your application to a different database during live migration.",
+	Short: "Prepare to point your application to a different database during live migration.",
 	Long:  "",
 }
 

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -161,7 +161,7 @@ func saveMigrationReportsFn(msr *metadb.MigrationStatusRecord) {
 	askAndStorePasswords(msr)
 	passwordsEnvVars := []string{
 		fmt.Sprintf("TARGET_DB_PASSWORD=%s", targetDBPassword),
-		fmt.Sprintf("FF_DB_PASSWORD=%s", fallForwardDBPassword),
+		fmt.Sprintf("SOURCE_REPLICA_DB_PASSWORD=%s", fallForwardDBPassword),
 		fmt.Sprintf("SOURCE_DB_PASSWORD=%s", sourceDBPassword),
 	}
 
@@ -234,7 +234,7 @@ func askAndStorePasswords(msr *metadb.MigrationStatusRecord) {
 		utils.ErrExit("getting target db password: %v", err)
 	}
 	if msr.FallForwardEnabled {
-		fallForwardDBPassword, err = askPassword("fall-forward DB", "", "FF_DB_PASSWORD")
+		fallForwardDBPassword, err = askPassword("source-replica DB", "", "SOURCE_REPLICA_DB_PASSWORD")
 		if err != nil {
 			utils.ErrExit("getting fall-forward db password: %v", err)
 		}
@@ -381,7 +381,7 @@ func cleanupFallForwardDB(msr *metadb.MigrationStatusRecord) {
 	ffconf := msr.FallForwardDBConf
 	ffconf.Password = fallForwardDBPassword
 	if fallForwardDBPassword == "" {
-		ffconf.Password, err = askPassword("fall-forward DB", ffconf.User, "FF_DB_PASSWORD")
+		ffconf.Password, err = askPassword("fall-forward DB", ffconf.User, "_DB_PASSWORD")
 		if err != nil {
 			utils.ErrExit("getting fall-forward db password: %v", err)
 		}

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -236,7 +236,7 @@ func askAndStorePasswords(msr *metadb.MigrationStatusRecord) {
 	if msr.FallForwardEnabled {
 		fallForwardDBPassword, err = askPassword("source-replica DB", "", "SOURCE_REPLICA_DB_PASSWORD")
 		if err != nil {
-			utils.ErrExit("getting fall-forward db password: %v", err)
+			utils.ErrExit("getting source-replica db password: %v", err)
 		}
 	}
 	if msr.FallbackEnabled {
@@ -376,25 +376,25 @@ func cleanupFallForwardDB(msr *metadb.MigrationStatusRecord) {
 		return
 	}
 
-	utils.PrintAndLog("cleaning up voyager state from fall-forward db...")
+	utils.PrintAndLog("cleaning up voyager state from source-replica db...")
 	var err error
 	ffconf := msr.FallForwardDBConf
 	ffconf.Password = fallForwardDBPassword
 	if fallForwardDBPassword == "" {
-		ffconf.Password, err = askPassword("fall-forward DB", ffconf.User, "_DB_PASSWORD")
+		ffconf.Password, err = askPassword("source-replica DB", ffconf.User, "SOURCE_REPLICA_DB_PASSWORD")
 		if err != nil {
-			utils.ErrExit("getting fall-forward db password: %v", err)
+			utils.ErrExit("getting source-replica db password: %v", err)
 		}
 	}
 	ffdb := tgtdb.NewTargetDB(ffconf)
 	err = ffdb.Init()
 	if err != nil {
-		utils.ErrExit("initializing fallforward db: %v", err)
+		utils.ErrExit("initializing source-replica db: %v", err)
 	}
 	defer ffdb.Finalize()
 	err = ffdb.ClearMigrationState(migrationUUID, exportDir)
 	if err != nil {
-		utils.ErrExit("clearing migration state from fallforward db: %v", err)
+		utils.ErrExit("clearing migration state from source-replica db: %v", err)
 	}
 }
 

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -29,7 +29,7 @@ var (
 	backupLogFiles        utils.BoolStr
 	backupDir             string
 	targetDBPassword      string
-	fallForwardDBPassword string
+	sourceReplicaDBPassword string
 	sourceDBPassword      string
 )
 
@@ -175,7 +175,7 @@ func saveDataMigrationReport(msr *metadb.MigrationStatusRecord) {
 	askAndStorePasswords(msr)
 	passwordsEnvVars := []string{
 		fmt.Sprintf("TARGET_DB_PASSWORD=%s", targetDBPassword),
-		fmt.Sprintf("SOURCE_REPLICA_DB_PASSWORD=%s", fallForwardDBPassword),
+		fmt.Sprintf("SOURCE_REPLICA_DB_PASSWORD=%s", sourceReplicaDBPassword),
 		fmt.Sprintf("SOURCE_DB_PASSWORD=%s", sourceDBPassword),
 	}
 	liveMigrationReportFilePath := filepath.Join(backupDir, "reports", "data_migration_report.txt")
@@ -249,7 +249,7 @@ func askAndStorePasswords(msr *metadb.MigrationStatusRecord) {
 		utils.ErrExit("getting target db password: %v", err)
 	}
 	if msr.FallForwardEnabled {
-		fallForwardDBPassword, err = askPassword("source-replica DB", "", "SOURCE_REPLICA_DB_PASSWORD")
+		sourceReplicaDBPassword, err = askPassword("source-replica DB", "", "SOURCE_REPLICA_DB_PASSWORD")
 		if err != nil {
 			utils.ErrExit("getting source-replica db password: %v", err)
 		}
@@ -393,21 +393,21 @@ func cleanupFallForwardDB(msr *metadb.MigrationStatusRecord) {
 
 	utils.PrintAndLog("cleaning up voyager state from source-replica db...")
 	var err error
-	ffconf := msr.FallForwardDBConf
-	ffconf.Password = fallForwardDBPassword
-	if fallForwardDBPassword == "" {
-		ffconf.Password, err = askPassword("source-replica DB", ffconf.User, "SOURCE_REPLICA_DB_PASSWORD")
+	sourceReplicaconf := msr.FallForwardDBConf
+	sourceReplicaconf.Password = sourceReplicaDBPassword
+	if sourceReplicaDBPassword == "" {
+		sourceReplicaconf.Password, err = askPassword("source-replica DB", sourceReplicaconf.User, "SOURCE_REPLICA_DB_PASSWORD")
 		if err != nil {
 			utils.ErrExit("getting source-replica db password: %v", err)
 		}
 	}
-	ffdb := tgtdb.NewTargetDB(ffconf)
-	err = ffdb.Init()
+	sourceReplicaDB := tgtdb.NewTargetDB(sourceReplicaconf)
+	err = sourceReplicaDB.Init()
 	if err != nil {
 		utils.ErrExit("initializing source-replica db: %v", err)
 	}
-	defer ffdb.Finalize()
-	err = ffdb.ClearMigrationState(migrationUUID, exportDir)
+	defer sourceReplicaDB.Finalize()
+	err = sourceReplicaDB.ClearMigrationState(migrationUUID, exportDir)
 	if err != nil {
 		utils.ErrExit("clearing migration state from source-replica db: %v", err)
 	}

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -61,7 +61,7 @@ func registerSourceDBConnFlags(cmd *cobra.Command, includeOracleCDBFlags bool) {
 	cmd.Flags().StringVar(&source.Host, "source-db-host", "localhost",
 		"source database server host")
 
-	cmd.Flags().IntVar(&source.Port, "source-db-port", -1,
+	cmd.Flags().IntVar(&source.Port, "source-db-port", 0,
 		"source database server port number. Default: Oracle(1521), MySQL(3306), PostgreSQL(5432)")
 
 	cmd.Flags().StringVar(&source.User, "source-db-user", "",
@@ -131,7 +131,7 @@ func setExportFlagsDefaults() {
 }
 
 func setSourceDefaultPort() {
-	if source.Port != -1 {
+	if source.Port != 0 {
 		return
 	}
 	switch source.DBType {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -41,8 +41,9 @@ var tableListFilePath string
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
-	Short: "export schema and data from compatible source database(Oracle, MySQL, PostgreSQL)",
-	Long:  `Export has various sub-commands i.e. export schema and export data to export from various compatible source databases(Oracle, MySQL, PostgreSQL).`,
+	Short: "export schema and data from compatible databases",
+	Long:  `Export has various sub-commands i.e. export schema, export data to export from various compatible source databases(Oracle, MySQL, PostgreSQL) 
+	and export data from target in case of live migration with fall-back/fall-forward workflows.`,
 }
 
 func init() {

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -234,11 +234,12 @@ func updateImportedEventsCountsInTheRow(row *rowData, tableName string, schemaNa
 
 	eventCounter, err := state.GetImportedEventsStatsForTable(tableName, migrationUUID)
 	if err != nil {
-		if !strings.Contains(err.Error(), "cannot assign NULL to *int64") {
+		if !strings.Contains(err.Error(), "cannot assign NULL to *int64") &&
+			!strings.Contains(err.Error(), "converting NULL to int64") { //TODO: handle better in GetImportedEventsStatsForTable() itself later
 			return fmt.Errorf("get imported events stats for table %q for DB type %s: %w", tableName, row.DBType, err)
 		} else {
 			//in case import streaming is not started yet, metadata will not be initialized
-			log.Warnf("streaming ingestion is not started yet for table %q for DB type %s", tableName, row.DBType)
+			log.Warnf("stream ingestion is not started yet for table %q for DB type %s", tableName, row.DBType)
 			eventCounter = &tgtdb.EventCounter{
 				NumInserts: 0,
 				NumUpdates: 0,
@@ -283,8 +284,8 @@ func getFinalRowCount(row rowData) int64 {
 func init() {
 	getCommand.AddCommand(getDataMigrationReportCmd)
 	registerCommonGlobalFlags(getDataMigrationReportCmd)
-	getDataMigrationReportCmd.Flags().StringVar(&ffDbPassword, "ff-db-password", "",
-		"password with which to connect to the target fall-forward DB server. Alternatively, you can also specify the password by setting the environment variable FF_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
+	getDataMigrationReportCmd.Flags().StringVar(&ffDbPassword, "source-replica-db-password", "",
+		"password with which to connect to the target fall-forward DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_REPLICA_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
 
 	getDataMigrationReportCmd.Flags().StringVar(&sourceDbPassword, "source-db-password", "",
 		"password with which to connect to the target source DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes")

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -139,7 +139,7 @@ func getDataMigrationReportCmdFn(msr *metadb.MigrationStatusRecord) {
 		if fBEnabled {
 			err = updateImportedEventsCountsInTheRow(&row, tableName, schemaName, msr.SourceDBAsTargetConf) //fall back IN counts
 			if err != nil {
-				utils.ErrExit("error while getting imported events for source DB in case of fall-back: %w\n", err)
+				utils.ErrExit("error while getting imported events for source DB in case of source-replica: %w\n", err)
 			}
 		}
 		addRowInTheTable(uitbl, row)
@@ -167,7 +167,7 @@ func getDataMigrationReportCmdFn(msr *metadb.MigrationStatusRecord) {
 			row.ExportedSnapshotRows = 0
 			err = updateImportedEventsCountsInTheRow(&row, tableName, schemaName, msr.FallForwardDBConf) //fall forward IN counts
 			if err != nil {
-				utils.ErrExit("error while getting imported events for fall-forward DB: %w\n", err)
+				utils.ErrExit("error while getting imported events for DB %s: %w\n", row.DBType, err)
 			}
 			addRowInTheTable(uitbl, row)
 		}
@@ -285,7 +285,7 @@ func init() {
 	getCommand.AddCommand(getDataMigrationReportCmd)
 	registerCommonGlobalFlags(getDataMigrationReportCmd)
 	getDataMigrationReportCmd.Flags().StringVar(&ffDbPassword, "source-replica-db-password", "",
-		"password with which to connect to the target fall-forward DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_REPLICA_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
+		"password with which to connect to the target Source-Replica DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_REPLICA_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
 
 	getDataMigrationReportCmd.Flags().StringVar(&sourceDbPassword, "source-db-password", "",
 		"password with which to connect to the target source DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes")

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -139,7 +139,7 @@ func getDataMigrationReportCmdFn(msr *metadb.MigrationStatusRecord) {
 		if fBEnabled {
 			err = updateImportedEventsCountsInTheRow(&row, tableName, schemaName, msr.SourceDBAsTargetConf) //fall back IN counts
 			if err != nil {
-				utils.ErrExit("error while getting imported events for source DB in case of source-replica: %w\n", err)
+				utils.ErrExit("error while getting imported events for source DB in case of fall-back: %w\n", err)
 			}
 		}
 		addRowInTheTable(uitbl, row)

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -34,7 +34,7 @@ import (
 )
 
 var targetDbPassword string
-var ffDbPassword string
+var sourceReplicaDbPassword string
 var sourceDbPassword string
 
 var getDataMigrationReportCmd = &cobra.Command{
@@ -284,7 +284,7 @@ func getFinalRowCount(row rowData) int64 {
 func init() {
 	getCommand.AddCommand(getDataMigrationReportCmd)
 	registerCommonGlobalFlags(getDataMigrationReportCmd)
-	getDataMigrationReportCmd.Flags().StringVar(&ffDbPassword, "source-replica-db-password", "",
+	getDataMigrationReportCmd.Flags().StringVar(&sourceReplicaDbPassword, "source-replica-db-password", "",
 		"password with which to connect to the target Source-Replica DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_REPLICA_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
 
 	getDataMigrationReportCmd.Flags().StringVar(&sourceDbPassword, "source-db-password", "",

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -203,14 +203,14 @@ func registerImportDataCommonFlags(cmd *cobra.Command) {
 		"path of the file containing the list of table names to import data")
 
 	defaultbatchSize := int64(DEFAULT_BATCH_SIZE_YUGABYTEDB)
-	if cmd.CommandPath() == "yb-voyager fall-forward setup" {
+	if cmd.CommandPath() == "yb-voyager import data to source-replica" {
 		defaultbatchSize = int64(DEFAULT_BATCH_SIZE_ORACLE)
 	}
 	cmd.Flags().Int64Var(&batchSize, "batch-size", defaultbatchSize,
 		"Size of batches in the number of rows generated for ingestion during import.")
 	defaultParallelismMsg := "By default, voyager will try if it can determine the total number of cores N and use N/2 as parallel jobs. " +
 		"Otherwise, it fall back to using twice the number of nodes in the cluster."
-	if cmd.CommandPath() == "yb-voyager fall-back setup" || cmd.CommandPath() == "yb-voyager fall-forward setup" {
+	if cmd.CommandPath() == "yb-voyager import data to source" || cmd.CommandPath() == "yb-voyager import data to source-replica" {
 		defaultParallelismMsg = "(default - oracle: 16)"
 	}
 	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", -1,

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -208,7 +208,7 @@ func registerImportDataCommonFlags(cmd *cobra.Command) {
 	defaultParallelismMsg := "By default, voyager will try if it can determine the total number of cores N and use N/2 as parallel jobs. " +
 		"Otherwise, it fall back to using twice the number of nodes in the cluster."
 	if cmd.CommandPath() == "yb-voyager import data to source" || cmd.CommandPath() == "yb-voyager import data to source-replica" {
-		defaultParallelismMsg = "(default: Oracle(16))"
+		defaultParallelismMsg = "(default: 16(Oracle))"
 	}
 	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", 0,
 		"number of parallel jobs to use while importing data. "+defaultParallelismMsg)

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -202,12 +202,8 @@ func registerImportDataCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tableListFilePath, "table-list-file-path", "",
 		"path of the file containing the list of table names to import data")
 
-	defaultbatchSize := int64(DEFAULT_BATCH_SIZE_YUGABYTEDB)
-	if cmd.CommandPath() == "yb-voyager import data to source-replica" {
-		defaultbatchSize = int64(DEFAULT_BATCH_SIZE_ORACLE)
-	}
-	cmd.Flags().Int64Var(&batchSize, "batch-size", defaultbatchSize,
-		"Size of batches in the number of rows generated for ingestion during import.")
+	cmd.Flags().Int64Var(&batchSize, "batch-size", -1,
+		fmt.Sprintf("Size of batches in the number of rows generated for ingestion during import. (default: target(%d), source-replica/source(%d))", DEFAULT_BATCH_SIZE_YUGABYTEDB, DEFAULT_BATCH_SIZE_ORACLE))
 	defaultParallelismMsg := "By default, voyager will try if it can determine the total number of cores N and use N/2 as parallel jobs. " +
 		"Otherwise, it fall back to using twice the number of nodes in the cluster."
 	if cmd.CommandPath() == "yb-voyager import data to source" || cmd.CommandPath() == "yb-voyager import data to source-replica" {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -151,7 +151,7 @@ func registerSourceReplicaDBAsTargetConnFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("source-replica-db-user")
 
 	cmd.Flags().StringVar(&tconf.Password, "source-replica-db-password", "",
-		"password with which to connect to the Source-Replica DB server. Alternatively, you can also specify the password by setting the environment variable FF_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
+		"password with which to connect to the Source-Replica DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_REPLICA_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
 
 	cmd.Flags().StringVar(&tconf.DBName, "source-replica-db-name", "",
 		"name of the database on the Source-Replica DB server on which import needs to be done")
@@ -305,7 +305,7 @@ func getTargetPassword(cmd *cobra.Command) {
 
 func getFallForwardDBPassword(cmd *cobra.Command) {
 	var err error
-	tconf.Password, err = getPassword(cmd, "ff-db-password", "FF_DB_PASSWORD")
+	tconf.Password, err = getPassword(cmd, "source-replica-db-password", "SOURCE_REPLICA_DB_PASSWORD")
 	if err != nil {
 		utils.ErrExit("error while getting ff-db-password: %w", err)
 	}

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -101,8 +101,9 @@ func registerTargetDBConnFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tconf.Host, "target-db-host", "127.0.0.1",
 		"host on which the YugabyteDB server is running")
 
-	cmd.Flags().IntVar(&tconf.Port, "target-db-port", -1,
+	cmd.Flags().IntVar(&tconf.Port, "target-db-port", 0,
 		"port on which the YugabyteDB YSQL API is running (Default: 5433)")
+
 
 	cmd.Flags().StringVar(&tconf.User, "target-db-user", "",
 		"username with which to connect to the target YugabyteDB server")
@@ -143,7 +144,7 @@ func registerSourceReplicaDBAsTargetConnFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tconf.Host, "source-replica-db-host", "127.0.0.1",
 		"host on which the Source-Replica DB server is running")
 
-	cmd.Flags().IntVar(&tconf.Port, "source-replica-db-port", -1,
+	cmd.Flags().IntVar(&tconf.Port, "source-replica-db-port", 0,
 		"port on which the Source-Replica DB server is running Default: ORACLE(1521)")
 
 	cmd.Flags().StringVar(&tconf.User, "source-replica-db-user", "",
@@ -202,14 +203,14 @@ func registerImportDataCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tableListFilePath, "table-list-file-path", "",
 		"path of the file containing the list of table names to import data")
 
-	cmd.Flags().Int64Var(&batchSize, "batch-size", -1,
+	cmd.Flags().Int64Var(&batchSize, "batch-size", 0,
 		fmt.Sprintf("Size of batches in the number of rows generated for ingestion during import. (default: target(%d), source-replica/source(%d))", DEFAULT_BATCH_SIZE_YUGABYTEDB, DEFAULT_BATCH_SIZE_ORACLE))
 	defaultParallelismMsg := "By default, voyager will try if it can determine the total number of cores N and use N/2 as parallel jobs. " +
 		"Otherwise, it fall back to using twice the number of nodes in the cluster."
 	if cmd.CommandPath() == "yb-voyager import data to source" || cmd.CommandPath() == "yb-voyager import data to source-replica" {
-		defaultParallelismMsg = "(default - oracle: 16)"
+		defaultParallelismMsg = "(default: Oracle(16))"
 	}
-	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", -1,
+	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", 0,
 		"number of parallel jobs to use while importing data. "+defaultParallelismMsg)
 
 	BoolVar(cmd.Flags(), &tconf.EnableUpsert, "enable-upsert", true,
@@ -263,7 +264,7 @@ func registerImportSchemaFlags(cmd *cobra.Command) {
 }
 
 func validateTargetPortRange() {
-	if tconf.Port == -1 {
+	if tconf.Port == 0 {
 		if tconf.TargetDBType == ORACLE {
 			tconf.Port = ORACLE_DEFAULT_PORT
 		} else if tconf.TargetDBType == YUGABYTEDB {
@@ -338,7 +339,7 @@ func checkOrSetDefaultTargetSSLMode() {
 }
 
 func validateBatchSizeFlag(numLinesInASplit int64) {
-	if batchSize == -1 {
+	if batchSize == 0 {
 		if tconf.TargetDBType == ORACLE {
 			batchSize = DEFAULT_BATCH_SIZE_ORACLE
 		} else {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -37,8 +37,8 @@ var tdb tgtdb.TargetDB
 
 var importCmd = &cobra.Command{
 	Use:   "import",
-	Short: "Import schema and data from compatible source database(Oracle, MySQL, PostgreSQL) into YugabyteDB",
-	Long:  `Import has various sub-commands i.e. import schema and import data to import into YugabyteDB from various compatible source databases(Oracle, MySQL, PostgreSQL).`,
+	Short: "Import schema and data from compatible source database to target database. ",
+	Long:  `Import has various sub-commands i.e. import schema, import data to import into YugabyteDB from various compatible source databases(Oracle, MySQL, PostgreSQL) and import data into source-replica/source to import snapshot data and new changes from target(YugabyteDB) in case of live migration with fall-back/fall-forward worflows.`,
 }
 
 func init() {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -136,7 +136,7 @@ func registerTargetDBConnFlags(cmd *cobra.Command) {
 
 func registerSourceDBAsTargetConnFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tconf.Password, "source-db-password", "",
-		"password with which to connect to the source DB server")
+		"source password to connect as the specified user on the source DB server. Alternatively, you can also specify the password by setting the environment variable SOURCE_DB_PASSWORD. If you don't provide a password via the CLI, yb-voyager will prompt you at runtime for a password. If the password contains special characters that are interpreted by the shell (for example, # and $), enclose the password in single quotes.")
 }
 
 func registerSourceReplicaDBAsTargetConnFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -64,9 +64,9 @@ var TableNameToSchema map[string]map[string]map[string]string
 
 var importDataCmd = &cobra.Command{
 	Use: "data",
-	Short: "Import data into target YugabyteDB database.\n" +
+	Short: "Import data from compatible source database to target database.\n" +
 		"For more details and examples, visit https://docs.yugabyte.com/preview/yugabyte-voyager/reference/data-migration/import-data/",
-	Long: `Import the data exported from the source database into the target YugabyteDB database.`,
+	Long: `Import the data exported from the source database into the target database and import data into source-replica/source to import snapshot data and new changes from target(YugabyteDB) in case of live migration with fall-back/fall-forward worflows..`,
 	Args: cobra.NoArgs,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if tconf.TargetDBType == "" {

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -34,7 +34,7 @@ import (
 
 var importDataStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Print status of an ongoing/completed import data/fall-forward setup.",
+	Short: "Print status of an ongoing/completed import data.",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		streamChanges, err := checkWithStreamingMode()

--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -47,6 +47,7 @@ func init() {
 	registerSourceDBAsTargetConnFlags(importDataToSourceCmd)
 	registerImportDataCommonFlags(importDataToSourceCmd)
 	hideImportFlagsInFallForwardOrBackCmds(importDataToSourceCmd)
+	importDataToSourceCmd.Flags().MarkHidden("batch-size")
 }
 
 func initTargetConfFromSourceConf() error {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -105,6 +105,7 @@ var noLockNeededList = []string{
 	"yb-voyager initiate cutover to source",
 	"yb-voyager initiate cutover to target",
 	"yb-voyager initiate cutover to source-replica",
+	"yb-voyager get data-migration-report",
 	"yb-voyager end",
 	"yb-voyager end migration",
 }

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -562,7 +562,7 @@ func (tdb *TargetOracleDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBat
 }
 
 func (tdb *TargetOracleDB) InitConnPool() error {
-	if tdb.tconf.Parallelism == -1 {
+	if tdb.tconf.Parallelism == 0 {
 		tdb.tconf.Parallelism = 16
 		log.Infof("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", tdb.tconf.Parallelism)
 	}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -200,7 +200,7 @@ func (yb *TargetYugabyteDB) InitConnPool() error {
 	}
 	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
 
-	if yb.tconf.Parallelism == -1 {
+	if yb.tconf.Parallelism == 0 {
 		yb.tconf.Parallelism = fetchDefaultParllelJobs(tconfs)
 		log.Infof("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", yb.tconf.Parallelism)
 	}


### PR DESCRIPTION
1. Fixed the case of streaming not started for import data to source-replica yet and the report is getting generated
2. Fixed --ff-db-password -> --source-replica-db-password and changed the user-facing FF_DB_PASSWORD -> SOURCE_REPLICA_DB_PASSWORD
3. misc user facing msgs around fall-forward/fall-back DB
4. added get data-migration-report to the `noNeedToLock` list