### PR TITLE
Removed extra handling for debezium export data for dumped files and dataFileDescriptor 

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -346,14 +346,14 @@ func addLeafPartitionsInTableList(tableList []sqlname.NameTuple) (map[string]str
 		allLeafPartitions := GetAllLeafPartitions(table)
 		switch true {
 		case len(allLeafPartitions) == 0 && rootTable != table: //leaf partition
-			partitionsToRootTableMap[qualifiedCatalogName] = rootTable.ForKey() // Unquoted->MinQuoted map as debezium uses Unquoted table name
+			partitionsToRootTableMap[qualifiedCatalogName] = rootTable.AsQualifiedCatalogName() // Unquoted->Unquoted map as debezium uses Unquoted table name
 			modifiedTableList = append(modifiedTableList, table)
 		case len(allLeafPartitions) == 0 && rootTable == table: //normal table
 			modifiedTableList = append(modifiedTableList, table)
 		case len(allLeafPartitions) > 0 && source.TableList != "": // table with partitions in table list
 			for _, leafPartition := range allLeafPartitions {
 				modifiedTableList = append(modifiedTableList, leafPartition)
-				partitionsToRootTableMap[leafPartition.AsQualifiedCatalogName()] = rootTable.ForKey()
+				partitionsToRootTableMap[leafPartition.AsQualifiedCatalogName()] = rootTable.AsQualifiedCatalogName()
 			}
 		}
 		// will be keeping root in the list as it might be required by some of the catalog queries

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -387,10 +387,6 @@ func checkAndHandleSnapshotComplete(config *dbzm.Config, status *dbzm.ExportStat
 			return false, fmt.Errorf("failed to write data file descriptor: %w", err)
 		}
 		log.Infof("snapshot export is complete.")
-		err = renameDbzmExportedDataFiles()
-		if err != nil {
-			return false, fmt.Errorf("failed to rename dbzm exported data files: %v", err)
-		}
 		displayExportedRowCountSnapshot(true)
 	}
 
@@ -457,55 +453,5 @@ func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error 
 		DataFileList: dataFileList,
 	}
 	dfd.Save()
