### PR TITLE
Add recommendation to run end-migration to prevent replication slot from filling up disk space

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -30,11 +30,11 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/color"
-	"golang.org/x/exp/slices"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/tebeka/atexit"
+	"golang.org/x/exp/slices"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/cp"
@@ -293,6 +293,9 @@ func exportPGSnapshotWithPGdump(ctx context.Context, cancel context.CancelFunc, 
 	if err != nil {
 		return fmt.Errorf("export snapshot: failed to create replication slot: %v", err)
 	}
+	utils.PrintAndLog(color.YellowString(fmt.Sprintf("Created replication slot '%s' on source PG database. "+
+		"Be sure to run 'end migration' command after completing/aborting this migration to drop the replication slot. "+
+		"This is important to avoid filling up disk space.", replicationSlotName)))
 	// pg_dump
 	err = exportDataOffline(ctx, cancel, finalTableList, tablesColumnList, res.SnapshotName)
 	if err != nil {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -293,9 +293,10 @@ func exportPGSnapshotWithPGdump(ctx context.Context, cancel context.CancelFunc, 
 	if err != nil {
 		return fmt.Errorf("export snapshot: failed to create replication slot: %v", err)
 	}
-	utils.PrintAndLog(color.YellowString(fmt.Sprintf("Created replication slot '%s' on source PG database. "+
+	yellowBold := color.New(color.FgYellow, color.Bold)
+	utils.PrintAndLog(yellowBold.Sprintf("Created replication slot '%s' on source PG database. "+
 		"Be sure to run 'end migration' command after completing/aborting this migration to drop the replication slot. "+
-		"This is important to avoid filling up disk space.", replicationSlotName)))
+		"This is important to avoid filling up disk space.", replicationSlotName))
 	// pg_dump
 	err = exportDataOffline(ctx, cancel, finalTableList, tablesColumnList, res.SnapshotName)
 	if err != nil {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -295,7 +295,7 @@ func exportPGSnapshotWithPGdump(ctx context.Context, cancel context.CancelFunc, 
 	}
 	yellowBold := color.New(color.FgYellow, color.Bold)
 	utils.PrintAndLog(yellowBold.Sprintf("Created replication slot '%s' on source PG database. "+
-		"Be sure to run 'end migration' command after completing/aborting this migration to drop the replication slot. "+
+		"Be sure to run 'initiate cutover to target'/'end migration' command after completing/aborting this migration to drop the replication slot. "+
 		"This is important to avoid filling up disk space.", replicationSlotName))
 	// pg_dump
 	err = exportDataOffline(ctx, cancel, finalTableList, tablesColumnList, res.SnapshotName)


### PR DESCRIPTION
Note: cutover also removes the slot, but it's simpler to just ask the user to run end-migration (which also removes the slot) as it also covers the case where the user aborts the migration mid-way. 