### PR TITLE
Bug Fix[DB-9997]: Archiver failed to exit on receiving signal from end migration command

### DIFF
--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -1,3 +1,18 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package cmd
 
 import (

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -229,7 +229,8 @@ func registerExportDataFlags(cmd *cobra.Command) {
 		"path of the file containing comma-separated list of table names to export data")
 
 	cmd.Flags().IntVar(&source.NumConnections, "parallel-jobs", 4,
-		"number of Parallel Jobs to extract data from source database")
+		"number of Parallel Jobs to extract data from source database.\n"+
+			"In case of BETA_FAST_DATA_EXPORT=1 or --export-type=snapshot-and-changes or --export-type=changes-only, this flag has no effect and the number of parallel jobs is fixed to 1.")
 
 	cmd.Flags().StringVar(&exportType, "export-type", SNAPSHOT_ONLY,
 		fmt.Sprintf("export type: (%s, %s[TECH PREVIEW])", SNAPSHOT_ONLY, SNAPSHOT_AND_CHANGES))

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -302,12 +302,6 @@ func exportPGSnapshotWithPGdump(ctx context.Context, cancel context.CancelFunc, 
 	utils.PrintAndLog(yellowBold.Sprintf("Created replication slot '%s' on source PG database. "+
 		"Be sure to run 'initiate cutover to target'/'end migration' command after completing/aborting this migration to drop the replication slot. "+
 		"This is important to avoid filling up disk space.", replicationSlotName))
-	// pg_dump
-	err = exportDataOffline(ctx, cancel, finalTableList, tablesColumnList, res.SnapshotName)
-	if err != nil {
-		log.Errorf("Export Data failed: %v", err)
-		return err
-	}
 
 	// save replication slot, publication name in MSR
 	err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
@@ -318,6 +312,14 @@ func exportPGSnapshotWithPGdump(ctx context.Context, cancel context.CancelFunc, 
 	if err != nil {
 		utils.ErrExit("update PGReplicationSlotName: update migration status record: %s", err)
 	}
+
+	// pg_dump
+	err = exportDataOffline(ctx, cancel, finalTableList, tablesColumnList, res.SnapshotName)
+	if err != nil {
+		log.Errorf("Export Data failed: %v", err)
+		return err
+	}
+
 	setDataIsExported()
 	return nil
 }

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -137,7 +137,7 @@ func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map
 		SnapshotMode:          snapshotMode,
 		TransactionOrdering:   transactionOrdering,
 	}
-	if source.DBType == "oracle" {
+	if source.DBType == ORACLE {
 		jdbcConnectionStringPrefix := "jdbc:oracle:thin:@"
 		if source.IsOracleCDBSetup() {
 			// uri = cdb uri
@@ -157,7 +157,7 @@ func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to determine if Oracle JDBC wallet location is set: %v", err)
 		}
-	} else if source.DBType == "yugabytedb" {
+	} else if source.DBType == YUGABYTEDB {
 		if exportType == CHANGES_ONLY {
 			ybServers := source.DB().GetServers()
 			masterPort := "7100"

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -162,7 +162,7 @@ func startExportDataFromTargetIfRequired() {
 	lockFile.Unlock() // unlock export dir from import data cmd before switching current process to ff/fb sync cmd
 
 	if tconf.SSLMode == "prefer" || tconf.SSLMode == "allow" {
-		utils.PrintAndLog(color.RedString("Warning: SSL mode '%s' is not supported for 'export data from target' yet. Downgrading it to 'disable'.\nIf you dont want these settings you can restart the 'export data from target' with a different value for --target-ssl-mode and --target-ssl-root-cert flag.", source.SSLMode))
+		utils.PrintAndLog(color.RedString("Warning: SSL mode '%s' is not supported for 'export data from target' yet. Downgrading it to 'disable'.\nIf you don't want these settings you can restart the 'export data from target' with a different value for --target-ssl-mode and --target-ssl-root-cert flag.", source.SSLMode))
 		tconf.SSLMode = "disable"
 	}
 	cmd := []string{"yb-voyager", "export", "data", "from", "target",

--- a/yb-voyager/src/metadb/metadataDB.go
+++ b/yb-voyager/src/metadb/metadataDB.go
@@ -457,8 +457,8 @@ func (m *MetaDB) GetSegmentsToBeDeleted() ([]utils.Segment, error) {
 }
 
 func (m *MetaDB) GetPendingSegments(importCount int) ([]utils.Segment, error) {
-	predicate := fmt.Sprintf(`(exporter_role == 'source_db_exporter' AND (imported_by_target_db_importer + imported_by_ff_db_importer + imported_by_fb_db_importer < %d)) OR
-		(exporter_role LIKE 'target_db_exporter%%' AND (imported_by_target_db_importer + imported_by_ff_db_importer + imported_by_fb_db_importer < 1))`, importCount)
+	predicate := fmt.Sprintf(`(exporter_role == 'source_db_exporter' AND (imported_by_target_db_importer + imported_by_source_replica_db_importer + imported_by_source_db_importer < %d)) OR
+		(exporter_role LIKE 'target_db_exporter%%' AND (imported_by_target_db_importer + imported_by_source_replica_db_importer + imported_by_source_db_importer < 1))`, importCount)
 	segments, err := m.querySegments(predicate)
 	if err != nil {
 		return nil, fmt.Errorf("fetch pending segments: %v", err)


### PR DESCRIPTION
Archiver's query in metaDB.GetPendingSegments() was using old columns names of queue_segments_meta table
- like 'imported_by_ff_db_importer' instead of 'imported_by_source_repica_db_importer'
- updated column names in the query

https://yugabyte.atlassian.net/browse/DB-9997