### PR TITLE
Bug fix: In Oracle live migration log mining flush table should be passed in upper case to debezium

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -232,6 +232,7 @@ func exportData() bool {
 	utils.PrintAndLog("table list for data export: %v", tableListToDisplay)
 
 	//finalTableList is with leaf partitions and root tables after this in the whole export flow to make all the catalog queries work fine
+
 	if changeStreamingIsEnabled(exportType) || useDebezium {
 		config, tableNametoApproxRowCountMap, err := prepareDebeziumConfig(partitionsToRootTableMap, finalTableList, tablesColumnList, leafPartitions)
 		if err != nil {
@@ -547,7 +548,13 @@ func getFinalTableColumnList() (map[string]string, []sqlname.NameTuple, *utils.S
 	tableListFromDB := source.DB().GetAllTableNames()
 	var err error
 	var fullTableList []sqlname.NameTuple
+	logMiningFlushTable := utils.GetLogMiningFlushTableName(migrationUUID)
 	for _, t := range tableListFromDB {
+		if source.DBType == ORACLE {
+			if t.ObjectName.Unquoted == logMiningFlushTable {
+				continue
+			}
+		}
 		schema, table := t.SchemaName.Unquoted, t.ObjectName.Unquoted
 		defaultSchemaName, _ := getDefaultSourceSchemaName()
 		//For partitions case there is no defined mapping and
@@ -813,11 +820,6 @@ func clearMigrationStateIfRequired() {
 		err = metadb.TruncateTablesInMetaDb(exportDir, []string{metadb.QUEUE_SEGMENT_META_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_PER_TABLE_TABLE_NAME})
 		if err != nil {
 			utils.ErrExit("Failed to truncate tables in metadb: %s", err)
-		}
-		//For dropping VOYAGER_LOG_MINING_FLUSH_{migrationUUID} table in oracle on start-clean
-		err = source.DB().ClearMigrationState(migrationUUID, exportDir)
-		if err != nil {
-			utils.ErrExit("failed to clear migration state: %s", err)
 		}
 	} else {
 		if !utils.IsDirectoryEmpty(exportDataDir) {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -552,6 +552,7 @@ func getFinalTableColumnList() (map[string]string, []sqlname.NameTuple, *utils.S
 	for _, t := range tableListFromDB {
 		if source.DBType == ORACLE {
 			if t.ObjectName.Unquoted == logMiningFlushTable {
+				//Ignore this table as this is for debezium's internal use
 				continue
 			}
 		}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -548,14 +548,7 @@ func getFinalTableColumnList() (map[string]string, []sqlname.NameTuple, *utils.S
 	tableListFromDB := source.DB().GetAllTableNames()
 	var err error
 	var fullTableList []sqlname.NameTuple
-	logMiningFlushTable := utils.GetLogMiningFlushTableName(migrationUUID)
 	for _, t := range tableListFromDB {
-		if source.DBType == ORACLE {
-			if t.ObjectName.Unquoted == logMiningFlushTable {
-				//Ignore this table as this is for debezium's internal use
-				continue
-			}
-		}
 		schema, table := t.SchemaName.Unquoted, t.ObjectName.Unquoted
 		defaultSchemaName, _ := getDefaultSourceSchemaName()
 		//For partitions case there is no defined mapping and

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -142,6 +142,10 @@ func (ora *Oracle) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error in scanning query rows for table names: %v", err)
 		}
+		if strings.HasPrefix(tableName, "VOYAGER_LOG_MINING_FLUSH_") {
+			//Ignore this table as this is for debezium's internal use
+			continue
+		}
 		tableNames = append(tableNames, tableName)
 	}
 

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -327,10 +327,8 @@ func (ora *Oracle) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList []
 		}
 	}
 
-	logMiningFlushTable := utils.GetLogMiningFlushTableName(migrationUUID)
 	for _, table := range tableList {
-		_, tname := table.ForCatalogQuery()
-		if !slices.Contains(unsupportedTableList, table) && tname != logMiningFlushTable {
+		if !slices.Contains(unsupportedTableList, table) {
 			filteredTableList = append(filteredTableList, table)
 		}
 	}

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -528,7 +528,7 @@ func ReadTableNameListFromFile(filePath string) ([]string, error) {
 func GetLogMiningFlushTableName(migrationUUID uuid.UUID) string {
 	// SQL tables doesn't support '-' in the name
 	convertedMigUUID := strings.Replace(migrationUUID.String(), "-", "_", -1)
-	return fmt.Sprintf("VOYAGER_LOG_MINING_FLUSH_%s", convertedMigUUID)
+	return fmt.Sprintf("VOYAGER_LOG_MINING_FLUSH_%s", strings.ToUpper(convertedMigUUID))
 }
 
 func ConvertStringSliceToInterface(slice []string) []interface{} {


### PR DESCRIPTION
1. The issue is when we resume export data and use the same log mining flush table, debezium is erroring out while creating the table again with the error `name already exist` as it checks first if the table exists or not and that check is failing to detect the existence of this table because of lowercase chars present in the table name we pass to debezium. Fixes https://yugabyte.atlassian.net/browse/DB-11433
2. Another issue for resumption is that if the user and schema of Oracle are the same for the migration then this log mining flush table is created in the Schema for which the migration is happening but the name registry wasn't aware of it in starting as it is created during the migration. So on resumption, the table list we fetch from Oracle will have that table name but the lookup will error out saying table not found in name registry. Fixes - https://yugabyte.atlassian.net/browse/DB-11434

Jenkins runs - 
1. Live migration tests with. oracle offline tests - https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/2593/
4. Oracle offline test with debezuim - https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/2592/