### PR TITLE
select 1 as first stmt in event batch on YB

### DIFF
--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -894,6 +894,8 @@ const (
 	SET_SESSION_REPLICATE_ROLE_TO_REPLICA = "SET session_replication_role TO replica" //Disable triggers or fkeys constraint checks.
 	SET_YB_ENABLE_UPSERT_MODE             = "SET yb_enable_upsert_mode to true"
 	SET_YB_DISABLE_TRANSACTIONAL_WRITES   = "SET yb_disable_transactional_writes to true" // Disable transactions to improve ingestion throughput.
+	// The "SELECT 1" workaround introduced in ExecuteBatch does not work if isolation level is read_committed. Therefore, for now, we are forcing REPEATABLE READ.
+	SET_DEFAULT_ISOLATION_LEVEL_REPEATABLE_READ = "SET default_transaction_isolation = 'repeatable read';"
 )
 
 func getYBSessionInitScript(tconf *TargetConf) []string {
@@ -903,6 +905,9 @@ func getYBSessionInitScript(tconf *TargetConf) []string {
 	}
 	if checkSessionVariableSupport(tconf, SET_SESSION_REPLICATE_ROLE_TO_REPLICA) {
 		sessionVars = append(sessionVars, SET_SESSION_REPLICATE_ROLE_TO_REPLICA)
+	}
+	if checkSessionVariableSupport(tconf, SET_DEFAULT_ISOLATION_LEVEL_REPEATABLE_READ) {
+		sessionVars = append(sessionVars, SET_DEFAULT_ISOLATION_LEVEL_REPEATABLE_READ)
 	}
 
 	if tconf.EnableUpsert {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -895,7 +895,7 @@ const (
 	SET_YB_ENABLE_UPSERT_MODE             = "SET yb_enable_upsert_mode to true"
 	SET_YB_DISABLE_TRANSACTIONAL_WRITES   = "SET yb_disable_transactional_writes to true" // Disable transactions to improve ingestion throughput.
 	// The "SELECT 1" workaround introduced in ExecuteBatch does not work if isolation level is read_committed. Therefore, for now, we are forcing REPEATABLE READ.
-	SET_DEFAULT_ISOLATION_LEVEL_REPEATABLE_READ = "SET default_transaction_isolation = 'repeatable read';"
+	SET_DEFAULT_ISOLATION_LEVEL_REPEATABLE_READ = "SET default_transaction_isolation = 'repeatable read'"
 )
 
 func getYBSessionInitScript(tconf *TargetConf) []string {


### PR DESCRIPTION
An additional safety net to workaround an issue in YB where in batched execution, transactions can be retried partially, breaking atomicity.
 SELECT 1 causes the ysql layer to record that data was sent back to the user, thereby, preventing retries.

Additionally, setting the default isolation level to repeatable_read because under read_committed, the SELECT 1 workaround does not work. 
https://yugabyte.slack.com/archives/CAR5BCH29/p1708320808330589