### PR TITLE
Bug: Schema modification not getting applied to case sensitive or case sensitive reserved words table

### DIFF
--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -118,12 +118,12 @@ jobs:
       - name: "TEST: pg-indexes"
         run: migtests/scripts/run-test.sh pg/indexes
 
-      - name: "TEST: pg-partitions"
-        run: migtests/scripts/run-test.sh pg/partitions 
+      # - name: "TEST: pg-partitions"
+      #   run: migtests/scripts/run-test.sh pg/partitions 
 
 
-      - name: "TEST: pg-partitions with (table-list)"
-        run: EXPORT_TABLE_LIST='customers,sales,emp,p2.boston,p2.london,p2.sydney,range_columns_partition_test,sales_region,test_partitions_sequences' migtests/scripts/run-test.sh pg/partitions 
+      # - name: "TEST: pg-partitions with (table-list)"
+      #   run: EXPORT_TABLE_LIST='customers,sales,emp,p2.boston,p2.london,p2.sydney,range_columns_partition_test,sales_region,test_partitions_sequences' migtests/scripts/run-test.sh pg/partitions 
 
       # Broken for v2.15 and v2.16: https://github.com/yugabyte/yugabyte-db/issues/14529
       # Fixed in 2.17.1.0-b368
@@ -186,11 +186,11 @@ jobs:
         run: migtests/scripts/live-migration-fallb-run-test.sh pg/basic-non-public-live-test
 
 
-      - name: "TEST: pg-live-migration-partitions-fall-forward"
-        run: migtests/scripts/live-migration-fallf-run-test.sh pg/partitions
+      # - name: "TEST: pg-live-migration-partitions-fall-forward"
+      #   run: migtests/scripts/live-migration-fallf-run-test.sh pg/partitions
 
       
-      - name: "TEST: pg-case-sensitivity-reserved-words-offline"
-        run: migtests/scripts/run-test.sh pg/case-sensitivity-reserved-words
+      # - name: "TEST: pg-case-sensitivity-reserved-words-offline"
+      #   run: migtests/scripts/run-test.sh pg/case-sensitivity-reserved-words
 
       

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -118,12 +118,12 @@ jobs:
       - name: "TEST: pg-indexes"
         run: migtests/scripts/run-test.sh pg/indexes
 
-      # - name: "TEST: pg-partitions"
-      #   run: migtests/scripts/run-test.sh pg/partitions 
+      - name: "TEST: pg-partitions"
+        run: migtests/scripts/run-test.sh pg/partitions 
 
 
-      # - name: "TEST: pg-partitions with (table-list)"
-      #   run: EXPORT_TABLE_LIST='customers,sales,emp,p2.boston,p2.london,p2.sydney,range_columns_partition_test,sales_region,test_partitions_sequences' migtests/scripts/run-test.sh pg/partitions 
+      - name: "TEST: pg-partitions with (table-list)"
+        run: EXPORT_TABLE_LIST='customers,sales,emp,p2.boston,p2.london,p2.sydney,range_columns_partition_test,sales_region,test_partitions_sequences' migtests/scripts/run-test.sh pg/partitions 
 
       # Broken for v2.15 and v2.16: https://github.com/yugabyte/yugabyte-db/issues/14529
       # Fixed in 2.17.1.0-b368
@@ -186,11 +186,11 @@ jobs:
         run: migtests/scripts/live-migration-fallb-run-test.sh pg/basic-non-public-live-test
 
 
-      # - name: "TEST: pg-live-migration-partitions-fall-forward"
-      #   run: migtests/scripts/live-migration-fallf-run-test.sh pg/partitions
+      - name: "TEST: pg-live-migration-partitions-fall-forward"
+        run: migtests/scripts/live-migration-fallf-run-test.sh pg/partitions
 
       
-      # - name: "TEST: pg-case-sensitivity-reserved-words-offline"
-      #   run: migtests/scripts/run-test.sh pg/case-sensitivity-reserved-words
+      - name: "TEST: pg-case-sensitivity-reserved-words-offline"
+        run: migtests/scripts/run-test.sh pg/case-sensitivity-reserved-words
 
       

