### PR TITLE
fix cdc key channel bug

### DIFF
--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -185,6 +185,9 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 	}
 
 	// hash event
+	// Note: hash the event before running the even through the value converter.
+	// This is because the value converter can generate different values (formatting vs no formatting) for the same key
+	// which will affect hash value.
 	h := hashEvent(event)
 
 	// preparing value converters for the streaming mode
@@ -193,7 +196,7 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 		return fmt.Errorf("error transforming event key fields: %v", err)
 	}
 
-	// insert into
+	// insert into channel
 	evChans[h] <- event
 	log.Tracef("inserted event %v into channel %v", event.Vsn, h)
 	return nil

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -185,7 +185,7 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 	}
 
 	// hash event
-	// Note: hash the event before running the even through the value converter.
+	// Note: hash the event before running the event through the value converter.
 	// This is because the value converter can generate different values (formatting vs no formatting) for the same key
 	// which will affect hash value.
 	h := hashEvent(event)
@@ -196,7 +196,6 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 		return fmt.Errorf("error transforming event key fields: %v", err)
 	}
 
-	// insert into channel
 	evChans[h] <- event
 	log.Tracef("inserted event %v into channel %v", event.Vsn, h)
 	return nil

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -185,7 +185,7 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 	}
 
 	// hash event
-	// Note: hash the event before running the event through the value converter.
+	// Note: hash the event before running the keys/values through the value converter.
 	// This is because the value converter can generate different values (formatting vs no formatting) for the same key
 	// which will affect hash value.
 	h := hashEvent(event)

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -194,18 +193,10 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 		return fmt.Errorf("error transforming event key fields: %v", err)
 	}
 
-	// insert into channel
+	// insert into
 	evChans[h] <- event
-	log.Infof("inserted event vsn-%s from table %s - %v into channel %v", event.Vsn, event.TableName, createKeyValuePairs(event.Key), h)
+	log.Tracef("inserted event %v into channel %v", event.Vsn, h)
 	return nil
-}
-func createKeyValuePairs(m map[string]*string) string {
-	b := new(bytes.Buffer)
-	for key, value := range m {
-		fmt.Fprintf(b, "%s=\"%s\"|", key, *(value))
-	}
-
-	return b.String()
 }
 
 // Returns a hash value between 0..NUM_EVENT_CHANNELS


### PR DESCRIPTION
We beed to hash the event before running the keys/values through the value converter.
This is because the value converter can generate different values (formatting vs no formatting) for the same key
which will affect hash value, and thus order the events.