### PR TITLE
Bug fixes: Partitions for PG adding leaf partitions in case table-list passed by user has root table and load data via root table into target

### DIFF
--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -114,8 +114,8 @@ jobs:
       - name: "TEST: pg-partitions"
         run: migtests/scripts/run-test.sh pg/partitions
 
-      - name: "TEST: pg-partitions"
-        run: EXPORT_TABLE_LIST='customers,sales,emp,p2.boston,p2.london,p2.sydney,range_columns_partition_test,sales_region' migtests/scripts/run-test.sh pg/partitions
+      - name: "TEST: pg-partitions with (table-list)"
+        run: EXPORT_TABLE_LIST='customers,sales,emp,p2.boston,p2.london,p2.sydney,range_columns_partition_test,sales_region' migtests/scripts/run-test.sh pg/partitions 
 
       # Broken for v2.15 and v2.16: https://github.com/yugabyte/yugabyte-db/issues/14529
       # Fixed in 2.17.1.0-b368

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -114,6 +114,9 @@ jobs:
       - name: "TEST: pg-partitions"
         run: migtests/scripts/run-test.sh pg/partitions
 
+      - name: "TEST: pg-partitions"
+        run: EXPORT_TABLE_LIST='customers,sales,emp,p2.boston,p2.london,p2.sydney,range_columns_partition_test,sales_region' migtests/scripts/run-test.sh pg/partitions
+
       # Broken for v2.15 and v2.16: https://github.com/yugabyte/yugabyte-db/issues/14529
       # Fixed in 2.17.1.0-b368
       - name: "TEST: pg-partitions-with-indexes"

--- a/migtests/tests/pg/partitions/fix-schema
+++ b/migtests/tests/pg/partitions/fix-schema
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+
+sed -i  's/p2\.boston/p2.boston_region/g' $TEST_DIR/export-dir/schema/tables/table.sql
+sed -i  's/p2\.london/p2.london_region/g' $TEST_DIR/export-dir/schema/tables/table.sql
+sed -i  's/p2\.sydney/p2.sydney_region/g' $TEST_DIR/export-dir/schema/tables/table.sql

