### PR TITLE
Change enable-upsert default to false

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -207,7 +207,7 @@ func registerImportDataCommonFlags(cmd *cobra.Command) {
 		"path of the file containing the list of the source db table names to import data")
 
 	BoolVar(cmd.Flags(), &tconf.EnableUpsert, "enable-upsert", false,
-		"Enable UPSERT mode on target tables")
+		"Enable UPSERT mode on target tables. WARNING: Ensure that tables on target YugabyteDB do not have secondary indexes. If a table has secondary indexes, setting this flag to true may lead to corruption of the indexes. (default false)")
 	BoolVar(cmd.Flags(), &tconf.UsePublicIP, "use-public-ip", false,
 		"Use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import (default false)\n"+
 			"Note: you might need to configure database to have public_ip available by setting server-broadcast-addresses.\n"+

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -206,7 +206,7 @@ func registerImportDataCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tableListFilePath, "table-list-file-path", "",
 		"path of the file containing the list of the source db table names to import data")
 
-	BoolVar(cmd.Flags(), &tconf.EnableUpsert, "enable-upsert", true,
+	BoolVar(cmd.Flags(), &tconf.EnableUpsert, "enable-upsert", false,
 		"Enable UPSERT mode on target tables")
 	BoolVar(cmd.Flags(), &tconf.UsePublicIP, "use-public-ip", false,
 		"Use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import (default false)\n"+

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -131,6 +131,10 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 		utils.ErrExit("initialize name registry: %v", err)
 	}
 
+	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && (tconf.EnableUpsert) {
+		utils.PrintAndLog(color.RedString("WARNING: Ensure that tables on target YugabyteDB do not have secondary indexes. If a table has secondary indexes, setting --enable-upsert to true may lead to corruption of the indexes."))
+	}
+
 	dataStore = datastore.NewDataStore(filepath.Join(exportDir, "data"))
 	dataFileDescriptor = datafile.OpenDescriptor(exportDir)
 	// TODO: handle case-sensitive in table names with oracle ff-db

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -282,7 +282,7 @@ func (event *Event) getPreparedInsertStmt(tdb TargetDB, targetDBType string) (st
 	columns := strings.Join(columnList, ", ")
 	values := strings.Join(valueList, ", ")
 	stmt := fmt.Sprintf(insertTemplate, event.TableNameTup.ForUserQuery(), columns, values)
-	if targetDBType == POSTGRESQL {
+	if targetDBType == POSTGRESQL || targetDBType == YUGABYTEDB {
 		keyColumns := utils.GetMapKeysSorted(event.Key)
 		for i, column := range keyColumns {
 			column, err := tdb.QuoteAttributeName(event.TableNameTup, column)

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -455,7 +455,7 @@ func (tdb *TargetOracleDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBat
 			if err != nil {
 				return false, fmt.Errorf("get sql stmt: %w", err)
 			}
-			if event.Op == "c" && tdb.tconf.EnableUpsert {
+			if event.Op == "c" {
 				// converting to an UPSERT
 				event.Op = "u"
 				updateStmt, err := event.GetSQLStmt(tdb)


### PR DESCRIPTION
- Change default value of enable-upsert to false as it is unsafe when secondary indexes are present. Added warning to help msg as well 
- In snapshot phase of import-data, we always check if the batch has already been imported. If so, we skip it.
- In CDC phase of import-data, if there are duplicate events (because debezium ensures at-least-once delivery), then we were relying on upsert_mode to ensure that we do not fail. Since now, upsert_mode will be set to false by default, I have added the ON CONFLICT DO NOTHING clause to INSERT statements.