### PR TITLE
Fix for "Error: docker-compose command not found" in GH actions

### DIFF
--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Start YugabyteDB cluster
         run: |
           docker pull yugabytedb/yugabyte:${{ matrix.version }}
-          VERSION=${{ matrix.version }} docker-compose -f migtests/setup/yb-docker-compose.yaml up -d
+          VERSION=${{ matrix.version }} docker compose -f migtests/setup/yb-docker-compose.yaml up -d
           sleep 20
 
       - name: Test YugabyteDB connection

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Start YugabyteDB cluster
         run: |
           docker pull yugabytedb/yugabyte:${{ matrix.version }}
-          VERSION=${{ matrix.version }} docker-compose -f migtests/setup/yb-docker-compose.yaml up -d
+          VERSION=${{ matrix.version }} docker compose -f migtests/setup/yb-docker-compose.yaml up -d
           sleep 20
 
       - name: Test YugabyteDB connection


### PR DESCRIPTION
Found this [discussion](https://github.com/orgs/community/discussions/116610) thread for this error where someone has mentioned to change `docker-compose` to `docker compose` as Github has changed something which is causing this failure.

> GitHub deprecated v1, and you need to change the command from, e.g., docker-compose build to docker compose build (remove the dash)