### PR TITLE
Bug fix: Using same ImportCount for Fall-Forward DB even after the exporter_role is switched to target_db_exporter i.e. cutover to target 

### DIFF
--- a/yb-voyager/src/metadb/metadataDB.go
+++ b/yb-voyager/src/metadb/metadataDB.go
@@ -436,7 +436,8 @@ func (m *MetaDB) GetExportedEventsStatsForTableAndExporterRole(exporterRole stri
 
 func (m *MetaDB) GetSegmentsToBeArchived(importCount int) ([]utils.Segment, error) {
 	predicate := fmt.Sprintf(`((exporter_role == 'source_db_exporter' AND (imported_by_target_db_importer + imported_by_ff_db_importer + imported_by_fb_db_importer = %d)) OR
-	(exporter_role LIKE 'target_db_exporter%%' AND (imported_by_target_db_importer + imported_by_ff_db_importer + imported_by_fb_db_importer = 1)))`, importCount)
+	(exporter_role LIKE 'target_db_exporter%%' AND (imported_by_target_db_importer + imported_by_ff_db_importer + imported_by_fb_db_importer = 1)))
+	AND archived = 0`, importCount)
 	segmentsToBeArchived, err := m.querySegments(predicate)
 	if err != nil {
 		return nil, fmt.Errorf("fetch segments to be archived: %v", err)


### PR DESCRIPTION
- due to which GetSegmentsToArchive() was not detected the segments for archiving

Bug fix: Added check condition 'archived = 0' in GetSegmetnsToBeArchived() in case of restart and resume