### PR TITLE
Avoid count(*) in assessment metadata db

### DIFF
--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -450,6 +450,7 @@ rebuild_debezium_server_voyager_plugin_local(){
 rebuild_voyager_local() {
 	VERSION="local"
 	install_yb_voyager
+	create_gather_assessment_metadata_dir
 	rebuild_debezium_server_voyager_plugin_local
 }
 

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -452,7 +452,6 @@ rebuild_voyager_local() {
 	install_yb_voyager
 	create_gather_assessment_metadata_dir
 	rebuild_debezium_server_voyager_plugin_local
-	create_gather_assessment_metadata_dir
 }
 
 get_passed_options() {

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -452,6 +452,7 @@ rebuild_voyager_local() {
 	install_yb_voyager
 	create_gather_assessment_metadata_dir
 	rebuild_debezium_server_voyager_plugin_local
+	create_gather_assessment_metadata_dir
 }
 
 get_passed_options() {

--- a/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/table-row-counts.psql
+++ b/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/table-row-counts.psql
@@ -24,8 +24,9 @@ BEGIN
             WHERE table_schema = schema_name AND table_type = 'BASE TABLE' 
         LOOP
             -- Execute dynamic SQL to insert row count data into temp_table
+            -- For now, setting 0 as row count because count(*) is too slow (SELECT %L, %L, COUNT(*) FROM %I.%I')
             EXECUTE format(
-                'INSERT INTO temp_table (schema_name, table_name, row_count) SELECT %L, %L, COUNT(*) FROM %I.%I',
+                'INSERT INTO temp_table (schema_name, table_name, row_count) VALUES ( %L, %L, 0 )',
                 table_record.table_schema,
                 table_record.table_name,
                 table_record.table_schema,

--- a/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/yb-voyager-pg-gather-assessment-metadata.sh
+++ b/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/yb-voyager-pg-gather-assessment-metadata.sh
@@ -103,8 +103,6 @@ for script in $SCRIPT_DIR/*.psql; do
         
         psql -q $pg_connection_string -f $script -v schema_list=$schema_list -v ON_ERROR_STOP=on -v measurement_type=final -v filename=$script_name-initial.csv
         mv table-index-iops.csv table-index-iops-final.csv
-    elif [ $script_name == "table-row-counts" ]; then
-        continue
     else
         psql -q $pg_connection_string -f $script -v schema_list=$schema_list -v ON_ERROR_STOP=on
     fi

--- a/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/yb-voyager-pg-gather-assessment-metadata.sh
+++ b/yb-voyager/src/srcdb/data/gather-assessment-metadata/postgresql/yb-voyager-pg-gather-assessment-metadata.sh
@@ -103,6 +103,8 @@ for script in $SCRIPT_DIR/*.psql; do
         
         psql -q $pg_connection_string -f $script -v schema_list=$schema_list -v ON_ERROR_STOP=on -v measurement_type=final -v filename=$script_name-initial.csv
         mv table-index-iops.csv table-index-iops-final.csv
+    elif [ $script_name == "table-row-counts" ]; then
+        continue
     else
         psql -q $pg_connection_string -f $script -v schema_list=$schema_list -v ON_ERROR_STOP=on
     fi


### PR DESCRIPTION
- Currently we do not use row counts of tables in sizing logic, and count(*) can be time-consuming for large tables, so commenting it out for now. 