### PR TITLE
Bug fix[DB-10369]: Statement prepared in the yb connection pool are not being used by pgx.Batch APIs during ExecuteBatch()

### DIFF
--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -577,12 +577,12 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 			ybBatch.Queue(stmt)
 		} else {
 			stmt := event.GetPreparedSQLStmt(yb.tconf.TargetDBType)
-
+			psName := event.GetPreparedStmtName()
 			params := event.GetParams()
-			if _, ok := stmtToPrepare[stmt]; !ok {
-				stmtToPrepare[event.GetPreparedStmtName()] = stmt
+			if _, ok := stmtToPrepare[psName]; !ok {
+				stmtToPrepare[psName] = stmt
 			}
-			ybBatch.Queue(stmt, params...)
+			ybBatch.Queue(psName, params...)
 		}
 	}
 


### PR DESCRIPTION
- reason being, the names with which statements were prepared by conn pool, were not being passed to Queue() function of pgx.Batch. Fixed by using the common name for each unique prepared statement.