### PR TITLE
Modified the installer script to automatically fetch and install the latest release from GH without hardcoded versions

### DIFF
--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -8,19 +8,54 @@ set -e
 ARGS_MACOS=$*
 ARGS_LINUX=$@
 
+LOG_FILE=/tmp/install-yb-voyager.log
 VERSION="latest"
 
-# Fetch the latest release name, tag name and commit hash from the github api
-LATEST_RELEASE_NAME=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"name":' | head -n 1 | awk -F '"' '{print $4}')
-LATEST_TAG_NAME=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"tag_name":' | head -n 1 | awk -F '"' '{print $4}')
-LATEST_TAGGED_COMMIT=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/git/refs/tags/${LATEST_TAG_NAME} | grep '"sha":' | head -n 1 | awk -F '"' '{print $4}')
+# Check if jq is installed
+if ! command -v jq &> /dev/null
+then
+	echo "ERROR: jq is not installed. Please install jq before running this script."
+	exit 1
+fi
+
+# Fetch the latest release data from the github api
+LATEST_RELEASE_DATA=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest)
+# Check if API call was successful
+if [ -z "$LATEST_RELEASE_DATA" ]
+then
+	echo "ERROR: Failed to fetch the latest release data from the github api."
+	exit 1
+fi
+
+# Extract the latest release name and tag name from the fetched data
+LATEST_RELEASE_NAME=$(echo "$LATEST_RELEASE_DATA" | jq -r '.name')
+LATEST_TAG_NAME=$(echo "$LATEST_RELEASE_DATA" | jq -r '.tag_name')
+
+# Fetch the commit hash of the latest tagged commit
+LATEST_TAG_DATA=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/git/refs/tags/${LATEST_TAG_NAME})
+# Check if API call was successful
+if [ -z "$LATEST_TAG_DATA" ]
+then
+	echo "ERROR: Failed to fetch the latest tagged commit data from the github api."
+	exit 1
+fi
+
+# Extract the commit hash from the fetched data using jq
+LATEST_TAGGED_COMMIT=$(echo "$LATEST_TAG_DATA" | jq -r '.object.sha')
+
+# Extract the version number from release name
 VOYAGER_VERSION=$(echo $LATEST_RELEASE_NAME | sed 's/v//')
 
-# This needs to be changed to the latest debezium release tag
+# Log all the fetched data in the LOG_FILE
+echo "LATEST_RELEASE_NAME=${LATEST_RELEASE_NAME}" >> $LOG_FILE
+echo "LATEST_TAG_NAME=${LATEST_TAG_NAME}" >> $LOG_FILE
+echo "LATEST_TAGGED_COMMIT=${LATEST_TAGGED_COMMIT}" >> $LOG_FILE
+echo "VOYAGER_VERSION=${VOYAGER_VERSION}" >> $LOG_FILE
+
 VOYAGER_RELEASE_NAME=${VOYAGER_RELEASE_NAME:-${LATEST_RELEASE_NAME}}
 DEBEZIUM_VERSION=${DEBEZIUM_VERSION:-"2.3.3-"${VOYAGER_VERSION}}
 
-# the hash corresponds to the yb-voyager/v1.7.1 tag
+# the hash corresponds to the latest tag's commit hash fetched using the github api
 YB_VOYAGER_GIT_HASH=${LATEST_TAGGED_COMMIT}
 
 
@@ -29,9 +64,6 @@ ONLY_PG="false"
 trap on_exit EXIT
 
 YUM="sudo yum install -y -q"
-
-
-LOG_FILE=/tmp/install-yb-voyager.log
 
 # commit hash in main branch after release 23.2
 # issues #489 #492 #247 in ora2pg were fixed after this change
@@ -59,6 +91,10 @@ touch $RC_FILE
 # just in case last execution of script stopped in between
 source $RC_FILE
 