--- a/migtests/tests/pg/partitions/validate
+++ b/migtests/tests/pg/partitions/validate
@@ -58,7 +58,7 @@ INSERT_QUERIES_INTO_TABLE_VERIFY_PARTITION = {
 	},
 	"List_partitions_in_different_schema" : {
 		"query": "INSERT INTO p1.sales_region  (id, amount, branch, region) VALUES (1001, 2000, 'Branch 1001','Sydney') ",
-		"partition_table_name": "sydney",
+		"partition_table_name": "sydney_region",
 		"schema_name": "p2"
 	},
 	"Range" : {

--- a/migtests/tests/pg/partitions/validate
+++ b/migtests/tests/pg/partitions/validate
@@ -31,9 +31,9 @@ EXPECTED_ROW_COUNT = {
  	"public.sales_region":		1000,
   	"public.sydney": 			333,
 	"p1.sales_region":			1000,
-	"p2.boston":    			334,
-	"p2.london":    			333,
-	"p2.sydney":    			333,
+	"p2.boston_region":    			334,
+	"p2.london_region":    			333,
+	"p2.sydney_region":    			333,
 	"public.range_columns_partition_test": 6,
 	"public.range_columns_partition_test_p0": 3,
 	"public.range_columns_partition_test_p1": 3

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -648,7 +648,6 @@ func getRenameTableMap(renameTablesList string) map[string]string {
 	return renameTableMap
 }
 
-
 func renameTableIfRequired(table string) string {
 	// required to rename the table name from leaf to root partition in case of pg_dump
 	// to be load data in target using via root table
@@ -658,6 +657,9 @@ func renameTableIfRequired(table string) string {
 	}
 	source = *msr.SourceDBConf
 	if source.DBType != POSTGRESQL {
+		return table
+	}
+	if msr.RenameTablesMap == "" {
 		return table
 	}
 	defaultSchema, noDefaultSchema := getDefaultPGSchema(source.Schema, "|")

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -351,13 +351,13 @@ func initMetaDB() {
 		utils.ErrExit("get migration status record: %v", err)
 	}
 	if msr.VoyagerVersion != utils.YB_VOYAGER_VERSION {
-		userFacingMsg := fmt.Sprintf("Voyager requires the entire migration workflow to be executed using a single Voyager version.\n" +
-		"The export-dir %q was created using version %q and the current version is %q. Either use Voyager %q to continue the migration or start afresh " + 
-		"with a new export-dir.", exportDir, msr.VoyagerVersion, utils.YB_VOYAGER_VERSION, msr.VoyagerVersion)
+		userFacingMsg := fmt.Sprintf("Voyager requires the entire migration workflow to be executed using a single Voyager version.\n"+
+			"The export-dir %q was created using version %q and the current version is %q. Either use Voyager %q to continue the migration or start afresh "+
+			"with a new export-dir.", exportDir, msr.VoyagerVersion, utils.YB_VOYAGER_VERSION, msr.VoyagerVersion)
 		if msr.VoyagerVersion == "" { //In case the export dir is already started from older version that will not have VoyagerVersion field in MSR
-			userFacingMsg = fmt.Sprintf("Voyager requires the entire migration workflow to be executed using a single Voyager version.\n" +
-		"The export-dir %q was created using older version and the current version is %q. Either use older version to continue the migration or start afresh " + 
-		"with a new export-dir.", exportDir, utils.YB_VOYAGER_VERSION)
+			userFacingMsg = fmt.Sprintf("Voyager requires the entire migration workflow to be executed using a single Voyager version.\n"+
+				"The export-dir %q was created using older version and the current version is %q. Either use older version to continue the migration or start afresh "+
+				"with a new export-dir.", exportDir, utils.YB_VOYAGER_VERSION)
 		}
 		utils.ErrExit(userFacingMsg)
 	}
@@ -635,4 +635,16 @@ func initBaseTargetEvent(bev *cp.BaseEvent, eventType string) {
 		DatabaseName:  tconf.DBName,
 		SchemaNames:   []string{tconf.Schema},
 	}
+}
+
+func getRenameTableMap(renameTablesList string) map[string]string {
+
+	list := strings.Split(renameTablesList, ",")
+	var renameTableMap map[string]string = make(map[string]string)
+	for _, renameTable := range list {
+		fromTable := strings.Split(renameTable, ":")[0]
+		toTable := strings.Split(renameTable, ":")[1]
+		renameTableMap[fromTable] = toTable
+	}
+	return renameTableMap
 }

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -637,17 +637,6 @@ func initBaseTargetEvent(bev *cp.BaseEvent, eventType string) {
 	}
 }
 
-func getRenameTableMap(renameTablesList string) map[string]string {
-	list := strings.Split(renameTablesList, ",")
-	var renameTableMap map[string]string = make(map[string]string)
-	for _, renameTable := range list {
-		fromTable := strings.Split(renameTable, ":")[0]
-		toTable := strings.Split(renameTable, ":")[1]
-		renameTableMap[fromTable] = toTable
-	}
-	return renameTableMap
-}
-
 func renameTableIfRequired(table string) string {
 	// required to rename the table name from leaf to root partition in case of pg_dump
 	// to be load data in target using via root table
@@ -659,7 +648,7 @@ func renameTableIfRequired(table string) string {
 	if source.DBType != POSTGRESQL {
 		return table
 	}
-	if msr.RenameTablesMap == "" {
+	if msr.RenameTablesMap == nil {
 		return table
 	}
 	defaultSchema, noDefaultSchema := getDefaultPGSchema(source.Schema, "|")
@@ -669,9 +658,8 @@ func renameTableIfRequired(table string) string {
 	tableName := sqlname.NewSourceNameFromMaybeQualifiedName(table, defaultSchema)
 	fromTable := tableName.Qualified.Unquoted
 
-	renameTablesMap := getRenameTableMap(msr.RenameTablesMap)
-	if renameTablesMap[fromTable] != "" {
-		table := sqlname.NewSourceNameFromQualifiedName(renameTablesMap[fromTable])
+	if msr.RenameTablesMap[fromTable] != "" {
+		table := sqlname.NewSourceNameFromQualifiedName(msr.RenameTablesMap[fromTable])
 		toTable := table.Qualified.MinQuoted
 		if table.SchemaName.MinQuoted == "public" {
 			toTable = table.ObjectName.MinQuoted

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -182,6 +182,12 @@ func exportData() bool {
 		utils.ErrExit("failed to add the leaf partitions in table list: %w", err)
 	}
 
+	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		record.RenameTablesMap = strings.Join(lo.MapToSlice(partitionsToRootTableMap, func(k, v string) string {
+			return fmt.Sprintf("%s:%s", k, v)
+		}), ",")
+	})
+
 	if changeStreamingIsEnabled(exportType) || useDebezium {
 		config, tableNametoApproxRowCountMap, err := prepareDebeziumConfig(finalTableList, tablesColumnList)
 		if err != nil {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -177,6 +177,11 @@ func exportData() bool {
 		os.Exit(0)
 	}
 
+	finalTableList, err = addLeafPartitionsInTableList(finalTableList)
+	if err != nil {
+		utils.ErrExit("failed to add the leaf partitions in table list: %w", err)
+	}
+
 	if changeStreamingIsEnabled(exportType) || useDebezium {
 		config, tableNametoApproxRowCountMap, err := prepareDebeziumConfig(finalTableList, tablesColumnList)
 		if err != nil {
@@ -270,6 +275,78 @@ func exportData() bool {
 		}
 		return true
 	}
+}
+
+// required only for postgresql/yugabytedb since GetAllTables() returns all tables and partitions
+func addLeafPartitionsInTableList(tableList []*sqlname.SourceName) ([]*sqlname.SourceName, error) {
+	requiredForSource := source.DBType == "postgresql" || source.DBType == "yugabytedb"
+	if !requiredForSource {
+		return tableList, nil
+	}
+	// here we are adding leaf partitions in the list only in yb or pg because events in the 
+	// these dbs are referred with leaf partitions only but in oracle root table is main point of reference 
+	// for partitions and in Oracle fall-forward/fall-back case we are doing renaming using the config `ybexporter.tables.rename` in dbzm 
+	// when event is coming from YB for leaf partitions it is getting renamed to root_table 
+	// ex - customers -> cust_other, cust_part11, cust_part12, cust_part22, cust_part21 
+	// events from oracle - will have customers for all of these partitions 
+	// events from yb,pg will have `cust_other, cust_part11, cust_part12, cust_part22, cust_part21` out of these leaf partitions only 
+	// using the dbzm we are renaming these events coming from yb to root_table for oracle.
+	// not required for pg to rename them.
+	
+	modifiedTableList := []*sqlname.SourceName{}
+
+	//TODO: optimisation to avoid multiple calls to DB with one call in the starting to fetch TablePartitionTree map.
+
+	//TODO: test when we upgrade to PG13+ as partitions are handled with root table
+	//Refer- https://debezium.zulipchat.com/#narrow/stream/302529-community-general/topic/Connector.20not.20working.20with.20partitions
+	for _, table := range tableList {
+		rootTable, err := GetRootTableOfPartition(table)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get root table of partition %s: %v", table.Qualified.MinQuoted, err)
+		}
+		allLeafPartitions := GetAllLeafPartitions(table)
+		switch true {
+		case len(allLeafPartitions) == 0 && rootTable != table: //leaf partition
+			partitionsToRootTableMap[table.Qualified.Unquoted] = rootTable.Qualified.MinQuoted // Unquoted->MinQuoted map as debezium uses Unquoted table name 
+			modifiedTableList = append(modifiedTableList, table)
+		case len(allLeafPartitions) == 0 && rootTable == table: //normal table
+			modifiedTableList = append(modifiedTableList, table)
+		case len(allLeafPartitions) > 0 && source.TableList != "": // table with partitions in table list
+			for _, leafPartition := range allLeafPartitions {
+				modifiedTableList = append(modifiedTableList, leafPartition)
+				partitionsToRootTableMap[leafPartition.Qualified.Unquoted] = rootTable.Qualified.MinQuoted
+			}
+		}
+	}
+	return lo.UniqBy(modifiedTableList, func(table *sqlname.SourceName) string {
+		return table.Qualified.MinQuoted
+	}), nil
+}
+
+func GetRootTableOfPartition(table *sqlname.SourceName) (*sqlname.SourceName, error) {
+	parentTable := source.DB().ParentTableOfPartition(table)
+	if parentTable == "" {
+		return table, nil
+	}
+	defaultSourceSchema, noDefaultSchema := getDefaultSourceSchemaName()
+	if noDefaultSchema {
+		return nil, fmt.Errorf("default schema not found")
+	}
+	return GetRootTableOfPartition(sqlname.NewSourceNameFromMaybeQualifiedName(parentTable, defaultSourceSchema))
+}
+
+func GetAllLeafPartitions(table *sqlname.SourceName) []*sqlname.SourceName {
+	allLeafPartitions := []*sqlname.SourceName{}
+	childPartitions := source.DB().GetPartitions(table)
+	for _, childPartition := range childPartitions {
+		leafPartitions := GetAllLeafPartitions(childPartition)
+		if len(leafPartitions) == 0 {
+			allLeafPartitions = append(allLeafPartitions, childPartition)
+		} else {
+			allLeafPartitions = append(allLeafPartitions, leafPartitions...)
+		}
+	}
+	return allLeafPartitions
 }
 
 func exportPGSnapshotWithPGdump(ctx context.Context, cancel context.CancelFunc, finalTableList []*sqlname.SourceName, tablesColumnList map[*sqlname.SourceName][]string) error {

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -60,10 +60,6 @@ func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map
 	default:
 		return nil, nil, fmt.Errorf("invalid export type %s", exportType)
 	}
-	tableList, err = addLeafPartitionsInTableList(tableList)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to add the leaf partitions in table list: %w", err)
-	}
 	fmt.Printf("num tables to export: %d\n", len(tableList))
 	utils.PrintAndLog("table list for data export: %v", tableList)
 	tableNameToApproxRowCountMap := getTableNameToApproxRowCountMap(tableList)
@@ -198,77 +194,6 @@ func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map
 	return config, tableNameToApproxRowCountMap, nil
 }
 
-// required only for postgresql/yugabytedb since GetAllTables() returns all tables and partitions
-func addLeafPartitionsInTableList(tableList []*sqlname.SourceName) ([]*sqlname.SourceName, error) {
-	requiredForSource := source.DBType == "postgresql" || source.DBType == "yugabytedb"
-	if !requiredForSource {
-		return tableList, nil
-	}
-	// here we are adding leaf partitions in the list only in yb or pg because events in the
-	// these dbs are referred with leaf partitions only but in oracle root table is main point of reference
-	// for partitions and in Oracle fall-forward/fall-back case we are doing renaming using the config `ybexporter.tables.rename` in dbzm
-	// when event is coming from YB for leaf partitions it is getting renamed to root_table
-	// ex - customers -> cust_other, cust_part11, cust_part12, cust_part22, cust_part21
-	// events from oracle - will have customers for all of these partitions
-	// events from yb,pg will have `cust_other, cust_part11, cust_part12, cust_part22, cust_part21` out of these leaf partitions only
-	// using the dbzm we are renaming these events coming from yb to root_table for oracle.
-	// not required for pg to rename them.
-
-	modifiedTableList := []*sqlname.SourceName{}
-
-	//TODO: optimisation to avoid multiple calls to DB with one call in the starting to fetch TablePartitionTree map.
-
-	//TODO: test when we upgrade to PG13+ as partitions are handled with root table
-	//Refer- https://debezium.zulipchat.com/#narrow/stream/302529-community-general/topic/Connector.20not.20working.20with.20partitions
-	for _, table := range tableList {
-		rootTable, err := GetRootTableOfPartition(table)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get root table of partition %s: %v", table.Qualified.MinQuoted, err)
-		}
-		allLeafPartitions := GetAllLeafPartitions(table)
-		switch true {
-		case len(allLeafPartitions) == 0 && rootTable != table: //leaf partition
-			partitionsToRootTableMap[table.Qualified.MinQuoted] = rootTable.Qualified.MinQuoted
-			modifiedTableList = append(modifiedTableList, table)
-		case len(allLeafPartitions) == 0 && rootTable == table: //normal table
-			modifiedTableList = append(modifiedTableList, table)
-		case len(allLeafPartitions) > 0 && source.TableList != "": // table with partitions in table list
-			for _, leafPartition := range allLeafPartitions {
-				modifiedTableList = append(modifiedTableList, leafPartition)
-				partitionsToRootTableMap[leafPartition.Qualified.MinQuoted] = rootTable.Qualified.MinQuoted
-			}
-		}
-	}
-	return lo.UniqBy(modifiedTableList, func(table *sqlname.SourceName) string {
-		return table.Qualified.MinQuoted
-	}), nil
-}
-
-func GetRootTableOfPartition(table *sqlname.SourceName) (*sqlname.SourceName, error) {
-	parentTable := source.DB().ParentTableOfPartition(table)
-	if parentTable == "" {
-		return table, nil
-	}
-	defaultSourceSchema, noDefaultSchema := getDefaultSourceSchemaName()
-	if noDefaultSchema {
-		return nil, fmt.Errorf("default schema not found")
-	}
-	return GetRootTableOfPartition(sqlname.NewSourceNameFromMaybeQualifiedName(parentTable, defaultSourceSchema))
-}
-
-func GetAllLeafPartitions(table *sqlname.SourceName) []*sqlname.SourceName {
-	allLeafPartitions := []*sqlname.SourceName{}
-	childPartitions := source.DB().GetPartitions(table)
-	for _, childPartition := range childPartitions {
-		leafPartitions := GetAllLeafPartitions(childPartition)
-		if len(leafPartitions) == 0 {
-			allLeafPartitions = append(allLeafPartitions, childPartition)
-		} else {
-			allLeafPartitions = append(allLeafPartitions, leafPartitions...)
-		}
-	}
-	return allLeafPartitions
-}
 
 func prepareSSLParamsForDebezium(exportDir string) error {
 	switch source.DBType {

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -104,6 +104,11 @@ func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map
 	tableRenameMapping := strings.Join(lo.MapToSlice(partitionsToRootTableMap, func(k, v string) string {
 		return fmt.Sprintf("%s:%s", k, v)
 	}), ",")
+
+	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		record.RenameTablesMap = tableRenameMapping
+	})
+	
 	config := &dbzm.Config{
 		RunId:          runId,
 		SourceDBType:   source.DBType,

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -105,10 +105,6 @@ func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map
 		return fmt.Sprintf("%s:%s", k, v)
 	}), ",")
 
-	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-		record.RenameTablesMap = tableRenameMapping
-	})
-	
 	config := &dbzm.Config{
 		RunId:          runId,
 		SourceDBType:   source.DBType,
@@ -198,7 +194,6 @@ func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map
 	}
 	return config, tableNameToApproxRowCountMap, nil
 }
