### PR TITLE
UX changes in data-migration-report for large set of tables

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -106,7 +106,7 @@ func getMappingForTableNameVsTableFileName(dataDirPath string, noWait bool) map[
 
 	pgRestorePath, err := srcdb.GetAbsPathOfPGCommand("pg_restore")
 	if err != nil {
-		utils.ErrExit("could not get absolute path of pg_restore command: %w", err)
+		utils.ErrExit("could not get absolute path of pg_restore command: %s", err)
 	}
 	pgRestoreCmd := exec.Command(pgRestorePath, "-l", dataDirPath)
 	stdOut, err := pgRestoreCmd.Output()

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -106,7 +106,7 @@ func getMappingForTableNameVsTableFileName(dataDirPath string, noWait bool) map[
 
 	pgRestorePath, err := srcdb.GetAbsPathOfPGCommand("pg_restore")
 	if err != nil {
-		utils.ErrExit("could not get absolute path of pg_restore command: %v", pgRestorePath)
+		utils.ErrExit("could not get absolute path of pg_restore command: %w", err)
 	}
 	pgRestoreCmd := exec.Command(pgRestorePath, "-l", dataDirPath)
 	stdOut, err := pgRestoreCmd.Output()


### PR DESCRIPTION
fixes - 
1. Added pagination in the report printed in `get data-migration-report` with max 10 rows in each table - https://yugabyte.atlassian.net/browse/DB-9629
2. Added a print statement before printing the report so that the user can gets an idea that something is running -https://yugabyte.atlassian.net/browse/DB-9618