### PR TITLE
Support sequences in pg_dump+dbzm live migration 

### DIFF
--- a/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -37,6 +37,7 @@ public class SequenceObjectUpdater {
         es.setSequenceMaxMap(this.sequenceMax);
     }
 
+    // columnSequenceMapstring: public.t1.id:public."t1_id_seq",public.cst1.id:public."cSS1"
     public void initColumnSequenceMap(String columnSequenceMapString){
         if (columnSequenceMapString == null){
             return;
@@ -60,6 +61,8 @@ public class SequenceObjectUpdater {
             this.sequenceMax.put(sequenceName, this.sequenceMax.getOrDefault(sequenceName, (long)0));
         }
     }
+
+    // initSequenceMapString: public."cSS1":4,public."t1_id_seq":9
     public void initSequenceMax(String initSequenceMapString, ConcurrentMap<String, Long> sequenceMax){
         this.sequenceMax = new ConcurrentHashMap<>();
         if (initSequenceMapString != null){

--- a/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -30,12 +30,6 @@ public class SequenceObjectUpdater {
         this.columnSequenceMap = new HashMap<>();
 
         es = ExportStatus.getInstance(dataDirStr);
-//        if (sequenceMax == null){
-//           this.sequenceMax = new ConcurrentHashMap<>();
-//        }
-//        else{
-//            this.sequenceMax = sequenceMax;
-//        }
 
         initSequenceMax(initSequenceMapString, sequenceMax);
         initColumnSequenceMap(columnSequenceMapString);

--- a/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -21,6 +21,8 @@ import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.server.BaseChangeConsumer;
 
+import static io.debezium.server.ybexporter.SequenceObjectUpdater.initSequenceMaxpropertyName;
+
 /**
  * Implementation of the consumer that exports the messages to file in a Yugabyte-compatible form.
  */
@@ -68,7 +70,8 @@ public class YbExporterConsumer extends BaseChangeConsumer {
         parser = new KafkaConnectRecordParser(dataDir, sourceType, tableMap);
         String propertyVal = PROP_PREFIX + SequenceObjectUpdater.propertyName;
         String columnSequenceMapString = config.getOptionalValue(propertyVal, String.class).orElse(null);
-        sequenceObjectUpdater = new SequenceObjectUpdater(dataDir, sourceType, columnSequenceMapString, exportStatus.getSequenceMaxMap());
+        String sequenceMaxMapString = config.getOptionalValue(PROP_PREFIX + SequenceObjectUpdater.initSequenceMaxpropertyName, String.class).orElse(null);
+        sequenceObjectUpdater = new SequenceObjectUpdater(dataDir, sourceType, columnSequenceMapString, sequenceMaxMapString, exportStatus.getSequenceMaxMap());
         recordTransformer = new DebeziumRecordTransformer();
 
         flusherThread = new Thread(this::flush);

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -197,23 +197,10 @@ func exportData() bool {
 				utils.ErrExit("get pg dump sequence values: %v", err)
 			}
 
-			utils.PrintAndLog("sourcenames - %s", sequenceValueMap)
 			var sequenceInitValues strings.Builder
 			for seqName, seqValue := range sequenceValueMap {
 				sequenceInitValues.WriteString(fmt.Sprintf("%s:%d,", seqName.Qualified.Quoted, seqValue))
 			}
-
-			// dbzmExportStatus := dbzm.ExportStatus{
-			// 	Mode:      "STREAMING",
-			// 	Sequences: map[string]int64{},
-			// }
-			// for seqName, seqValue := range sequenceValueMap {
-			// 	dbzmExportStatus.Sequences[seqName.Qualified.Quoted] = seqValue
-			// }
-			// err = dbzmExportStatus.WriteToDisk(filepath.Join(exportDir, "data", "export_status.json"))
-			// if err != nil {
-			// 	utils.ErrExit("write dbzm status to disk: %v", err)
-			// }
 
 			config.SnapshotMode = "never"
 			config.ReplicationSlotName = msr.PGReplicationSlotName

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	SchemaNames                 string
 	TableList                   []string
 	ColumnSequenceMapping       string
+	InitSequenceMaxMapping      string
 	TableRenameMapping          string
 	ColumnList                  []string
 	Uri                         string
@@ -93,6 +94,7 @@ var baseSinkConfigTemplate = `
 debezium.sink.type=ybexporter
 debezium.sink.ybexporter.dataDir=%s
 debezium.sink.ybexporter.column_sequence.map=%s
+debezium.sink.ybexporter.sequence.max.map=%s
 debezium.sink.ybexporter.tables.rename=%s
 debezium.sink.ybexporter.queueSegmentMaxBytes=%d
 debezium.sink.ybexporter.metadata.db.path=%s
@@ -254,6 +256,7 @@ func (c *Config) String() string {
 
 			dataDir,
 			c.ColumnSequenceMapping,
+			c.InitSequenceMaxMapping,
 			c.TableRenameMapping,
 			queueSegmentMaxBytes,
 			c.MetadataDBPath,
@@ -284,6 +287,7 @@ func (c *Config) String() string {
 
 			dataDir,
 			c.ColumnSequenceMapping,
+			c.InitSequenceMaxMapping,
 			c.TableRenameMapping,
 			queueSegmentMaxBytes,
 			c.MetadataDBPath,
@@ -308,6 +312,7 @@ func (c *Config) String() string {
 
 			dataDir,
 			c.ColumnSequenceMapping,
+			c.InitSequenceMaxMapping,
 			c.TableRenameMapping,
 			queueSegmentMaxBytes,
 			c.MetadataDBPath,
@@ -337,6 +342,7 @@ func (c *Config) String() string {
 
 			dataDir,
 			c.ColumnSequenceMapping,
+			c.InitSequenceMaxMapping,
 			c.TableRenameMapping,
 			queueSegmentMaxBytes,
 			c.MetadataDBPath,

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -328,7 +328,7 @@ func (pg *PostgreSQL) GetAllSequences() []string {
 		if err != nil {
 			utils.ErrExit("error in scanning query rows for sequence names: %v\n", err)
 		}
-		sequenceNames = append(sequenceNames, fmt.Sprintf("%s.%s", sequenceSchema, sequenceName))
+		sequenceNames = append(sequenceNames, fmt.Sprintf(`%s."%s"`, sequenceSchema, sequenceName))
 	}
 	return sequenceNames
 }


### PR DESCRIPTION
- When starting dbzm for the cdc phase, extract sequence last values from pg_dump output and init dbzm with those values. This is needed to handle scenarios where there are no events corresponding to a table in the cdc phase (in which case debezium will not be able to track the max value of the corresponding sequences). 
- Support case sensitivity in sequence names

Caveat:
- sequences that are not owned by any column are not supported.