### PR TITLE
Bug fix for cutover to target --prepare-for-fallback true  if user ran it accidentally and answer no in the prompt

### DIFF
--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -147,7 +147,7 @@ main() {
 	trap - SIGINT SIGTERM EXIT SIGSEGV SIGHUP
 
 	step "Initiating cutover"
-	yes | yb-voyager initiate cutover to target --export-dir ${EXPORT_DIR} --prepare-for-fall-back true
+	yb-voyager initiate cutover to target --export-dir ${EXPORT_DIR} --prepare-for-fall-back true --yes
 
 	for ((i = 0; i < 5; i++)); do
     if [ "$(yb-voyager cutover status --export-dir "${EXPORT_DIR}" | grep -oP 'cutover to target status: \K\S+')" != "COMPLETED" ]; then
@@ -174,7 +174,7 @@ main() {
 	trap - SIGINT SIGTERM EXIT SIGSEGV SIGHUP
 
 	step "Initiating cutover to source"
-	yes | yb-voyager initiate cutover to source --export-dir ${EXPORT_DIR}
+	yb-voyager initiate cutover to source --export-dir ${EXPORT_DIR} --yes
 
 	for ((i = 0; i < 5; i++)); do
     if [ "$(yb-voyager cutover status --export-dir "${EXPORT_DIR}" | grep -oP 'cutover to source status: \K\S+')" != "COMPLETED" ]; then

--- a/migtests/scripts/live-migration-fallf-run-test.sh
+++ b/migtests/scripts/live-migration-fallf-run-test.sh
@@ -169,7 +169,7 @@ main() {
 	sleep 2m
 
 	step "Initiating cutover"
-	yes | yb-voyager initiate cutover to target --export-dir ${EXPORT_DIR}
+	yb-voyager initiate cutover to target --export-dir ${EXPORT_DIR} --yes
 
 	for ((i = 0; i < 5; i++)); do
     if [ "$(yb-voyager cutover status --export-dir "${EXPORT_DIR}" | grep -oP 'cutover to target status: \K\S+')" != "COMPLETED" ]; then
@@ -196,7 +196,7 @@ main() {
 	trap - SIGINT SIGTERM EXIT SIGSEGV SIGHUP
 
 	step "Initiating cutover to source-replica"
-	yes | yb-voyager initiate cutover to source-replica --export-dir ${EXPORT_DIR}
+	yb-voyager initiate cutover to source-replica --export-dir ${EXPORT_DIR} --yes
 
 	for ((i = 0; i < 5; i++)); do
     if [ "$(yb-voyager cutover status --export-dir "${EXPORT_DIR}" | grep -oP 'cutover to source-replica status: \K\S+')" != "COMPLETED" ]; then

--- a/yb-voyager/cmd/cutover.go
+++ b/yb-voyager/cmd/cutover.go
@@ -46,6 +46,9 @@ func init() {
 	rootCmd.AddCommand(cutoverRootCmd)
 	initiateCmd.AddCommand(cutoverCmd)
 	cutoverCmd.AddCommand(cutoverToCmd)
+	cutoverToCmd.PersistentFlags().BoolVarP(&utils.DoNotPrompt, "yes", "y", false,
+		"assume answer as yes for all questions during migration (default false)")
+	cutoverToCmd.PersistentFlags().MarkHidden("yes") //for non TTY shell e.g jenkins for docker case
 }
 
 func InitiateCutover(dbRole string) error {

--- a/yb-voyager/cmd/cutover.go
+++ b/yb-voyager/cmd/cutover.go
@@ -51,7 +51,7 @@ func init() {
 	cutoverToCmd.PersistentFlags().MarkHidden("yes") //for non TTY shell e.g jenkins for docker case
 }
 
-func InitiateCutover(dbRole string) error {
+func InitiateCutover(dbRole string, prepareforFallback bool) error {
 	userFacingActionMsg := fmt.Sprintf("cutover to %s", dbRole)
 	if !utils.AskPrompt(fmt.Sprintf("Are you sure you want to initiate %s? (y/n)", userFacingActionMsg)) {
 		utils.PrintAndLog("Aborting %s", userFacingActionMsg)
@@ -66,6 +66,9 @@ func InitiateCutover(dbRole string) error {
 				utils.PrintAndLog(alreadyInitiatedMsg)
 			}
 			record.CutoverToTargetRequested = true
+			if prepareforFallback {
+				record.FallForwardEnabled = true
+			}
 		case "source-replica":
 			if record.CutoverToSourceReplicaRequested {
 				utils.PrintAndLog(alreadyInitiatedMsg)

--- a/yb-voyager/cmd/cutover.go
+++ b/yb-voyager/cmd/cutover.go
@@ -67,7 +67,7 @@ func InitiateCutover(dbRole string, prepareforFallback bool) error {
 			}
 			record.CutoverToTargetRequested = true
 			if prepareforFallback {
-				record.FallForwardEnabled = true
+				record.FallbackEnabled = true
 			}
 		case "source-replica":
 			if record.CutoverToSourceReplicaRequested {

--- a/yb-voyager/cmd/cutoverToSource.go
+++ b/yb-voyager/cmd/cutoverToSource.go
@@ -26,7 +26,7 @@ var cutoverToSourceCmd = &cobra.Command{
 	Long:  `Initiate cutover to source DB`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		err := InitiateCutover("source")
+		err := InitiateCutover("source", false)
 		if err != nil {
 			utils.ErrExit("failed to initiate fallback: %v", err)
 		}

--- a/yb-voyager/cmd/cutoverToSourceReplica.go
+++ b/yb-voyager/cmd/cutoverToSourceReplica.go
@@ -26,7 +26,7 @@ var cutoverToSourceReplicaCmd = &cobra.Command{
 	Long:  `Initiate cutover to source-replica DB`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		err := InitiateCutover("source-replica")
+		err := InitiateCutover("source-replica", false)
 		if err != nil {
 			utils.ErrExit("failed to initiate fallforward: %v", err)
 		}

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -53,12 +53,9 @@ var cutoverToTargetCmd = &cobra.Command{
 				utils.ErrExit("cannot prepare for fall-back. Fall-forward workflow already enabled.")
 			}
 		}
-		err = InitiateCutover("target")
+		err = InitiateCutover("target", bool(prepareForFallBack))
 		if err != nil {
 			utils.ErrExit("failed to initiate cutover: %v", err)
-		}
-		if prepareForFallBack {
-			updateFallBackEnabledInMetaDB()
 		}
 	},
 }

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -66,12 +66,3 @@ func init() {
 	BoolVar(cutoverToTargetCmd.Flags(), &prepareForFallBack, "prepare-for-fall-back", false,
 		"prepare for fallback by streaming changes from target DB back to source DB. Not applicable for fall-forward workflow.")
 }
-
-func updateFallBackEnabledInMetaDB() {
-	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-		record.FallbackEnabled = true
-	})
-	if err != nil {
-		utils.ErrExit("error while updating fall back enabled in meta db: %v", err)
-	}
-}

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -52,13 +52,14 @@ var cutoverToTargetCmd = &cobra.Command{
 			if msr.FallForwardEnabled {
 				utils.ErrExit("cannot prepare for fall-back. Fall-forward workflow already enabled.")
 			}
-			updateFallBackEnabledInMetaDB()
 		}
 		err = InitiateCutover("target")
 		if err != nil {
 			utils.ErrExit("failed to initiate cutover: %v", err)
 		}
-
+		if prepareForFallBack {
+			updateFallBackEnabledInMetaDB()
+		}
 	},
 }
 


### PR DESCRIPTION
1. Fixes the issue where user accidentally ran `initiate cutover to target --prepare-for-fallback t` and answer No in the prompt, in that case `msr.FallbackEnabled` was still getting set and hence get data-migration-report was erroring out.
3. added a hidden flag `--yes` for cutover prompt. 