-	return nil
-}
-
-// handle renaming for tables having case sensitivity and reserved keywords
-func renameDbzmExportedDataFiles() error {
-	status, err := dbzm.ReadExportStatus(filepath.Join(exportDir, "data", "export_status.json"))
-	if err != nil {
-		return fmt.Errorf("failed to read export status during renaming exported data files: %w", err)
-	}
-	if status == nil {
-		return fmt.Errorf("export status is empty during renaming exported data files")
-	}
-
-	for i := 0; i < len(status.Tables); i++ {
-		tableName := status.Tables[i].TableName
-		// either case sensitive(postgresql) or reserved keyword(any source db)
-		if (!sqlname.IsAllLowercase(tableName) && source.DBType == POSTGRESQL) ||
-			sqlname.IsReservedKeywordPG(tableName) {
-			tableName = fmt.Sprintf("\"%s\"", status.Tables[i].TableName)
-		}
-
-		oldFilePath := filepath.Join(exportDir, "data", status.Tables[i].FileName)
-		newFilePath := filepath.Join(exportDir, "data", tableName+"_data.sql")
-		if status.Tables[i].SchemaName != "public" && source.DBType == POSTGRESQL {
-			newFilePath = filepath.Join(exportDir, "data", status.Tables[i].SchemaName+"."+tableName+"_data.sql")
-		}
-
-		if utils.FileOrFolderExists(newFilePath) { //In case of restarts rename should not be done again else it will error out
-			log.Infof("Skipping renaming files as they are already renamed")
-			continue
-		}
-
-		log.Infof("Renaming %s to %s", oldFilePath, newFilePath)
-		err = os.Rename(oldFilePath, newFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to rename dbzm exported data file: %w", err)
-		}
-
-		//rename table schema file as well
-		oldTableSchemaFilePath := filepath.Join(exportDir, "data", "schemas", SOURCE_DB_EXPORTER_ROLE, strings.Replace(status.Tables[i].FileName, "_data.sql", "_schema.json", 1))
-		newTableSchemaFilePath := filepath.Join(exportDir, "data", "schemas", SOURCE_DB_EXPORTER_ROLE, tableName+"_schema.json")
-		if status.Tables[i].SchemaName != "public" && source.DBType == POSTGRESQL {
-			newTableSchemaFilePath = filepath.Join(exportDir, "data", "schemas", SOURCE_DB_EXPORTER_ROLE, status.Tables[i].SchemaName+"."+tableName+"_schema.json")
-		}
-		log.Infof("Renaming %s to %s", oldTableSchemaFilePath, newTableSchemaFilePath)
-		err = os.Rename(oldTableSchemaFilePath, newTableSchemaFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to rename dbzm exported table schema file: %w", err)
-		}
-	}
 	return nil
 }

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -435,11 +435,11 @@ func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error 
 		// TODO: TableName and FilePath must be quoted by debezium plugin.
 		tableNameTup, err := namereg.NameReg.LookupTableName(fmt.Sprintf("%s.%s", table.SchemaName, table.TableName))
 		if err != nil {
-			return fmt.Errorf("lookup for table name %s: ", err)
+			return fmt.Errorf("lookup for table name %s: %v", table.TableName,  err)
 		}
 		fileEntry := &datafile.FileEntry{
 			TableName: tableNameTup.ForKey(),
-			FilePath:  fmt.Sprintf("%s_data.sql", tableNameTup.CurrentName.MinQualified.Unquoted),
+			FilePath:  table.FileName,
 			RowCount:  table.ExportedRowCountSnapshot,
 			FileSize:  -1, // Not available.
 		}

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -433,13 +433,13 @@ func writeDataFileDescriptor(exportDir string, status *dbzm.ExportStatus) error 
 	dataFileList := make([]*datafile.FileEntry, 0)
 	for _, table := range status.Tables {
 		// TODO: TableName and FilePath must be quoted by debezium plugin.
-		tableNameTup, err := namereg.NameReg.LookupTableName(table.TableName)
+		tableNameTup, err := namereg.NameReg.LookupTableName(fmt.Sprintf("%s.%s", table.SchemaName, table.TableName))
 		if err != nil {
 			return fmt.Errorf("lookup for table name %s: ", err)
 		}
 		fileEntry := &datafile.FileEntry{
 			TableName: tableNameTup.ForKey(),
-			FilePath:  fmt.Sprintf("%s_data.sql", table.TableName),
+			FilePath:  fmt.Sprintf("%s_data.sql", tableNameTup.CurrentName.MinQualified.Unquoted),
 			RowCount:  table.ExportedRowCountSnapshot,
 			FileSize:  -1, // Not available.
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1215,23 +1215,6 @@ func getDfdTableNameToExportedColumns(dataFileDescriptor *datafile.Descriptor) *
 	return result
 }
 
-func quoteIdentifierIfRequired(identifier string) string {
-	if sqlname.IsQuoted(identifier) {
-		return identifier
-	}
-	// TODO: Use either sourceDBType or source.DBType throughout the code.
-	// In the export code path source.DBType is used. In the import code path
-	// sourceDBType is used.
-	dbType := source.DBType
-	if dbType == "" {
-		dbType = sourceDBType
-	}
-	if sqlname.IsReservedKeywordPG(identifier) ||
-		((dbType == POSTGRESQL || dbType == YUGABYTEDB) && sqlname.IsCaseSensitive(identifier, dbType)) {
-		return fmt.Sprintf(`"%s"`, identifier)
-	}
-	return identifier
-}
 
 func checkExportDataDoneFlag() {
 	metaInfoDir := filepath.Join(exportDir, metaInfoDirName)

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -40,8 +40,8 @@ type MigrationStatusRecord struct {
 	PGReplicationSlotName                           string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
 	PGPublicationName                               string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
 	SnapshotMechanism                               string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump)
-	SourceRenameTablesMap                           map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.MinQuoted for renaming the leaf partitions to root table in case of PG migration
-	TargetRenameTablesMap                           map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.MinQuoted for renaming the leaf partitions to root table in case of PG migration
+	SourceRenameTablesMap                           map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
+	TargetRenameTablesMap                           map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
 	IsExportTableListSet                            bool              `json:"IsExportTableListSet"`
 }
 


### PR DESCRIPTION
- changed the `partitionsToRootTableMap` passed to debezium to have root table as Unquoted instead of Quoted 
- Removed renaming of debezium dumped exported files (data and schema).
- Removed extra handling of case sensitive and reserved words in dataFileDescriptor for debezium