### PR TITLE
DB-11697: if unable to generate appropriate recommendation, notify users to reach out to yb customer support

### DIFF
--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -249,6 +249,8 @@ func pickBestRecommendation(recommendation map[int]IntermediateRecommendation) I
 	// If no valid recommendation was found, select the recommendation with the maximum number of cores
 	if !foundRecommendation {
 		finalRecommendation = recommendation[maxCores]
+		// notify customers to reach out to the Yugabyte customer support team for further assistance
+		finalRecommendation.FailureReasoning = "Unable to determine appropriate sizing recommendation. Please reach out to the Yugabyte customer support team at https://support.yugabyte.com for further assistance."
 	}
 
 	// Return the best recommendation

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -250,7 +250,7 @@ func pickBestRecommendation(recommendation map[int]IntermediateRecommendation) I
 	if !foundRecommendation {
 		finalRecommendation = recommendation[maxCores]
 		// notify customers to reach out to the Yugabyte customer support team for further assistance
-		finalRecommendation.FailureReasoning = "Unable to determine appropriate sizing recommendation. Please reach out to the Yugabyte customer support team at https://support.yugabyte.com for further assistance."
+		finalRecommendation.FailureReasoning = "Unable to determine appropriate sizing recommendation. Reach out to the Yugabyte customer support team at https://support.yugabyte.com for further assistance."
 	}
 
 	// Return the best recommendation


### PR DESCRIPTION
this is in accordance with the jira task: https://yugabyte.atlassian.net/browse/DB-11697

The content(to be reviewed) of the message shown to the customers in failure cases:
```
Unable to determine appropriate sizing recommendation. Reach out to the Yugabyte customer support team at https://support.yugabyte.com for further assistance.
```