--- a/migtests/tests/pg/case-sensitivity-reserved-words/add-pk-from-alter-to-create
+++ b/migtests/tests/pg/case-sensitivity-reserved-words/add-pk-from-alter-to-create
@@ -27,7 +27,10 @@ for i in range(len(create_tables)):
         columns = match.group(2)
 
         # Add the primary key constraint to the CREATE TABLE statement
-        create_table = create_tables[i] + '    PRIMARY KEY (' + columns + '),\n'
+        if "WITH" in create_tables[i]:
+            create_table = create_tables[i].replace(') WITH', ',' + 'PRIMARY KEY (' +  columns + ')) WITH')
+        else:
+            create_table = create_tables[i] + '    PRIMARY KEY (' + columns + '),\n'
         output.append(create_table)
 
 with open(table_file_path, 'w') as file:

--- a/migtests/tests/pg/datatypes/validate
+++ b/migtests/tests/pg/datatypes/validate
@@ -146,9 +146,10 @@ def migration_completed_checks(tgt):
 
 def YB_specific_checks(tgt):
 	print("Verifying the colocation of the tables")
-	# for table_name, expected_colocation in EXPECTED_COLOCATION_OF_TABLES.items():
-	# 	actual_colocation = tgt.check_table_colocation(table_name)
-	# 	assert actual_colocation == (expected_colocation == 't'), f"Table '{table_name}' colocation mismatch. Expected: {expected_colocation}, Actual: {actual_colocation}"
+	# TODO: fetch the expected table list from assessmentReport.json file
+	for table_name, expected_colocation in EXPECTED_COLOCATION_OF_TABLES.items():
+		actual_colocation = tgt.check_table_colocation(table_name)
+		assert actual_colocation == (expected_colocation == 't'), f"Table '{table_name}' colocation mismatch. Expected: {expected_colocation}, Actual: {actual_colocation}"
 
 
 if __name__ == "__main__":

--- a/migtests/tests/pg/datatypes/validate
+++ b/migtests/tests/pg/datatypes/validate
@@ -146,9 +146,9 @@ def migration_completed_checks(tgt):
 
 def YB_specific_checks(tgt):
 	print("Verifying the colocation of the tables")
-	for table_name, expected_colocation in EXPECTED_COLOCATION_OF_TABLES.items():
-		actual_colocation = tgt.check_table_colocation(table_name)
-		assert actual_colocation == (expected_colocation == 't'), f"Table '{table_name}' colocation mismatch. Expected: {expected_colocation}, Actual: {actual_colocation}"
+	# for table_name, expected_colocation in EXPECTED_COLOCATION_OF_TABLES.items():
+	# 	actual_colocation = tgt.check_table_colocation(table_name)
+	# 	assert actual_colocation == (expected_colocation == 't'), f"Table '{table_name}' colocation mismatch. Expected: {expected_colocation}, Actual: {actual_colocation}"
 
 
 if __name__ == "__main__":

--- a/migtests/tests/pg/partitions/add-pk-from-alter-to-create
+++ b/migtests/tests/pg/partitions/add-pk-from-alter-to-create
@@ -27,7 +27,10 @@ for i in range(len(create_tables)):
         columns = match.group(2)
 
         # Add the primary key constraint to the CREATE TABLE statement
-        create_table = create_tables[i] + '    PRIMARY KEY (' + columns + '),\n'
+        if "WITH" in create_tables[i]:
+            create_table = create_tables[i].replace(') WITH', ',' + 'PRIMARY KEY (' +  columns + ')) WITH')
+        else:
+            create_table = create_tables[i] + '    PRIMARY KEY (' + columns + '),\n'
         output.append(create_table)
 
 with open(table_file_path, 'w') as file:

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -231,7 +231,7 @@ func applyMigrationAssessmentRecommendations() error {
 		return fmt.Errorf("failed to parse json report file %q: %w", assessmentReportPath, err)
 	}
 
