### PR TITLE
Fixed Bug: Progress bar hangs in import data when empty table is present in snapshot

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -238,6 +238,8 @@ func exportData() bool {
 		}
 		return true
 	} else {
+		fmt.Printf("num tables to export: %d\n", len(finalTableList))
+		utils.PrintAndLog("table list for data export: %v", finalTableList)
 		err = exportDataOffline(ctx, cancel, finalTableList, tablesColumnList, "")
 		if err != nil {
 			log.Errorf("Export Data failed: %v", err)
@@ -360,8 +362,6 @@ func getFinalTableColumnList() ([]*sqlname.SourceName, map[*sqlname.SourceName][
 }
 
 func exportDataOffline(ctx context.Context, cancel context.CancelFunc, finalTableList []*sqlname.SourceName, tablesColumnList map[*sqlname.SourceName][]string, snapshotName string) error {
-	fmt.Printf("num tables to export: %d\n", len(finalTableList))
-	utils.PrintAndLog("table list for data export: %v", finalTableList)
 	exportDataStart := make(chan bool)
 	quitChan := make(chan bool)             //for checking failure/errors of the parallel goroutines
 	exportSuccessChan := make(chan bool, 1) //Check if underlying tool has exited successfully.

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -217,6 +217,11 @@ func discoverFilesToImport() []*ImportFileTask {
 	}
 
 	for i, fileEntry := range dataFileDescriptor.DataFileList {
+		if fileEntry.RowCount == 0 {
+			// In case of PG Live migration  pg_dump and dbzm both are used and we don't skip empty tables 
+			// but pb hangs for empty so skipping empty tables in snapshot import 
+			continue
+		}
 		task := &ImportFileTask{
 			ID:        i,
 			FilePath:  fileEntry.FilePath,


### PR DESCRIPTION
1. fixes https://yugabyte.atlassian.net/browse/DB-9513, In PG live migration, where we use pg_dump for snapshot we don't skip passing empty tables in table-list to pg_dump and pg_dump gives a datafile for that, and hence when importing on target the progress bar for those empty tables hangs.  FIX: skipping those tables while creating `importFileTasks` 
2. fixed printing of table-list twice on UI for PG live migration