### PR TITLE
[PG OFFLINE EXPORT DATA] Fix double quote single table in table-list 

### DIFF
--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -89,7 +89,7 @@ jobs:
 
     - name:  "TEST: pg-case-sensitivity-single-table"
       run: migtests/scripts/run-test-export-data.sh pg/case-sensitivity-single-table
-      
+
     - name: "TEST: pg-dvdrental"
       run: migtests/scripts/run-test.sh pg/dvdrental 
 
@@ -128,8 +128,6 @@ jobs:
       
     - name:  "TEST: pg-multiple-schemas"
       run: migtests/scripts/run-test.sh pg/multiple-schemas
-
-    
 
     - name: "Set up gcp environment"
       env:

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -87,6 +87,9 @@ jobs:
         echo "127.0.0.1	yb-tserver-n1" | sudo tee -a /etc/hosts
         psql "postgresql://yugabyte@yb-tserver-n1:5433/yugabyte" -c "SELECT version();"
 
+    - name:  "TEST: pg-case-sensitivity-single-table"
+      run: migtests/scripts/run-test-export-data.sh pg/case-sensitivity-single-table
+      
     - name: "TEST: pg-dvdrental"
       run: migtests/scripts/run-test.sh pg/dvdrental 
 
@@ -126,8 +129,7 @@ jobs:
     - name:  "TEST: pg-multiple-schemas"
       run: migtests/scripts/run-test.sh pg/multiple-schemas
 
-    - name:  "TEST: pg-case-sensitivity-single-table"
-      run: migtests/scripts/run-test-export-data.sh pg/case-sensitivity-single-table
+    
 
     - name: "Set up gcp environment"
       env:

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -126,6 +126,9 @@ jobs:
     - name:  "TEST: pg-multiple-schemas"
       run: migtests/scripts/run-test.sh pg/multiple-schemas
 
+    - name:  "TEST: pg-case-sensitivity-single-table"
+      run: migtests/scripts/run-test-export-data.sh pg/case-sensitivity-single-table
+
     - name: "Set up gcp environment"
       env:
         GCS_CLIENT_ID: ${{ secrets.PGUPTA_GCS_CLIENT_ID }}

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -252,6 +252,11 @@ export_data() {
 		--yes
 		--start-clean 1
 	"
+	if [ "${TABLE_LIST}" != "" ]
+	then
+		args="${args} --table-list ${TABLE_LIST}"
+	fi
+
 	if [ "${SOURCE_DB_ORACLE_TNS_ALIAS}" != "" ]
 	then
 		args="${args} --oracle-tns-alias ${SOURCE_DB_ORACLE_TNS_ALIAS}"

--- a/migtests/scripts/run-test-export-data.sh
+++ b/migtests/scripts/run-test-export-data.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# -ne 1 ]
+then
+	echo "Usage: $0 TEST_NAME"
+	exit 1
+fi
+
+set -x
+
+export TEST_NAME=$1
+
+export REPO_ROOT="${PWD}"
+export SCRIPTS="${REPO_ROOT}/migtests/scripts"
+export TESTS_DIR="${REPO_ROOT}/migtests/tests"
+export TEST_DIR="${TESTS_DIR}/${TEST_NAME}"
+export EXPORT_DIR=${EXPORT_DIR:-"${TEST_DIR}/export-dir"}
+
+export PYTHONPATH="${REPO_ROOT}/migtests/lib"
+
+# Order of env.sh import matters.
+source ${TEST_DIR}/env.sh
+source ${SCRIPTS}/${SOURCE_DB_TYPE}/env.sh
+source ${SCRIPTS}/yugabytedb/env.sh
+
+source ${SCRIPTS}/functions.sh
+
+main() {
+	echo "Deleting the parent export-dir present in the test directory"
+	rm -rf ${EXPORT_DIR}	
+	echo "Creating export-dir in the parent test directory"
+	mkdir -p ${EXPORT_DIR}
+	echo "Assigning permissions to the export-dir to execute init-db, cleanup-db scripts"
+	chmod +x ${TEST_DIR}/init-db ${TEST_DIR}/cleanup-db
+
+	step "START: ${TEST_NAME}"
+	print_env
+
+	pushd ${TEST_DIR}
+
+	step "Initialise source database."
+	./init-db
+
+	step "Grant source database user permissions"
+	grant_permissions ${SOURCE_DB_NAME} ${SOURCE_DB_TYPE} ${SOURCE_DB_SCHEMA}
+
+	step "Check the Voyager version installed"
+	yb-voyager version
+
+	step "Export data."
+	# false if exit code of export_data is non-zero
+	export_data || { 
+		cat_log_file "yb-voyager-export-data.log"
+		cat_log_file "debezium-source_db_exporter.log"
+		exit 1
+	}
+
+	ls -l ${EXPORT_DIR}/data
+	cat ${EXPORT_DIR}/data/export_status.json || echo "No export_status.json found."
+	cat ${EXPORT_DIR}/metainfo/dataFileDescriptor.json
+
+	step "Fix data."
+	if [ -x "${TEST_DIR}/fix-data" ]
+	then
+		"${TEST_DIR}/fix-data" ${EXPORT_DIR}
+	fi
+	
+	step "End Migration: clearing metainfo about state of migration from everywhere."
+	end_migration --yes
+
+	step "Clean up"
+	./cleanup-db
+	rm -rf "${EXPORT_DIR}/*"
+	run_ysql yugabyte "DROP DATABASE IF EXISTS ${TARGET_DB_NAME};"
+}
+
+main

--- a/migtests/tests/pg/case-sensitivity-single-table/cleanup-db
+++ b/migtests/tests/pg/case-sensitivity-single-table/cleanup-db
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+source ${SCRIPTS}/functions.sh
+
+
+echo "Deleting ${SOURCE_DB_NAME} database on source"
+run_psql postgres "DROP DATABASE ${SOURCE_DB_NAME};"

--- a/migtests/tests/pg/case-sensitivity-single-table/env.sh
+++ b/migtests/tests/pg/case-sensitivity-single-table/env.sh
@@ -1,0 +1,3 @@
+export SOURCE_DB_TYPE="postgresql"
+export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"pg_case_sensitivity_single_table"}
+export SOURCE_DB_SCHEMA="public"

