### PR TITLE
Bug Fix: non-public target-db-schema for Oracle source errors in import data to source-replica

### DIFF
--- a/yb-voyager/src/dbzm/valueConverter.go
+++ b/yb-voyager/src/dbzm/valueConverter.go
@@ -161,12 +161,12 @@ func (conv *DebeziumValueConverter) shouldFormatAsPerSourceDatatypes() bool {
 }
 
 func (conv *DebeziumValueConverter) ConvertEvent(ev *tgtdb.Event, table string, formatIfRequired bool) error {
-	err := conv.convertMap(table, ev.Key, ev.ExporterRole, formatIfRequired)
+	err := conv.convertMap(ev.SchemaName, table, ev.Key, ev.ExporterRole, formatIfRequired)
 	if err != nil {
 		return fmt.Errorf("convert event key: %w", err)
 	}
 
-	err = conv.convertMap(table, ev.Fields, ev.ExporterRole, formatIfRequired)
+	err = conv.convertMap(ev.SchemaName, table, ev.Fields, ev.ExporterRole, formatIfRequired)
 	if err != nil {
 		return fmt.Errorf("convert event fields: %w", err)
 	}
@@ -186,11 +186,15 @@ func checkSourceExporter(exporterRole string) bool {
 	return exporterRole == "source_db_exporter"
 }
 
-func (conv *DebeziumValueConverter) convertMap(tableName string, m map[string]*string, exportSourceType string, formatIfRequired bool) error {
+func (conv *DebeziumValueConverter) convertMap(eventSchema string, tableName string, m map[string]*string, exportSourceType string, formatIfRequired bool) error {
 	var schemaRegistry *SchemaRegistry
+	targetTableName := tableName
 	if checkSourceExporter(exportSourceType) {
 		schemaRegistry = conv.schemaRegistrySource
 	} else {
+		if eventSchema != "public" {
+			targetTableName = fmt.Sprintf("%s.%s", eventSchema, tableName)
+		}
 		schemaRegistry = conv.schemaRegistryTarget
 	}
 	for column, value := range m {
@@ -198,7 +202,7 @@ func (conv *DebeziumValueConverter) convertMap(tableName string, m map[string]*s
 			continue
 		}
 		columnValue := *value
-		colType, err := schemaRegistry.GetColumnType(tableName, column, conv.shouldFormatAsPerSourceDatatypes())
+		colType, err := schemaRegistry.GetColumnType(targetTableName, column, conv.shouldFormatAsPerSourceDatatypes())
 		if err != nil {
 			return fmt.Errorf("fetch column schema: %w", err)
 		}


### PR DESCRIPTION
Issue - with this fix in this PR: https://github.com/yugabyte/yb-voyager/pull/1254, for renaming the schema files for YB source for non-public schema names. SchemaRegistry was failing for  `import data to source-replica` for the non-public target-db-schema case where it is trying to find the file with the `table_schema.json` name but with the fix in the above PR, it is now changed to `schema_name.table_schema.json`. So, we need a fix on valueConverter side to pass the appropriate table name for non-public target schema to SchemaRegistry.
Fix - passing the qualified name to schemaRegistry
