### PR TITLE
DB-9858 Wait for 2 min for yb cdc initialization to complete. 

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -379,17 +379,18 @@ func getCutoverStatus() string {
 	a := msr.CutoverToTargetRequested
 	b := msr.CutoverProcessedBySourceExporter
 	c := msr.CutoverProcessedByTargetImporter
-	d := msr.ExportFromTargetFallForwardStarted
-	ffDBExists := msr.FallForwardEnabled
+
 	if !a {
 		return NOT_INITIATED
-	} else if !ffDBExists && a && b && c {
+	}
+	if msr.FallForwardEnabled && a && b && c && msr.ExportFromTargetFallForwardStarted {
 		return COMPLETED
-	} else if a && b && c && d {
+	} else if msr.FallbackEnabled && a && b && c && msr.ExportFromTargetFallBackStarted {
+		return COMPLETED
+	} else if !msr.FallForwardEnabled && !msr.FallbackEnabled && a && b && c {
 		return COMPLETED
 	}
 	return INITIATED
-
 }
 
 func checkStreamingMode() (bool, error) {

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -475,18 +475,21 @@ func checkAndHandleSnapshotComplete(config *dbzm.Config, status *dbzm.ExportStat
 		color.Blue("streaming changes to a local queue file...")
 		if isTargetDBExporter(exporterRole) {
 			utils.PrintAndLog("Waiting to initialize export of change data from target DB...")
+			// only events received after yb cdc initialization will be emitted by debezium.
+			// Therefore, we sleep to allow yb cdc connector to initialize and only then mark the cutover to be complete.
+			// Ideally, we should have a more reliable way to determine that init is complete. This is a temp solution.
 			time.Sleep(2 * time.Minute)
-		}
-		err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-			if exporterRole == TARGET_DB_EXPORTER_FB_ROLE {
-				record.ExportFromTargetFallBackStarted = true
-			} else {
-				record.ExportFromTargetFallForwardStarted = true
-			}
+			err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+				if exporterRole == TARGET_DB_EXPORTER_FB_ROLE {
+					record.ExportFromTargetFallBackStarted = true
+				} else {
+					record.ExportFromTargetFallForwardStarted = true
+				}
 
-		})
-		if err != nil {
-			utils.ErrExit("failed to update migration status record for export data from target start: %v", err)
+			})
+			if err != nil {
+				utils.ErrExit("failed to update migration status record for export data from target start: %v", err)
+			}
 		}
 		if !disablePb {
 			go reportStreamingProgress()

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -46,17 +45,6 @@ var exportDataFromTargetCmd = &cobra.Command{
 			utils.ErrExit("failed to setup source conf from target conf in MSR: %v", err)
 		}
 		exportDataCmd.PreRun(cmd, args)
-		err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-			if exporterRole == TARGET_DB_EXPORTER_FB_ROLE {
-				record.ExportFromTargetFallBackStarted = true
-			} else {
-				record.ExportFromTargetFallForwardStarted = true
-			}
-
-		})
-		if err != nil {
-			utils.ErrExit("failed to update migration status record for fall-back sync started: %v", err)
-		}
 		exportDataCmd.Run(cmd, args)
 	},
 }


### PR DESCRIPTION
1. Add a sleep of 2 min to wait for 2 min for yb cdc initialization to complete. 
2. Only then, set msr fields to indicate that export-data-from-target has started. As a result cutover status remains "INITIATED" as long as we are waiting for yb cdc to initialize. 