### PR TITLE
Init NameRegistry

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -41,6 +41,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/jsonfile"
@@ -155,6 +156,10 @@ func exportData() bool {
 	source.DB().CheckRequiredToolsAreInstalled()
 	saveSourceDBConfInMSR()
 	saveExportTypeInMSR()
+	err = namereg.InitNameRegistry(exportDir, exporterRole, &source, source.DB(), nil, nil)
+	if err != nil {
+		utils.ErrExit("initialize name registry: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -111,6 +111,11 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	sourceDBType = GetSourceDBTypeFromMSR()
 	sqlname.SourceDBType = sourceDBType
 
+	if tconf.TargetDBType == YUGABYTEDB {
+		tconf.Schema = strings.ToLower(tconf.Schema)
+	} else if tconf.TargetDBType == ORACLE && !utils.IsQuotedString(tconf.Schema) {
+		tconf.Schema = strings.ToUpper(tconf.Schema)
+	}
 	tdb = tgtdb.NewTargetDB(&tconf)
 	err := tdb.Init()
 	if err != nil {
@@ -385,11 +390,7 @@ func updateTargetConfInMigrationStatus() {
 }
 
 func importData(importFileTasks []*ImportFileTask) {
-	if tconf.TargetDBType == YUGABYTEDB {
-		tconf.Schema = strings.ToLower(tconf.Schema)
-	} else if tconf.TargetDBType == ORACLE && !utils.IsQuotedString(tconf.Schema) {
-		tconf.Schema = strings.ToUpper(tconf.Schema)
-	}
+
 	err := retrieveMigrationUUID()
 	if err != nil {
 		utils.ErrExit("failed to get migration UUID: %w", err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -84,9 +84,6 @@ var importDataCmd = &cobra.Command{
 		}
 	},
 	Run: importDataCommandFn,
-	PostRun: func(cmd *cobra.Command, args []string) {
-		tdb.Finalize()
-	},
 }
 
 var importDataToCmd = &cobra.Command{
@@ -160,6 +157,7 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	}
 
 	importData(importFileTasks)
+	tdb.Finalize()
 	if changeStreamingIsEnabled(importType) {
 		startExportDataFromTargetIfRequired()
 	}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -84,6 +84,9 @@ var importDataCmd = &cobra.Command{
 		}
 	},
 	Run: importDataCommandFn,
+	PostRun: func(cmd *cobra.Command, args []string) {
+		tdb.Finalize()
+	},
 }
 
 var importDataToCmd = &cobra.Command{
@@ -121,7 +124,6 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	if err != nil {
 		utils.ErrExit("Failed to initialize the target DB: %s", err)
 	}
-	defer tdb.Finalize()
 
 	err = namereg.InitNameRegistry(exportDir, importerRole, nil, nil, &tconf, tdb)
 	if err != nil {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -42,6 +42,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -109,6 +110,19 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	checkExportDataDoneFlag()
 	sourceDBType = GetSourceDBTypeFromMSR()
 	sqlname.SourceDBType = sourceDBType
+
+	tdb = tgtdb.NewTargetDB(&tconf)
+	err := tdb.Init()
+	if err != nil {
+		utils.ErrExit("Failed to initialize the target DB: %s", err)
+	}
+	defer tdb.Finalize()
+
+	err = namereg.InitNameRegistry(exportDir, importerRole, nil, nil, &tconf, tdb)
+	if err != nil {
+		utils.ErrExit("initialize name registry: %v", err)
+	}
+
 	dataStore = datastore.NewDataStore(filepath.Join(exportDir, "data"))
 	dataFileDescriptor = datafile.OpenDescriptor(exportDir)
 	// TODO: handle case-sensitive in table names with oracle ff-db
@@ -392,12 +406,7 @@ func importData(importFileTasks []*ImportFileTask) {
 	if err != nil {
 		utils.ErrExit("Failed to get migration status record: %s", err)
 	}
-	tdb = tgtdb.NewTargetDB(&tconf)
-	err = tdb.Init()
-	if err != nil {
-		utils.ErrExit("Failed to initialize the target DB: %s", err)
-	}
-	defer tdb.Finalize()
+
 	if msr.SnapshotMechanism == "debezium" {
 		valueConverter, err = dbzm.NewValueConverter(exportDir, tdb, tconf, importerRole, msr.SourceDBConf.DBType)
 	} else {
@@ -679,7 +688,7 @@ func classifyTasks(state *ImportDataState, tasks []*ImportFileTask) (pendingTask
 func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	tableNames := importFileTasksToTableNames(tasks)
 	renamedTablesNames := make([]string, 0)
-	for _, tableName := range tableNames {//In case partitions are changed during the migration, need to check root table
+	for _, tableName := range tableNames { //In case partitions are changed during the migration, need to check root table
 		renamedTablesNames = append(renamedTablesNames, renameTableIfRequired(tableName))
 	}
 	renamedTablesNames = lo.Uniq(renamedTablesNames)

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -67,6 +67,11 @@ var importDataFileCmd = &cobra.Command{
 		reportProgressInBytes = true
 		validateBatchSizeFlag(batchSize)
 		checkImportDataFileFlags(cmd)
+
+		sourceDBType = POSTGRESQL // dummy value - this command is not affected by it
+		sqlname.SourceDBType = sourceDBType
+		CreateMigrationProjectIfNotExists(sourceDBType, exportDir)
+
 		tconf.Schema = strings.ToLower(tconf.Schema)
 		tdb = tgtdb.NewTargetDB(&tconf)
 		err := tdb.Init()
@@ -77,9 +82,7 @@ var importDataFileCmd = &cobra.Command{
 		if err != nil {
 			utils.ErrExit("initialize name registry: %v", err)
 		}
-		sourceDBType = POSTGRESQL // dummy value - this command is not affected by it
-		sqlname.SourceDBType = sourceDBType
-		CreateMigrationProjectIfNotExists(sourceDBType, exportDir)
+
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/yb-voyager/src/namereg/dummy_name_registry.json
+++ b/yb-voyager/src/namereg/dummy_name_registry.json
@@ -1,0 +1,34 @@
+{
+  "SourceDBType": "oracle",
+  "SourceDBSchemaNames": [
+    "SAKILA"
+  ],
+  "DefaultSourceDBSchemaName": "SAKILA",
+  "SourceDBTableNames": {
+    "SAKILA": [
+      "TABLE1",
+      "TABLE2",
+      "MixedCaps",
+      "lower_caps"
+    ],
+    "SAKILA_FF": [
+      "TABLE1",
+      "TABLE2",
+      "MixedCaps",
+      "lower_caps"
+    ]
+  },
+  "YBSchemaNames": [
+    "ybsakila"
+  ],
+  "DefaultYBSchemaName": "ybsakila",
+  "YBTableNames": {
+    "ybsakila": [
+      "table1",
+      "table2",
+      "mixedcaps",
+      "lower_caps"
+    ]
+  },
+  "DefaultSourceReplicaDBSchemaName": "SAKILA_FF"
+}

--- a/yb-voyager/src/namereg/namereg.go
+++ b/yb-voyager/src/namereg/namereg.go
@@ -34,6 +34,8 @@ const (
 	IMPORT_FILE_ROLE                = "import_file"
 )
 
+var NameReg NameRegistry
+
 type NameRegistry struct {
 	SourceDBType string
 
@@ -72,6 +74,14 @@ func NewNameRegistry(
 		tconf:    tconf,
 		tdb:      tdb,
 	}
+}
+
+func InitNameRegistry(
+	exportDir string, role string,
+	sconf *srcdb.Source, sdb srcdb.SourceDB,
+	tconf *tgtdb.TargetConf, tdb tgtdb.TargetDB) error {
+	NameReg = *NewNameRegistry(exportDir, role, sconf, sdb, tconf, tdb)
+	return NameReg.Init()
 }
 
 func (reg *NameRegistry) Init() error {

--- a/yb-voyager/src/namereg/namereg.go
+++ b/yb-voyager/src/namereg/namereg.go
@@ -255,7 +255,7 @@ func (reg *NameRegistry) LookupTableName(tableNameArg string) (*sqlname.NameTupl
 	if schemaName == reg.DefaultSourceSideSchemaName() || schemaName == reg.DefaultYBSchemaName {
 		schemaName = ""
 	}
-	// ntup := &NameTuple{}
+
 	var sourceName *sqlname.ObjectName
 	var targetName *sqlname.ObjectName
 	if reg.SourceDBTableNames != nil { // nil for `import data file` mode.
@@ -299,8 +299,6 @@ func (reg *NameRegistry) LookupTableName(tableNameArg string) (*sqlname.NameTupl
 			}
 		}
 	}
-	// // Set the current table name based on the mode.
-	// ntup.SetMode(reg.role)
 	if sourceName == nil && targetName == nil {
 		return nil, &ErrNameNotFound{ObjectType: "table", Name: tableNameArg}
 	}

--- a/yb-voyager/src/namereg/namereg_test.go
+++ b/yb-voyager/src/namereg/namereg_test.go
@@ -10,399 +10,70 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
-func TestPGDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-
-	// Test NewTableName() with PostgreSQL and default schema "public" and
-	// a table name belonging to default schema.
-	tableName := newObjectName(POSTGRESQL, "public", "public", "table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "public",
-		FromDefaultSchema: true,
-		Qualified: identifier{
-			Quoted:    `public."table1"`,
-			Unquoted:  "public.table1",
-			MinQuoted: "public.table1",
-		},
-		Unqualified: identifier{
-			Quoted:    `"table1"`,
-			Unquoted:  "table1",
-			MinQuoted: "table1",
-		},
-		MinQualified: identifier{
-			Quoted:    `"table1"`,
-			Unquoted:  "table1",
-			MinQuoted: "table1",
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+var oracleToYBNameRegistry = &NameRegistry{
+	SourceDBType:              ORACLE,
+	role:                      TARGET_DB_IMPORTER_ROLE,
+	SourceDBSchemaNames:       []string{"SAKILA"},
+	YBSchemaNames:             []string{"public"},
+	DefaultSourceDBSchemaName: "SAKILA",
+	DefaultYBSchemaName:       "public",
+	//DefaultSourceReplicaDBSchemaName: "SAKILA_FF", // Will be set using SetDefaultSourceReplicaDBSchemaName().
+	SourceDBTableNames: map[string][]string{
+		"SAKILA": {`TABLE1`, `TABLE2`, `Table2`, `MixedCaps`, `MixedCaps1`, `MixedCAPS1`, `lower_caps`},
+	},
+	YBTableNames: map[string][]string{
+		"public": {"table1", "table2", `Table2`, `mixedcaps`, `MixedCaps1`, `MixedCAPS1`, "lower_caps"},
+	},
 }
 
-func TestPGNonDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with PostgreSQL and default schema "public" and
-	// a table name belonging to a non-default schema.
-	tableName := newObjectName(POSTGRESQL, "public", "schema1", "table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "schema1",
-		FromDefaultSchema: false,
-		Qualified: identifier{
-			Quoted:    `schema1."table1"`,
-			Unquoted:  "schema1.table1",
-			MinQuoted: "schema1.table1",
-		},
-		Unqualified: identifier{
-			Quoted:    `"table1"`,
-			Unquoted:  "table1",
-			MinQuoted: "table1",
-		},
-		MinQualified: identifier{
-			Quoted:    `schema1."table1"`,
-			Unquoted:  "schema1.table1",
-			MinQuoted: "schema1.table1",
-		},
+func buildNameTuple(reg *NameRegistry, sourceSchema, sourceTable, targetSchema, targetTable string) *sqlname.NameTuple {
+	var sourceName *sqlname.ObjectName
+	var targetName *sqlname.ObjectName
+	if sourceSchema != "" && sourceTable != "" {
+		sourceName = sqlname.NewObjectName(reg.SourceDBType, sourceSchema, sourceSchema, sourceTable)
 	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Qualified)
-}
-
-func TestPGDefaultSchemaCaseSensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with PostgreSQL and default schema "public" and
-	// a case-sensitive name with mixed cases.
-	tableName := newObjectName(POSTGRESQL, "public", "public", "Table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "public",
-		FromDefaultSchema: true,
-		Qualified: identifier{
-			Quoted:    `public."Table1"`,
-			Unquoted:  `public.Table1`,
-			MinQuoted: `public."Table1"`,
-		},
-		Unqualified: identifier{
-			Quoted:    `"Table1"`,
-			Unquoted:  `Table1`,
-			MinQuoted: `"Table1"`,
-		},
-		MinQualified: identifier{
-			Quoted:    `"Table1"`,
-			Unquoted:  `Table1`,
-			MinQuoted: `"Table1"`,
-		},
+	if targetSchema != "" && targetTable != "" {
+		targetName = sqlname.NewObjectName(YUGABYTEDB, targetSchema, targetSchema, targetTable)
 	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+	return NewNameTuple(reg.role, sourceName, targetName)
 }
-
-func TestPGNonDefaultSchemaCaseSensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with PostgreSQL and default schema "public" and
-	// a case-sensitive name with mixed cases.
-	tableName := newObjectName(POSTGRESQL, "public", "schema1", "Table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "schema1",
-		FromDefaultSchema: false,
-		Qualified: identifier{
-			Quoted:    `schema1."Table1"`,
-			Unquoted:  `schema1.Table1`,
-			MinQuoted: `schema1."Table1"`,
-		},
-		Unqualified: identifier{
-			Quoted:    `"Table1"`,
-			Unquoted:  `Table1`,
-			MinQuoted: `"Table1"`,
-		},
-		MinQualified: identifier{
-			Quoted:    `schema1."Table1"`,
-			Unquoted:  `schema1.Table1`,
-			MinQuoted: `schema1."Table1"`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Qualified)
-}
-
-//=====================================================
-
-func TestOracleDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with Oracle and default schema "SAKILA" and
-	// a table name belonging to default schema.
-	tableName := newObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "SAKILA",
-		FromDefaultSchema: true,
-		Qualified: identifier{
-			Quoted:    `SAKILA."TABLE1"`,
-			Unquoted:  `SAKILA.TABLE1`,
-			MinQuoted: `SAKILA.TABLE1`,
-		},
-		Unqualified: identifier{
-			Quoted:    `"TABLE1"`,
-			Unquoted:  `TABLE1`,
-			MinQuoted: `TABLE1`,
-		},
-		MinQualified: identifier{
-			Quoted:    `"TABLE1"`,
-			Unquoted:  `TABLE1`,
-			MinQuoted: `TABLE1`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Unqualified)
-}
-
-func TestOracleNonDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with Oracle and default schema "SAKILA" and
-	// a table name belonging to a non-default schema.
-	tableName := newObjectName(ORACLE, "SAKILA", "SCHEMA1", "TABLE1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "SCHEMA1",
-		FromDefaultSchema: false,
-		Qualified: identifier{
-			Quoted:    `SCHEMA1."TABLE1"`,
-			Unquoted:  `SCHEMA1.TABLE1`,
-			MinQuoted: `SCHEMA1.TABLE1`,
-		},
-		Unqualified: identifier{
-			Quoted:    `"TABLE1"`,
-			Unquoted:  `TABLE1`,
-			MinQuoted: `TABLE1`,
-		},
-		MinQualified: identifier{
-			Quoted:    `SCHEMA1."TABLE1"`,
-			Unquoted:  `SCHEMA1.TABLE1`,
-			MinQuoted: `SCHEMA1.TABLE1`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Qualified)
-}
-
-func TestOracleDefaultSchemaCaseSensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with Oracle and default schema "SAKILA" and
-	// a case-sensitive name with mixed cases.
-	tableName := newObjectName(ORACLE, "SAKILA", "SAKILA", "Table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "SAKILA",
-		FromDefaultSchema: true,
-		Qualified: identifier{
-			Quoted:    `SAKILA."Table1"`,
-			Unquoted:  `SAKILA.Table1`,
-			MinQuoted: `SAKILA."Table1"`,
-		},
-		Unqualified: identifier{
-			Quoted:    `"Table1"`,
-			Unquoted:  `Table1`,
-			MinQuoted: `"Table1"`,
-		},
-		MinQualified: identifier{
-			Quoted:    `"Table1"`,
-			Unquoted:  `Table1`,
-			MinQuoted: `"Table1"`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Unqualified)
-}
-
-func TestOracleNonDefaultSchemaCaseSensitiveTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with Oracle and default schema "SAKILA" and
-	// a case-sensitive name with mixed cases.
-	tableName := newObjectName(ORACLE, "SAKILA", "SCHEMA1", "Table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "SCHEMA1",
-		FromDefaultSchema: false,
-		Qualified: identifier{
-			Quoted:    `SCHEMA1."Table1"`,
-			Unquoted:  `SCHEMA1.Table1`,
-			MinQuoted: `SCHEMA1."Table1"`,
-		},
-		Unqualified: identifier{
-			Quoted:    `"Table1"`,
-			Unquoted:  `Table1`,
-			MinQuoted: `"Table1"`,
-		},
-		MinQualified: identifier{
-			Quoted:    `SCHEMA1."Table1"`,
-			Unquoted:  `SCHEMA1.Table1`,
-			MinQuoted: `SCHEMA1."Table1"`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Qualified)
-}
-
-//=====================================================
-
-func TestMySQLDefaultSchemaCaseSensitiveLowerCaseTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with MySQL and default schema "sakila" and
-	// a table name belonging to default schema.
-	tableName := newObjectName(MYSQL, "sakila", "sakila", "table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "sakila",
-		FromDefaultSchema: true,
-		Qualified: identifier{
-			Quoted:    `sakila.table1`,
-			Unquoted:  `sakila.table1`,
-			MinQuoted: `sakila.table1`,
-		},
-		Unqualified: identifier{
-			Quoted:    `table1`,
-			Unquoted:  `table1`,
-			MinQuoted: `table1`,
-		},
-		MinQualified: identifier{
-			Quoted:    `table1`,
-			Unquoted:  `table1`,
-			MinQuoted: `table1`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Unqualified)
-}
-
-func TestMySQLNonDefaultSchemaCaseSensitiveLowerCaseTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with MySQL and default schema "sakila" and
-	// a table name belonging to a non-default schema.
-	tableName := newObjectName(MYSQL, "sakila", "schema1", "table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "schema1",
-		FromDefaultSchema: false,
-		Qualified: identifier{
-			Quoted:    `schema1.table1`,
-			Unquoted:  `schema1.table1`,
-			MinQuoted: `schema1.table1`,
-		},
-		Unqualified: identifier{
-			Quoted:    `table1`,
-			Unquoted:  `table1`,
-			MinQuoted: `table1`,
-		},
-		MinQualified: identifier{
-			Quoted:    `schema1.table1`,
-			Unquoted:  `schema1.table1`,
-			MinQuoted: `schema1.table1`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Qualified)
-}
-
-func TestMySQLDefaultSchemaCaseSensitiveMixedCaseTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with MySQL and default schema "sakila" and
-	// a case-sensitive name with mixed cases.
-	tableName := newObjectName(MYSQL, "sakila", "sakila", "Table1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "sakila",
-		FromDefaultSchema: true,
-		Qualified: identifier{
-			Quoted:    `sakila.Table1`,
-			Unquoted:  `sakila.Table1`,
-			MinQuoted: `sakila.Table1`,
-		},
-		Unqualified: identifier{
-			Quoted:    `Table1`,
-			Unquoted:  `Table1`,
-			MinQuoted: `Table1`,
-		},
-		MinQualified: identifier{
-			Quoted:    `Table1`,
-			Unquoted:  `Table1`,
-			MinQuoted: `Table1`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Unqualified)
-}
-
-func TestMySQLNonDefaultSchemaCaseSensitiveUpperCaseTableName(t *testing.T) {
-	assert := assert.New(t)
-	// Test NewTableName() with MySQL and default schema "sakila" and
-	// a case-sensitive name with all upper case letters.
-	tableName := newObjectName(MYSQL, "sakila", "schema1", "TABLE1")
-	assert.NotNil(tableName)
-	expectedTableName := &ObjectName{
-		SchemaName:        "schema1",
-		FromDefaultSchema: false,
-		Qualified: identifier{
-			Quoted:    `schema1.TABLE1`,
-			Unquoted:  `schema1.TABLE1`,
-			MinQuoted: `schema1.TABLE1`,
-		},
-		Unqualified: identifier{
-			Quoted:    `TABLE1`,
-			Unquoted:  `TABLE1`,
-			MinQuoted: `TABLE1`,
-		},
-		MinQualified: identifier{
-			Quoted:    `schema1.TABLE1`,
-			Unquoted:  `schema1.TABLE1`,
-			MinQuoted: `schema1.TABLE1`,
-		},
-	}
-	assert.Equal(expectedTableName, tableName)
-	assert.Equal(tableName.MinQualified, tableName.Qualified)
-}
-
-//=====================================================
 
 func TestNameTuple(t *testing.T) {
 	assert := assert.New(t)
+	sourceName := sqlname.NewObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1")
+	targetName := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "table1")
 
-	ntup := &NameTuple{
-		SourceName: newObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1"),
-		TargetName: newObjectName(YUGABYTEDB, "public", "public", "table1"),
-	}
-	ntup.SetMode(TARGET_DB_IMPORTER_ROLE)
+	ntup := NewNameTuple(TARGET_DB_IMPORTER_ROLE, sourceName, targetName)
+
 	assert.Equal(ntup.CurrentName, ntup.TargetName)
 	assert.Equal(ntup.ForUserQuery(), `public."table1"`)
 	schemaName, tableName := ntup.ForCatalogQuery()
 	assert.Equal(schemaName, `public`)
 	assert.Equal(tableName, `table1`)
 
-	ntup.SetMode(SOURCE_REPLICA_DB_IMPORTER_ROLE)
+	ntup = NewNameTuple(SOURCE_REPLICA_DB_IMPORTER_ROLE, sourceName, targetName)
+
 	assert.Equal(ntup.CurrentName, ntup.SourceName)
 	assert.Equal(ntup.ForUserQuery(), `SAKILA."TABLE1"`)
 	schemaName, tableName = ntup.ForCatalogQuery()
 	assert.Equal(schemaName, `SAKILA`)
 	assert.Equal(tableName, `TABLE1`)
 
-	ntup.SetMode(SOURCE_DB_EXPORTER_ROLE)
+	ntup = NewNameTuple(SOURCE_DB_EXPORTER_ROLE, sourceName, targetName)
 	assert.Equal(ntup.CurrentName, ntup.SourceName)
 
-	ntup.SetMode(TARGET_DB_EXPORTER_FF_ROLE)
+	ntup = NewNameTuple(TARGET_DB_EXPORTER_FF_ROLE, sourceName, targetName)
 	assert.Equal(ntup.CurrentName, ntup.TargetName)
 }
 
 func TestNameTupleMatchesPattern(t *testing.T) {
 	assert := assert.New(t)
-
-	ntup := &NameTuple{
-		SourceName: newObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1"),
-		TargetName: newObjectName(YUGABYTEDB, "public", "sakila", "table1"),
-	}
-	ntup.SetMode(TARGET_DB_IMPORTER_ROLE)
+	sourceName := sqlname.NewObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1")
+	targetName := sqlname.NewObjectName(YUGABYTEDB, "public", "sakila", "table1")
+	ntup := NewNameTuple(TARGET_DB_IMPORTER_ROLE, sourceName, targetName)
 
 	testCases := []struct {
 		pattern string
@@ -434,37 +105,6 @@ func TestNameTupleMatchesPattern(t *testing.T) {
 	}
 }
 
-//=====================================================
-
-var oracleToYBNameRegistry = &NameRegistry{
-	SourceDBType:              ORACLE,
-	role:                      TARGET_DB_IMPORTER_ROLE,
-	SourceDBSchemaNames:       []string{"SAKILA"},
-	YBSchemaNames:             []string{"public"},
-	DefaultSourceDBSchemaName: "SAKILA",
-	DefaultYBSchemaName:       "public",
-	//DefaultSourceReplicaDBSchemaName: "SAKILA_FF", // Will be set using SetDefaultSourceReplicaDBSchemaName().
-	SourceDBTableNames: map[string][]string{
-		"SAKILA": {`TABLE1`, `TABLE2`, `Table2`, `MixedCaps`, `MixedCaps1`, `MixedCAPS1`, `lower_caps`},
-	},
-	YBTableNames: map[string][]string{
-		"public": {"table1", "table2", `Table2`, `mixedcaps`, `MixedCaps1`, `MixedCAPS1`, "lower_caps"},
-	},
-}
-
-func buildNameTuple(reg *NameRegistry, sourceSchema, sourceTable, targetSchema, targetTable string) *NameTuple {
-	ntup := &NameTuple{}
-
-	if sourceSchema != "" && sourceTable != "" {
-		ntup.SourceName = newObjectName(reg.SourceDBType, sourceSchema, sourceSchema, sourceTable)
-	}
-	if targetSchema != "" && targetTable != "" {
-		ntup.TargetName = newObjectName(YUGABYTEDB, targetSchema, targetSchema, targetTable)
-	}
-	ntup.SetMode(reg.role)
-	return ntup
-}
-
 func TestNameRegistrySuccessfulLookup(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -477,7 +117,7 @@ func TestNameRegistrySuccessfulLookup(t *testing.T) {
 
 	var testCases = []struct {
 		tableNames []string
-		expected   *NameTuple
+		expected   *sqlname.NameTuple
 	}{
 		{[]string{
 			// YB side variants:
@@ -582,7 +222,7 @@ func TestDifferentSchemaInSameDBAsSourceReplica1(t *testing.T) {
 
 	var testCases = []struct {
 		tableNames []string
-		expected   *NameTuple
+		expected   *sqlname.NameTuple
 	}{
 		{[]string{
 			// YB side variants:

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -529,7 +529,7 @@ WHERE parent.relname='%s' AND nmsp_parent.nspname = '%s' `, tableName.ObjectName
 		}
 		if tableName.ObjectName.MinQuoted != tableName.ObjectName.Unquoted {
 			// case sensitive unquoted table name returns unquoted parititons name as well
-			// so we need to add quotes around them 
+			// so we need to add quotes around them
 			partitions = append(partitions, sqlname.NewSourceName(childSchema, fmt.Sprintf(`"%s"`, childTable)))
 		} else {
 			partitions = append(partitions, sqlname.NewSourceName(childSchema, childTable))

--- a/yb-voyager/src/utils/sqlname/nametuple.go
+++ b/yb-voyager/src/utils/sqlname/nametuple.go
@@ -1,0 +1,193 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package sqlname
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/samber/lo"
+)
+
+//================================================
+
+type identifier struct {
+	Quoted, Unquoted, MinQuoted string
+}
+
+// Can be a name of a table, sequence, materialised view, etc.
+type ObjectName struct {
+	SchemaName        string
+	FromDefaultSchema bool
+
+	Qualified    identifier
+	Unqualified  identifier
+	MinQualified identifier
+}
+
+func NewObjectName(dbType, defaultSchemaName, schemaName, tableName string) *ObjectName {
+	result := &ObjectName{
+		SchemaName:        schemaName,
+		FromDefaultSchema: schemaName == defaultSchemaName,
+		Qualified: identifier{
+			Quoted:    schemaName + "." + quote2(dbType, tableName),
+			Unquoted:  schemaName + "." + tableName,
+			MinQuoted: schemaName + "." + minQuote2(tableName, dbType),
+		},
+		Unqualified: identifier{
+			Quoted:    quote2(dbType, tableName),
+			Unquoted:  tableName,
+			MinQuoted: minQuote2(tableName, dbType),
+		},
+	}
+	result.MinQualified = lo.Ternary(result.FromDefaultSchema, result.Unqualified, result.Qualified)
+	return result
+}
+
+func (nv *ObjectName) String() string {
+	return nv.MinQualified.MinQuoted
+}
+
+func (nv *ObjectName) MatchesPattern(pattern string) (bool, error) {
+	parts := strings.Split(pattern, ".")
+	switch true {
+	case len(parts) == 2:
+		if !strings.EqualFold(parts[0], nv.SchemaName) {
+			return false, nil
+		}
+		pattern = parts[1]
+	case len(parts) == 1:
+		if !nv.FromDefaultSchema {
+			return false, nil
+		}
+		pattern = parts[0]
+	default:
+		return false, fmt.Errorf("invalid pattern: %s", pattern)
+	}
+	match1, err := filepath.Match(pattern, nv.Unqualified.Unquoted)
+	if err != nil {
+		return false, fmt.Errorf("invalid pattern: %s", pattern)
+	}
+	if match1 {
+		return true, nil
+	}
+	match2, err := filepath.Match(pattern, nv.Unqualified.Quoted)
+	if err != nil {
+		return false, fmt.Errorf("invalid pattern: %s", pattern)
+	}
+	return match2, nil
+}
+
+// <SourceTableName, TargetTableName>
+type NameTuple struct {
+	// Mode        string
+	CurrentName *ObjectName
+	SourceName  *ObjectName
+	TargetName  *ObjectName
+}
+
+func (t1 *NameTuple) Equals(t2 *NameTuple) bool {
+	return reflect.DeepEqual(t1, t2)
+}
+
+// func (t *NameTuple) SetMode(mode string) {
+// 	t.Mode = mode
+// 	switch mode {
+// 	case TARGET_DB_IMPORTER_ROLE:
+// 		t.CurrentName = t.TargetName
+// 	case SOURCE_DB_IMPORTER_ROLE:
+// 		t.CurrentName = t.SourceName
+// 	case SOURCE_REPLICA_DB_IMPORTER_ROLE:
+// 		t.CurrentName = t.SourceName
+// 	case SOURCE_DB_EXPORTER_ROLE:
+// 		t.CurrentName = t.SourceName
+// 	case TARGET_DB_EXPORTER_FF_ROLE, TARGET_DB_EXPORTER_FB_ROLE:
+// 		t.CurrentName = t.TargetName
+// 	default:
+// 		t.CurrentName = nil
+// 	}
+// }
+
+func (t *NameTuple) String() string {
+	return t.CurrentName.String()
+}
+
+func (t *NameTuple) MatchesPattern(pattern string) (bool, error) {
+	for _, tableName := range []*ObjectName{t.SourceName, t.TargetName} {
+		if tableName == nil {
+			continue
+		}
+		match, err := tableName.MatchesPattern(pattern)
+		if err != nil {
+			return false, err
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (t *NameTuple) ForUserQuery() string {
+	return t.CurrentName.Qualified.Quoted
+}
+
+func (t *NameTuple) ForCatalogQuery() (string, string) {
+	return t.CurrentName.SchemaName, t.CurrentName.Unqualified.Unquoted
+}
+
+func (t *NameTuple) ForKey() string {
+	if t.SourceName != nil {
+		return t.SourceName.Qualified.Quoted
+	}
+	return t.TargetName.Qualified.Quoted
+}
+
+//================================================
+
+func quote2(dbType, name string) string {
+	switch dbType {
+	case POSTGRESQL, YUGABYTEDB, ORACLE:
+		return `"` + name + `"`
+	case MYSQL:
+		return name
+	default:
+		panic("unknown source db type")
+	}
+}
+
+func minQuote2(objectName, sourceDBType string) string {
+	switch sourceDBType {
+	case YUGABYTEDB, POSTGRESQL:
+		if IsAllLowercase(objectName) && !IsReservedKeywordPG(objectName) {
+			return objectName
+		} else {
+			return `"` + objectName + `"`
+		}
+	case MYSQL:
+		return objectName
+	case ORACLE:
+		if IsAllUppercase(objectName) && !IsReservedKeywordOracle(objectName) {
+			return objectName
+		} else {
+			return `"` + objectName + `"`
+		}
+	default:
+		panic("invalid source db type")
+	}
+}

--- a/yb-voyager/src/utils/sqlname/nametuple_test.go
+++ b/yb-voyager/src/utils/sqlname/nametuple_test.go
@@ -1,0 +1,362 @@
+package sqlname
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPGDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test NewTableName() with PostgreSQL and default schema "public" and
+	// a table name belonging to default schema.
+	tableName := NewObjectName(POSTGRESQL, "public", "public", "table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "public",
+		FromDefaultSchema: true,
+		Qualified: identifier{
+			Quoted:    `public."table1"`,
+			Unquoted:  "public.table1",
+			MinQuoted: "public.table1",
+		},
+		Unqualified: identifier{
+			Quoted:    `"table1"`,
+			Unquoted:  "table1",
+			MinQuoted: "table1",
+		},
+		MinQualified: identifier{
+			Quoted:    `"table1"`,
+			Unquoted:  "table1",
+			MinQuoted: "table1",
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+}
+
+func TestPGNonDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with PostgreSQL and default schema "public" and
+	// a table name belonging to a non-default schema.
+	tableName := NewObjectName(POSTGRESQL, "public", "schema1", "table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "schema1",
+		FromDefaultSchema: false,
+		Qualified: identifier{
+			Quoted:    `schema1."table1"`,
+			Unquoted:  "schema1.table1",
+			MinQuoted: "schema1.table1",
+		},
+		Unqualified: identifier{
+			Quoted:    `"table1"`,
+			Unquoted:  "table1",
+			MinQuoted: "table1",
+		},
+		MinQualified: identifier{
+			Quoted:    `schema1."table1"`,
+			Unquoted:  "schema1.table1",
+			MinQuoted: "schema1.table1",
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Qualified)
+}
+
+func TestPGDefaultSchemaCaseSensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with PostgreSQL and default schema "public" and
+	// a case-sensitive name with mixed cases.
+	tableName := NewObjectName(POSTGRESQL, "public", "public", "Table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "public",
+		FromDefaultSchema: true,
+		Qualified: identifier{
+			Quoted:    `public."Table1"`,
+			Unquoted:  `public.Table1`,
+			MinQuoted: `public."Table1"`,
+		},
+		Unqualified: identifier{
+			Quoted:    `"Table1"`,
+			Unquoted:  `Table1`,
+			MinQuoted: `"Table1"`,
+		},
+		MinQualified: identifier{
+			Quoted:    `"Table1"`,
+			Unquoted:  `Table1`,
+			MinQuoted: `"Table1"`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+}
+
+func TestPGNonDefaultSchemaCaseSensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with PostgreSQL and default schema "public" and
+	// a case-sensitive name with mixed cases.
+	tableName := NewObjectName(POSTGRESQL, "public", "schema1", "Table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "schema1",
+		FromDefaultSchema: false,
+		Qualified: identifier{
+			Quoted:    `schema1."Table1"`,
+			Unquoted:  `schema1.Table1`,
+			MinQuoted: `schema1."Table1"`,
+		},
+		Unqualified: identifier{
+			Quoted:    `"Table1"`,
+			Unquoted:  `Table1`,
+			MinQuoted: `"Table1"`,
+		},
+		MinQualified: identifier{
+			Quoted:    `schema1."Table1"`,
+			Unquoted:  `schema1.Table1`,
+			MinQuoted: `schema1."Table1"`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Qualified)
+}
+
+//=====================================================
+
+func TestOracleDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with Oracle and default schema "SAKILA" and
+	// a table name belonging to default schema.
+	tableName := NewObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "SAKILA",
+		FromDefaultSchema: true,
+		Qualified: identifier{
+			Quoted:    `SAKILA."TABLE1"`,
+			Unquoted:  `SAKILA.TABLE1`,
+			MinQuoted: `SAKILA.TABLE1`,
+		},
+		Unqualified: identifier{
+			Quoted:    `"TABLE1"`,
+			Unquoted:  `TABLE1`,
+			MinQuoted: `TABLE1`,
+		},
+		MinQualified: identifier{
+			Quoted:    `"TABLE1"`,
+			Unquoted:  `TABLE1`,
+			MinQuoted: `TABLE1`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+}
+
+func TestOracleNonDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with Oracle and default schema "SAKILA" and
+	// a table name belonging to a non-default schema.
+	tableName := NewObjectName(ORACLE, "SAKILA", "SCHEMA1", "TABLE1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "SCHEMA1",
+		FromDefaultSchema: false,
+		Qualified: identifier{
+			Quoted:    `SCHEMA1."TABLE1"`,
+			Unquoted:  `SCHEMA1.TABLE1`,
+			MinQuoted: `SCHEMA1.TABLE1`,
+		},
+		Unqualified: identifier{
+			Quoted:    `"TABLE1"`,
+			Unquoted:  `TABLE1`,
+			MinQuoted: `TABLE1`,
+		},
+		MinQualified: identifier{
+			Quoted:    `SCHEMA1."TABLE1"`,
+			Unquoted:  `SCHEMA1.TABLE1`,
+			MinQuoted: `SCHEMA1.TABLE1`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Qualified)
+}
+
+func TestOracleDefaultSchemaCaseSensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with Oracle and default schema "SAKILA" and
+	// a case-sensitive name with mixed cases.
+	tableName := NewObjectName(ORACLE, "SAKILA", "SAKILA", "Table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "SAKILA",
+		FromDefaultSchema: true,
+		Qualified: identifier{
+			Quoted:    `SAKILA."Table1"`,
+			Unquoted:  `SAKILA.Table1`,
+			MinQuoted: `SAKILA."Table1"`,
+		},
+		Unqualified: identifier{
+			Quoted:    `"Table1"`,
+			Unquoted:  `Table1`,
+			MinQuoted: `"Table1"`,
+		},
+		MinQualified: identifier{
+			Quoted:    `"Table1"`,
+			Unquoted:  `Table1`,
+			MinQuoted: `"Table1"`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+}
+
+func TestOracleNonDefaultSchemaCaseSensitiveTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with Oracle and default schema "SAKILA" and
+	// a case-sensitive name with mixed cases.
+	tableName := NewObjectName(ORACLE, "SAKILA", "SCHEMA1", "Table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "SCHEMA1",
+		FromDefaultSchema: false,
+		Qualified: identifier{
+			Quoted:    `SCHEMA1."Table1"`,
+			Unquoted:  `SCHEMA1.Table1`,
+			MinQuoted: `SCHEMA1."Table1"`,
+		},
+		Unqualified: identifier{
+			Quoted:    `"Table1"`,
+			Unquoted:  `Table1`,
+			MinQuoted: `"Table1"`,
+		},
+		MinQualified: identifier{
+			Quoted:    `SCHEMA1."Table1"`,
+			Unquoted:  `SCHEMA1.Table1`,
+			MinQuoted: `SCHEMA1."Table1"`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Qualified)
+}
+
+//=====================================================
+
+func TestMySQLDefaultSchemaCaseSensitiveLowerCaseTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with MySQL and default schema "sakila" and
+	// a table name belonging to default schema.
+	tableName := NewObjectName(MYSQL, "sakila", "sakila", "table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "sakila",
+		FromDefaultSchema: true,
+		Qualified: identifier{
+			Quoted:    `sakila.table1`,
+			Unquoted:  `sakila.table1`,
+			MinQuoted: `sakila.table1`,
+		},
+		Unqualified: identifier{
+			Quoted:    `table1`,
+			Unquoted:  `table1`,
+			MinQuoted: `table1`,
+		},
+		MinQualified: identifier{
+			Quoted:    `table1`,
+			Unquoted:  `table1`,
+			MinQuoted: `table1`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+}
+
+func TestMySQLNonDefaultSchemaCaseSensitiveLowerCaseTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with MySQL and default schema "sakila" and
+	// a table name belonging to a non-default schema.
+	tableName := NewObjectName(MYSQL, "sakila", "schema1", "table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "schema1",
+		FromDefaultSchema: false,
+		Qualified: identifier{
+			Quoted:    `schema1.table1`,
+			Unquoted:  `schema1.table1`,
+			MinQuoted: `schema1.table1`,
+		},
+		Unqualified: identifier{
+			Quoted:    `table1`,
+			Unquoted:  `table1`,
+			MinQuoted: `table1`,
+		},
+		MinQualified: identifier{
+			Quoted:    `schema1.table1`,
+			Unquoted:  `schema1.table1`,
+			MinQuoted: `schema1.table1`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Qualified)
+}
+
+func TestMySQLDefaultSchemaCaseSensitiveMixedCaseTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with MySQL and default schema "sakila" and
+	// a case-sensitive name with mixed cases.
+	tableName := NewObjectName(MYSQL, "sakila", "sakila", "Table1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "sakila",
+		FromDefaultSchema: true,
+		Qualified: identifier{
+			Quoted:    `sakila.Table1`,
+			Unquoted:  `sakila.Table1`,
+			MinQuoted: `sakila.Table1`,
+		},
+		Unqualified: identifier{
+			Quoted:    `Table1`,
+			Unquoted:  `Table1`,
+			MinQuoted: `Table1`,
+		},
+		MinQualified: identifier{
+			Quoted:    `Table1`,
+			Unquoted:  `Table1`,
+			MinQuoted: `Table1`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Unqualified)
+}
+
+func TestMySQLNonDefaultSchemaCaseSensitiveUpperCaseTableName(t *testing.T) {
+	assert := assert.New(t)
+	// Test NewTableName() with MySQL and default schema "sakila" and
+	// a case-sensitive name with all upper case letters.
+	tableName := NewObjectName(MYSQL, "sakila", "schema1", "TABLE1")
+	assert.NotNil(tableName)
+	expectedTableName := &ObjectName{
+		SchemaName:        "schema1",
+		FromDefaultSchema: false,
+		Qualified: identifier{
+			Quoted:    `schema1.TABLE1`,
+			Unquoted:  `schema1.TABLE1`,
+			MinQuoted: `schema1.TABLE1`,
+		},
+		Unqualified: identifier{
+			Quoted:    `TABLE1`,
+			Unquoted:  `TABLE1`,
+			MinQuoted: `TABLE1`,
+		},
+		MinQualified: identifier{
+			Quoted:    `schema1.TABLE1`,
+			Unquoted:  `schema1.TABLE1`,
+			MinQuoted: `schema1.TABLE1`,
+		},
+	}
+	assert.Equal(expectedTableName, tableName)
+	assert.Equal(tableName.MinQualified, tableName.Qualified)
+}
+
+//=====================================================

--- a/yb-voyager/src/utils/sqlname/sqlname.go
+++ b/yb-voyager/src/utils/sqlname/sqlname.go
@@ -172,7 +172,7 @@ func quote(s string, dbType string) string {
 	case ORACLE:
 		return `"` + strings.ToUpper(s) + `"`
 	default:
-		panic("unknown source db type")
+		panic("unknown source db type " + dbType)
 	}
 }
 


### PR DESCRIPTION
- Initialize NameRegistry in import-data, export-data, import-data-to-file
- Move NameTuple, ObjectName to sqlname to enable use of these objects in srcdb/tgtdb (to avoid cyclic dependency). 