### PR TITLE
Report Non PK tables and multiple schemas as not supported in live migration 

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -159,6 +159,11 @@ func exportData() bool {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if source.DBType == POSTGRESQL && changeStreamingIsEnabled(exportType) {
+		if len(strings.Split(source.Schema, "|")) > 1 {
+			utils.ErrExit("This voyager release does not support live-migration for more than one schema in --source-db-schema.")
+		}
+	}
 	finalTableList, tablesColumnList := getFinalTableColumnList()
 
 	if len(finalTableList) == 0 {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -365,6 +365,10 @@ func reportUnsupportedTables(finalTableList []*sqlname.SourceName) {
 	//report Partitions or case sensitive tables
 	var caseSensitiveTables []string
 	var partitionedTables []string
+	allNonPKTables, err := source.DB().GetNonPKTables()
+	if err != nil {
+		utils.ErrExit("get non-pk tables: %v", err)
+	}
 	var nonPKTables []string
 	for _, table := range finalTableList {
 		if source.DBType == POSTGRESQL {
@@ -379,7 +383,7 @@ func reportUnsupportedTables(finalTableList []*sqlname.SourceName) {
 				partitionedTables = append(partitionedTables, table.Qualified.MinQuoted)
 			}
 		}
-		if source.DB().IsNonPKTable(table) {
+		if lo.Contains(allNonPKTables, table.Qualified.MinQuoted) {
 			nonPKTables = append(nonPKTables, table.Qualified.MinQuoted)
 		}
 	}
@@ -396,7 +400,7 @@ func reportUnsupportedTables(finalTableList []*sqlname.SourceName) {
 		utils.PrintAndLog("Table names without a Primary key: %s", nonPKTables)
 	}
 	utils.ErrExit("This voyager release does not support live-migration for tables without a primary key, tables with case sensitive name and partitioned tables.\n" +
-	"You can exclude these tables using the --exclude-table-list argument.")
+		"You can exclude these tables using the --exclude-table-list argument.")
 }
 
 func getFinalTableColumnList() ([]*sqlname.SourceName, map[*sqlname.SourceName][]string) {

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -355,7 +355,7 @@ func (ms *MySQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) 
 func (ms *MySQL) IsNonPKTable(tableName *sqlname.SourceName) bool {
 	query := fmt.Sprintf("SELECT count(*)" +
 	"FROM information_schema.KEY_COLUMN_USAGE" +
-	"WHERE TABLE_NAME = '%s' AND TABLE_SCHEMA = '%s' AND CONSTRAINT_NAME = 'PRIMARY'", tableName.ObjectName.MinQuoted, source.DBName)
+	"WHERE TABLE_NAME = '%s' AND TABLE_SCHEMA = '%s' AND CONSTRAINT_NAME = 'PRIMARY'", tableName.ObjectName.MinQuoted, tableName.SchemaName.MinQuoted)
 	count := 0
 	err := ms.db.QueryRow(query).Scan(&count)
 	if err != nil {

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -353,5 +353,13 @@ func (ms *MySQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) 
 }
 
 func (ms *MySQL) IsNonPKTable(tableName *sqlname.SourceName) bool {
-	panic("not implemented")
+	query := fmt.Sprintf("SELECT count(*)" +
+	"FROM information_schema.KEY_COLUMN_USAGE" +
+	"WHERE TABLE_NAME = '%s' AND TABLE_SCHEMA = '%s' AND CONSTRAINT_NAME = 'PRIMARY'", tableName.ObjectName.MinQuoted, source.DBName)
+	count := 0
+	err := ms.db.QueryRow(query).Scan(&count)
+	if err != nil {
+		utils.ErrExit("Failed to query %q for primary key of %q: %s", query, tableName.String(), err)
+	}
+	return count == 0
 }

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -365,13 +365,13 @@ func (ms *MySQL) GetNonPKTables() ([]string, error) {
 		FROM 
 			information_schema.KEY_COLUMN_USAGE
 		WHERE 
-			TABLE_SCHEMA = 'release_qual' 
+			TABLE_SCHEMA = '%s' 
 			AND CONSTRAINT_NAME = 'PRIMARY' 
 		GROUP BY 
 			table_name
 	) pk_count ON t.table_name = pk_count.table_name
 	WHERE 
-		t.TABLE_SCHEMA = '%s'`, ms.source.DBName)
+		t.TABLE_SCHEMA = '%s'`, ms.source.DBName, ms.source.DBName)
 	rows, err := ms.db.Query(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query %q for primary key of %q: %w", query, ms.source.DBName, err)

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -353,9 +353,9 @@ func (ms *MySQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) 
 }
 
 func (ms *MySQL) IsNonPKTable(tableName *sqlname.SourceName) bool {
-	query := fmt.Sprintf("SELECT count(*)" +
-	"FROM information_schema.KEY_COLUMN_USAGE" +
-	"WHERE TABLE_NAME = '%s' AND TABLE_SCHEMA = '%s' AND CONSTRAINT_NAME = 'PRIMARY'", tableName.ObjectName.MinQuoted, tableName.SchemaName.MinQuoted)
+	query := fmt.Sprintf(`SELECT count(*) 
+	FROM information_schema.KEY_COLUMN_USAGE 
+	WHERE TABLE_NAME = '%s' AND TABLE_SCHEMA = '%s' AND CONSTRAINT_NAME = 'PRIMARY'`, tableName.ObjectName.MinQuoted, tableName.SchemaName.MinQuoted)
 	count := 0
 	err := ms.db.QueryRow(query).Scan(&count)
 	if err != nil {

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -377,7 +377,7 @@ func (ms *MySQL) GetNonPKTables() ([]string, error) {
 		return nil, fmt.Errorf("failed to query %q for primary key of %q: %w", query, ms.source.DBName, err)
 	}
 	defer rows.Close()
-	var unsupportedTables []string
+	var nonPKTables []string
 	for rows.Next() {
 		var count int
 		var tableName string
@@ -387,8 +387,8 @@ func (ms *MySQL) GetNonPKTables() ([]string, error) {
 		}
 		table := sqlname.NewSourceName(ms.source.DBName, tableName)
 		if count == 0 {
-			unsupportedTables = append(unsupportedTables, table.Qualified.MinQuoted)
+			nonPKTables = append(nonPKTables, table.Qualified.MinQuoted)
 		}
 	}
-	return unsupportedTables, nil
+	return nonPKTables, nil
 }

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -351,3 +351,7 @@ func (ms *MySQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) 
 	log.Infof("ClearMigrationState not implemented yet for MySQL")
 	return nil
 }
+
+func (ms *MySQL) IsNonPKTable(tableName *sqlname.SourceName) bool {
+	panic("not implemented")
+}

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -471,10 +471,10 @@ func (ora *Oracle) GetNonPKTables() ([]string, error) {
 	LEFT JOIN (
 		SELECT COUNT(constraint_name) AS count, table_name
 		FROM ALL_CONSTRAINTS
-		WHERE constraint_type = 'P' AND owner = 'ADMIN'
+		WHERE constraint_type = 'P' AND owner = '%s'
 		GROUP BY table_name
 	) pk_count ON at.table_name = pk_count.table_name
-	WHERE at.owner = '%s'`, ora.source.Schema)
+	WHERE at.owner = '%s'`, ora.source.Schema, ora.source.Schema)
 	rows, err := ora.db.Query(query)
 	if err != nil {
 		return nil, fmt.Errorf("error in querying source database for unsupported tables: %v", err)

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -466,11 +466,12 @@ func (ora *Oracle) ClearMigrationState(migrationUUID uuid.UUID, exportDir string
 }
 
 func (ora *Oracle) IsNonPKTable(tableName *sqlname.SourceName) bool {
-	query := fmt.Sprintf("SELECT constraint_name from ALL_CONSTRAINTS where constraint_type='P' and OWNER='%s' and TABLE_NAME='%s' ;", tableName.SchemaName.Unquoted, tableName.ObjectName.Unquoted)
-	isNonPKTable := ""
-	err := ora.db.QueryRow(query).Scan(&isNonPKTable)
+	query := fmt.Sprintf(`SELECT count(constraint_name) from ALL_CONSTRAINTS where constraint_type='P' 
+	and OWNER='%s' and TABLE_NAME='%s'`, tableName.SchemaName.Unquoted, tableName.ObjectName.Unquoted)
+	count := 0
+	err := ora.db.QueryRow(query).Scan(&count)
 	if err != nil && err != sql.ErrNoRows {
 		utils.ErrExit("error in query to check if table %v is a non-pk table: %v", tableName, err)
 	}
-	return isNonPKTable == ""
+	return count == 0
 }

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -466,7 +466,7 @@ func (ora *Oracle) ClearMigrationState(migrationUUID uuid.UUID, exportDir string
 }
 
 func (ora *Oracle) IsNonPKTable(tableName *sqlname.SourceName) bool {
-	query := fmt.Sprintf("select constraint_name from all_constraints where constraint_type='P' and owner='%s' and table_name='%s' ;", tableName.SchemaName.Unquoted, tableName.ObjectName.Unquoted)
+	query := fmt.Sprintf("SELECT constraint_name from ALL_CONSTRAINTS where constraint_type='P' and OWNER='%s' and TABLE_NAME='%s' ;", tableName.SchemaName.Unquoted, tableName.ObjectName.Unquoted)
 	isNonPKTable := ""
 	err := ora.db.QueryRow(query).Scan(&isNonPKTable)
 	if err != nil && err != sql.ErrNoRows {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -464,3 +464,13 @@ func (ora *Oracle) ClearMigrationState(migrationUUID uuid.UUID, exportDir string
 	}
 	return nil
 }
+
+func (ora *Oracle) IsNonPKTable(tableName *sqlname.SourceName) bool {
+	query := fmt.Sprintf("select constraint_name from all_constraints where constraint_type='P' and owner='%s' and table_name='%s' ;", tableName.SchemaName.Unquoted, tableName.ObjectName.Unquoted)
+	isNonPKTable := ""
+	err := ora.db.QueryRow(query).Scan(&isNonPKTable)
+	if err != nil && err != sql.ErrNoRows {
+		utils.ErrExit("error in query to check if table %v is a non-pk table: %v", tableName, err)
+	}
+	return isNonPKTable == ""
+}

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -480,7 +480,7 @@ func (ora *Oracle) GetNonPKTables() ([]string, error) {
 		return nil, fmt.Errorf("error in querying source database for unsupported tables: %v", err)
 	}
 	defer rows.Close()
-	var unsupportedTables []string
+	var nonPKTables []string
 	for rows.Next() {
 		var count int
 		var tableName string
@@ -490,8 +490,8 @@ func (ora *Oracle) GetNonPKTables() ([]string, error) {
 		}
 		table := sqlname.NewSourceName(ora.source.Schema, fmt.Sprintf(`"%s"`, tableName))
 		if count == 0 {
-			unsupportedTables = append(unsupportedTables, table.Qualified.MinQuoted)
+			nonPKTables = append(nonPKTables, table.Qualified.MinQuoted)
 		}
 	}
-	return unsupportedTables, nil
+	return nonPKTables, nil
 }

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -605,7 +605,7 @@ func (pg *PostgreSQL) GetNonPKTables() ([]string, error) {
 	query := fmt.Sprintf(PG_QUERY_TO_CHECK_IF_TABLE_HAS_PK, querySchemaList)
 	rows, err := pg.db.Query(context.Background(), query)
 	if err != nil {
-		return nil, fmt.Errorf("error in querying(%q) source database for primary key: %v\n", query, err)
+		return nil, fmt.Errorf("error in querying(%q) source database for primary key: %v", query, err)
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -613,7 +613,7 @@ func (pg *PostgreSQL) GetNonPKTables() ([]string, error) {
 		var pkCount int
 		err := rows.Scan(&schemaName, &tableName, &pkCount)
 		if err != nil {
-			return nil, fmt.Errorf("error in scanning query rows for primary key: %v\n", err)
+			return nil, fmt.Errorf("error in scanning query rows for primary key: %v", err)
 		}
 		table := sqlname.NewSourceName(schemaName, fmt.Sprintf(`"%s"`, tableName))
 		if pkCount == 0 {

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -49,7 +49,7 @@ type SourceDB interface {
 	GetServers() []string
 	GetPartitions(table *sqlname.SourceName) []*sqlname.SourceName
 	ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error
-	IsNonPKTable(tableName *sqlname.SourceName) bool
+	GetNonPKTables() ([]string, error)
 }
 
 func newSourceDB(source *Source) SourceDB {

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
@@ -48,6 +49,7 @@ type SourceDB interface {
 	GetServers() []string
 	GetPartitions(table *sqlname.SourceName) []*sqlname.SourceName
 	ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error
+	IsNonPKTable(tableName *sqlname.SourceName) bool
 }
 
 func newSourceDB(source *Source) SourceDB {

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -453,7 +453,7 @@ func (yb *YugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportDir str
 	return nil
 }
 
-func (yb *PostgreSQL) IsNonPKTable(tableName *sqlname.SourceName) bool {
+func (yb *YugabyteDB) IsNonPKTable(tableName *sqlname.SourceName) bool {
 	table := tableName.ObjectName.MinQuoted
 	if tableName.SchemaName.MinQuoted != "public" {
 		table = tableName.Qualified.MinQuoted
@@ -463,7 +463,7 @@ func (yb *PostgreSQL) IsNonPKTable(tableName *sqlname.SourceName) bool {
 	JOIN pg_attribute a ON a.attnum = ANY(con.conkey)
 	WHERE con.contype = 'p' 
 	AND conrelid::regclass::text = '%s'`, table)
-	rows, err := pg.db.Query(context.Background(), query)
+	rows, err := yb.conn.Query(context.Background(), query)
 	if err != nil {
 		utils.ErrExit("error in querying(%q) source database for primary key: %v\n", query, err)
 	}

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -458,11 +458,7 @@ func (yb *YugabyteDB) IsNonPKTable(tableName *sqlname.SourceName) bool {
 	if tableName.SchemaName.MinQuoted != "public" {
 		table = tableName.Qualified.MinQuoted
 	}
-	query := fmt.Sprintf(`SELECT DISTINCT(conname) AS constraint_name
-	FROM pg_constraint con
-	JOIN pg_attribute a ON a.attnum = ANY(con.conkey)
-	WHERE con.contype = 'p' 
-	AND conrelid::regclass::text = '%s'`, table)
+	query := fmt.Sprintf(PG_QUERY_TO_CHECK_IF_TABLE_HAS_PK, table)
 	rows, err := yb.conn.Query(context.Background(), query)
 	if err != nil {
 		utils.ErrExit("error in querying(%q) source database for primary key: %v\n", query, err)

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -458,11 +458,11 @@ func (yb *YugabyteDB) IsNonPKTable(tableName *sqlname.SourceName) bool {
 	if tableName.SchemaName.MinQuoted != "public" {
 		table = tableName.Qualified.MinQuoted
 	}
+	count := 0
 	query := fmt.Sprintf(PG_QUERY_TO_CHECK_IF_TABLE_HAS_PK, table)
-	rows, err := yb.conn.Query(context.Background(), query)
+	err := yb.conn.QueryRow(context.Background(), query).Scan(&count)
 	if err != nil {
 		utils.ErrExit("error in querying(%q) source database for primary key: %v\n", query, err)
 	}
-	defer rows.Close()
-	return !rows.Next()
+	return count == 0
 }

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -456,7 +456,9 @@ func (yb *YugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportDir str
 
 func (yb *YugabyteDB) GetNonPKTables() ([]string, error) {
 	var nonPKTables []string
-	query := fmt.Sprintf(PG_QUERY_TO_CHECK_IF_TABLE_HAS_PK, yb.source.Schema)
+	schemaList := strings.Split(yb.source.Schema, "|")
+	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
+	query := fmt.Sprintf(PG_QUERY_TO_CHECK_IF_TABLE_HAS_PK, querySchemaList)
 	rows, err := yb.conn.Query(context.Background(), query)
 	if err != nil {
 		utils.ErrExit("error in querying(%q) source database for primary key: %v\n", query, err)


### PR DESCRIPTION
Reporting all the non-pk tables in the table list for the users to exclude them as in live migration non-pk tables are not supported. 
Reporting multiple schemas as not supported

Jenkins - https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/1904