### PR TITLE
Sizing Calculator: colocated/sharded table list update, reasoning update

### DIFF
--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -95,6 +95,8 @@ const (
 	GITHUB_RAW_LINK          = "https://raw.githubusercontent.com/yugabyte/yb-voyager/main/yb-voyager/src/migassessment/resources"
 	EXPERIMENT_DATA_FILENAME = "yb_2024_0_source.db"
 	DBS_DIR                  = "dbs"
+	SIZE_UNIT_GB             = "GB"
+	SIZE_UNIT_MB             = "MB"
 )
 
 var ExperimentDB *sql.DB
@@ -853,26 +855,26 @@ Returns:
 func getReasoning(recommendation IntermediateRecommendation, shardedObjects []SourceDBMetadata,
 	cumulativeIndexCountSharded int, colocatedObjects []SourceDBMetadata, cumulativeIndexCountColocated int) string {
 	// Calculate size and throughput of colocated objects
-	colocatedObjectsSize, colocatedReads, colocatedWrites := getObjectsSize(colocatedObjects)
+	colocatedObjectsSize, colocatedReads, colocatedWrites, sizeUnitColocated := getObjectsSize(colocatedObjects)
 	reasoning := fmt.Sprintf("Recommended instance type with %v vCPU and %v GiB memory could fit ",
 		recommendation.VCPUsPerInstance, recommendation.VCPUsPerInstance*recommendation.MemoryPerCore)
 
 	// Add information about colocated objects if they exist
 	if len(colocatedObjects) > 0 {
-		reasoning += fmt.Sprintf("%v objects(%v tables and %v indexes) with %0.4f GB size and throughput "+
+		reasoning += fmt.Sprintf("%v objects(%v tables and %v indexes) with %0.2f %v size and throughput "+
 			"requirement of %v reads/sec and %v writes/sec as colocated.", len(colocatedObjects),
 			len(colocatedObjects)-cumulativeIndexCountColocated, cumulativeIndexCountColocated, colocatedObjectsSize,
-			colocatedReads, colocatedWrites)
+			sizeUnitColocated, colocatedReads, colocatedWrites)
 	}
 	// Add information about sharded objects if they exist
 	if len(shardedObjects) > 0 {
 		// Calculate size and throughput of sharded objects
-		shardedObjectsSize, shardedReads, shardedWrites := getObjectsSize(shardedObjects)
+		shardedObjectsSize, shardedReads, shardedWrites, sizeUnitSharded := getObjectsSize(shardedObjects)
 		// Construct reasoning for sharded objects
-		shardedReasoning := fmt.Sprintf("%v objects(%v tables and %v indexes) with %0.4f GB size and throughput "+
+		shardedReasoning := fmt.Sprintf("%v objects(%v tables and %v indexes) with %0.2f %v size and throughput "+
 			"requirement of %v reads/sec and %v writes/sec ", len(shardedObjects),
 			len(shardedObjects)-cumulativeIndexCountSharded, cumulativeIndexCountSharded, shardedObjectsSize,
-			shardedReads, shardedWrites)
+			sizeUnitSharded, shardedReads, shardedWrites)
 		// If colocated objects exist, add sharded objects information as rest of the objects need to be migrated as sharded
 		if len(colocatedObjects) > 0 {
 			reasoning += " Rest " + shardedReasoning + " need to be migrated as range partitioned tables"
@@ -892,12 +894,14 @@ Parameters:
 Returns:
   - The total size of the objects (in float64 representing GB).
   - The total number of select operations per second across all objects (in int64).
-  - The total number of insert operations per second across all objects (in int64)
+  - The total number of insert operations per second across all objects (in int64).
+  - The size unit for the total size
 */
-func getObjectsSize(objects []SourceDBMetadata) (float64, int64, int64) {
+func getObjectsSize(objects []SourceDBMetadata) (float64, int64, int64, string) {
 	var objectsSize float64 = 0
 	var objectSelectOps int64 = 0
 	var objectInsertOps int64 = 0
+	var sizeUnit = SIZE_UNIT_GB
 
 	for _, object := range objects {
 		// Accumulate size and throughput values
@@ -905,8 +909,14 @@ func getObjectsSize(objects []SourceDBMetadata) (float64, int64, int64) {
 		objectSelectOps += object.ReadsPerSec
 		objectInsertOps += object.WritesPerSec
 	}
+	// if object size is less than 1 GB, convert it to MB
+	if objectsSize < 1 {
+		sizeUnit = SIZE_UNIT_MB
+		objectsSize = objectsSize * 1024
+	}
+
 	// Return the accumulated size and throughput values
-	return objectsSize, objectSelectOps, objectInsertOps
+	return objectsSize, objectSelectOps, objectInsertOps, sizeUnit
 }
 
 /*


### PR DESCRIPTION
- updated the colocated and sharded list to only include table names(i.e remove the index names from the list)
- update the reasoning to show the split of table count and index count along with the current object count.

Example: a database with 24 tables and 31 indexes.
Screenshot of the updated report:
<img width="828" alt="Screenshot 2024-05-07 at 3 52 48 PM" src="https://github.com/yugabyte/yb-voyager/assets/56402576/13507f4c-6908-41ca-8bd9-2b53029830cc">

sizing assessment json part of the report:
```
	"Sizing": {
		"SizingRecommendation": {
			"ColocatedTables": [
				"public.auth_user_user_permissions",
				"public.service_client",
				"public.auth_group",
				"public.auth_user_groups",
				"public.auth_group_permissions",
				"public.service_baseline",
				"public.django_migrations",
				"public.django_session",
				"public.service_grafana",
				"public.auth_permission",
				"public.django_content_type",
				"public.auth_user",
				"public.django_admin_log",
				"public.service_portal",
				"public.service_perfreportreleaselink",
				"public.service_testfield",
				"public.service_universetemplate",
				"public.service_perfstudionodedetails",
				"public.service_perfstudiopipeline",
				"public.service_perfstudiologs",
				"public.service_regressionalerting",
				"public.service_clusterconfig",
				"public.service_microbenchmarkoutput",
				"public.service_test"
			],
			"ColocatedReasoning": "Recommended instance type with 2 vCPU and 8 GiB memory could fit 55 objects(24 tables and 31 indexes) with 0.1161 GB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated.",
			"ShardedTables": null,
			"NumNodes": 3,
			"VCPUsPerInstance": 2,
			"MemoryPerInstance": 8,
			"OptimalSelectConnectionsPerNode": 5,
			"OptimalInsertConnectionsPerNode": 6,
			"EstimatedTimeInMinForImport": 1,
			"ParallelVoyagerJobs": 1
		},
		"FailureReasoning": ""
	}
```