+# get data from github api fetched data using grep etc
+get_data_from_gh_api_json() {
+	echo $1 | grep '$2' | head -n 1 | awk -F '"' '{print $4}'
+}
 
 on_exit() {
 	rc=$?

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -586,18 +586,21 @@ install_yb_voyager() {
 }
 
 install_yb_voyager_latest_release() {
-	# Download tarball from github release
+	# download tarball from github release
 	yb_voyager_filename="yb-voyager.tar.gz"
 	wget -nv "https://github.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/${VOYAGER_RELEASE_NAME}.tar.gz" -O ${yb_voyager_filename}
+	
 	# untar and make modifications
 	tar -xzf ${yb_voyager_filename}
 	pushd yb-voyager-yb-voyager-${VOYAGER_RELEASE_NAME} > /dev/null
 	pushd yb-voyager > /dev/null
+	
 	# modify versions
 	cat src/utils/version.go
 	sed -i "s/YB_VOYAGER_VERSION = \".*\"/YB_VOYAGER_VERSION = \"$VOYAGER_VERSION\"/" src/utils/version.go
 	cat src/utils/version.go
     sed -i "s/const DEBEZIUM_VERSION = \".*\"/const DEBEZIUM_VERSION = \"$DEBEZIUM_VERSION\"/" src/dbzm/dbzm.go
+	
 	# build
 	$GO install
 	popd > /dev/null

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -10,12 +10,18 @@ ARGS_LINUX=$@
 
 VERSION="latest"
 
+# Fetch the latest release name, tag name and commit hash from the github api
+latestReleaseName=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"name":' | head -n 1 | awk -F '"' '{print $4}')
+latestTagName=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"tag_name":' | head -n 1 | awk -F '"' '{print $4}')
+latestTaggedCommit=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/git/refs/tags/${latestTagName} | grep '"sha":' | head -n 1 | awk -F '"' '{print $4}')
+VOYAGER_VERSION=$(echo $latestReleaseName | sed 's/v//')
+
 # This needs to be changed to the latest debezium release tag
-VOYAGER_RELEASE_TAG=${VOYAGER_RELEASE_TAG:-"v1.7.1"}
-DEBEZIUM_VERSION=${DEBEZIUM_VERSION:-"2.3.3-1.7.1"}
+VOYAGER_RELEASE_NAME=${VOYAGER_RELEASE_NAME:-${latestReleaseName}}
+DEBEZIUM_VERSION=${DEBEZIUM_VERSION:-"2.3.3-"${latestVersionNumber}}
 
 # the hash corresponds to the yb-voyager/v1.7.1 tag
-YB_VOYAGER_GIT_HASH="bf206d6640e85daafabcc0344cd4d599b9f024ea" 
+YB_VOYAGER_GIT_HASH=${latestTaggedCommit}
 
 
 ONLY_PG="false"
@@ -277,7 +283,7 @@ install_debezium_server_latest_release() {
 	output "Installing debezium:${DEBEZIUM_VERSION}"
 	debezium_server_filename="debezium-server.tar.gz"
 	# download
-	wget -nv "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager/${VOYAGER_RELEASE_TAG}/${debezium_server_filename}"
+	wget -nv "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager/${VOYAGER_RELEASE_NAME}/${debezium_server_filename}"
 	# delete contents of /opt/yb-voyager/debezium-server if exists. 
 	# This is done to ensure that older version jars are not left behind in the lib dir.
 	if [ -d /opt/yb-voyager/debezium-server ]
@@ -560,8 +566,11 @@ install_yb_voyager() {
 	GO=${GO:-"go"}
 	if [ "${VERSION}" == "latest" ]
 	then
-		$GO install github.com/yugabyte/yb-voyager/yb-voyager@${YB_VOYAGER_GIT_HASH}
-		sudo mv -f $HOME/go/bin/yb-voyager /usr/local/bin
+		# $GO install github.com/yugabyte/yb-voyager/yb-voyager@${YB_VOYAGER_GIT_HASH}
+		# Download tarball from github release
+		
+		install_yb_voyager_latest_release
+	
 		return
 	fi
 
@@ -578,6 +587,28 @@ install_yb_voyager() {
 	popd > /dev/null
 	popd > /dev/null
 	sudo mv -f $HOME/go/bin/yb-voyager /usr/local/bin
+}
+
+install_yb_voyager_latest_release() {
+	# Download tarball from github release
+	yb_voyager_filename="yb-voyager.tar.gz"
+	wget -nv "https://github.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/${VOYAGER_RELEASE_NAME}.tar.gz" -O ${yb_voyager_filename}
+	# untar and make modifications
+	tar -xzf ${yb_voyager_filename}
+	pushd yb-voyager-yb-voyager-${VOYAGER_RELEASE_NAME} > /dev/null
+	pushd yb-voyager > /dev/null
+	# modify versions
+	sed -i "s/YB_VOYAGER_VERSION = \".*\"/YB_VOYAGER_VERSION = \"$VOYAGER_VERSION\"/" src/utils/version.go
+    sed -i "s/const DEBEZIUM_VERSION = \".*\"/const DEBEZIUM_VERSION = \"$DEBEZIUM_VERSION\"/" src/dbzm/dbzm.go
+	# build
+	$GO install
+	popd > /dev/null
+	popd > /dev/null
+	sudo mv -f $HOME/go/bin/yb-voyager /usr/local/bin
+
+	# cleanup
+	rm -rf yb-voyager-yb-voyager-${VOYAGER_RELEASE_NAME}
+	rm ${yb_voyager_filename}
 }
 
 

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -11,17 +11,17 @@ ARGS_LINUX=$@
 VERSION="latest"
 
 # Fetch the latest release name, tag name and commit hash from the github api
-latestReleaseName=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"name":' | head -n 1 | awk -F '"' '{print $4}')
-latestTagName=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"tag_name":' | head -n 1 | awk -F '"' '{print $4}')
-latestTaggedCommit=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/git/refs/tags/${latestTagName} | grep '"sha":' | head -n 1 | awk -F '"' '{print $4}')
-VOYAGER_VERSION=$(echo $latestReleaseName | sed 's/v//')
+LATEST_RELEASE_NAME=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"name":' | head -n 1 | awk -F '"' '{print $4}')
+LATEST_TAG_NAME=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/releases/latest | grep '"tag_name":' | head -n 1 | awk -F '"' '{print $4}')
+LATEST_TAGGED_COMMIT=$(curl -s https://api.github.com/repos/yugabyte/yb-voyager/git/refs/tags/${LATEST_TAG_NAME} | grep '"sha":' | head -n 1 | awk -F '"' '{print $4}')
+VOYAGER_VERSION=$(echo $LATEST_RELEASE_NAME | sed 's/v//')
 
 # This needs to be changed to the latest debezium release tag
-VOYAGER_RELEASE_NAME=${VOYAGER_RELEASE_NAME:-${latestReleaseName}}
+VOYAGER_RELEASE_NAME=${VOYAGER_RELEASE_NAME:-${LATEST_RELEASE_NAME}}
 DEBEZIUM_VERSION=${DEBEZIUM_VERSION:-"2.3.3-"${VOYAGER_VERSION}}
 
 # the hash corresponds to the yb-voyager/v1.7.1 tag
-YB_VOYAGER_GIT_HASH=${latestTaggedCommit}
+YB_VOYAGER_GIT_HASH=${LATEST_TAGGED_COMMIT}
 
 
 ONLY_PG="false"

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -18,7 +18,7 @@ VOYAGER_VERSION=$(echo $latestReleaseName | sed 's/v//')
 
 # This needs to be changed to the latest debezium release tag
 VOYAGER_RELEASE_NAME=${VOYAGER_RELEASE_NAME:-${latestReleaseName}}
-DEBEZIUM_VERSION=${DEBEZIUM_VERSION:-"2.3.3-"${latestVersionNumber}}
+DEBEZIUM_VERSION=${DEBEZIUM_VERSION:-"2.3.3-"${VOYAGER_VERSION}}
 
 # the hash corresponds to the yb-voyager/v1.7.1 tag
 YB_VOYAGER_GIT_HASH=${latestTaggedCommit}

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -596,9 +596,7 @@ install_yb_voyager_latest_release() {
 	pushd yb-voyager > /dev/null
 	
 	# modify versions
-	cat src/utils/version.go
 	sed -i "s/YB_VOYAGER_VERSION = \".*\"/YB_VOYAGER_VERSION = \"$VOYAGER_VERSION\"/" src/utils/version.go
-	cat src/utils/version.go
     sed -i "s/const DEBEZIUM_VERSION = \".*\"/const DEBEZIUM_VERSION = \"$DEBEZIUM_VERSION\"/" src/dbzm/dbzm.go
 	
 	# build

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -40,10 +40,9 @@ then
 	exit 1
 fi
 
-# Extract the commit hash from the fetched data using jq
 LATEST_TAGGED_COMMIT=$(echo "$LATEST_TAG_DATA" | jq -r '.object.sha')
 
-# Extract the version number from release name
+# The release name is like v1.7.2, we can get the voyager version by removing the v
 VOYAGER_VERSION=$(echo $LATEST_RELEASE_NAME | sed 's/v//')
 
 # Log all the fetched data in the LOG_FILE
@@ -90,11 +89,6 @@ RC_FILE="$HOME/.yb-voyager.rc"
 touch $RC_FILE
 # just in case last execution of script stopped in between
 source $RC_FILE
-
-# get data from github api fetched data using grep etc
-get_data_from_gh_api_json() {
-	echo $1 | grep '$2' | head -n 1 | awk -F '"' '{print $4}'
-}
 
 on_exit() {
 	rc=$?

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -566,11 +566,7 @@ install_yb_voyager() {
 	GO=${GO:-"go"}
 	if [ "${VERSION}" == "latest" ]
 	then
-		# $GO install github.com/yugabyte/yb-voyager/yb-voyager@${YB_VOYAGER_GIT_HASH}
-		# Download tarball from github release
-		
 		install_yb_voyager_latest_release
-	
 		return
 	fi
 
@@ -598,7 +594,9 @@ install_yb_voyager_latest_release() {
 	pushd yb-voyager-yb-voyager-${VOYAGER_RELEASE_NAME} > /dev/null
 	pushd yb-voyager > /dev/null
 	# modify versions
+	cat src/utils/version.go
 	sed -i "s/YB_VOYAGER_VERSION = \".*\"/YB_VOYAGER_VERSION = \"$VOYAGER_VERSION\"/" src/utils/version.go
+	cat src/utils/version.go
     sed -i "s/const DEBEZIUM_VERSION = \".*\"/const DEBEZIUM_VERSION = \"$DEBEZIUM_VERSION\"/" src/dbzm/dbzm.go
 	# build
 	$GO install

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -566,7 +566,8 @@ install_yb_voyager() {
 	GO=${GO:-"go"}
 	if [ "${VERSION}" == "latest" ]
 	then
-		install_yb_voyager_latest_release
+		$GO install github.com/yugabyte/yb-voyager/yb-voyager@${YB_VOYAGER_GIT_HASH}
+		sudo mv -f $HOME/go/bin/yb-voyager /usr/local/bin
 		return
 	fi
 
@@ -584,32 +585,6 @@ install_yb_voyager() {
 	popd > /dev/null
 	sudo mv -f $HOME/go/bin/yb-voyager /usr/local/bin
 }
-
-install_yb_voyager_latest_release() {
-	# download tarball from github release
-	yb_voyager_filename="yb-voyager.tar.gz"
-	wget -nv "https://github.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/${VOYAGER_RELEASE_NAME}.tar.gz" -O ${yb_voyager_filename}
-	
-	# untar and make modifications
-	tar -xzf ${yb_voyager_filename}
-	pushd yb-voyager-yb-voyager-${VOYAGER_RELEASE_NAME} > /dev/null
-	pushd yb-voyager > /dev/null
-	
-	# modify versions
-	sed -i "s/YB_VOYAGER_VERSION = \".*\"/YB_VOYAGER_VERSION = \"$VOYAGER_VERSION\"/" src/utils/version.go
-    sed -i "s/const DEBEZIUM_VERSION = \".*\"/const DEBEZIUM_VERSION = \"$DEBEZIUM_VERSION\"/" src/dbzm/dbzm.go
-	
-	# build
-	$GO install
-	popd > /dev/null
-	popd > /dev/null
-	sudo mv -f $HOME/go/bin/yb-voyager /usr/local/bin
-
-	# cleanup
-	rm -rf yb-voyager-yb-voyager-${VOYAGER_RELEASE_NAME}
-	rm ${yb_voyager_filename}
-}
-
 
 # Output a line to both STDOUT and STDERR. Use this function to output something to
 # user as well as in the log file.


### PR DESCRIPTION
- Using GH API to fetch the release name and tag name of the latest release on GH.
- From this we are extracting the voyager version and populating the version variables getting used in the script