### PR TITLE
 use go-json instead of encoding/json

### DIFF
--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -16,10 +16,11 @@ limitations under the License.
 package tgtdb
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/goccy/go-json"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"


### PR DESCRIPTION
We used to use go-json as it is more performant compared to encoding/json. 
This change got reverted when we introduced manual unmarshalling. 
