### PR TITLE
Clean up pgx usage in ExecuteBatch

### DIFF
--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -570,8 +570,8 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 
 		br := tx.SendBatch(ctx, &ybBatch)
 		defer func() {
-			if err = br.Close(); err != nil {
-				log.Errorf("error closing batch: %v", err)
+			if closeErr := br.Close(); closeErr != nil {
+				log.Errorf("error closing batch: %v", closeErr)
 			}
 		}()
 		for i := 0; i < len(batch.Events); i++ {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -557,8 +557,8 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 
 		br := tx.SendBatch(ctx, &ybBatch)
 		defer func() {
-			if err = br.Close(); err != nil {
-				log.Errorf("error closing batch: %v", err)
+			if closeErr := br.Close(); closeErr != nil {
+				log.Errorf("error closing batch: %v", closeErr)
 			}
 		}()
 		for i := 0; i < len(batch.Events); i++ {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -555,17 +555,18 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 			}
 		}
 
-		br := conn.SendBatch(ctx, &ybBatch)
+		br := tx.SendBatch(ctx, &ybBatch)
+		defer func() {
+			if err = br.Close(); err != nil {
+				log.Errorf("error closing batch: %v", err)
+			}
+		}()
 		for i := 0; i < len(batch.Events); i++ {
 			_, err := br.Exec()
 			if err != nil {
 				log.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
 				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
 			}
-		}
-		if err = br.Close(); err != nil {
-			log.Errorf("error closing batch: %v", err)
-			return false, fmt.Errorf("error closing batch: %v", err)
 		}
 
 		updateVsnQuery := batch.GetChannelMetadataUpdateQuery(migrationUUID)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -556,17 +556,24 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		}
 
 		br := tx.SendBatch(ctx, &ybBatch)
-		defer func() {
+		closeBatch := func() error {
 			if closeErr := br.Close(); closeErr != nil {
 				log.Errorf("error closing batch: %v", closeErr)
+				return closeErr
 			}
-		}()
+			return nil
+		}
 		for i := 0; i < len(batch.Events); i++ {
 			_, err := br.Exec()
 			if err != nil {
 				log.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
+				closeBatch()
 				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
 			}
+		}
+		err = closeBatch()
+		if err != nil {
+			return false, err
 		}
 
 		updateVsnQuery := batch.GetChannelMetadataUpdateQuery(migrationUUID)


### PR DESCRIPTION
1. Use `tx.SendBatch` instead of `conn.SendBatch`. It's harmless to use `conn.SendBatch` inside a transaction, but it's less confusing this way. Reference - https://github.com/jackc/pgx/issues/879#issuecomment-1974900237
2. ~~Defer BatchResults.Close() so that we close the batch even if there is an error. As per [docs](https://github.com/jackc/pgx/blob/master/batch.go#L97), best practice to close before re-using the connection. Again, this is not really an issue because we don't re-use the same connection if there's an error, but it's cleaner this way.~~ Defer does not work. Need to call close in both scenarios - normal as well as error because we use the same connection to Exec metadata queries in the same function,.