### PR TITLE
DB-9772 Remove "export data failed" msg when process shutdown requested by end migration

### DIFF
--- a/yb-voyager/main.go
+++ b/yb-voyager/main.go
@@ -47,6 +47,7 @@ func registerSignalHandlers() {
 			cmd.ProcessShutdownRequested = true
 		case syscall.SIGUSR2:
 			utils.PrintAndLog("\nReceived signal to terminate due to end migration command. Exiting...")
+			cmd.ProcessShutdownRequested = true
 		case syscall.SIGUSR1:
 			cmd.StopArchiverSignal = true
 			return


### PR DESCRIPTION
export-data does not report failures if `ProcessShutdownRequested==true` which is the case also when end-migration command is run.