### PR TITLE
Use .tmp suffix instead of /tmp for schema files generated by debezium

### DIFF
--- a/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -164,10 +164,10 @@ public class ExportStatus {
             if ((sourceType.equals("postgresql") || sourceType.equals("yb")) && (!t.schemaName.equals("public"))) {
                 fileName = t.schemaName + "." + fileName;
             }
-            String tempPath = String.format("/tmp/%s_%s_schema.json", exporterRole, fileName);
-            File tempFile = new File(tempPath);
             String schemaFilePath = String.format("%s/schemas/%s/%s_schema.json", dataDir, exporterRole, fileName);
             File schemaFile = new File(schemaFilePath);
+            String tempPath = String.format("%s.tmp", schemaFilePath);
+            File tempFile = new File(tempPath);
             // writing to a temp file and moving later to achieve atomic write.
             schemaWriter.writeValue(tempFile, tableSchema);
             Files.move(tempFile.toPath(), schemaFile.toPath(), ATOMIC_MOVE);

--- a/yb-voyager/src/utils/schemareg/schemaRegistry.go
+++ b/yb-voyager/src/utils/schemareg/schemaRegistry.go
@@ -123,6 +123,9 @@ func (sreg *SchemaRegistry) Init() error {
 		return fmt.Errorf("failed to read schema dir %s: %w", schemaDir, err)
 	}
 	for _, schemaFile := range schemaFiles {
+		if strings.HasSuffix(schemaFile.Name(), ".tmp") {
+			continue
+		}
 		schemaFilePath := filepath.Join(schemaDir, schemaFile.Name())
 		schemaFile, err := os.Open(schemaFilePath)
 		if err != nil {


### PR DESCRIPTION
Placing the tmp file in /tmp causes AtomicMoveException in docker (because of having to move across different volumes. Therefore, we place the tmp file in the same directory as that of the final file we want to write. 