### PR TITLE
Export Data: Retrieve unique key info before starting pg dump

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -239,6 +239,7 @@ func exportData() bool {
 			log.Errorf("Failed to prepare dbzm config: %v", err)
 			return false
 		}
+		saveTableToUniqueKeyColumnsMapInMetaDB(finalTableList)
 		if source.DBType == POSTGRESQL && changeStreamingIsEnabled(exportType) {
 			// pg live migration. Steps are as follows:
 			// 1. create publication, replication slot.
@@ -279,7 +280,6 @@ func exportData() bool {
 			config.PublicationName = msr.PGPublicationName
 			config.InitSequenceMaxMapping = sequenceInitValues.String()
 		}
-		saveTableToUniqueKeyColumnsMapInMetaDB(finalTableList)
 		err = debeziumExportData(ctx, config, tableNametoApproxRowCountMap)
 		if err != nil {
 			log.Errorf("Export Data using debezium failed: %v", err)


### PR DESCRIPTION
In PG live migration flow, we currently 
1. open a connection
1. gather data from server
1. run pg dump
1. gather some more information from server
1. start debezium. 

Because pg_dump can take a long time, we are seeing some connection failures (`broken pipe` for example) in step 4. 
Modifying the logic so that step 4 is done in step2, so that we don't have to use the connection again after pg_dump. 

This is a temporary fix. Meanwhile, we should find out how to properly handle these type of errors either via config/retries/etc. 