### PR TITLE
Bug fix: For Oracle live migration export data resumption was failing…

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -815,11 +815,6 @@ func clearMigrationStateIfRequired() {
 		if err != nil {
 			utils.ErrExit("Failed to truncate tables in metadb: %s", err)
 		}
-		//For dropping VOYAGER_LOG_MINING_FLUSH_{migrationUUID} table in oracle on start-clean
-		err = source.DB().ClearMigrationState(migrationUUID, exportDir)
-		if err != nil {
-			utils.ErrExit("failed to clear migration state: %s", err)
-		}
 	} else {
 		if !utils.IsDirectoryEmpty(exportDataDir) {
 			if (changeStreamingIsEnabled(exportType)) &&

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -134,6 +134,10 @@ func (ora *Oracle) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error in scanning query rows for table names: %v", err)
 		}
+		if strings.HasPrefix(tableName, "VOYAGER_LOG_MINING_FLUSH_") {
+			//Ignore this table as this is for debezium's internal use
+			continue
+		}
 		tableNames = append(tableNames, tableName)
 	}
 
@@ -314,10 +318,8 @@ func (ora *Oracle) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList []
 		}
 	}
 
-	logMiningFlushTable := utils.GetLogMiningFlushTableName(migrationUUID)
 	for _, table := range tableList {
-		_, tname := table.ForCatalogQuery()
-		if !slices.Contains(unsupportedTableList, table) && tname != logMiningFlushTable {
+		if !slices.Contains(unsupportedTableList, table) {
 			filteredTableList = append(filteredTableList, table)
 		}
 	}

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -528,7 +528,7 @@ func ReadTableNameListFromFile(filePath string) ([]string, error) {
 func GetLogMiningFlushTableName(migrationUUID uuid.UUID) string {
 	// SQL tables doesn't support '-' in the name
 	convertedMigUUID := strings.Replace(migrationUUID.String(), "-", "_", -1)
-	return fmt.Sprintf("VOYAGER_LOG_MINING_FLUSH_%s", convertedMigUUID)
+	return fmt.Sprintf("VOYAGER_LOG_MINING_FLUSH_%s", strings.ToUpper(convertedMigUUID))
 }
 
 func ConvertStringSliceToInterface(slice []string) []interface{} {


### PR DESCRIPTION
… (#1524)

1. The issue is when we resume export data and use the same log mining flush table, debezium is erroring out while creating the table again with the error name already exist as it checks first if the table exists or not and that check is failing to detect the existence of this table because of lowercase chars present in the table name we pass to debezium. Fixes https://yugabyte.atlassian.net/browse/DB-11433
2. Another issue for resumption is that if the user and schema of Oracle are the same for the migration then this log mining flush table is created in the Schema for which the migration is happening but the name registry wasn't aware of it in starting as it is created during the migration. So on resumption, the table list we fetch from Oracle will have that table name but the lookup will error out saying table not found in name registry. Fixes - https://yugabyte.atlassian.net/browse/DB-11434