### PR TITLE
Modified Migration Assessment HTML Report

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -166,7 +166,6 @@ func assessMigration() (err error) {
 	if err != nil {
 		utils.PrintAndLog("failed to run assessment: %v", err)
 	}
-	assessmentReport.Sizing = migassessment.SizingReport
 
 	err = generateAssessmentReport()
 	if err != nil {
@@ -228,6 +227,13 @@ func runAssessment() error {
 		return fmt.Errorf("failed to perform sizing and sharding assessment: %w", err)
 	}
 
+	assessmentReport.Sizing = migassessment.SizingReport
+
+	shardedTables, _ := assessmentReport.GetShardedTablesRecommendation()
+	colocatedTables, _ := assessmentReport.GetColocatedTablesRecommendation()
+	log.Infof("Recommendation: colocated tables: %v", colocatedTables)
+	log.Infof("Recommendation: sharded tables: %v", shardedTables)
+	log.Infof("Recommendation: Cluster size: %s", assessmentReport.GetClusterSizingRecommendation())
 	return nil
 }
 
@@ -568,7 +574,10 @@ func generateAssessmentReportHtml(reportDir string) error {
 	}()
 
 	log.Infof("creating template for assessment report...")
-	tmpl := template.Must(template.New("report").Parse(string(bytesTemplate)))
+	funcMap := template.FuncMap{
+		"split": split,
+	}
+	tmpl := template.Must(template.New("report").Funcs(funcMap).Parse(string(bytesTemplate)))
 
 	log.Infof("execute template for assessment report...")
 	err = tmpl.Execute(file, assessmentReport)
@@ -578,6 +587,10 @@ func generateAssessmentReportHtml(reportDir string) error {
 
 	utils.PrintAndLog("generated HTML assessment report at: %s", htmlReportFilePath)
 	return nil
+}
+
+func split(value string, delimiter string) []string {
+	return strings.Split(value, delimiter)
 }
 
 func validateSourceDBTypeForAssessMigration() {

--- a/yb-voyager/cmd/assessmentReport.template
+++ b/yb-voyager/cmd/assessmentReport.template
@@ -30,6 +30,7 @@
             border: 1px solid #ddd;
             padding: 8px;
             text-align: left;
+            vertical-align: top; /* Vertically center content in table cells */
         }
         th {
             background-color: #f2f2f2;
@@ -41,12 +42,11 @@
         li {
             margin: 5px 0;
         }
-        .table-container {
-            display: flex;
-            justify-content: space-between;
-        }
-        .table-container > div {
-            width: 48%;
+        .scrollable-div {
+            max-height: 300px;
+            overflow-y: scroll;
+            border: 1px solid #ccc;
+            padding: 10px;
         }
     </style>
 </head>
@@ -71,39 +71,18 @@
             <tr>
                 <td>{{.ObjectType}}</td>
                 <td>{{.TotalCount}}</td>
-                <td>{{.ObjectNames}}</td>
+                <td>
+                    <div class="scrollable-div">
+                        {{range split .ObjectNames ","}}
+                            {{.}}<br>
+                        {{end}}
+                    </div>
+                </td>
             </tr>
             {{end}}
         </table>
 
-        <h2>Unsupported Data Types</h2>
-        <table>
-            <tr>
-                <th>Schema</th>
-                <th>Table</th>
-                <th>Column</th>
-                <th>Data Type</th>
-            </tr>
-            {{range .UnsupportedDataTypes}}
-            <tr>
-                <td>{{.SchemaName}}</td>
-                <td>{{.TableName}}</td>
-                <td>{{.ColumnName}}</td>
-                <td>{{.DataType}}</td>
-            </tr>
-            {{end}}
-        </table>
-
-        <h2>Unsupported Features</h2>
-        {{range .UnsupportedFeatures}}
-        <h3>{{.FeatureName}}</h3>
-        <ul>
-            {{range .ObjectNames}}
-            <li>{{.}}</li>
-            {{end}}
-        </ul>
-        {{end}}
-            {{with .Sizing}}
+        {{with .Sizing}}
             <h2>Sharding Recommendations</h2>
                 {{ if eq .FailureReasoning "" }}
                     {{ with .SizingRecommendation }}
@@ -113,8 +92,20 @@
                                 <th>Sharded Tables</th>
                             </tr>
                             <tr>
-                                <td>{{range .ColocatedTables}}{{.}}<br>{{end}}</td>
-                                <td>{{range .ShardedTables}}{{.}}<br>{{end}}</td>
+                                <td>
+                                    <div class="scrollable-div">
+                                        {{range .ColocatedTables}}
+                                            {{.}}<br>
+                                        {{end}}
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="scrollable-div">
+                                        {{range .ShardedTables}}
+                                            {{.}}<br>
+                                        {{end}}
+                                    </div>
+                                </td>
                             </tr>
                         </table>
                     <h2>Sizing Recommendations</h2>
@@ -136,9 +127,51 @@
                 {{ end }}
                 {{else}}
                     <p>Could not perform sizing assessment:  {{ .FailureReasoning }}</p>
-                {{ end }}
+            {{ end }}
+        {{end}}
 
+        <h2>Unsupported Data Types</h2>
+        {{ if .UnsupportedDataTypes }}
+            <div class="scrollable-div">
+                <table>
+                    <tr>
+                        <th>Schema</th>
+                        <th>Table</th>
+                        <th>Column</th>
+                        <th>Data Type</th>
+                    </tr>
+                    {{range .UnsupportedDataTypes}}
+                    <tr>
+                        <td>{{.SchemaName}}</td>
+                        <td>{{.TableName}}</td>
+                        <td>{{.ColumnName}}</td>
+                        <td>{{.DataType}}</td>
+                    </tr>
+                    {{end}}
+                </table>
+            </div>
+        {{ else }}
+            <p>No unsupported data types detected in the assessed schemas.</p>
+        {{ end }}
+
+        <h2>Unsupported Features</h2>
+        {{ $hasUnsupportedFeatures := false }}
+        {{range .UnsupportedFeatures}}
+            {{if .ObjectNames}} <!-- Check if ObjectNames is not empty -->
+                {{ $hasUnsupportedFeatures = true }}
+                <h3>{{.FeatureName}}</h3>
+                <ul>
+                    <div class="scrollable-div">
+                        {{range .ObjectNames}}
+                            <li>{{.}}</li>
+                        {{end}}
+                    </div>
+                </ul>
             {{end}}
+        {{end}}
+        {{if not $hasUnsupportedFeatures}} <!-- Check if no unsupported features were found -->
+            <p>No unsupported features among detected among the ones assessed.</p>
+        {{end}}
     </div>
 </body>
 </html>

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -975,3 +975,17 @@ func (ar *AssessmentReport) GetColocatedTablesRecommendation() ([]string, error)
 
 	return ar.Sizing.SizingRecommendation.ColocatedTables, nil
 }
+
+func (ar *AssessmentReport) GetClusterSizingRecommendation() string {
+	if ar.Sizing == nil {
+		return ""
+	}
+
+	if ar.Sizing.FailureReasoning != "" {
+		return ar.Sizing.FailureReasoning
+	}
+
+	return fmt.Sprintf("Num Nodes: %f, vCPU per instance: %d, Memory per instance: %d, Estimated Import Time: %f minutes",
+		ar.Sizing.SizingRecommendation.NumNodes, ar.Sizing.SizingRecommendation.VCPUsPerInstance,
+		ar.Sizing.SizingRecommendation.MemoryPerInstance, ar.Sizing.SizingRecommendation.EstimatedTimeInMinForImport)
+}


### PR DESCRIPTION
To make the tables scrollable for the sections where a large list of object names is possible

- also added checks in Unsupported Features and Unsupported Datatypes sections to non-empty subsections and display relevant text if nothing is unsupported

-- also moved the Recommendation section above from last

For example this is how the scrollable sections will look:
![image](https://github.com/yugabyte/yb-voyager/assets/42322654/02314c3b-f59c-425c-97bd-99ae1d1bdba3)
![image](https://github.com/yugabyte/yb-voyager/assets/42322654/ace2aadd-113f-40e3-813b-32f84b2841e1)

