### PR TITLE
Introduced new metadata table 'Object_Type_Mapping(schema, table, object_type)' to deal with partitioned table in Migration Assessment

### DIFF
--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -35,8 +35,12 @@ const (
 	TABLE_ROW_COUNTS         = "table_row_counts"
 	TABLE_COLUMNS_COUNT      = "table_columns_count"
 	INDEX_TO_TABLE_MAPPING   = "index_to_table_mapping"
+	OBJECT_TYPE_MAPPING      = "object_type_mapping"
 	TABLE_COLUMNS_DATA_TYPES = "table_columns_data_types"
 	TABLE_INDEX_STATS        = "table_index_stats"
+
+	PARTITIONED_TABLE_OBJECT_TYPE = "partitioned table"
+	PARTITIONED_INDEX_OBJECT_TYPE = "partitioned index"
 )
 
 type TableIndexStats struct {
@@ -49,6 +53,7 @@ type TableIndexStats struct {
 	ReadsPerSecond  *int64  `json:"ReadsPerSecond"`
 	WritesPerSecond *int64  `json:"WritesPerSecond"`
 	IsIndex         bool    `json:"IsIndex"`
+	ObjectType      string  `json:"ObjectType"`
 	ParentTableName *string `json:"ParentTableName"`
 	SizeInBytes     *int64  `json:"SizeInBytes"`
 }
@@ -102,6 +107,11 @@ func InitAssessmentDB() error {
 			table_name		TEXT,
 			PRIMARY KEY (index_schema, index_name));`, INDEX_TO_TABLE_MAPPING),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			schema_name     TEXT,
+			object_name     TEXT,
+			object_type     TEXT,
+			PRIMARY KEY (schema_name, object_name));`, OBJECT_TYPE_MAPPING),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			schema_name		TEXT,
 			table_name		TEXT,
 			column_name		TEXT,
@@ -118,6 +128,7 @@ func InitAssessmentDB() error {
 			reads_per_second	INTEGER,
 			writes_per_second	INTEGER,
 			is_index            BOOLEAN,
+			object_type			TEXT,
 			parent_table_name   TEXT,
 			size_in_bytes       INTEGER,
 			PRIMARY KEY(schema_name, object_name));`, TABLE_INDEX_STATS),
@@ -190,7 +201,7 @@ func (adb *AssessmentDB) BulkInsert(table string, records [][]string) error {
 }
 
 const (
-	InsertTableStats = `INSERT INTO %s (schema_name, object_name, row_count, column_count, reads, writes, is_index, parent_table_name, size_in_bytes)
+	InsertTableStats = `INSERT INTO %s (schema_name, object_name, row_count, column_count, reads, writes, is_index, object_type, parent_table_name, size_in_bytes)
 	SELECT 
 		trc.schema_name,
 		trc.table_name AS object_name,
@@ -199,15 +210,18 @@ const (
 		tii.seq_reads AS reads,
 		tii.row_writes AS writes,
 		0 AS is_index,
+		otm.object_type,
 		NULL AS parent_table_name,
 		tis.size_in_bytes
 	FROM %s trc
 	LEFT JOIN %s tii ON trc.schema_name = tii.schema_name AND trc.table_name = tii.object_name and tii.measurement_type='initial'
 	LEFT JOIN %s tis ON trc.schema_name = tis.schema_name AND trc.table_name = tis.object_name
-	LEFT JOIN %s tcc ON trc.schema_name = tcc.schema_name AND trc.table_name = tcc.object_name;`
+	LEFT JOIN %s tcc ON trc.schema_name = tcc.schema_name AND trc.table_name = tcc.object_name
+	LEFT JOIN %s otm ON trc.schema_name = otm.schema_name AND trc.table_name = otm.object_name
+	WHERE otm.object_type NOT IN ('%s', '%s');`
 
 	// No insertion into 'column_count' for indexes
-	InsertIndexStats = `INSERT INTO %s (schema_name, object_name, row_count, reads, writes, is_index, parent_table_name, size_in_bytes)
+	InsertIndexStats = `INSERT INTO %s (schema_name, object_name, row_count, reads, writes, is_index, object_type, parent_table_name, size_in_bytes)
 	SELECT 
 		itm.index_schema AS schema_name,
 		itm.index_name AS object_name,
@@ -215,11 +229,14 @@ const (
 		tii.seq_reads AS reads,
 		tii.row_writes AS writes,
 		1 AS is_index,
+		otm.object_type,
 		itm.table_schema || '.' || itm.table_name AS parent_table_name,
 		tis.size_in_bytes
 	FROM %s itm
 	LEFT JOIN %s tii ON itm.index_schema = tii.schema_name AND itm.index_name = tii.object_name and tii.measurement_type='initial'
-	LEFT JOIN %s tis ON itm.index_schema = tis.schema_name AND itm.index_name = tis.object_name;`
+	LEFT JOIN %s tis ON itm.index_schema = tis.schema_name AND itm.index_name = tis.object_name
+	LEFT JOIN %s otm ON itm.index_schema = otm.schema_name AND itm.index_name = otm.object_name
+	WHERE otm.object_type NOT IN ('%s', '%s');`
 
 	CreateTempTable = `CREATE TEMP TABLE read_write_rates AS
 	SELECT