-	shardedTables, err := report.GetShardedTablesRecommendation()
+	shardedTables, err := report.GetColocatedTablesRecommendation()
 	if err != nil {
 		return fmt.Errorf("failed to fetch sharded tables recommendation: %w", err)
 	} else {

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -245,7 +245,7 @@ func applyMigrationAssessmentRecommendations() error {
 	return nil
 }
 
-func applyShardedTablesRecommendation(shardedTables []string) (err error) {
+func applyShardedTablesRecommendation(shardedTables []string) error {
 	if shardedTables == nil {
 		log.Info("list of sharded tables is null hence all the tables are recommended as colocated")
 		return nil
@@ -261,7 +261,6 @@ func applyShardedTablesRecommendation(shardedTables []string) (err error) {
 	var newSQLFileContent strings.Builder
 	sqlInfoArr := parseSqlFileForObjectType(filePath, "TABLE")
 	for _, sqlInfo := range sqlInfoArr {
-		var modifiedSqlStmt string
 		/*
 			We can rely on pg_query to detect if it is CreateTable and also table name
 			but due to time constraint this module can't be tested thoroughly so relying on the existing as much as possible
@@ -269,21 +268,16 @@ func applyShardedTablesRecommendation(shardedTables []string) (err error) {
 			We can pass the whole .sql file as a string also to pg_query.Parse() all the statements at once.
 			But avoiding that also specially for cases where the SQL syntax can be invalid
 		*/
-		// parsing only the Recommended Sharded Tables
-		if sqlInfo.objName != "" && slices.Contains(shardedTables, sqlInfo.objName) {
-			log.Infof("applying sharding recommendation for table=%q", sqlInfo.objName)
-			modifiedSqlStmt, err = applyShardingRecommendation(&sqlInfo)
-			if err != nil {
-				log.Errorf("failed to apply sharding recommendation for table=%q: %v", sqlInfo.objName, err)
-				fmt.Printf("Unable to apply sharding recommendation for table=%q, continuing without applying...\n", sqlInfo.objName)
-				fmt.Printf("Please manually add the clause \"WITH (colocation = false)\" to the CREATE TABLE DDL of the '%s' table.\n", sqlInfo.objName)
-				modifiedSqlStmt = sqlInfo.formattedStmt
-			} else {
-				log.Infof("original ddl - %s", sqlInfo.stmt)
-				log.Infof("modified ddl - %s", modifiedSqlStmt)
-			}
-		} else {
-			modifiedSqlStmt = sqlInfo.formattedStmt
+		modifiedSqlStmt, match, err := applyShardingRecommendationIfMatching(&sqlInfo, shardedTables)
+		if match && err != nil {
+			log.Errorf("failed to apply sharding recommendation for table=%q: %v", sqlInfo.objName, err)
+			fmt.Printf("Unable to apply sharding recommendation for table=%q, continuing without applying...\n", sqlInfo.objName)
+			fmt.Printf("Please manually add the clause \"WITH (colocation = false)\" to the CREATE TABLE DDL of the '%s' table.\n", sqlInfo.objName)
+		} else if err != nil {
+			log.Errorf("failed to apply sharding recommendation for table=%q: %v", sqlInfo.objName, err)
+		} else if match && err == nil {
+			log.Infof("original ddl - %s", sqlInfo.stmt)
+			log.Infof("modified ddl - %s", modifiedSqlStmt)
 		}
 
 		_, err = newSQLFileContent.WriteString(modifiedSqlStmt + "\n\n")
@@ -295,7 +289,7 @@ func applyShardedTablesRecommendation(shardedTables []string) (err error) {
 	// rename existing table.sql file to table.sql.orig
 	backupPath := filePath + ".orig"
 	log.Infof("renaming existing file '%s' --> '%s.orig'", filePath, backupPath)
-	err = os.Rename(filePath, filePath+".orig")
+	err := os.Rename(filePath, filePath+".orig")
 	if err != nil {
 		return fmt.Errorf("error renaming file %s: %w", filePath, err)
 	}
@@ -320,34 +314,47 @@ func applyShardedTablesRecommendation(shardedTables []string) (err error) {
 }
 
 /*
-applyShardingRecommendation uses pg_query module to parse the given SQL stmt
+applyShardingRecommendationIfMatching uses pg_query module to parse the given SQL stmt
 In case of any errors or unexpected behaviour it return the original DDL
 so in worse only recommendation of that table won't be followed.
 
 # It can handle cases like multiple options in WITH clause
 
+returns:
+modifiedSqlStmt: original stmt if not sharded else modified stmt with colocation clause
+match: true if its a sharded table and should be modified
+error: nil/non-nil
+
 Drawback: pg_query module doesn't have functionality to format the query after parsing
 so the CREATE TABLE for sharding recommended tables will be one-liner
 */
-func applyShardingRecommendation(sqlInfo *sqlInfo) (string, error) {
+func applyShardingRecommendationIfMatching(sqlInfo *sqlInfo, shardedTables []string) (string, bool, error) {
 	stmt := sqlInfo.stmt
+	formattedStmt := sqlInfo.formattedStmt
 	parseTree, err := pg_query.Parse(stmt)
 	if err != nil {
-		return stmt, fmt.Errorf("error parsing the stmt-%s: %v", stmt, err)
+		return formattedStmt, false, fmt.Errorf("error parsing the stmt-%s: %v", stmt, err)
 	}
 
 	if len(parseTree.Stmts) == 0 {
 		log.Warnf("parse tree is empty for stmt=%s for table '%s'", stmt, sqlInfo.objName)
-		return stmt, nil
+		return formattedStmt, false, nil
 	}
 
 	// Access the first statement directly
 	createStmtNode, ok := parseTree.Stmts[0].Stmt.Node.(*pg_query.Node_CreateStmt)
 	if !ok { // return the original sql if it's not a CreateStmt
 		log.Infof("stmt=%s is not createTable as per the parse tree, expected tablename=%s", stmt, sqlInfo.objName)
-		return stmt, nil
+		return formattedStmt, false, nil
 	}
 	createTableStmt := createStmtNode.CreateStmt
+
+	// Extract schema and table name
+	relation := createTableStmt.Relation
+	parsedTableName := relation.Schemaname + "." + relation.Relname
+	if !slices.Contains(shardedTables, parsedTableName) {
+		return formattedStmt, false, nil
+	}
 
 	colocationOption := &pg_query.DefElem{
 		Defname: COLOCATION_CLAUSE,
@@ -371,14 +378,14 @@ func applyShardingRecommendation(sqlInfo *sqlInfo) (string, error) {
 		})
 	}
 
-	log.Infof("deparsing the query after updating stmt's parse tree")
+	log.Infof("deparsing the updated parse tre into a stmt for table '%s'", parsedTableName)
 	modifiedQuery, err := pg_query.Deparse(parseTree)
 	if err != nil {
-		return stmt, fmt.Errorf("error deparsing the parseTree into the query: %w", err)
+		return formattedStmt, true, fmt.Errorf("error deparsing the parseTree into the query: %w", err)
 	}
 
 	// adding semi-colon at the end
-	return fmt.Sprintf("%s;", modifiedQuery), nil
+	return fmt.Sprintf("%s;", modifiedQuery), true, nil
 }
 
 func createExportSchemaStartedEvent() cp.ExportSchemaStartedEvent {


### PR DESCRIPTION
Discovered some cases where sharding recommendation was not getting applied to the case-sensitive or reserved keywords tables.
For example: for the same table report stored `public.case` and our object name(extract from DDL) had `public."case"` due to `case` being a reserved word.

- Fix: Using the pg_query parser to fetch the table name(not quotes but proper casing) and compare it with the names of recommended sharded tables in the assessmentReport

**Ignore the changes in second commit, its a temporary commit just for testing purpose**