### PR TITLE
Integrated assess-migration command in the end to end automation test workflow (#1521)

### DIFF
--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -75,6 +75,8 @@ main() {
 			cat_log_file "yb-voyager-assess-migration.log"
 			exit 1
 		fi
+
+		post_assess_migration
 	fi
 
 	step "Export schema."

--- a/migtests/scripts/live-migration-fallf-run-test.sh
+++ b/migtests/scripts/live-migration-fallf-run-test.sh
@@ -83,6 +83,8 @@ main() {
 			cat_log_file "yb-voyager-assess-migration.log"
 			exit 1
 		fi
+
+		post_assess_migration
 	fi
 
 	step "Export schema."

--- a/migtests/scripts/live-migration-run-test.sh
+++ b/migtests/scripts/live-migration-run-test.sh
@@ -74,6 +74,8 @@ main() {
 			cat_log_file "yb-voyager-assess-migration.log"
 			exit 1
 		fi
+
+		post_assess_migration
 	fi
 
 	step "Export schema."

--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -74,6 +74,8 @@ main() {
 			cat_log_file "yb-voyager-assess-migration.log"
 			exit 1
 		fi
+
+		post_assess_migration
 	fi
 
 	step "Export schema."

--- a/migtests/tests/oracle/basic-live-test/validateAfterChanges
+++ b/migtests/tests/oracle/basic-live-test/validateAfterChanges
@@ -72,6 +72,7 @@ def migration_completed_checks_yb():
 	global db_schema
 	db_schema="test_schema"
 	yb.run_checks(migration_completed_checks)
+ 
 
 def migration_completed_checks_ff():
 	print("Running tests on Oracle source replica")

--- a/migtests/tests/pg/basic-non-public-live-test/validate
+++ b/migtests/tests/pg/basic-non-public-live-test/validate
@@ -48,6 +48,10 @@ EXPECTED_SUM_OF_COLUMN = {
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
+	yb.run_checks(YB_specific_checks)
+
+def YB_specific_checks(tgt):
+	yb.verify_colocation(tgt)
 
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")

--- a/migtests/tests/pg/basic-non-public-live-test/validateAfterChanges
+++ b/migtests/tests/pg/basic-non-public-live-test/validateAfterChanges
@@ -73,7 +73,7 @@ def change_expected_values():
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
-
+	
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")
 	yb.run_checks(migration_completed_checks, db_type="source_replica")

--- a/migtests/tests/pg/basic-public-live-test/validate
+++ b/migtests/tests/pg/basic-public-live-test/validate
@@ -46,6 +46,10 @@ EXPECTED_SUM_OF_COLUMN = {
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
+	yb.run_checks(YB_specific_checks)
+
+def YB_specific_checks(tgt):
+	yb.verify_colocation(tgt)
 
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")

--- a/migtests/tests/pg/basic-public-live-test/validateAfterChanges
+++ b/migtests/tests/pg/basic-public-live-test/validateAfterChanges
@@ -72,7 +72,7 @@ def change_expected_values():
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
-
+	
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")
 	yb.run_checks(migration_completed_checks, db_type="source_replica")

--- a/migtests/tests/pg/case-sensitivity-reserved-words/validate
+++ b/migtests/tests/pg/case-sensitivity-reserved-words/validate
@@ -47,6 +47,10 @@ EXPECTED_ROW_COUNT = {
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
+	yb.run_checks(YB_specific_checks)
+
+def YB_specific_checks(tgt):
+	yb.verify_colocation(tgt)
 
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")

--- a/migtests/tests/pg/case-sensitivity-reserved-words/validateAfterChanges
+++ b/migtests/tests/pg/case-sensitivity-reserved-words/validateAfterChanges
@@ -82,7 +82,7 @@ def change_expected_values():
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
-
+	
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")
 	yb.run_checks(migration_completed_checks, db_type="source_replica")

--- a/migtests/tests/pg/datatypes/validate
+++ b/migtests/tests/pg/datatypes/validate
@@ -60,8 +60,7 @@ EXPECTED_COLOCATION_OF_TABLES = {
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
- 
-	yb.run_checks(YB_specific_checks) 
+	yb.run_checks(YB_specific_checks)
 
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")
@@ -145,12 +144,7 @@ def migration_completed_checks(tgt):
 	tgt.assert_all_values_of_col("null_and_default", "b", "public", expected_values=[False, None])
 
 def YB_specific_checks(tgt):
-	print("Verifying the colocation of the tables")
-	# TODO: fetch the expected table list from assessmentReport.json file
-	for table_name, expected_colocation in EXPECTED_COLOCATION_OF_TABLES.items():
-		actual_colocation = tgt.check_table_colocation(table_name)
-		assert actual_colocation == (expected_colocation == 't'), f"Table '{table_name}' colocation mismatch. Expected: {expected_colocation}, Actual: {actual_colocation}"
-
+	yb.verify_colocation(tgt)
 
 if __name__ == "__main__":
 	main()

--- a/migtests/tests/pg/datatypes/validateAfterChanges
+++ b/migtests/tests/pg/datatypes/validateAfterChanges
@@ -96,7 +96,7 @@ def change_expected_values():
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
-
+	
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")
 	yb.run_checks(migration_completed_checks, db_type="source_replica")

--- a/migtests/tests/pg/multiple-schemas/validate
+++ b/migtests/tests/pg/multiple-schemas/validate
@@ -34,6 +34,10 @@ EXPECTED_ROW_COUNT = {
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
+	yb.run_checks(YB_specific_checks)
+
+def YB_specific_checks(tgt):
+	yb.verify_colocation(tgt)
 
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")

--- a/migtests/tests/pg/multiple-schemas/validateAfterChanges
+++ b/migtests/tests/pg/multiple-schemas/validateAfterChanges
@@ -74,7 +74,7 @@ def change_expected_values():
 def migration_completed_checks_yb():
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
-
+	
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")
 	yb.run_checks(migration_completed_checks, db_type="source_replica")

--- a/migtests/tests/pg/partitions/fix-schema
+++ b/migtests/tests/pg/partitions/fix-schema
@@ -10,3 +10,8 @@ sed -i  's/p2\.sydney/p2.sydney_region/g' $TEST_DIR/export-dir/schema/tables/tab
 sed -i  's/p2\.boston/p2.boston_region/g' $TEST_DIR/export-dir/schema/tables/INDEXES_table.sql
 sed -i  's/p2\.london/p2.london_region/g' $TEST_DIR/export-dir/schema/tables/INDEXES_table.sql
 sed -i  's/p2\.sydney/p2.sydney_region/g' $TEST_DIR/export-dir/schema/tables/INDEXES_table.sql
+
+# Added so that the validations work(to check the recommendations in target YB applied or not)
+sed -i  's/p2\.boston/p2.boston_region/g' $TEST_DIR/export-dir/assessment/reports/assessmentReport.json
+sed -i  's/p2\.london/p2.london_region/g' $TEST_DIR/export-dir/assessment/reports/assessmentReport.json
+sed -i  's/p2\.sydney/p2.sydney_region/g' $TEST_DIR/export-dir/assessment/reports/assessmentReport.json

--- a/migtests/tests/pg/partitions/validate
+++ b/migtests/tests/pg/partitions/validate
@@ -23,6 +23,10 @@ def migration_completed_checks_yb():
 		EXPECTED_ROW_COUNT_P1_SALES_REGION_PARTITIONS[table_name] = row_count
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
+	yb.run_checks(YB_specific_checks)
+
+def YB_specific_checks(tgt):
+	yb.verify_colocation(tgt)
 
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")

--- a/migtests/tests/pg/partitions/validateAfterChanges
+++ b/migtests/tests/pg/partitions/validateAfterChanges
@@ -26,7 +26,7 @@ def migration_completed_checks_yb():
 		EXPECTED_ROW_COUNT_P1_SALES_REGION_PARTITIONS[table_name] = row_count
 	print("Running tests on YB")
 	yb.run_checks(migration_completed_checks)
-
+	
 def migration_completed_checks_ff():
 	print("Running tests on PG source replica")
 	yb.run_checks(migration_completed_checks, db_type="source_replica")


### PR DESCRIPTION
- In most of the test cases(small data size) all tables are recommended to be colocated by the sizer algorithm. With this commit, we are modifying the assessment report to randomly move atleast 30% of tables to sharded category so that DDLs are modified and that can be tested in the automation.

- Now for all the PG tests(offline or live) the applied recommendation will be verified on Target YB whether they are as per the assessment report.