--- a/migtests/tests/pg/case-sensitivity-single-table/env.sh
+++ b/migtests/tests/pg/case-sensitivity-single-table/env.sh
@@ -1,4 +1,4 @@
 export SOURCE_DB_TYPE="postgresql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"pg_case_sensitivity_single_table"}
 export SOURCE_DB_SCHEMA="public"
-export TABLE_LIST="'\"Mixed_Case_Table_Name_Test\"'"
+export TABLE_LIST="\"Mixed_Case_Table_Name_Test\""

--- a/migtests/tests/pg/case-sensitivity-single-table/env.sh
+++ b/migtests/tests/pg/case-sensitivity-single-table/env.sh
@@ -1,3 +1,4 @@
 export SOURCE_DB_TYPE="postgresql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"pg_case_sensitivity_single_table"}
 export SOURCE_DB_SCHEMA="public"
+export TABLE_LIST="'\"Mixed_Case_Table_Name_Test\"'"

--- a/migtests/tests/pg/case-sensitivity-single-table/env.sh
+++ b/migtests/tests/pg/case-sensitivity-single-table/env.sh
@@ -1,4 +1,4 @@
 export SOURCE_DB_TYPE="postgresql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"pg_case_sensitivity_single_table"}
 export SOURCE_DB_SCHEMA="public"
-export TABLE_LIST="'\"Mixed_Case_Table_Name_Test\"'"
+export TABLE_LIST='\'"Mixed_Case_Table_Name_Test"\''

--- a/migtests/tests/pg/case-sensitivity-single-table/env.sh
+++ b/migtests/tests/pg/case-sensitivity-single-table/env.sh
@@ -1,4 +1,4 @@
 export SOURCE_DB_TYPE="postgresql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"pg_case_sensitivity_single_table"}
 export SOURCE_DB_SCHEMA="public"
-export TABLE_LIST="\"Mixed_Case_Table_Name_Test\""
+export TABLE_LIST="'\"Mixed_Case_Table_Name_Test\"'"

