### PR TITLE
Store the TableListExportedFromSource in MSR for debezium offline case as well

### DIFF
--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -71,7 +71,7 @@ func prepareDebeziumConfig(partitionsToRootTableMap map[string]string, tableList
 		}
 		dbzmTableList = append(dbzmTableList, table.AsQualifiedCatalogName())
 	}
-	if exporterRole == SOURCE_DB_EXPORTER_ROLE && changeStreamingIsEnabled(exportType) {
+	if exporterRole == SOURCE_DB_EXPORTER_ROLE {
 		err = storeTableListInMSR(tableList)
 		if err != nil {
 			utils.ErrExit("error while storing the table-list in msr: %v", err)


### PR DESCRIPTION
1. To avoid any errors or issues, we should store this table-list in msr in all the cases as we rely on this table-list at a few places now.
fixes - https://yugabyte.atlassian.net/browse/DB-10761