### PR TITLE
Bug Fix: Installer script and DockerFile fixes for gather assessment metadata scripts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update && apt-get install -y curl perl make libdbi-perl locales && \
     curl -L https://cpanmin.us | perl - --self-upgrade && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    apt-get install -y tzdata wget openjdk-17-jre git sudo gcc && \
+    apt-get install -y tzdata wget rsync openjdk-17-jre git sudo gcc && \
     apt-get upgrade -y binutils && \
     curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
     git clone https://github.com/yugabyte/yb-voyager.git && \

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -767,7 +767,7 @@ create_gather_assessment_metadata_dir() {
 	if [ "${VERSION}" == "latest" ]
 	then
 		# TODO: Replace the YB_VOYAGER_GIT_HASH_TEMP with the release tagged YB_VOYAGER_GIT_HASH
-		YB_VOYAGER_GIT_HASH_TEMP="96eb3de7374e52279382c0fb01cf74bc5f9bb3fe"
+		YB_VOYAGER_GIT_HASH_TEMP="bd6c645fb233880d282c9691a7df6583bea0ec06"
 		TAR_URL="https://github.com/yugabyte/yb-voyager/raw/$YB_VOYAGER_GIT_HASH_TEMP/$scripts_dir_path/${scripts_dir_name}.tar.gz"
 		sudo wget -nv -O /tmp/${scripts_dir_name}.tar.gz $TAR_URL
 		sudo tar -xzf /tmp/${scripts_dir_name}.tar.gz -C $scripts_parent_dir 1>&2

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -759,7 +759,7 @@ create_pg_dump_args_file() {
 
 create_gather_assessment_metadata_dir() {	
 	scripts_parent_dir="/etc/yb-voyager"
-	scripts_dir_path="yb-voyager/src/srcdb/data/"
+	scripts_dir_path="yb-voyager/src/srcdb/data"
 	scripts_dir_name="gather-assessment-metadata"
 	sudo mkdir -p $scripts_parent_dir
 


### PR DESCRIPTION
1. Fixes in the installer script for the latest installation of `gather-assessment-metadata.tar.gz` 
2. DockerFile fix for local installation of voyager - adding `rsync` to apt-get install.