### PR TITLE
Bug fix[DB-11613]: Handle erroring out if any of the metadata SQL script(SQLPlus or psql) returns empty file(no rows)

### DIFF
--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -162,6 +162,9 @@ func NewAssessmentDB(sourceDBType string) (*AssessmentDB, error) {
 }
 
 func (adb *AssessmentDB) BulkInsert(table string, records [][]string) error {
+	if len(records) == 0 {
+		return nil
+	}
 	ctx := context.Background()
 	tx, err := adb.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {


### PR DESCRIPTION
- it was erroring out because the BulkInsert() function was trying to access the empty slice of records[][]

fixes - https://yugabyte.atlassian.net/issues/DB-11613