### PR TITLE
Bug fixes related to metaDB and pg_dump schema.sql file parsing (#1511)

### DIFF
--- a/yb-voyager/src/metadb/metadataDB.go
+++ b/yb-voyager/src/metadb/metadataDB.go
@@ -331,7 +331,7 @@ func UpdateJsonObjectInMetaDB[T any](m *MetaDB, key string, updateFn func(obj *T
 	}
 	defer func() {
 		err := tx.Rollback()
-		if err != nil {
+		if err != nil && !errors.Is(err, sql.ErrTxDone) {
 			log.Errorf("failed to rollback transaction on meta db: %v", err)
 		}
 	}()

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -92,7 +92,7 @@ func parseSchemaFile(exportDir string, schemaDir string, exportObjectTypesList [
 	if utils.FileOrFolderExists(filepath.Join(schemaDir, "schema.sql")) { // assess-migration workflow
 		schemaFilePath = filepath.Join(schemaDir, "schema.sql")
 	}
-	
+
 	log.Infof("begun parsing the schema file %q", schemaFilePath)
 	lines := readSchemaFile(schemaFilePath)
 	var delimiterIndexes []int
@@ -135,7 +135,7 @@ func parseSchemaFile(exportDir string, schemaDir string, exportObjectTypesList [
 				objSqlStmts["SEQUENCE"].WriteString(stmts)
 			case "INDEX", "INDEX ATTACH":
 				objSqlStmts["INDEX"].WriteString(stmts)
-			case "TABLE", "DEFAULT", "CONSTRAINT", "FK CONSTRAINT":
+			case "TABLE", "DEFAULT", "CONSTRAINT", "FK CONSTRAINT", "CHECK CONSTRAINT":
 				objSqlStmts["TABLE"].WriteString(stmts)
 			case "TABLE ATTACH":
 				alterAttachPartition.WriteString(stmts)


### PR DESCRIPTION
* Ignoring meta DB rollback to log failures/errors in case of Transaction is done/aborted already

* Adding 'ALTER TABLE .. ADD CONSTRAINT ...' in table.sql instead of uncategoried.sql 
  for example: below DDL was present in uncategorized.sql
 -- Name: rna constraint_rna_seq_long_n; Type: CHECK CONSTRAINT; Schema: rnacen; Owner: -
 

   ALTER TABLE rnacen.rna
       ADD CONSTRAINT constraint_rna_seq_long_n CHECK (((seq_long IS NULL) OR (((len - length(replace(seq_long, 'N'::text, ''::text))))::numeric <= round((0.1 * (len)::numeric))))) NOT VALID;