### PR TITLE
Changed installation method of OIC in ubuntu in the installer script (#1484)

### DIFF
--- a/docker/yb-voyager-docker
+++ b/docker/yb-voyager-docker
@@ -46,10 +46,6 @@ volume_dirs=("--export-dir"
 "--assessment-metadata-dir"
 "--assessment-report-path")
 
-store_in_file=("--source-ssl-cert"
-"--source-ssl-key"
-"--source-ssl-root-cert")
-
 file_name="voyager-metadata.txt"
 
 # Loop through the array and capture the environment variables
@@ -101,11 +97,6 @@ do
 	if [[ " ${volume_dirs[@]} " =~ " ${v} " ]]
 	then
 		map_host_path_inside_container
-		# If the flag is --source-ssl-cert, --source-ssl-key, --source-ssl-root-cert then save them in a local text file. Store both flag and the path in the file. Save each flag in a new line.
-		if [[ " ${store_in_file[@]} " =~ " ${v} " ]]
-		then
-			echo "${v} ${dir_path}" >> $file_name
-		fi
 		i=$(( $i + 1))
 		continue
 	fi
@@ -167,17 +158,6 @@ if [ -t 1 ]
 then 
 	tty="-it"
 fi
-
-# If the command is end migration then map the paths saved in the file to the container. There are multiple flag names and paths saved in the file.
-if [[ ${argv[0]} == "end" ] && [ ${argv[1]} == "migration" ] && [ -f $file_name ]] 
-then
-	while IFS= read -r line
-	do
-		IFS=' ' read -r -a array <<< "$line"
-		map_host_path_inside_container "${array[0]}" "${array[1]}"
-	done < $file_name
-fi
-
 
 dockerCmd="docker run ${exported_vars} ${tty} ${gcp_vol} ${s3_vol} ${azure_vol} ${volume_mappings} --pid=host --network=host --rm --privileged ${platform} yugabytedb/yb-voyager yb-voyager ${argv[*]}"
 

--- a/docker/yb-voyager-docker
+++ b/docker/yb-voyager-docker
@@ -46,8 +46,6 @@ volume_dirs=("--export-dir"
 "--assessment-metadata-dir"
 "--assessment-report-path")
 
-file_name="voyager-metadata.txt"
-
 # Loop through the array and capture the environment variables
 for var_name in "${variables[@]}"; do
   var=$(env | grep -E "$var_name")

--- a/docker/yb-voyager-docker
+++ b/docker/yb-voyager-docker
@@ -46,6 +46,12 @@ volume_dirs=("--export-dir"
 "--assessment-metadata-dir"
 "--assessment-report-path")
 
+store_in_file=("--source-ssl-cert"
+"--source-ssl-key"
+"--source-ssl-root-cert")
+
+file_name="voyager-metadata.txt"
+
 # Loop through the array and capture the environment variables
 for var_name in "${variables[@]}"; do
   var=$(env | grep -E "$var_name")
@@ -95,6 +101,11 @@ do
 	if [[ " ${volume_dirs[@]} " =~ " ${v} " ]]
 	then
 		map_host_path_inside_container
+		# If the flag is --source-ssl-cert, --source-ssl-key, --source-ssl-root-cert then save them in a local text file. Store both flag and the path in the file. Save each flag in a new line.
+		if [[ " ${store_in_file[@]} " =~ " ${v} " ]]
+		then
+			echo "${v} ${dir_path}" >> $file_name
+		fi
 		i=$(( $i + 1))
 		continue
 	fi
@@ -156,6 +167,17 @@ if [ -t 1 ]
 then 
 	tty="-it"
 fi
+
+# If the command is end migration then map the paths saved in the file to the container. There are multiple flag names and paths saved in the file.
+if [[ ${argv[0]} == "end" ] && [ ${argv[1]} == "migration" ] && [ -f $file_name ]] 
+then
+	while IFS= read -r line
+	do
+		IFS=' ' read -r -a array <<< "$line"
+		map_host_path_inside_container "${array[0]}" "${array[1]}"
+	done < $file_name
+fi
+
 
 dockerCmd="docker run ${exported_vars} ${tty} ${gcp_vol} ${s3_vol} ${azure_vol} ${volume_mappings} --pid=host --network=host --rm --privileged ${platform} yugabytedb/yb-voyager yb-voyager ${argv[*]}"
 

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -840,25 +840,17 @@ ubuntu_install_postgres() {
 
 ubuntu_install_oracle_instant_clients() {
 	output "Installing Oracle Instant Clients."
-	sudo apt-get -y install alien 1>&2
-	ubuntu_install_oic oracle-instantclient-tools
-	ubuntu_install_oic oracle-instantclient-basic
-	ubuntu_install_oic oracle-instantclient-devel
-	ubuntu_install_oic oracle-instantclient-jdbc
-	ubuntu_install_oic oracle-instantclient-sqlplus
+	wget https://s3.us-west-2.amazonaws.com/downloads.yugabyte.com/repos/reporpms/yb-apt-repo_1.0.0_all.deb
+	sudo apt-get install -y ./yb-apt-repo_1.0.0_all.deb 1>&2
+	sudo apt-get update -y 1>&2
+	sudo apt-get install -y oracle-instantclient-tools=21.5.0.0.0-1 1>&2
+	sudo apt-get install -y oracle-instantclient-basic=21.5.0.0.0-1 1>&2
+	sudo apt-get install -y oracle-instantclient-devel=21.5.0.0.0-1 1>&2
+	sudo apt-get install -y oracle-instantclient-jdbc=21.5.0.0.0-1 1>&2
+	sudo apt-get install -y oracle-instantclient-sqlplus=21.5.0.0.0-1 1>&2
+	sudo apt-get remove -y yb-apt-repo 1>&2
+	rm -f yb-apt-repo_1.0.0_all.deb 1>&2
 	output "Installed Oracle Instance Clients."
-}
-
-ubuntu_install_oic() {
-	if dpkg -l | grep -q -w $1
-	then
-		echo "$1 is already installed."
-	else
-		rpm_name="$1-21.5.0.0.0-1.x86_64.rpm"
-		wget -nv https://download.oracle.com/otn_software/linux/instantclient/215000/${rpm_name} 1>&2
-		sudo alien -i ${rpm_name} 1>&2
-		rm ${rpm_name}
-	fi
 }
 
 #=============================================================================


### PR DESCRIPTION
Docker build uses an ubuntu image and installs yb-voyager using the installer script on it. The docker build was failing because alien command was failing to convert the sqlplus OIC from rpm to deb. So, using our already converted OIC clients from our own apt repository.