### PR TITLE
Added retries in executing alter queries on Target YugabyteDB for error "Errors occurred while reaching out to the tablet servers"

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -260,7 +260,11 @@ func displayExportedRowCountSnapshot(snapshotViaDebezium bool) {
 }
 
 func displayImportedRowCountSnapshot(state *ImportDataState, tasks []*ImportFileTask) {
-	fmt.Printf("import report\n")
+	if importerRole == IMPORT_FILE_ROLE {
+		fmt.Printf("import report\n")
+	} else {
+		fmt.Printf("snapshot import report\n")
+	}
 	tableList := importFileTasksToTableNames(tasks)
 	err := retrieveMigrationUUID()
 	if err != nil {

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -51,7 +51,7 @@ var cutoverToTargetCmd = &cobra.Command{
 		}
 		if prepareForFallBack {
 			if msr.FallForwardEnabled {
-				utils.ErrExit("cannot prepare for fall-back. Fall-forward workflow already enabled.")
+				utils.ErrExit("Live migration with Fall-forward workflow is already started on this export-dir. So --prepare-for-fall-back is not applicable.")
 			}
 			if msr.SourceDBConf.DBType == POSTGRESQL {
 				utils.ErrExit("Live migration with Fall-back is not supported for PostgreSQL sourceDB.")

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -223,6 +223,7 @@ const BATCH_METADATA_TABLE_NAME = BATCH_METADATA_TABLE_SCHEMA + "." + "ybvoyager
 const EVENT_CHANNELS_METADATA_TABLE_NAME = BATCH_METADATA_TABLE_SCHEMA + "." + "ybvoyager_import_data_event_channels_metainfo"
 const EVENTS_PER_TABLE_METADATA_TABLE_NAME = BATCH_METADATA_TABLE_SCHEMA + "." + "ybvoyager_imported_event_count_by_table"
 const YB_DEFAULT_PARALLELISM_FACTOR = 2 // factor for default parallelism in case fetchDefaultParallelJobs() is not able to get the no of cores
+const ALTER_QUERY_RETRY_COUNT = 5
 
 func (yb *TargetYugabyteDB) CreateVoyagerSchema() error {
 	cmds := []string{
@@ -1055,24 +1056,34 @@ func (yb *TargetYugabyteDB) alterColumns(tableColumnsMap map[string][]string, al
 			query := fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s %s`, qualifiedTableName, column, alterAction)
 			batch.Queue(query)
 		}
-
-		err := yb.connPool.WithConn(func(conn *pgx.Conn) (bool, error) {
-			br := conn.SendBatch(context.Background(), &batch)
-			for i := 0; i < batch.Len(); i++ {
-				_, err := br.Exec()
-				if err != nil {
-					log.Errorf("executing query to alter columns for table(%s): %v", qualifiedTableName, err)
-					return false, fmt.Errorf("executing query to alter columns for table(%s): %w", qualifiedTableName, err)
+		var sleepIntervalSec = 0
+		for i := 0; i < ALTER_QUERY_RETRY_COUNT; i++ {
+			err := yb.connPool.WithConn(func(conn *pgx.Conn) (bool, error) {
+				br := conn.SendBatch(context.Background(), &batch)
+				for i := 0; i < batch.Len(); i++ {
+					_, err := br.Exec()
+					if err != nil {
+						log.Errorf("executing query to alter columns for table(%s): %v", qualifiedTableName, err)
+						return false, fmt.Errorf("executing query to alter columns for table(%s): %w", qualifiedTableName, err)
+					}
 				}
+				if err := br.Close(); err != nil {
+					log.Errorf("closing batch of queries to alter columns for table(%s): %v", qualifiedTableName, err)
+					return false, fmt.Errorf("closing batch of queries to alter columns for table(%s): %w", qualifiedTableName, err)
+				}
+				return false, nil
+			})
+			if err != nil {
+				log.Errorf("error in altering columns for table(%s): %v", qualifiedTableName, err)
+				if !strings.Contains(err.Error(), "while reaching out to the tablet servers") {
+					return err
+				}
+				sleepIntervalSec += 10
+				log.Infof("retrying after %d seconds for table(%s)", sleepIntervalSec, qualifiedTableName)
+				time.Sleep(time.Duration(sleepIntervalSec) * time.Second)
+			} else {
+				break
 			}
-			if err := br.Close(); err != nil {
-				log.Errorf("closing batch of queries to alter columns for table(%s): %v", qualifiedTableName, err)
-				return false, fmt.Errorf("closing batch of queries to alter columns for table(%s): %w", qualifiedTableName, err)
-			}
-			return false, nil
-		})
-		if err != nil {
-			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
On a single node YB cluster executing multiple alter statements after the data load is erroring out with error - `Errors occurred while reaching out to the tablet servers`. Added 5 retries with constant backoff of 10 sec for that.
Fix - https://yugabyte.atlassian.net/browse/DB-9869
and few misc UI changes
Jenkins - https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/1864