### PR TITLE
Remove logging of cleaning up child processes in case there are no child processes 

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -529,7 +529,6 @@ func getDefaultPGSchema(schema string) (string, bool) {
 }
 
 func CleanupChildProcesses() {
-	log.Info("Cleaning up child processes...")
 	myPid := os.Getpid()
 	processes, err := ps.Processes()
 	if err != nil {
@@ -538,6 +537,9 @@ func CleanupChildProcesses() {
 	childProcesses := lo.Filter(processes, func(process ps.Process, _ int) bool {
 		return process.PPid() == myPid
 	})
+	if len(childProcesses) > 0 {
+		log.Info("Cleaning up child processes...")
+	}
 	for _, process := range childProcesses {
 		pid := process.Pid()
 		log.Infof("shutting down child pid %d", pid)


### PR DESCRIPTION
For `yb-voyager version` cmd, removed the log line of cleaning up child processes.
```
[centos@ip-10-9-14-120 ~]$ /home/centos/code/yb-voyager/yb-voyager/yb-voyager version
VERSION=main
GIT_COMMIT_HASH=2854b2292057a3b4f5f882bba5eeeaa9640098ac
LAST_COMMIT_DATE=2024-01-24T12:33:32Z
INFO[0000] Cleaning up child processes...  
```