### PR TITLE
Added support for Unique key columns Conflict Resolution for Oracle migrations

### DIFF
--- a/migtests/scripts/live-migration-fallf-run-test.sh
+++ b/migtests/scripts/live-migration-fallf-run-test.sh
@@ -170,11 +170,13 @@ main() {
 	step "Initiating cutover"
 	yb-voyager initiate cutover to target --export-dir ${EXPORT_DIR} --yes
 
-	for ((i = 0; i < 5; i++)); do
+	# max sleep time = 15 * 20s = 5 minutes, but that much sleep will be in failure cases
+	# in success case it will exit as soon as cutover is COMPLETED + 20sec
+	for ((i = 0; i < 15; i++)); do
     if [ "$(yb-voyager cutover status --export-dir "${EXPORT_DIR}" | grep -oP 'cutover to target status: \K\S+')" != "COMPLETED" ]; then
         echo "Waiting for cutover to be COMPLETED..."
-        sleep 1m
-        if [ "$i" -eq 4 ]; then
+        sleep 20
+        if [ "$i" -eq 14 ]; then
             tail_log_file "yb-voyager-export-data.log"
             tail_log_file "yb-voyager-import-data.log"
 			tail_log_file "debezium-source_db_exporter.log"
@@ -197,11 +199,11 @@ main() {
 	step "Initiating cutover to source-replica"
 	yb-voyager initiate cutover to source-replica --export-dir ${EXPORT_DIR} --yes
 
-	for ((i = 0; i < 5; i++)); do
+	for ((i = 0; i < 15; i++)); do
     if [ "$(yb-voyager cutover status --export-dir "${EXPORT_DIR}" | grep -oP 'cutover to source-replica status: \K\S+')" != "COMPLETED" ]; then
         echo "Waiting for switchover to be COMPLETED..."
         sleep 20
-        if [ "$i" -eq 4 ]; then
+        if [ "$i" -eq 14 ]; then
             tail_log_file "yb-voyager-import-data-to-source-replica.log"
             tail_log_file "yb-voyager-export-data-from-target.log"
 			tail_log_file "debezium-target_db_exporter_ff.log"

--- a/migtests/tests/oracle/basic-live-test/snapshot_data.sql
+++ b/migtests/tests/oracle/basic-live-test/snapshot_data.sql
@@ -3,11 +3,11 @@ insert into x values(2,3);
 insert into x values(3,4);
 
 -- INSERT INITIAL DATA
--- INSERT INTO user_table (email) VALUES ('user1@example.com');
--- INSERT INTO user_table (email) VALUES ('user2@example.com');
--- INSERT INTO user_table (email) VALUES ('user3@example.com');
--- INSERT INTO user_table (email) VALUES ('user4@example.com');
--- INSERT INTO user_table (email) VALUES ('user5@example.com');
--- INSERT INTO user_table (email) VALUES ('user6@example.com');
--- INSERT INTO user_table (email) VALUES ('user7@example.com');
--- INSERT INTO user_table (email) VALUES ('user8@example.com');
+INSERT INTO user_table VALUES (1, 'user1@example.com', 'active');
+INSERT INTO user_table VALUES (2, 'user2@example.com', 'active');
+INSERT INTO user_table VALUES (3, 'user3@example.com', 'active');
+INSERT INTO user_table VALUES (4, 'user4@example.com', 'active');
+INSERT INTO user_table VALUES (5, 'user5@example.com', 'active');
+INSERT INTO user_table VALUES (6, 'user6@example.com', 'active');
+INSERT INTO user_table VALUES (7, 'user7@example.com', 'active');
+INSERT INTO user_table VALUES (8, 'user8@example.com', 'active');

--- a/migtests/tests/oracle/basic-live-test/snapshot_schema.sql
+++ b/migtests/tests/oracle/basic-live-test/snapshot_schema.sql
@@ -1,7 +1,7 @@
 create table x(id int primary key,id2 int);
 
--- CREATE TABLE user_table (
---     id SERIAL PRIMARY KEY,
---     email VARCHAR(255) UNIQUE,
---     status VARCHAR(50) DEFAULT 'active'
--- );
+CREATE TABLE user_table (
+    id INT PRIMARY KEY,
+    email VARCHAR(255) UNIQUE,
+    status VARCHAR(50) DEFAULT 'active'
+);

--- a/migtests/tests/oracle/basic-live-test/source_delta.sql
+++ b/migtests/tests/oracle/basic-live-test/source_delta.sql
@@ -6,24 +6,24 @@ update x set id2=20 where id=5;
 insert into x values(6,5);
 
 -- DISABLING THIS PART OF THE TEST [Case-Sensitivity handling required for Oracle]
--- -- DMLs which can possible cause conflicts on import side (DELETE-INSERT, UPDATE-INSERT, DELETE-UPDATE, UPDATE-UPDATE)
+-- DMLs which can possible cause conflicts on import side (DELETE-INSERT, UPDATE-INSERT, DELETE-UPDATE, UPDATE-UPDATE)
 
--- -- DELETE-INSERT CONFLICT
--- -- Delete a row (id=1) and then insert with the same unique key value (id=9)
--- DELETE FROM user_table WHERE id = 1;
--- INSERT INTO user_table (id, email) VALUES (9, 'user1@example.com');
+-- DELETE-INSERT CONFLICT
+-- Delete a row (id=1) and then insert with the same unique key value (id=9)
+DELETE FROM user_table WHERE id = 1;
+INSERT INTO user_table (id, email) VALUES (9, 'user1@example.com');
 
--- -- UPDATE-INSERT CONFLICT
--- -- Update a row (id=2) and then insert with the same unique key value (id=10)
--- UPDATE user_table SET email = 'updated_user2@example.com' WHERE id = 2;
--- INSERT INTO user_table (id, email) VALUES (10, 'user2@example.com');
+-- UPDATE-INSERT CONFLICT
+-- Update a row (id=2) and then insert with the same unique key value (id=10)
+UPDATE user_table SET email = 'updated_user2@example.com' WHERE id = 2;
+INSERT INTO user_table (id, email) VALUES (10, 'user2@example.com');
 
--- -- DELETE-UPDATE CONFLICT
--- -- Delete a row (id=3) and then update another row with the same unique key value (id=5)
--- DELETE FROM user_table WHERE id = 3;
--- UPDATE user_table SET email = 'user3@example.com' WHERE id = 5;
+-- DELETE-UPDATE CONFLICT
+-- Delete a row (id=3) and then update another row with the same unique key value (id=5)
+DELETE FROM user_table WHERE id = 3;
+UPDATE user_table SET email = 'user3@example.com' WHERE id = 5;
 
--- -- UPDATE-UPDATE CONFLICT
--- -- Update a row (id=4) and then update another row with the same unique key value (id=6)
--- UPDATE user_table SET email = 'updated_user4@example.com' WHERE id = 4;
--- UPDATE user_table SET email = 'user4@example.com' WHERE id = 6;
+-- UPDATE-UPDATE CONFLICT
+-- Update a row (id=4) and then update another row with the same unique key value (id=6)
+UPDATE user_table SET email = 'updated_user4@example.com' WHERE id = 4;
+UPDATE user_table SET email = 'user4@example.com' WHERE id = 6;

--- a/migtests/tests/oracle/basic-live-test/target_delta.sql
+++ b/migtests/tests/oracle/basic-live-test/target_delta.sql
@@ -4,3 +4,24 @@ update test_schema.x set id2=10 where id=9;
 delete from test_schema.x where id=5;
 update test_schema.x set id2=60 where id=5;
 insert into test_schema.x values(100,5);
+
+
+INSERT into test_schema.user_table (id, email) VALUES (13, 'user13@example.com');
+INSERT into test_schema.user_table (id, email) VALUES (14, 'user14@example.com');
+
+-- conflicting DMLs
+-- DELETE-INSERT CONFLICT
+DELETE FROM test_schema.user_table WHERE id = 7;
+INSERT into test_schema.user_table (id, email) VALUES (11, 'user7@example.com');
+
+-- UPDATE-INSERT CONFLICT
+UPDATE test_schema.user_table SET email = 'userxyz@example.com' where id = 8;
+INSERT into test_schema.user_table (id, email) VALUES (12, 'user8@example.com');
+
+-- DELETE-UPDATE CONFLICT
+DELETE FROM test_schema.user_table WHERE id = 9;
+UPDATE test_schema.user_table SET email = 'user1@example.com' WHERE id = 13;
+
+-- UPDATE-UPDATE CONFLICT
+UPDATE test_schema.user_table SET email = 'user10@example.com' WHERE id = 10;
+UPDATE test_schema.user_table SET email = 'user2@example.com' WHERE id = 14;

--- a/migtests/tests/oracle/basic-live-test/validate
+++ b/migtests/tests/oracle/basic-live-test/validate
@@ -24,7 +24,7 @@ def main():
 
 EXPECTED_ROW_COUNT = {
 	'x':3,
- 	# 'user_table': 8
+ 	'user_table': 8
 }
 
 EXPECTED_SUM_OF_COLUMN = {
@@ -32,9 +32,9 @@ EXPECTED_SUM_OF_COLUMN = {
 		'id': '6',
 		'id2': '9'
 	},
-	# 'user_table': {
-	# 	'id': '36',
-	# }
+	'user_table': {
+		'id': '36',
+	}
 }
 
 def migration_completed_checks_yb():

--- a/migtests/tests/oracle/basic-live-test/validateAfterChanges
+++ b/migtests/tests/oracle/basic-live-test/validateAfterChanges
@@ -36,7 +36,7 @@ EXPECTED_SUM_OF_COLUMN = {
 
 EXPECTED_ROW_COUNT_FF = {
 	'x':7,
-	'user_table': 8
+	'user_table': 10
 }
 
 EXPECTED_SUM_OF_COLUMN_FF = {
@@ -45,7 +45,7 @@ EXPECTED_SUM_OF_COLUMN_FF = {
 		'id2': '53'
 	},
 	'user_table': {
-		'id': '51',
+		'id': '85',
 	}
 }
 

--- a/migtests/tests/oracle/basic-live-test/validateAfterChanges
+++ b/migtests/tests/oracle/basic-live-test/validateAfterChanges
@@ -21,7 +21,7 @@ def main():
 
 EXPECTED_ROW_COUNT = {
 	'x':5,
-	# 'user_table': 8
+	'user_table': 8
 }
 
 EXPECTED_SUM_OF_COLUMN = {
@@ -29,20 +29,23 @@ EXPECTED_SUM_OF_COLUMN = {
 		'id': '18',
 		'id2': '43'
 	},
-	# 'user_table': {
-	# 	'id': '51',
-	# }
+	'user_table': {
+		'id': '51',
+	}
 }
 
 EXPECTED_ROW_COUNT_FF = {
 	'x':7,
-	# 'user_table': 8
+	'user_table': 8
 }
 
 EXPECTED_SUM_OF_COLUMN_FF = {
 	'x': {
 		'id': '133',
 		'id2': '53'
+	},
+	'user_table': {
+		'id': '51',
 	}
 }
 

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -95,7 +95,6 @@ func NewConflictDetectionCache(tableToIdentityColumnNames map[string][]string, e
 }
 
 func (c *ConflictDetectionCache) Put(event *tgtdb.Event) {
-	log.Infof("putting event(vsn=%d) in conflict detection cache", event.Vsn)
 	c.Lock()
 	defer c.Unlock()
 	c.m[event.Vsn] = event
@@ -141,7 +140,6 @@ func (c *ConflictDetectionCache) RemoveEvents(batch *tgtdb.EventBatch) {
 }
 
 func (c *ConflictDetectionCache) eventsConfict(cachedEvent, incomingEvent *tgtdb.Event) bool {
-	log.Infof("checking for conflict between event1(%v) and event2(%v)", cachedEvent.String(), incomingEvent.String())
 	if !c.eventsAreOfSameTable(cachedEvent, incomingEvent) {
 		return false
 	}
@@ -151,7 +149,6 @@ func (c *ConflictDetectionCache) eventsConfict(cachedEvent, incomingEvent *tgtdb
 		maybeQualifiedName = fmt.Sprintf("%s.%s", cachedEvent.SchemaName, cachedEvent.TableName)
 	}
 	uniqueKeyColumns := c.tableToUniqueKeyColumns[maybeQualifiedName]
-	log.Infof("uniqueKeyColumns for maybeQualifiedName=%s are %v", maybeQualifiedName, uniqueKeyColumns)
 	/*
 		Not checking for value of unique key values conflict in case of export from yb because of inconsistency issues in before values of events provided by yb-cdc
 		TODO(future): Fix this in our debezium voyager plugin
@@ -179,7 +176,6 @@ func (c *ConflictDetectionCache) eventsConfict(cachedEvent, incomingEvent *tgtdb
 	}
 
 	for _, column := range uniqueKeyColumns {
-		log.Infof("comparing column %s for event1.BeforeFields[%s]=%+v and event2.Fields[%s]=%+v", column, column, cachedEvent.BeforeFields[column], column, incomingEvent.Fields[column])
 		if cachedEvent.BeforeFields[column] == nil || incomingEvent.Fields[column] == nil {
 			return false
 		}

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
@@ -97,10 +96,6 @@ func NewConflictDetectionCache(tableToIdentityColumnNames map[string][]string, e
 	c.sourceDBType = sourceDBType
 	c.evChans = evChans
 	return c
-}
-
-func (c *ConflictDetectionCache) String() string {
-	return spew.Sdump(c)
 }
 
 func (c *ConflictDetectionCache) Put(event *tgtdb.Event) {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -367,7 +367,7 @@ func validateExportTypeFlag() {
 	}
 }
 
-func saveExportTypeInMetaDB() {
+func saveExportTypeInMSR() {
 	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		record.ExportType = exportType
 	})

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -154,7 +154,7 @@ func exportData() bool {
 	checkSourceDBCharset()
 	source.DB().CheckRequiredToolsAreInstalled()
 	saveSourceDBConfInMSR()
-	saveExportTypeInMetaDB()
+	saveExportTypeInMSR()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -218,6 +218,7 @@ func exportData() bool {
 			config.PublicationName = msr.PGPublicationName
 			config.InitSequenceMaxMapping = sequenceInitValues.String()
 		}
+		saveTableToUniqueKeyColumnsMappingInMetaDB(finalTableList)
 		err = debeziumExportData(ctx, config, tableNametoApproxRowCountMap)
 		if err != nil {
 			log.Errorf("Export Data using debezium failed: %v", err)
@@ -269,7 +270,6 @@ func exportData() bool {
 		}
 		return true
 	}
-
 }
 
 func exportPGSnapshotWithPGdump(ctx context.Context, cancel context.CancelFunc, finalTableList []*sqlname.SourceName, tablesColumnList map[*sqlname.SourceName][]string) error {
@@ -819,4 +819,8 @@ func createUpdateExportedRowCountEventList(tableNames []string) []*cp.UpdateExpo
 	}
 
 	return result
+}
+
+func saveTableToUniqueKeyColumnsMappingInMetaDB(finalTableList []*sqlname.SourceName) {
+	source.DB().GetTableToUniqueKeyColumnsMap(finalTableList)
 }

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -828,7 +828,8 @@ func saveTableToUniqueKeyColumnsMapInMetaDB(tableList []*sqlname.SourceName) {
 	}
 
 	log.Infof("updating metaDB with table to unique key columns map: %v", res)
-	err = metadb.UpdateJsonObjectInMetaDB(metaDB, metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, func(record *map[string][]string) {
+	key := fmt.Sprintf("%s_%s", metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, exporterRole)
+	err = metadb.UpdateJsonObjectInMetaDB(metaDB, key, func(record *map[string][]string) {
 		*record = res
 	})
 	if err != nil {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -827,7 +827,9 @@ func saveTableToUniqueKeyColumnsMapInMetaDB(tableList []*sqlname.SourceName) {
 		utils.ErrExit("get table to unique key columns map: %v", err)
 	}
 
-	err = metaDB.InsertJsonObject(nil, metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, res)
+	err = metadb.UpdateJsonObjectInMetaDB(metaDB, metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, func(record *map[string][]string) {
+		*record = res
+	})
 	if err != nil {
 		utils.ErrExit("insert table to unique key columns map: %v", err)
 	}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -218,7 +218,7 @@ func exportData() bool {
 			config.PublicationName = msr.PGPublicationName
 			config.InitSequenceMaxMapping = sequenceInitValues.String()
 		}
-		saveTableToUniqueKeyColumnsMappingInMetaDB(finalTableList)
+		saveTableToUniqueKeyColumnsMapInMetaDB(finalTableList)
 		err = debeziumExportData(ctx, config, tableNametoApproxRowCountMap)
 		if err != nil {
 			log.Errorf("Export Data using debezium failed: %v", err)
@@ -821,6 +821,14 @@ func createUpdateExportedRowCountEventList(tableNames []string) []*cp.UpdateExpo
 	return result
 }
 
-func saveTableToUniqueKeyColumnsMappingInMetaDB(finalTableList []*sqlname.SourceName) {
-	source.DB().GetTableToUniqueKeyColumnsMap(finalTableList)
+func saveTableToUniqueKeyColumnsMapInMetaDB(tableList []*sqlname.SourceName) {
+	res, err := source.DB().GetTableToUniqueKeyColumnsMap(tableList)
+	if err != nil {
+		utils.ErrExit("get table to unique key columns map: %v", err)
+	}
+
+	err = metaDB.InsertJsonObject(nil, metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, res)
+	if err != nil {
+		utils.ErrExit("insert table to unique key columns map: %v", err)
+	}
 }

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -827,6 +827,7 @@ func saveTableToUniqueKeyColumnsMapInMetaDB(tableList []*sqlname.SourceName) {
 		utils.ErrExit("get table to unique key columns map: %v", err)
 	}
 
+	log.Infof("updating metaDB with table to unique key columns map: %v", res)
 	err = metadb.UpdateJsonObjectInMetaDB(metaDB, metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, func(record *map[string][]string) {
 		*record = res
 	})

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -219,8 +219,8 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 		For more details about ConflictDetectionCache see the comment on line 11 in [conflictDetectionCache.go](../conflictDetectionCache.go)
 	*/
 	tableNameForUniqueKeyColumns := tableName
-	if isTargetDBExporter(event.ExporterRole) {
-		tableNameForUniqueKeyColumns = event.SchemaName + "." + tableName
+	if isTargetDBExporter(event.ExporterRole) && event.SchemaName != "public" {
+		tableNameForUniqueKeyColumns = event.SchemaName + "." + event.TableName
 	}
 	uniqueKeyCols := conflictDetectionCache.tableToUniqueKeyColumns[tableNameForUniqueKeyColumns]
 	if len(uniqueKeyCols) > 0 {

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -86,13 +86,6 @@ func streamChanges(state *ImportDataState, tableNames []string) error {
 		evChans = append(evChans, make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE))
 		processingDoneChans = append(processingDoneChans, make(chan bool, 1))
 	}
-	log.Info("initializing conflict detection cache")
-	tableToUniqueKeyColumns, err := getTableToUniqueKeyColumnsMapFromMetaDB()
-	// tableToUniqueKeyColumns, err := tdb.GetTableToUniqueKeyColumnsMap(tableNames)
-	if err != nil {
-		return fmt.Errorf("get table unique key columns map: %s", err)
-	}
-	conflictDetectionCache = NewConflictDetectionCache(tableToUniqueKeyColumns, evChans, sourceDBType)
 
 	log.Infof("streaming changes from %s", eventQueue.QueueDirPath)
 	for !eventQueue.EndOfQueue { // continuously get next segments to stream
@@ -140,10 +133,27 @@ func streamChangesFromSegment(
 	}
 
 	log.Infof("streaming changes for segment %s", segment.FilePath)
+	segmentFirstEvent := true
 	for !segment.IsProcessed() {
 		event, err := segment.NextEvent()
 		if err != nil {
 			return err
+		}
+
+		// possibility of cutover(for example: source changed from PG to YB)
+		if segmentFirstEvent {
+			segmentFirstEvent = false
+			/*
+				Note: `sourceDBType` is a global variable, which always represent the initial source db type
+				it does not change even after cutover to target but for conflict detection cache,
+				we need to use the actual source db type at the moment since we save information live TableToUniqueKeyColumns during export
+				to reuse it during import
+			*/
+			sourceDBTypeForConflictCache := sourceDBType
+			if isTargetDBExporter(event.ExporterRole) {
+				sourceDBTypeForConflictCache = "yugabytedb"
+			}
+			initializeConflictDetectionCache(evChans, event.ExporterRole, sourceDBTypeForConflictCache)
 		}
 
 		if event == nil && segment.IsProcessed() {
@@ -208,7 +218,11 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 		Checking for all possible conflicts among events
 		For more details about ConflictDetectionCache see the comment on line 11 in [conflictDetectionCache.go](../conflictDetectionCache.go)
 	*/
-	uniqueKeyCols := conflictDetectionCache.tableToUniqueKeyColumns[tableName]
+	tableNameForUniqueKeyColumns := tableName
+	if isTargetDBExporter(event.ExporterRole) {
+		tableNameForUniqueKeyColumns = event.SchemaName + "." + tableName
+	}
+	uniqueKeyCols := conflictDetectionCache.tableToUniqueKeyColumns[tableNameForUniqueKeyColumns]
 	if len(uniqueKeyCols) > 0 {
 		if event.Op == "d" {
 			conflictDetectionCache.Put(event)
@@ -319,10 +333,21 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 	done <- true
 }
 
-func getTableToUniqueKeyColumnsMapFromMetaDB() (map[string][]string, error) {
+func initializeConflictDetectionCache(evChans []chan *tgtdb.Event, exporterRole string, sourceDBTypeForConflictCache string) {
+	tableToUniqueKeyColumns, err := getTableToUniqueKeyColumnsMapFromMetaDB(exporterRole)
+	if err != nil {
+		utils.ErrExit("get table unique key columns map: %s", err)
+	}
+	log.Infof("initializing conflict detection cache")
+	conflictDetectionCache = NewConflictDetectionCache(tableToUniqueKeyColumns, evChans, sourceDBTypeForConflictCache)
+}
+
+func getTableToUniqueKeyColumnsMapFromMetaDB(exporterRole string) (map[string][]string, error) {
 	log.Infof("fetching table to unique key columns map from metaDB")
 	var res map[string][]string
-	found, err := metaDB.GetJsonObject(nil, metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, &res)
+
+	key := fmt.Sprintf("%s_%s", metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, exporterRole)
+	found, err := metaDB.GetJsonObject(nil, key, &res)
 	if err != nil {
 		return nil, err
 	}

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -209,7 +209,6 @@ func handleEvent(event *tgtdb.Event, evChans []chan *tgtdb.Event) error {
 		For more details about ConflictDetectionCache see the comment on line 11 in [conflictDetectionCache.go](../conflictDetectionCache.go)
 	*/
 	uniqueKeyCols := conflictDetectionCache.tableToUniqueKeyColumns[tableName]
-	log.Infof("uniqueKeyCols for table %s: %v", tableName, uniqueKeyCols)
 	if len(uniqueKeyCols) > 0 {
 		if event.Op == "d" {
 			conflictDetectionCache.Put(event)
@@ -321,6 +320,7 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 }
 
 func getTableToUniqueKeyColumnsMapFromMetaDB() (map[string][]string, error) {
+	log.Infof("fetching table to unique key columns map from metaDB")
 	var res map[string][]string
 	found, err := metaDB.GetJsonObject(nil, metadb.TABLE_TO_UNIQUE_KEY_COLUMNS_KEY, &res)
 	if err != nil {
@@ -329,6 +329,6 @@ func getTableToUniqueKeyColumnsMapFromMetaDB() (map[string][]string, error) {
 	if !found {
 		return nil, fmt.Errorf("table to unique key columns map not found in metaDB")
 	}
-	log.Infof("Table to unique key columns map: %v", res)
+	log.Infof("fetched table to unique key columns map: %v", res)
 	return res, nil
 }

--- a/yb-voyager/src/dbzm/valueConverter.go
+++ b/yb-voyager/src/dbzm/valueConverter.go
@@ -170,7 +170,7 @@ func (conv *DebeziumValueConverter) shouldFormatAsPerSourceDatatypes() bool {
 func (conv *DebeziumValueConverter) ConvertEvent(ev *tgtdb.Event, table string, formatIfRequired bool) error {
 	err := conv.convertMap(ev.SchemaName, table, ev.Key, ev.ExporterRole, formatIfRequired)
 	if err != nil {
-		return fmt.Errorf("convert event key: %w", err)
+		return fmt.Errorf("convert event(vsn=%d) key: %w", ev.Vsn, err)
 	}
 
 	err = conv.convertMap(ev.SchemaName, table, ev.Fields, ev.ExporterRole, formatIfRequired)

--- a/yb-voyager/src/metadb/metadataDB.go
+++ b/yb-voyager/src/metadb/metadataDB.go
@@ -39,6 +39,7 @@ var (
 	TARGET_DB_IDENTITY_COLUMNS_KEY             = "target_db_identity_columns_key"
 	FF_DB_IDENTITY_COLUMNS_KEY                 = "ff_db_identity_columns_key"
 	SOURCE_INDEXES_INFO_KEY                    = "source_indexes_info_key"
+	TABLE_TO_UNIQUE_KEY_COLUMNS_KEY            = "table_to_unique_key_columns_key"
 	ErrNoQueueSegmentsFound                    = errors.New("no queue segments found")
 )
 

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -347,7 +347,7 @@ func (ms *MySQL) GetPartitions(tableName *sqlname.SourceName) []*sqlname.SourceN
 	panic("not implemented")
 }
 
-func (ms *MySQL) GetTableToUniqueKeyColumnsMap(tableList []string) (map[string][]string, error) {
+func (ms *MySQL) GetTableToUniqueKeyColumnsMap(tableList []*sqlname.SourceName) (map[string][]string, error) {
 	return nil, nil
 }
 

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -347,6 +347,10 @@ func (ms *MySQL) GetPartitions(tableName *sqlname.SourceName) []*sqlname.SourceN
 	panic("not implemented")
 }
 
+func (ms *MySQL) GetTableToUniqueKeyColumnsMap(tableList []string) (map[string][]string, error) {
+	return nil, nil
+}
+
 func (ms *MySQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
 	log.Infof("ClearMigrationState not implemented yet for MySQL")
 	return nil

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -508,6 +508,10 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 	return partitions
 }
 
+func (pg *PostgreSQL) GetTableToUniqueKeyColumnsMap(tableList []string) (map[string][]string, error) {
+	return nil, nil
+}
+
 func (pg *PostgreSQL) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
 	log.Infof("ClearMigrationState not implemented yet for PostgreSQL")
 	return nil

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -48,6 +48,7 @@ type SourceDB interface {
 	GetAllSequences() []string
 	GetServers() []string
 	GetPartitions(table *sqlname.SourceName) []*sqlname.SourceName
+	GetTableToUniqueKeyColumnsMap(tableList []*sqlname.SourceName) (map[string][]string, error)
 	ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error
 	GetNonPKTables() ([]string, error)
 }

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
+	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
@@ -434,8 +435,53 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 	return partitions
 }
 
-func (yb *YugabyteDB) GetTableToUniqueKeyColumnsMap(tableList []string) (map[string][]string, error) {
-	return nil, nil
+const ybQueryTmplForUniqCols = `
+SELECT tc.table_schema, tc.table_name, kcu.column_name
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+	AND tc.table_schema = kcu.table_schema
+    AND tc.table_name = kcu.table_name
+WHERE tc.table_schema = ANY('{%s}') AND tc.table_name = ANY('{%s}') AND tc.constraint_type = 'UNIQUE';
+`
+
+func (yb *YugabyteDB) GetTableToUniqueKeyColumnsMap(tableList []*sqlname.SourceName) (map[string][]string, error) {
+	log.Infof("getting unique key columns for tables: %v", tableList)
+	result := make(map[string][]string)
+	var querySchemaList, queryTableList []string
+	for i := 0; i < len(tableList); i++ {
+		schema, table := tableList[i].SchemaName.Unquoted, tableList[i].ObjectName.Unquoted
+		querySchemaList = append(querySchemaList, schema)
+		queryTableList = append(queryTableList, table)
+	}
+
+	querySchemaList = lo.Uniq(querySchemaList)
+	query := fmt.Sprintf(ybQueryTmplForUniqCols, strings.Join(querySchemaList, ","), strings.Join(queryTableList, ","))
+	log.Infof("query to get unique key columns: %s", query)
+	rows, err := yb.conn.Query(context.Background(), query)
+	if err != nil {
+		return nil, fmt.Errorf("querying unique key columns: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schemaName, tableName, colName string
+		err := rows.Scan(&schemaName, &tableName, &colName)
+		if err != nil {
+			return nil, fmt.Errorf("scanning row for unique key column name: %w", err)
+		}
+		if schemaName != "public" {
+			tableName = fmt.Sprintf("%s.%s", schemaName, tableName)
+		}
+		result[tableName] = append(result[tableName], colName)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, fmt.Errorf("error iterating over rows for unique key columns: %w", err)
+	}
+	log.Infof("unique key columns for tables: %v", result)
+	return result, nil
 }
 
 func (yb *YugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -434,6 +434,10 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 	return partitions
 }
 
+func (yb *YugabyteDB) GetTableToUniqueKeyColumnsMap(tableList []string) (map[string][]string, error) {
+	return nil, nil
+}
+
 func (yb *YugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error {
 	log.Infof("ClearMigrationState not implemented yet for YugabyteDB")
 	return nil

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -58,6 +58,31 @@ func (e *Event) String() string {
 		e.Vsn, e.Op, e.SchemaName, e.TableName, mapStr(e.Key), mapStr(e.BeforeFields), mapStr(e.Fields), e.ExporterRole)
 }
 
+func (e *Event) Copy() Event {
+	keyCopy := make(map[string]*string, len(e.Key))
+	for k, v := range e.Key {
+		keyCopy[k] = v
+	}
+	fieldsCopy := make(map[string]*string, len(e.Fields))
+	for k, v := range e.Fields {
+		fieldsCopy[k] = v
+	}
+	beforeFieldsCopy := make(map[string]*string, len(e.BeforeFields))
+	for k, v := range e.BeforeFields {
+		beforeFieldsCopy[k] = v
+	}
+	return Event{
+		Vsn:          e.Vsn,
+		Op:           e.Op,
+		SchemaName:   e.SchemaName,
+		TableName:    e.TableName,
+		Key:          keyCopy,
+		Fields:       fieldsCopy,
+		BeforeFields: beforeFieldsCopy,
+		ExporterRole: e.ExporterRole,
+	}
+}
+
 func (e *Event) IsCutoverToTarget() bool {
 	return e.Op == "cutover.target"
 }

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -58,27 +58,18 @@ func (e *Event) String() string {
 		e.Vsn, e.Op, e.SchemaName, e.TableName, mapStr(e.Key), mapStr(e.BeforeFields), mapStr(e.Fields), e.ExporterRole)
 }
 
-func (e *Event) Copy() Event {
-	keyCopy := make(map[string]*string, len(e.Key))
-	for k, v := range e.Key {
-		keyCopy[k] = v
+func (e *Event) Copy() *Event {
+	idFn := func(k string, v *string) (string, *string) {
+		return k, v
 	}
-	fieldsCopy := make(map[string]*string, len(e.Fields))
-	for k, v := range e.Fields {
-		fieldsCopy[k] = v
-	}
-	beforeFieldsCopy := make(map[string]*string, len(e.BeforeFields))
-	for k, v := range e.BeforeFields {
-		beforeFieldsCopy[k] = v
-	}
-	return Event{
+	return &Event{
 		Vsn:          e.Vsn,
 		Op:           e.Op,
 		SchemaName:   e.SchemaName,
 		TableName:    e.TableName,
-		Key:          keyCopy,
-		Fields:       fieldsCopy,
-		BeforeFields: beforeFieldsCopy,
+		Key:          lo.MapEntries(e.Key, idFn),
+		Fields:       lo.MapEntries(e.Fields, idFn),
+		BeforeFields: lo.MapEntries(e.BeforeFields, idFn),
 		ExporterRole: e.ExporterRole,
 	}
 }

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -54,8 +54,8 @@ func (e *Event) String() string {
 		return "{" + strings.Join(elements, ", ") + "}"
 	}
 
-	return fmt.Sprintf("Event{vsn=%v, op=%v, schema=%v, table=%v, key=%v, fields=%v, exporter_role=%v}",
-		e.Vsn, e.Op, e.SchemaName, e.TableName, mapStr(e.Key), mapStr(e.Fields), e.ExporterRole)
+	return fmt.Sprintf("Event{vsn=%v, op=%v, schema=%v, table=%v, key=%v, before_fields=%v, fields=%v, exporter_role=%v}",
+		e.Vsn, e.Op, e.SchemaName, e.TableName, mapStr(e.Key), mapStr(e.BeforeFields), mapStr(e.Fields), e.ExporterRole)
 }
 
 func (e *Event) IsCutoverToTarget() bool {


### PR DESCRIPTION
Required due to different casing in Oracle vs YugabyteDB
Problem Statement: Previously the events were coming from Oracle(having casing of Oracle) and the information like TableToUniqueKeyColumns map mapping was coming from Target DB(having casing of YB or PG/Oracle based on forward migration or FF/FB)
So during comparison, because of that difference in casing it was very complex to manual handle of change the casing depending on sourceDBType

Solution: Shifted the logic for fetching TableToUniqueKeyColumns also to source DB, so the difference in casing won’t be there.