@@ -258,8 +275,10 @@ const (
 // populate table_index_stats table using the data from other tables
 func (adb *AssessmentDB) PopulateMigrationAssessmentStats() error {
 	statements := []string{
-		fmt.Sprintf(InsertTableStats, TABLE_INDEX_STATS, TABLE_ROW_COUNTS, TABLE_INDEX_IOPS, TABLE_INDEX_SIZES, TABLE_COLUMNS_COUNT),
-		fmt.Sprintf(InsertIndexStats, TABLE_INDEX_STATS, INDEX_TO_TABLE_MAPPING, TABLE_INDEX_IOPS, TABLE_INDEX_SIZES),
+		fmt.Sprintf(InsertTableStats, TABLE_INDEX_STATS, TABLE_ROW_COUNTS, TABLE_INDEX_IOPS, TABLE_INDEX_SIZES,
+			TABLE_COLUMNS_COUNT, OBJECT_TYPE_MAPPING, PARTITIONED_TABLE_OBJECT_TYPE, PARTITIONED_INDEX_OBJECT_TYPE),
+		fmt.Sprintf(InsertIndexStats, TABLE_INDEX_STATS, INDEX_TO_TABLE_MAPPING, TABLE_INDEX_IOPS, TABLE_INDEX_SIZES,
+			OBJECT_TYPE_MAPPING, PARTITIONED_TABLE_OBJECT_TYPE, PARTITIONED_INDEX_OBJECT_TYPE),
 		fmt.Sprintf(CreateTempTable, TABLE_INDEX_IOPS, TABLE_INDEX_IOPS),
 		UpdateStatsWithRates,
 	}

--- a/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/object_type_mapping.psql
+++ b/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/object_type_mapping.psql
@@ -1,4 +1,3 @@
--- Create a temporary table to store the query results
 CREATE TEMP TABLE temp_table AS
 SELECT
     n.nspname AS schema_name,
@@ -9,22 +8,17 @@ SELECT
         WHEN c.relkind = 'i' THEN 'index'
         WHEN c.relkind = 'I' THEN 'partitioned index'
         ELSE 'unknown'
-    END AS object_type,
-    pg_catalog.pg_relation_size(c.oid) AS size_in_bytes
-FROM 
-    pg_catalog.pg_class c
-JOIN 
-    pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    END AS object_type
+FROM
+    pg_class c
+JOIN
+    pg_namespace n ON c.relnamespace = n.oid
 LEFT JOIN
     pg_catalog.pg_index pi ON pi.indexrelid = c.oid AND (c.relkind = 'i' OR c.relkind = 'I')
 WHERE 
     (c.relkind IN ('r', 'p', 'i', 'I')) AND NOT (c.relkind IN ('i', 'I') AND pi.indisprimary)
     AND n.nspname = ANY(ARRAY[string_to_array(:'schema_list', '|')]);
 
-
--- TODO: handle storing the info(column names) with schema name(required in case of multi schema migration)
--- Output the contents of the temporary table to a CSV file
-
-\copy temp_table TO 'table-index-sizes.csv' WITH CSV HEADER;
+\copy temp_table to 'object-type-mapping.csv' WITH CSV HEADER;
 
 DROP TABLE temp_table;

--- a/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/table-columns-count.psql
+++ b/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/table-columns-count.psql
@@ -3,14 +3,19 @@ SELECT
     n.nspname AS schema_name,
     c.relname AS object_name,
     CASE 
-        WHEN c.relkind = 'r' THEN 'table'
-        ELSE 'index'
+        WHEN c.relkind = 'r' THEN 'table' 
+        WHEN c.relkind = 'p' THEN 'partitioned table'
+        WHEN c.relkind = 'i' THEN 'index'
+        WHEN c.relkind = 'I' THEN 'partitioned index'
+        ELSE 'unknown'
     END AS object_type,
     CASE
-        WHEN c.relkind = 'r' THEN
-            (SELECT COUNT(*) FROM pg_attribute WHERE attrelid = c.oid AND attnum > 0)
-        ELSE
-            (SELECT COUNT(*) FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indexrelid WHERE i.indrelid = c.oid)
+        WHEN c.relkind IN ('r', 'p') THEN
+            (SELECT COUNT(*) FROM pg_attribute WHERE attrelid = c.oid AND attnum > 0 AND NOT attisdropped)
+        WHEN c.relkind IN ('i', 'I') AND NOT EXISTS (
+            SELECT 1 FROM pg_index WHERE indexrelid = c.oid AND indisprimary
+        ) THEN
+            (SELECT COUNT(*) FROM pg_attribute WHERE attrelid = c.oid AND attnum > 0 AND NOT attisdropped)
     END AS column_count
 FROM
     pg_class c
@@ -19,7 +24,7 @@ JOIN
 LEFT JOIN
     pg_index pi ON pi.indexrelid = c.oid
 WHERE
-    (c.relkind = 'r' OR (c.relkind = 'i' AND NOT pi.indisprimary))
+    (c.relkind IN ('r', 'p', 'i', 'I')) AND NOT (c.relkind IN ('i', 'I') AND pi.indisprimary)
     AND n.nspname = ANY(ARRAY[string_to_array(:'schema_list', '|')]);
 
 \copy temp_table to 'table-columns-count.csv' WITH CSV HEADER;

--- a/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/table-index-iops.psql
+++ b/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/table-index-iops.psql
@@ -2,7 +2,13 @@ CREATE TEMP TABLE temp_table AS
 SELECT
     n.nspname AS schema_name,
     c.relname AS object_name,
-    CASE WHEN c.relkind = 'r' THEN 'table' ELSE 'index' END AS object_type,
+    CASE 
+        WHEN c.relkind = 'r' THEN 'table' 
+        WHEN c.relkind = 'p' THEN 'partitioned table'
+        WHEN c.relkind = 'i' THEN 'index'
+        WHEN c.relkind = 'I' THEN 'partitioned index'
+        ELSE 'unknown'
+    END AS object_type,
     CASE 
         WHEN c.relkind = 'r' THEN psut.seq_tup_read
         WHEN c.relkind = 'i' THEN psi.idx_scan
@@ -24,8 +30,7 @@ LEFT JOIN
     pg_index pi ON pi.indexrelid = c.oid
 WHERE
     n.nspname = ANY(ARRAY[string_to_array(:'schema_list', '|')])
-    AND (c.relkind = 'r' OR (c.relkind = 'i' AND NOT pi.indisprimary))
-    AND (psut.schemaname = n.nspname OR psi.schemaname = n.nspname);
+    AND (c.relkind IN ('r', 'p', 'i', 'I')) AND NOT (c.relkind IN ('i', 'I') AND pi.indisprimary);
 
 -- Now you can use the temporary table to fetch the data
 \copy temp_table TO 'table-index-iops.csv' WITH CSV HEADER;


### PR DESCRIPTION
- Now we are categorizing objects into 4 types mainly - table, partitioned table, index, partitioned index

- sizer logic/code remains the same since TABLE_INDEX_STATS is filtered to not store any unnecessary info related to partitions

- Also optimized other existing metadata queries wherever possible