### PR TITLE
Removed the check for fall back from PG live migration

### DIFF
--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -53,9 +53,6 @@ var cutoverToTargetCmd = &cobra.Command{
 			if msr.FallForwardEnabled {
 				utils.ErrExit("Live migration with Fall-forward workflow is already started on this export-dir. So --prepare-for-fall-back is not applicable.")
 			}
-			if msr.SourceDBConf.DBType == POSTGRESQL {
-				utils.ErrExit("Live migration with Fall-back is not supported for PostgreSQL sourceDB.")
-			}
 		}
 		err = InitiateCutover("target", bool(prepareForFallBack))
 		if err != nil {


### PR DESCRIPTION
Removed the check from cutover to target which denies switching to the fall back workflow in PG live migration.