### PR TITLE
Removed encoding specific symbols from user facing messages

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -133,13 +133,13 @@ func exportDataCommandFn(cmd *cobra.Command, args []string) {
 		callhome.PackAndSendPayload(exportDir)
 
 		setDataIsExported()
-		color.Green("Export of data complete \u2705")
+		color.Green("Export of data complete")
 		log.Info("Export of data completed.")
 		startFallBackSetupIfRequired()
 	} else if ProcessShutdownRequested {
 		log.Info("Shutting down as SIGINT/SIGTERM received.")
 	} else {
-		color.Red("Export of data failed! Check %s/logs for more details. \u274C", exportDir)
+		color.Red("Export of data failed! Check %s/logs for more details.", exportDir)
 		log.Error("Export of data failed.")
 		atexit.Exit(1)
 	}


### PR DESCRIPTION
Currently we use some symbols to indicate whether the data export was complete or not.
These symbols are UTF-8 encoding specific and are displayed as ? for other machines.
Output: `Export of data complete ?`

This output might confuse the user. Thus removing such symbols. 