### PR TITLE
Atomic write of schema file

### DIFF
--- a/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -164,7 +164,7 @@ public class ExportStatus {
             if ((sourceType.equals("postgresql") || sourceType.equals("yb")) && (!t.schemaName.equals("public"))) {
                 fileName = t.schemaName + "." + fileName;
             }
-            String tempPath = String.format("/tmp/%s_schema.json", fileName);
+            String tempPath = String.format("/tmp/%s_%s_schema.json", exporterRole, fileName);
             File tempFile = new File(tempPath);
             String schemaFilePath = String.format("%s/schemas/%s/%s_schema.json", dataDir, exporterRole, fileName);
             File schemaFile = new File(schemaFilePath);


### PR DESCRIPTION
Atomically write the schema file for each table. 
Non-atomic writes were leading to situations where the importer notices the file(while trying to re-initialize the schema registry), tries to read the file, and fails with an EOF error. 