-
 
 func prepareSSLParamsForDebezium(exportDir string) error {
 	switch source.DBType {

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -39,10 +39,9 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
-var partitionsToRootTableMap = make(map[string]string)
 var ybCDCClient *dbzm.YugabyteDBCDCClient
 
-func prepareDebeziumConfig(tableList []*sqlname.SourceName, tablesColumnList map[*sqlname.SourceName][]string) (*dbzm.Config, map[string]int64, error) {
+func prepareDebeziumConfig(partitionsToRootTableMap map[string]string, tableList []*sqlname.SourceName, tablesColumnList map[*sqlname.SourceName][]string) (*dbzm.Config, map[string]int64, error) {
 	runId = time.Now().String()
 	absExportDir, err := filepath.Abs(exportDir)
 	if err != nil {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -717,37 +717,6 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 }
 
-func renameTableIfRequired(table string) string {
-	// required to rename the table name from leaf to root partition in case of pg_dump
-	// to be load data in target using via root table
-	msr, err := metaDB.GetMigrationStatusRecord()
-	if err != nil {
-		utils.ErrExit("Failed to get migration status record: %s", err)
-	}
-	source = *msr.SourceDBConf
-	if source.DBType != POSTGRESQL {
-		return table
-	}
-	defaultSchema, noDefaultSchema := getDefaultPGSchema(source.Schema, "|")
-	if noDefaultSchema && len(strings.Split(table, ".")) <= 1 {
-		utils.ErrExit("no default schema found to qualify table %s", table)
-	}
-	tableName := sqlname.NewSourceNameFromMaybeQualifiedName(table, defaultSchema)
-	fromTable := tableName.Qualified.Unquoted
-
-	renameTablesMap := getRenameTableMap(msr.RenameTablesMap)
-	if renameTablesMap[fromTable] != "" {
-		table := sqlname.NewSourceNameFromQualifiedName(renameTablesMap[fromTable])
-		toTable := table.Qualified.MinQuoted
-		if table.SchemaName.MinQuoted == "public" {
-			toTable = table.ObjectName.MinQuoted
-		}
-		log.Infof("renaming table %s to %s for ImportBatchArgs", fromTable, toTable)
-		return toTable
-	}
-	return table
-}
-
 func getImportBatchArgsProto(tableName, filePath string) *tgtdb.ImportBatchArgs {
 	columns := TableToColumnNames[tableName]
 	columns, err := tdb.IfRequiredQuoteColumnNames(tableName, columns)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -678,7 +678,12 @@ func classifyTasks(state *ImportDataState, tasks []*ImportFileTask) (pendingTask
 
 func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	tableNames := importFileTasksToTableNames(tasks)
-	nonEmptyTableNames := tdb.GetNonEmptyTables(tableNames)
+	renamedTablesNames := make([]string, 0)
+	for _, tableName := range tableNames {//In case of load partitions via root table, need to check root table
+		renamedTablesNames = append(renamedTablesNames, renameTableIfRequired(tableName))
+	}
+	renamedTablesNames = lo.Uniq(renamedTablesNames)
+	nonEmptyTableNames := tdb.GetNonEmptyTables(renamedTablesNames)
 	if len(nonEmptyTableNames) > 0 {
 		utils.PrintAndLog("Following tables are not empty. "+
 			"TRUNCATE them before importing data with --start-clean.\n%s",

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -679,7 +679,7 @@ func classifyTasks(state *ImportDataState, tasks []*ImportFileTask) (pendingTask
 func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	tableNames := importFileTasksToTableNames(tasks)
 	renamedTablesNames := make([]string, 0)
-	for _, tableName := range tableNames {//In case of load partitions via root table, need to check root table
+	for _, tableName := range tableNames {//In case partitions are changed during the migration, need to check root table
 		renamedTablesNames = append(renamedTablesNames, renameTableIfRequired(tableName))
 	}
 	renamedTablesNames = lo.Uniq(renamedTablesNames)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -717,6 +717,37 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 }
 
+func renameTableIfRequired(table string) string {
+	// required to rename the table name from leaf to root partition in case of pg_dump
+	// to be load data in target using via root table
+	msr, err := metaDB.GetMigrationStatusRecord()
+	if err != nil {
+		utils.ErrExit("Failed to get migration status record: %s", err)
+	}
+	source = *msr.SourceDBConf
+	if source.DBType != POSTGRESQL {
+		return table
+	}
+	defaultSchema, noDefaultSchema := getDefaultPGSchema(source.Schema, "|")
+	if noDefaultSchema && len(strings.Split(table, ".")) <= 1 {
+		utils.ErrExit("no default schema found to qualify table %s", table)
+	}
+	tableName := sqlname.NewSourceNameFromMaybeQualifiedName(table, defaultSchema)
+	fromTable := tableName.Qualified.Unquoted
+
+	renameTablesMap := getRenameTableMap(msr.RenameTablesMap)
+	if renameTablesMap[fromTable] != "" {
+		table := sqlname.NewSourceNameFromQualifiedName(renameTablesMap[fromTable])
+		toTable := table.Qualified.MinQuoted
+		if table.SchemaName.MinQuoted == "public" {
+			toTable = table.ObjectName.MinQuoted
+		}
+		log.Infof("renaming table %s to %s for ImportBatchArgs", fromTable, toTable)
+		return toTable
+	}
+	return table
+}
+
 func getImportBatchArgsProto(tableName, filePath string) *tgtdb.ImportBatchArgs {
 	columns := TableToColumnNames[tableName]
 	columns, err := tdb.IfRequiredQuoteColumnNames(tableName, columns)
@@ -729,7 +760,7 @@ func getImportBatchArgsProto(tableName, filePath string) *tgtdb.ImportBatchArgs 
 		fileFormat = datafile.TEXT
 	}
 	importBatchArgsProto := &tgtdb.ImportBatchArgs{
-		TableName:  tableName,
+		TableName:  renameTableIfRequired(tableName),
 		Columns:    columns,
 		FileFormat: fileFormat,
 		Delimiter:  dataFileDescriptor.Delimiter,

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -39,6 +40,7 @@ type MigrationStatusRecord struct {
 	PGReplicationSlotName                           string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
 	PGPublicationName                               string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
 	SnapshotMechanism                               string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump)
+	RenameTablesMap                                 string            `json:"RenameTablesMap"`
 }
 
 const MIGRATION_STATUS_KEY = "migration_status"

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -40,7 +40,7 @@ type MigrationStatusRecord struct {
 	PGReplicationSlotName                           string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
 	PGPublicationName                               string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
 	SnapshotMechanism                               string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump)
-	RenameTablesMap                                 string            `json:"RenameTablesMap"`
+	RenameTablesMap                                 map[string]string `json:"RenameTablesMap"`       // map of table.Qualified.Unquoted -> table.Qualified.MinQuoted for renaming the leaf partitions to root table in case of PG migration
 }
 
 const MIGRATION_STATUS_KEY = "migration_status"

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -125,7 +125,7 @@ func parseAndCreateTocTextFile(dataDirPath string) {
 func createTableListPatterns(tableList []*sqlname.SourceName) string {
 	var tableListPattern string
 	for _, table := range tableList {
-		tableListPattern += fmt.Sprintf("--table='%s' ", table.Qualified.MinQuoted)
+		tableListPattern += fmt.Sprintf("--table='%s' ", table.Qualified.MinQuoted) 
 	}
 
 	return strings.TrimPrefix(tableListPattern, "--table=")

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -501,7 +501,13 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 		if err != nil {
 			utils.ErrExit("Error in scanning for child partitions of table=%s: %v", tableName, err)
 		}
-		partitions = append(partitions, sqlname.NewSourceName(childSchema, childTable))
+		if tableName.ObjectName.MinQuoted != tableName.ObjectName.Unquoted {
+			// case sensitive unquoted table name returns unquoted parititons name as well
+			// so we need to add quotes around them 
+			partitions = append(partitions, sqlname.NewSourceName(childSchema, fmt.Sprintf(`"%s"`, childTable)))
+		} else {
+			partitions = append(partitions, sqlname.NewSourceName(childSchema, childTable))
+		}
 	}
 	if rows.Err() != nil {
 		utils.ErrExit("Error in scanning for child partitions of table=%s: %v", tableName, rows.Err())

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -427,7 +427,13 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 		if err != nil {
 			utils.ErrExit("Error in scanning for child partitions of table=%s: %v", tableName, err)
 		}
-		partitions = append(partitions, sqlname.NewSourceName(childSchema, childTable))
+		if tableName.ObjectName.MinQuoted != tableName.ObjectName.Unquoted {
+			// case sensitive unquoted table name returns unquoted parititons name as well
+			// so we need to add quotes around them 
+			partitions = append(partitions, sqlname.NewSourceName(childSchema, fmt.Sprintf(`"%s"`, childTable)))
+		} else {
+			partitions = append(partitions, sqlname.NewSourceName(childSchema, childTable))
+		}
 	}
 	if rows.Err() != nil {
 		utils.ErrExit("Error in scanning for child partitions of table=%s: %v", tableName, rows.Err())


### PR DESCRIPTION
This patch includes two bug fixes in the case of pg_dump for offline and live migration's snapshot phase.
example - 
```
customers (root table) -> cust_other, cust_part11, cust_part12, cust_part22, cust_part21 (leaf partitions)
```

1. In case the user has passed the root table in table-list `--table-list 'customers'`, no data will be exported as pg_dump dumps the data for leaf partitions only, so in such case, we need to get the leaf partitions of this table and then pass those to pg_dump.
2. While importing data of partitions in target we use the name with which the export data has dumped the data which is leaf partitions but in case the user has changed the partition strategy, list, or names this will not work so in any situation the root table is the only source of truth and we should load data in target via root table.

Jenkins pipelines for Oracle and live migration tests -
https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/2033/