--- a/migtests/tests/pg/case-sensitivity-single-table/env.sh
+++ b/migtests/tests/pg/case-sensitivity-single-table/env.sh
@@ -1,4 +1,4 @@
 export SOURCE_DB_TYPE="postgresql"
 export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"pg_case_sensitivity_single_table"}
 export SOURCE_DB_SCHEMA="public"
-export TABLE_LIST='\'"Mixed_Case_Table_Name_Test"\''
+export TABLE_LIST='"Mixed_Case_Table_Name_Test"'

--- a/migtests/tests/pg/case-sensitivity-single-table/init-db
+++ b/migtests/tests/pg/case-sensitivity-single-table/init-db
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+source ${SCRIPTS}/functions.sh
+
+
+echo "Creating ${SOURCE_DB_NAME} database on source"
+run_psql postgres "DROP DATABASE IF EXISTS ${SOURCE_DB_NAME};"
+run_psql postgres "CREATE DATABASE ${SOURCE_DB_NAME};"
+
+echo "Initialising source database."
+
+run_psql ${SOURCE_DB_NAME} "\i pg_case_sensitivity_single_table.sql;"
+
+
+echo "Check source database."
+run_psql ${SOURCE_DB_NAME} "SELECT count(*) FROM Recipients;"

--- a/migtests/tests/pg/case-sensitivity-single-table/init-db
+++ b/migtests/tests/pg/case-sensitivity-single-table/init-db
@@ -16,4 +16,4 @@ run_psql ${SOURCE_DB_NAME} "\i pg_case_sensitivity_single_table.sql;"
 
 
 echo "Check source database."
-run_psql ${SOURCE_DB_NAME} "SELECT count(*) FROM Recipients;"
+run_psql ${SOURCE_DB_NAME} "SELECT count(*) FROM \"Mixed_Case_Table_Name_Test\";"

--- a/migtests/tests/pg/case-sensitivity-single-table/pg_case_sensitivity_single_table.sql
+++ b/migtests/tests/pg/case-sensitivity-single-table/pg_case_sensitivity_single_table.sql
@@ -1,0 +1,16 @@
+-- single table with case sensitive table name 
+-- Note: do not add sequences or any other tables to this test, as the bug occurs only when there is a single table. 
+drop table if exists "Mixed_Case_Table_Name_Test";
+
+create table "Mixed_Case_Table_Name_Test" (
+	id int primary key,
+	name VARCHAR(50)
+);
+
+-- aut int NOT NULL GENERATED ALWAYS AS ((id*9)+1) stored
+
+insert into "Mixed_Case_Table_Name_Test" (id, name) values (1, 'Modestine');
+insert into "Mixed_Case_Table_Name_Test" (id, name) values (2, 'Genna');
+insert into "Mixed_Case_Table_Name_Test" (id, name) values (3, 'Tess');
+insert into "Mixed_Case_Table_Name_Test" (id, name) values (4, 'Magnum');
+insert into "Mixed_Case_Table_Name_Test" (id, name) values (5, 'Mitzi');

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -76,7 +76,9 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 	if err != nil {
 		utils.ErrExit("Error while preparing pg_dump arguments: %v", err)
 	}
+	utils.PrintAndLog("templated file outputt = %s", output)
 
+	// iniData, err := ini.LoadSources(ini.LoadOptions{PreserveSurroundedQuote: true}, output.Bytes())
 	iniData, err := ini.Load(output.Bytes())
 	if err != nil {
 		utils.ErrExit("Error while ini loading pg_dump arguments file: %v", err)
@@ -99,7 +101,7 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 		} else {
 			arg += fmt.Sprintf(`=%s`, key.Value())
 		}
-
+		utils.PrintAndLog("Writing arg %s to args", arg)
 		args.WriteString(arg)
 	}
 	return args.String()

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -76,10 +76,8 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 	if err != nil {
 		utils.ErrExit("Error while preparing pg_dump arguments: %v", err)
 	}
-	utils.PrintAndLog("templated file outputt = %s", output)
 
-	// iniData, err := ini.LoadSources(ini.LoadOptions{PreserveSurroundedQuote: true}, output.Bytes())
-	iniData, err := ini.Load(output.Bytes())
+	iniData, err := ini.LoadSources(ini.LoadOptions{PreserveSurroundedQuote: true}, output.Bytes())
 	if err != nil {
 		utils.ErrExit("Error while ini loading pg_dump arguments file: %v", err)
 	}
