### PR TITLE
Fix comparison logic in live migration batch rows affected

### DIFF
--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -684,8 +684,8 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 
 func logDiscrepancyInEventBatchIfAny(batch *EventBatch, rowsAffectedInserts, rowsAffectedDeletes, rowsAffectedUpdates int64) {
 	if !(rowsAffectedInserts == batch.EventCounts.NumInserts &&
-		rowsAffectedInserts == batch.EventCounts.NumDeletes &&
-		rowsAffectedInserts == batch.EventCounts.NumUpdates) {
+		rowsAffectedDeletes == batch.EventCounts.NumDeletes &&
+		rowsAffectedUpdates == batch.EventCounts.NumUpdates) {
 		var vsns []int64
 		for _, e := range batch.Events {
 			vsns = append(vsns, e.Vsn)


### PR DESCRIPTION
Currently, we seem to be comparing the wrong values of rows affected with the batch inserts/updates/deletes. 
While this won't functionally cause any problems, this will lead to :
1. False positive warning logs
2. Very quick growth in logs because of unnecessary logging. (~ 400MB per hour in one experimental run)

Testing:
- manually tested:
    - before: for all batches, we were getting a log
    - now: not getting a log by default; should only come up in an actual discrepancy