### PR TITLE
[DB-11205] Improved export schema output regarding applying assessment recommendations. 

### DIFF
--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -116,12 +116,13 @@ func exportSchema() error {
 	if err != nil {
 		return err
 	}
-	utils.PrintAndLog("\nExported schema files created under directory: %s\n\n", filepath.Join(exportDir, "schema"))
 
 	err = applyMigrationAssessmentRecommendations()
 	if err != nil {
 		return fmt.Errorf("failed to apply migration assessment recommendation to the schema files: %w", err)
 	}
+
+	utils.PrintAndLog("\nExported schema files created under directory: %s\n\n", filepath.Join(exportDir, "schema"))
 
 	payload := callhome.GetPayload(exportDir, migrationUUID)
 	payload.SourceDBType = source.DBType
@@ -239,6 +240,7 @@ func applyMigrationAssessmentRecommendations() error {
 			return fmt.Errorf("failed to apply colocated vs sharded table recommendation: %w", err)
 		}
 	}
+	utils.PrintAndLog("Applied assessment recommendations.")
 
 	return nil
 }


### PR DESCRIPTION
- Irrespective of whether we actually changed the schema (to add `WITH COLOCATION false` , we print a msg indicating that we have applied the assessment recommendations 
- Make the last msg be `Exported schema files created under directory: ...` 


Sample outputs

(non-empty sharded tables)
```
exporting the schema           done
Modified CREATE TABLE statements in "schema/tables/table.sql" according to the colocation and sharding recommendations of the assessment report.
The original DDLs have been preserved in "schema/tables/table.sql.orig" for reference.
Applied assessment recommendations.

Exported schema files created under directory: /Users/amakala/Documents/test/assessment/schema
```

(all colocated tables; no change to schema required)
```
exporting the schema           done
Applied assessment recommendations.

Exported schema files created under directory: /Users/amakala/Documents/test/assessment/schema
```