@@ -101,7 +99,6 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 		} else {
 			arg += fmt.Sprintf(`=%s`, key.Value())
 		}
-		utils.PrintAndLog("Writing arg %s to args", arg)
 		args.WriteString(arg)
 	}
 	return args.String()

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -77,7 +77,7 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 		utils.ErrExit("Error while preparing pg_dump arguments: %v", err)
 	}
 
-	iniData, err := ini.LoadSources(ini.LoadOptions{PreserveSurroundedQuote: true}, output.Bytes())
+	iniData, err := ini.LoadSources(ini.LoadOptions{PreserveSurroundedQuote: false}, output.Bytes())
 	if err != nil {
 		utils.ErrExit("Error while ini loading pg_dump arguments file: %v", err)
 	}

--- a/yb-voyager/src/srcdb/pg_dump.go
+++ b/yb-voyager/src/srcdb/pg_dump.go
@@ -77,7 +77,7 @@ func getPgDumpArgsFromFile(sectionToRead string) string {
 		utils.ErrExit("Error while preparing pg_dump arguments: %v", err)
 	}
 
-	iniData, err := ini.LoadSources(ini.LoadOptions{PreserveSurroundedQuote: false}, output.Bytes())
+	iniData, err := ini.LoadSources(ini.LoadOptions{PreserveSurroundedQuote: true}, output.Bytes())
 	if err != nil {
 		utils.ErrExit("Error while ini loading pg_dump arguments file: %v", err)
 	}

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -43,7 +43,6 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 
 	pgDumpArgs.DataDirPath = filepath.Join(exportDir, "data")
 	pgDumpArgs.TablesListPattern = createTableListPatterns(tableList)
-	utils.PrintAndLog("pgdump tableListpattern = %s", pgDumpArgs.TablesListPattern)
 	pgDumpArgs.ParallelJobs = strconv.Itoa(source.NumConnections)
 	pgDumpArgs.DataFormat = "directory"
 
@@ -124,7 +123,6 @@ func createTableListPatterns(tableList []*sqlname.SourceName) string {
 	var tableListPattern string
 	for _, table := range tableList {
 		tableListPattern += fmt.Sprintf("--table='%s' ", table.Qualified.MinQuoted)
-		utils.PrintAndLog("added %s to table list pattern", tableListPattern)
 	}
 
 	return strings.TrimPrefix(tableListPattern, "--table=")

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -43,6 +43,7 @@ func pgdumpExportDataOffline(ctx context.Context, source *Source, connectionUri 
 
 	pgDumpArgs.DataDirPath = filepath.Join(exportDir, "data")
 	pgDumpArgs.TablesListPattern = createTableListPatterns(tableList)
+	utils.PrintAndLog("pgdump tableListpattern = %s", pgDumpArgs.TablesListPattern)
 	pgDumpArgs.ParallelJobs = strconv.Itoa(source.NumConnections)
 	pgDumpArgs.DataFormat = "directory"
 
@@ -123,6 +124,7 @@ func createTableListPatterns(tableList []*sqlname.SourceName) string {
 	var tableListPattern string
 	for _, table := range tableList {
 		tableListPattern += fmt.Sprintf("--table='%s' ", table.Qualified.MinQuoted)
+		utils.PrintAndLog("added %s to table list pattern", tableListPattern)
 	}
 
 	return strings.TrimPrefix(tableListPattern, "--table=")


### PR DESCRIPTION
In cases where there is a single table provided in the table-list, there is a bug. 
The ini file generated(after executing the template) for pg_dump args has the following: `table='public."TEST_SIMPLE"'`
When we parse this ini file, by default, the single quotes surrounding the value is dropped. 

This results in pg_dump command being generated as `--table=public."TEST_SIMPLE"`, (expected: `table='public."TEST_SIMPLE"'`) . 

This PR fixes the bug by passing the option `PreserveSurroundedQuote` to the ini file loader. 

This case works perfectly fine when there are more than one tables. In such a case, the ini value in file is of the following - `table='public."TEST_SIMPLE"' --table='public.kv'`. This is NOT interpreted as surrounding quotes by ini, and therefore, it doesn't drop the  quotes.