### PR TITLE
Harden the validation of batch and parallism flags

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -343,7 +343,8 @@ func registerFlagsForTarget(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", 0,
 		"number of parallel jobs to use while importing data. By default, voyager will try if it can determine the total "+
 			"number of cores N and use N/4 as parallel jobs. "+
-			"Otherwise, it fall back to using twice the number of nodes in the cluster.")
+			"Otherwise, it fall back to using twice the number of nodes in the cluster. "+
+			"Any value less than 1 reverts to the default calculation.")
 }
 
 func registerFlagsForSourceReplica(cmd *cobra.Command) {
@@ -351,11 +352,12 @@ func registerFlagsForSourceReplica(cmd *cobra.Command) {
 		fmt.Sprintf("Size of batches in the number of rows generated for ingestion during import. default: ORACLE(%d), POSTGRESQL(%d)", DEFAULT_BATCH_SIZE_ORACLE, DEFAULT_BATCH_SIZE_POSTGRESQL))
 	cmd.Flags().IntVar(&tconf.Parallelism, "parallel-jobs", 0,
 		"number of parallel jobs to use while importing data. default: For PostgreSQL(voyager will try if it can determine the total "+
-			"number of cores N and use N/2 as parallel jobs else it will fall back to 8) and Oracle(16)")
+			"number of cores N and use N/2 as parallel jobs else it will fall back to 8) and Oracle(16). "+
+			"Any value less than 1 reverts to the default calculation.")
 }
 
 func validateBatchSizeFlag(numLinesInASplit int64) {
-	if batchSize == 0 {
+	if batchSize <= 0 {
 		if tconf.TargetDBType == ORACLE {
 			batchSize = DEFAULT_BATCH_SIZE_ORACLE
 		} else if tconf.TargetDBType == POSTGRESQL {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -201,7 +201,7 @@ func (yb *TargetYugabyteDB) InitConnPool() error {
 	}
 	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
 
-	if yb.tconf.Parallelism == 0 {
+	if yb.tconf.Parallelism <= 0 {
 		yb.tconf.Parallelism = fetchDefaultParallelJobs(tconfs, YB_DEFAULT_PARALLELISM_FACTOR)
 		log.Infof("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", yb.tconf.Parallelism)
 	}


### PR DESCRIPTION
Because there was not validation on if the batch and parallism flags were less than zero - an exact check, rather than a less than or equal, one could get a go panic later in the execution because parallism was directly passed as an argument to make a channel.

The panic may look like this:

```
panic: makechan: size out of range

goroutine 1 [running]:
github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb.NewConnectionPool(...)
        /home/ec2-user/rpmbuild/BUILD/yb-voyager-yb-voyager-v1.6.5/yb-voyager/src/tgtdb/conn_pool.go:54
github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb.(*TargetYugabyteDB).InitConnPool(0xc0001ac740)
        /home/ec2-user/rpmbuild/BUILD/yb-voyager-yb-voyager-v1.6.5/yb-voyager/src/tgtdb/yugabytedb.go:214 +0x2ef
github.com/yugabyte/yb-voyager/yb-voyager/cmd.importData({0xc000941000, 0x196, 0x200})
        /home/ec2-user/rpmbuild/BUILD/yb-voyager-yb-voyager-v1.6.5/yb-voyager/cmd/importData.go:411 +0x909
github.com/yugabyte/yb-voyager/yb-voyager/cmd.importDataCommandFn(0x2c07740?, {0xc000908240?, 0x12?, 0x12?})
        /home/ec2-user/rpmbuild/BUILD/yb-voyager-yb-voyager-v1.6.5/yb-voyager/cmd/importData.go:141 +0x37f
```

This commit just reverts batch and parallism to default behavior for any value less than or equal to 0

This is especially important because commit
5c4d79764b67418702dda694f9a64022e8b8c031 changed the default value of these flags from -1 to 0, meaning that older, acceptable values would trigger a panic.