### PR TITLE
sizing calc: db-11948: handle null values for size_in_bytes column in source metadata table_index_stats

### DIFF
--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -1121,7 +1121,7 @@ func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata
 			   parent_table_name, 
 			   size_in_bytes 
 		FROM %v 
-		ORDER BY size_in_bytes ASC
+		ORDER BY IFNULL(size_in_bytes, 0) ASC
 	`, GetTableIndexStatName())
 	rows, err := sourceDB.Query(query)
 	if err != nil {

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -33,17 +33,17 @@ import (
 )
 
 type SourceDBMetadata struct {
-	SchemaName      string         `db:"schema_name"`
-	ObjectName      string         `db:"object_name"`
-	RowCount        sql.NullInt64  `db:"row_count,string"`
-	ColumnCount     sql.NullInt64  `db:"column_count,string"`
-	Reads           sql.NullInt64  `db:"reads,string"`
-	Writes          sql.NullInt64  `db:"writes,string"`
-	ReadsPerSec     sql.NullInt64  `db:"reads_per_second,string"`
-	WritesPerSec    sql.NullInt64  `db:"writes_per_second,string"`
-	IsIndex         bool           `db:"is_index,string"`
-	ParentTableName sql.NullString `db:"parent_table_name"`
-	Size            float64        `db:"size_in_bytes,string"`
+	SchemaName      string          `db:"schema_name"`
+	ObjectName      string          `db:"object_name"`
+	RowCount        sql.NullInt64   `db:"row_count,string"`
+	ColumnCount     sql.NullInt64   `db:"column_count,string"`
+	Reads           sql.NullInt64   `db:"reads,string"`
+	Writes          sql.NullInt64   `db:"writes,string"`
+	ReadsPerSec     sql.NullInt64   `db:"reads_per_second,string"`
+	WritesPerSec    sql.NullInt64   `db:"writes_per_second,string"`
+	IsIndex         bool            `db:"is_index,string"`
+	ParentTableName sql.NullString  `db:"parent_table_name"`
+	Size            sql.NullFloat64 `db:"size_in_bytes,string"`
 }
 
 type ExpDataShardedLimit struct {
@@ -368,11 +368,11 @@ func findNumNodesNeededBasedOnTabletsRequired(sourceIndexMetadata []SourceDBMeta
 		if len(rec.ShardedTables) != 0 && rec.FailureReasoning == "" {
 			// Iterate over each table and its indexes to find out how many tablets are needed
 			for _, table := range rec.ShardedTables {
-				_, tabletsRequired := getThresholdAndTablets(rec.NumNodes, table.Size)
+				_, tabletsRequired := getThresholdAndTablets(rec.NumNodes, lo.Ternary(table.Size.Valid, table.Size.Float64, 0))
 				for _, index := range sourceIndexMetadata {
 					if index.ParentTableName.Valid && (index.ParentTableName.String == (table.SchemaName + "." + table.ObjectName)) {
 						// calculating tablets required for each of the index
-						_, tabletsRequiredForIndex := getThresholdAndTablets(rec.NumNodes, index.Size)
+						_, tabletsRequiredForIndex := getThresholdAndTablets(rec.NumNodes, lo.Ternary(index.Size.Valid, index.Size.Float64, 0))
 						// tablets required for each table is the sum of tablets required for the table and its indexes
 						tabletsRequired += tabletsRequiredForIndex
 					}
@@ -553,7 +553,7 @@ func shardingBasedOnOperations(sourceIndexMetadata []SourceDBMetadata,
 			newInsertOpsPerSec := cumulativeInsertOpsPerSec + lo.Ternary(table.WritesPerSec.Valid, table.WritesPerSec.Int64, 0) + indexWrites
 
 			// Calculate total object size
-			objectTotalSize := table.Size + indexesSizeSum
+			objectTotalSize := lo.Ternary(table.Size.Valid, table.Size.Float64, 0) + indexesSizeSum
 
 			// Calculate needed cores based on operations
 			neededCores :=
@@ -579,7 +579,7 @@ func shardingBasedOnOperations(sourceIndexMetadata []SourceDBMetadata,
 		for _, remainingTable := range previousRecommendation.ColocatedTables[numColocated:] {
 			shardedObjects = append(shardedObjects, remainingTable)
 			_, indexesSizeSumSharded, _, _ := checkAndFetchIndexes(remainingTable, sourceIndexMetadata)
-			cumulativeSizeSharded += remainingTable.Size + indexesSizeSumSharded
+			cumulativeSizeSharded += lo.Ternary(remainingTable.Size.Valid, remainingTable.Size.Float64, 0) + indexesSizeSumSharded
 		}
 
 		// Update recommendation for the current colocated limit
@@ -628,7 +628,7 @@ func shardingBasedOnTableSizeAndCount(sourceTableMetadata []SourceDBMetadata,
 			indexesOfTable, indexesSizeSum, _, _ := checkAndFetchIndexes(table, sourceIndexMetadata)
 			// Calculate new object count and total size
 			newObjectCount := cumulativeObjectCount + int64(len(indexesOfTable)) + 1
-			objectTotalSize := table.Size + indexesSizeSum
+			objectTotalSize := lo.Ternary(table.Size.Valid, table.Size.Float64, 0) + indexesSizeSum
 			newCumulativeSize := cumulativeColocatedSizeSum + objectTotalSize
 
 			// Check if adding the current table exceeds max colocated size supported or max supported num tables
@@ -650,7 +650,7 @@ func shardingBasedOnTableSizeAndCount(sourceTableMetadata []SourceDBMetadata,
 		for _, remainingTable := range sourceTableMetadata[numColocated:] {
 			shardedObjects = append(shardedObjects, remainingTable)
 			_, indexesSizeSumSharded, _, _ := checkAndFetchIndexes(remainingTable, sourceIndexMetadata)
-			cumulativeSizeSharded += remainingTable.Size + indexesSizeSumSharded
+			cumulativeSizeSharded += lo.Ternary(remainingTable.Size.Valid, remainingTable.Size.Float64, 0) + indexesSizeSumSharded
 		}
 		// Update recommendation for the current colocated limit
 		previousRecommendation := recommendation[int(colocatedLimit.numCores.Float64)]
@@ -866,7 +866,7 @@ func calculateTimeTakenAndParallelJobsForImportColocatedObjects(dbObjects []Sour
 	var maxSizeOfFetchedRow float64
 	var parallelJobs int64
 	for _, dbObject := range dbObjects {
-		size += dbObject.Size
+		size += lo.Ternary(dbObject.Size.Valid, dbObject.Size.Float64, 0)
 	}
 	// find the rows in experiment data about the approx row matching the size
 	selectQuery := fmt.Sprintf(`
@@ -934,11 +934,12 @@ func calculateTimeTakenAndParallelJobsForImportShardedObjects(shardedTables []So
 	// find the rows in experiment data about the approx row matching the size
 	for _, table := range shardedTables {
 		// find closest record from experiment data for the size of the table
-		closestLoadTime := findClosestRecordFromExpDataShardedLoadTime(shardedLoadTimes, table.Size)
+		tableSize := lo.Ternary(table.Size.Valid, table.Size.Float64, 0)
+		closestLoadTime := findClosestRecordFromExpDataShardedLoadTime(shardedLoadTimes, tableSize)
 		// get multiplication factor for every table based on the number of indexes
 		loadTimeMultiplicationFactor := getMultiplicationFactorForImportTimeBasedOnIndexes(table, sourceIndexMetadata, indexImpacts)
 		// calculate the time taken for import for every table and add it to overall import time
-		importTime += loadTimeMultiplicationFactor * ((closestLoadTime.migrationTimeSecs.Float64 * table.Size) / closestLoadTime.csvSizeGB.Float64) / 60
+		importTime += loadTimeMultiplicationFactor * ((closestLoadTime.migrationTimeSecs.Float64 * tableSize) / closestLoadTime.csvSizeGB.Float64) / 60
 	}
 
 	return math.Ceil(importTime), shardedLoadTimes[0].parallelThreads.Int64, nil
@@ -1144,13 +1145,13 @@ func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata
 			return nil, nil, 0.0, fmt.Errorf("failed to read from result set of query source metadata [%s]: %w", query, err)
 		}
 		// convert bytes to GB
-		metadata.Size = utils.BytesToGB(metadata.Size)
+		metadata.Size.Float64 = utils.BytesToGB(lo.Ternary(metadata.Size.Valid, metadata.Size.Float64, 0))
 		if metadata.IsIndex {
 			sourceIndexMetadata = append(sourceIndexMetadata, metadata)
 		} else {
 			sourceTableMetadata = append(sourceTableMetadata, metadata)
 		}
-		totalSourceDBSize += metadata.Size
+		totalSourceDBSize += metadata.Size.Float64
 	}
 	if err := rows.Err(); err != nil {
 		return nil, nil, 0.0, fmt.Errorf("failed to query source metadata with query [%s]: %w", query, err)
@@ -1186,7 +1187,7 @@ func checkAndFetchIndexes(table SourceDBMetadata, indexes []SourceDBMetadata) ([
 	for _, index := range indexes {
 		if index.ParentTableName.Valid && (index.ParentTableName.String == (table.SchemaName + "." + table.ObjectName)) {
 			indexesOfTable = append(indexesOfTable, index)
-			indexesSizeSum += index.Size
+			indexesSizeSum += lo.Ternary(index.Size.Valid, index.Size.Float64, 0)
 			cumulativeSelectOpsPerSecIdx += lo.Ternary(index.ReadsPerSec.Valid, index.ReadsPerSec.Int64, 0)
 			cumulativeInsertOpsPerSecIdx += lo.Ternary(index.ReadsPerSec.Valid, index.ReadsPerSec.Int64, 0)
 		}
@@ -1259,7 +1260,7 @@ func getObjectsSize(objects []SourceDBMetadata) (float64, int64, int64, string) 
 
 	for _, object := range objects {
 		// Accumulate size and throughput values
-		objectsSize += object.Size
+		objectsSize += lo.Ternary(object.Size.Valid, object.Size.Float64, 0)
 		objectSelectOps += lo.Ternary(object.ReadsPerSec.Valid, object.ReadsPerSec.Int64, 0)
 		objectInsertOps += lo.Ternary(object.WritesPerSec.Valid, object.WritesPerSec.Int64, 0)
 	}

--- a/yb-voyager/src/migassessment/sizing_test.go
+++ b/yb-voyager/src/migassessment/sizing_test.go
@@ -26,8 +26,7 @@ import (
 	"testing"
 )
 
-var AssessmentDbSelectQuery = fmt.Sprintf("SELECT schema_name, object_name, row_count, reads_per_second, writes_per_second, "+
-	"is_index, parent_table_name, size_in_bytes FROM %v ORDER BY size_in_bytes ASC", TABLE_INDEX_STATS)
+var AssessmentDbSelectQuery = fmt.Sprintf("(?i)SELECT schema_name,.* FROM %v ORDER BY .* ASC", TABLE_INDEX_STATS)
 var AssessmentDBColumns = []string{"schema_name", "object_name", "row_count", "reads_per_second", "writes_per_second",
 	"is_index", "parent_table_name", "size_in_bytes"}
 
@@ -964,8 +963,8 @@ func TestGetReasoning_OnlyColocatedObjects(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 8, MemoryPerCore: 8}
 	var shardedObjects []SourceDBMetadata
 	colocatedObjects := []SourceDBMetadata{
-		{Size: sql.NullFloat64{Float64: 50.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 500}},
-		{Size: sql.NullFloat64{Float64: 30.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1500}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 50.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 500}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 30.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1500}},
 	}
 	expected := "Recommended instance type with 8 vCPU and 64 GiB memory could fit 2 objects(2 tables and 0 " +
 		"explicit/implicit indexes) with 80.00 GB size and throughput requirement of 3000 reads/sec and " +
@@ -981,8 +980,8 @@ func TestGetReasoning_OnlyColocatedObjects(t *testing.T) {
 func TestGetReasoning_OnlyShardedObjects(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 16, MemoryPerCore: 4}
 	shardedObjects := []SourceDBMetadata{
-		{Size: sql.NullFloat64{Float64: 100.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 4000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 3000}},
-		{Size: sql.NullFloat64{Float64: 200.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 5000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 100.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 4000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 3000}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 200.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 5000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
 	}
 	var colocatedObjects []SourceDBMetadata
 	expected := "Recommended instance type with 16 vCPU and 64 GiB memory could fit 2 objects(2 tables and 0 " +
@@ -999,11 +998,11 @@ func TestGetReasoning_OnlyShardedObjects(t *testing.T) {
 func TestGetReasoning_ColocatedAndShardedObjects(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 32, MemoryPerCore: 2}
 	shardedObjects := []SourceDBMetadata{
-		{Size: sql.NullFloat64{Float64: 150.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 7000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 6000}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 150.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 7000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 6000}},
 	}
 	colocatedObjects := []SourceDBMetadata{
-		{Size: sql.NullFloat64{Float64: 70.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
-		{Size: sql.NullFloat64{Float64: 50.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1000}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 70.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 50.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1000}},
 	}
 	expected := "Recommended instance type with 32 vCPU and 64 GiB memory could fit 2 objects(2 tables and 0 " +
 		"explicit/implicit indexes) with 120.00 GB size and throughput requirement of 5000 reads/sec and " +
@@ -1021,10 +1020,10 @@ func TestGetReasoning_ColocatedAndShardedObjects(t *testing.T) {
 func TestGetReasoning_Indexes(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 4, MemoryPerCore: 16}
 	shardedObjects := []SourceDBMetadata{
-		{Size: sql.NullFloat64{Float64: 200.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 6000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 200.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 6000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
 	}
 	colocatedObjects := []SourceDBMetadata{
-		{Size: sql.NullFloat64{Float64: 100.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
+		{Size: sql.NullFloat64{Valid: true, Float64: 100.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
 	}
 	expected := "Recommended instance type with 4 vCPU and 64 GiB memory could fit 1 objects(0 tables and " +
 		"1 explicit/implicit indexes) with 100.00 GB size and throughput requirement of 3000 reads/sec and " +

--- a/yb-voyager/src/migassessment/sizing_test.go
+++ b/yb-voyager/src/migassessment/sizing_test.go
@@ -155,7 +155,7 @@ func TestGetSourceMetadata_NoRows(t *testing.T) {
 // validate if the source table of size in colocated limit is correctly placed in colocated table recommendation
 func TestShardingBasedOnTableSizeAndCount_TableWithSizePlacedInColocated(t *testing.T) {
 	sourceTableMetadata := []SourceDBMetadata{
-		{SchemaName: "public", ObjectName: "table1", Size: 100},
+		{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 	}
 	var sourceIndexMetadata []SourceDBMetadata
 	recommendation := map[int]IntermediateRecommendation{4: {}, 8: {}, 16: {}}
@@ -163,7 +163,7 @@ func TestShardingBasedOnTableSizeAndCount_TableWithSizePlacedInColocated(t *test
 	expectedRecommendation := map[int]IntermediateRecommendation{
 		4: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 100},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 			},
 			ShardedTables: nil,
 			ColocatedSize: 100,
@@ -171,7 +171,7 @@ func TestShardingBasedOnTableSizeAndCount_TableWithSizePlacedInColocated(t *test
 		},
 		8: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 100},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 			},
 			ShardedTables: nil,
 			ColocatedSize: 100,
@@ -179,7 +179,7 @@ func TestShardingBasedOnTableSizeAndCount_TableWithSizePlacedInColocated(t *test
 		},
 		16: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 100},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 			},
 			ShardedTables: nil,
 			ColocatedSize: 100,
@@ -196,11 +196,11 @@ func TestShardingBasedOnTableSizeAndCount_TableWithSizePlacedInColocated(t *test
 // recommendation
 func TestShardingBasedOnTableSizeAndCount_WithIndexes_ColocateAll(t *testing.T) {
 	sourceTableMetadata := []SourceDBMetadata{
-		{SchemaName: "public", ObjectName: "table1", Size: 100},
+		{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 	}
 	sourceIndexMetadata := []SourceDBMetadata{
 		{
-			SchemaName: "public", ObjectName: "index1", Size: 10, IsIndex: true,
+			SchemaName: "public", ObjectName: "index1", Size: sql.NullFloat64{Float64: 10, Valid: true}, IsIndex: true,
 			ParentTableName: sql.NullString{String: "public.table1", Valid: true},
 		},
 	}
@@ -209,21 +209,21 @@ func TestShardingBasedOnTableSizeAndCount_WithIndexes_ColocateAll(t *testing.T) 
 	expectedRecommendation := map[int]IntermediateRecommendation{
 		4: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 100},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 			},
 			ShardedTables: nil,
 			ColocatedSize: 110, // Table size + index size
 		},
 		8: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 100},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 			},
 			ShardedTables: nil,
 			ColocatedSize: 110, // Table size + index size
 		},
 		16: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 100},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 100, Valid: true}},
 			},
 			ShardedTables: nil,
 			ColocatedSize: 110, // Table size + index size
@@ -239,8 +239,8 @@ func TestShardingBasedOnTableSizeAndCount_WithIndexes_ColocateAll(t *testing.T) 
 // to be put in sharded
 func TestShardingBasedOnTableSizeAndCount_ColocatedLimitExceededBySize(t *testing.T) {
 	sourceTableMetadata := []SourceDBMetadata{
-		{SchemaName: "public", ObjectName: "table1", Size: 110},
-		{SchemaName: "public", ObjectName: "table2", Size: 500},
+		{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 110, Valid: true}},
+		{SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 500, Valid: true}},
 	}
 	var sourceIndexMetadata []SourceDBMetadata
 	recommendation := map[int]IntermediateRecommendation{4: {}, 8: {}, 16: {}}
@@ -248,30 +248,30 @@ func TestShardingBasedOnTableSizeAndCount_ColocatedLimitExceededBySize(t *testin
 	expectedRecommendation := map[int]IntermediateRecommendation{
 		4: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 110},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 110, Valid: true}},
 			},
 			ShardedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table2", Size: 500},
+				{SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 500, Valid: true}},
 			},
 			ColocatedSize: 110,
 			ShardedSize:   500,
 		},
 		8: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 110},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 110, Valid: true}},
 			},
 			ShardedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table2", Size: 500},
+				{SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 500, Valid: true}},
 			},
 			ColocatedSize: 110,
 			ShardedSize:   500,
 		},
 		16: {
 			ColocatedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 110},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 110, Valid: true}},
 			},
 			ShardedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table2", Size: 500},
+				{SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 500, Valid: true}},
 			},
 			ColocatedSize: 110,
 			ShardedSize:   500,
@@ -290,7 +290,7 @@ func TestShardingBasedOnTableSizeAndCount_ColocatedLimitExceededByCount(t *testi
 	sourceTableMetadata := make([]SourceDBMetadata, numTables)
 	for i := 0; i < numTables; i++ {
 		sourceTableMetadata[i] =
-			SourceDBMetadata{SchemaName: "public", ObjectName: fmt.Sprintf("table%v", i), Size: 0.0001}
+			SourceDBMetadata{SchemaName: "public", ObjectName: fmt.Sprintf("table%v", i), Size: sql.NullFloat64{Float64: 0.0001, Valid: true}}
 	}
 
 	var sourceIndexMetadata []SourceDBMetadata
@@ -321,8 +321,8 @@ func TestShardingBasedOnTableSizeAndCount_ColocatedLimitExceededByCount(t *testi
 // validate if the tables of size more than max colocated size supported are put in the sharded tables
 func TestShardingBasedOnTableSizeAndCount_NoColocatedTables(t *testing.T) {
 	sourceTableMetadata := []SourceDBMetadata{
-		{SchemaName: "public", ObjectName: "table1", Size: 600},
-		{SchemaName: "public", ObjectName: "table2", Size: 500},
+		{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 600, Valid: true}},
+		{SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 500, Valid: true}},
 	}
 	var sourceIndexMetadata []SourceDBMetadata
 	recommendation := map[int]IntermediateRecommendation{4: {}, 8: {}, 16: {}}
@@ -358,12 +358,20 @@ func TestShardingBasedOnTableSizeAndCount_NoColocatedTables(t *testing.T) {
 func TestShardingBasedOnOperations_CanSupportOpsRequirement(t *testing.T) {
 	// Define test data
 	sourceIndexMetadata := []SourceDBMetadata{
-		{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
+		{
+			ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+			ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+			WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+		},
 	}
 	recommendation := map[int]IntermediateRecommendation{
 		4: {
 			ColocatedTables: []SourceDBMetadata{
-				{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
+				{
+					ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
 			},
 			ShardedTables: []SourceDBMetadata{},
 			ColocatedSize: 10.0,
@@ -371,7 +379,11 @@ func TestShardingBasedOnOperations_CanSupportOpsRequirement(t *testing.T) {
 		},
 		8: {
 			ColocatedTables: []SourceDBMetadata{
-				{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
+				{
+					ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
 			},
 			ShardedTables: []SourceDBMetadata{},
 			ColocatedSize: 10.0,
@@ -379,7 +391,11 @@ func TestShardingBasedOnOperations_CanSupportOpsRequirement(t *testing.T) {
 		},
 		16: {
 			ColocatedTables: []SourceDBMetadata{
-				{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
+				{
+					ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
 			},
 			ShardedTables: []SourceDBMetadata{},
 			ColocatedSize: 10.0,
@@ -403,12 +419,20 @@ func TestShardingBasedOnOperations_CanSupportOpsRequirement(t *testing.T) {
 func TestShardingBasedOnOperations_CannotSupportOpsAndNeedsSharding(t *testing.T) {
 	// Define test data
 	sourceIndexMetadata := []SourceDBMetadata{
-		{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000}},
+		{
+			ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+			ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 1000000},
+			WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000},
+		},
 	}
 	recommendation := map[int]IntermediateRecommendation{
 		4: {
 			ColocatedTables: []SourceDBMetadata{
-				{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000}},
+				{
+					ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 1000000},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000},
+				},
 			},
 			ShardedTables: []SourceDBMetadata{},
 			ColocatedSize: 10.0,
@@ -416,7 +440,11 @@ func TestShardingBasedOnOperations_CannotSupportOpsAndNeedsSharding(t *testing.T
 		},
 		8: {
 			ColocatedTables: []SourceDBMetadata{
-				{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000}},
+				{
+					ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 1000000},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000},
+				},
 			},
 			ShardedTables: []SourceDBMetadata{},
 			ColocatedSize: 10.0,
@@ -424,7 +452,11 @@ func TestShardingBasedOnOperations_CannotSupportOpsAndNeedsSharding(t *testing.T
 		},
 		16: {
 			ColocatedTables: []SourceDBMetadata{
-				{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000}},
+				{
+					ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 1000000},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50000000},
+				},
 			},
 			ShardedTables: []SourceDBMetadata{},
 			ColocatedSize: 10.0,
@@ -459,8 +491,16 @@ func TestCheckShardedTableLimit_WithinLimit(t *testing.T) {
 	recommendation := map[int]IntermediateRecommendation{
 		16: {
 			ShardedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
-				{SchemaName: "public", ObjectName: "table2", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
+				{
+					SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
+				{
+					SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
 			},
 			VCPUsPerInstance: 16,
 			MemoryPerCore:    4,
@@ -488,8 +528,16 @@ func TestCheckShardedTableLimit_LimitExceeded(t *testing.T) {
 	recommendation := map[int]IntermediateRecommendation{
 		16: {
 			ShardedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
-				{SchemaName: "public", ObjectName: "table2", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
+				{
+					SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
+				{
+					SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
 			},
 			VCPUsPerInstance: 16,
 			MemoryPerCore:    4,
@@ -515,8 +563,16 @@ func TestCheckShardedTableLimit_LimitExceeded(t *testing.T) {
 func TestFindNumNodesNeededBasedOnThroughputRequirement_CanSupportOps(t *testing.T) {
 	// Define test data
 	sourceIndexMetadata := []SourceDBMetadata{
-		{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}},
-		{ObjectName: "table2", Size: 20.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 200}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 100}},
+		{
+			ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+			ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+			WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+		},
+		{
+			ObjectName: "table2", Size: sql.NullFloat64{Float64: 20.0, Valid: true},
+			ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 200},
+			WritesPerSec: sql.NullInt64{Valid: true, Int64: 100},
+		},
 	}
 
 	shardedThroughput := []ExpDataThroughput{
@@ -531,8 +587,14 @@ func TestFindNumNodesNeededBasedOnThroughputRequirement_CanSupportOps(t *testing
 
 	recommendation := map[int]IntermediateRecommendation{
 		4: {
-			ColocatedTables:                 []SourceDBMetadata{},
-			ShardedTables:                   []SourceDBMetadata{{ObjectName: "table1", Size: 10.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 100}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 50}}},
+			ColocatedTables: []SourceDBMetadata{},
+			ShardedTables: []SourceDBMetadata{
+				{
+					ObjectName: "table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
+			},
 			OptimalSelectConnectionsPerNode: 50,
 			OptimalInsertConnectionsPerNode: 25,
 		},
@@ -570,7 +632,11 @@ func TestFindNumNodesNeededBasedOnThroughputRequirement_NeedMoreNodes(t *testing
 	recommendation := map[int]IntermediateRecommendation{
 		4: {
 			ShardedTables: []SourceDBMetadata{
-				{ObjectName: "table2", Size: 20.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 5000}},
+				{
+					ObjectName: "table2", Size: sql.NullFloat64{Float64: 20.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 2000},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 5000},
+				},
 			},
 			VCPUsPerInstance: 4,
 			MemoryPerCore:    4,
@@ -602,8 +668,8 @@ func TestFindNumNodesNeededBasedOnTabletsRequired_CanSupportTablets(t *testing.T
 		4: {
 			ColocatedTables: []SourceDBMetadata{},
 			ShardedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 10},
-				{SchemaName: "public", ObjectName: "table2", Size: 60},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 10, Valid: true}},
+				{SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 60, Valid: true}},
 			},
 			VCPUsPerInstance: 4,
 			NumNodes:         3,
@@ -622,8 +688,14 @@ func TestFindNumNodesNeededBasedOnTabletsRequired_CanSupportTablets(t *testing.T
 func TestFindNumNodesNeededBasedOnTabletsRequired_NeedMoreNodes(t *testing.T) {
 	// Define test data
 	sourceIndexMetadata := []SourceDBMetadata{
-		{SchemaName: "public", ObjectName: "index1", Size: 7, ParentTableName: sql.NullString{String: "public.table1"}},
-		{SchemaName: "public", ObjectName: "index2", Size: 3, ParentTableName: sql.NullString{String: "public.table2"}},
+		{
+			SchemaName: "public", ObjectName: "index1", Size: sql.NullFloat64{Float64: 7, Valid: true},
+			ParentTableName: sql.NullString{String: "public.table1"},
+		},
+		{
+			SchemaName: "public", ObjectName: "index2", Size: sql.NullFloat64{Float64: 3, Valid: true},
+			ParentTableName: sql.NullString{String: "public.table2"},
+		},
 	}
 	shardedLimits := []ExpDataShardedLimit{
 		{
@@ -635,8 +707,8 @@ func TestFindNumNodesNeededBasedOnTabletsRequired_NeedMoreNodes(t *testing.T) {
 		4: {
 			ColocatedTables: []SourceDBMetadata{},
 			ShardedTables: []SourceDBMetadata{
-				{SchemaName: "public", ObjectName: "table1", Size: 125},
-				{SchemaName: "public", ObjectName: "table2", Size: 60},
+				{SchemaName: "public", ObjectName: "table1", Size: sql.NullFloat64{Float64: 125, Valid: true}},
+				{SchemaName: "public", ObjectName: "table2", Size: sql.NullFloat64{Float64: 60, Valid: true}},
 			},
 			VCPUsPerInstance: 4,
 			NumNodes:         3,
@@ -736,7 +808,10 @@ func TestCalculateTimeTakenAndParallelJobsForImportColocatedObjects_ValidateForm
 		WillReturnRows(rows)
 
 	// Define test data
-	dbObjects := []SourceDBMetadata{{Size: 30.0}, {Size: 20.0}}
+	dbObjects := []SourceDBMetadata{
+		{Size: sql.NullFloat64{Float64: 30.0, Valid: true}},
+		{Size: sql.NullFloat64{Float64: 20.0, Valid: true}},
+	}
 
 	// Call the function
 	estimatedTime, parallelJobs, err :=
@@ -766,7 +841,7 @@ func TestCalculateTimeTakenAndParallelJobsForImportColocatedObjects_ValidateForm
 func TestCalculateTimeTakenAndParallelJobsForImportShardedObjects_ValidateImportTimeTableWithoutIndex(t *testing.T) {
 	// Define test data
 	shardedTables := []SourceDBMetadata{
-		{ObjectName: "table0", SchemaName: "public", Size: 23.0},
+		{ObjectName: "table0", SchemaName: "public", Size: sql.NullFloat64{Float64: 23.0, Valid: true}},
 	}
 	var sourceIndexMetadata []SourceDBMetadata
 	shardedLoadTimes := []ExpDataShardedLoadTime{
@@ -796,7 +871,7 @@ func TestCalculateTimeTakenAndParallelJobsForImportShardedObjects_ValidateImport
 func TestCalculateTimeTakenAndParallelJobsForImportShardedObjects_ValidateImportTimeTableWithOneIndex(t *testing.T) {
 	// Define test data
 	shardedTables := []SourceDBMetadata{
-		{ObjectName: "table0", SchemaName: "public", Size: 23.0},
+		{ObjectName: "table0", SchemaName: "public", Size: sql.NullFloat64{Float64: 23.0, Valid: true}},
 	}
 	sourceIndexMetadata := []SourceDBMetadata{
 		{ObjectName: "table0_idx1", ParentTableName: sql.NullString{Valid: true, String: "public.table0"}},
@@ -831,7 +906,7 @@ func TestCalculateTimeTakenAndParallelJobsForImportShardedObjects_ValidateImport
 func TestCalculateTimeTakenAndParallelJobsForImportShardedObjects_ValidateImportTimeTableWithFiveIndexes(t *testing.T) {
 	// Define test data
 	shardedTables := []SourceDBMetadata{
-		{ObjectName: "table0", SchemaName: "public", Size: 23.0},
+		{ObjectName: "table0", SchemaName: "public", Size: sql.NullFloat64{Float64: 23.0, Valid: true}},
 	}
 	sourceIndexMetadata := []SourceDBMetadata{
 		{ObjectName: "table0_idx1", ParentTableName: sql.NullString{Valid: true, String: "public.table0"}},
@@ -889,8 +964,8 @@ func TestGetReasoning_OnlyColocatedObjects(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 8, MemoryPerCore: 8}
 	var shardedObjects []SourceDBMetadata
 	colocatedObjects := []SourceDBMetadata{
-		{Size: 50.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 500}},
-		{Size: 30.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1500}},
+		{Size: sql.NullFloat64{Float64: 50.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 1000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 500}},
+		{Size: sql.NullFloat64{Float64: 30.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1500}},
 	}
 	expected := "Recommended instance type with 8 vCPU and 64 GiB memory could fit 2 objects(2 tables and 0 " +
 		"explicit/implicit indexes) with 80.00 GB size and throughput requirement of 3000 reads/sec and " +
@@ -906,8 +981,8 @@ func TestGetReasoning_OnlyColocatedObjects(t *testing.T) {
 func TestGetReasoning_OnlyShardedObjects(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 16, MemoryPerCore: 4}
 	shardedObjects := []SourceDBMetadata{
-		{Size: 100.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 4000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 3000}},
-		{Size: 200.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 5000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
+		{Size: sql.NullFloat64{Float64: 100.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 4000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 3000}},
+		{Size: sql.NullFloat64{Float64: 200.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 5000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
 	}
 	var colocatedObjects []SourceDBMetadata
 	expected := "Recommended instance type with 16 vCPU and 64 GiB memory could fit 2 objects(2 tables and 0 " +
@@ -924,11 +999,11 @@ func TestGetReasoning_OnlyShardedObjects(t *testing.T) {
 func TestGetReasoning_ColocatedAndShardedObjects(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 32, MemoryPerCore: 2}
 	shardedObjects := []SourceDBMetadata{
-		{Size: 150.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 7000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 6000}},
+		{Size: sql.NullFloat64{Float64: 150.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 7000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 6000}},
 	}
 	colocatedObjects := []SourceDBMetadata{
-		{Size: 70.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
-		{Size: 50.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1000}},
+		{Size: sql.NullFloat64{Float64: 70.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
+		{Size: sql.NullFloat64{Float64: 50.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 2000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 1000}},
 	}
 	expected := "Recommended instance type with 32 vCPU and 64 GiB memory could fit 2 objects(2 tables and 0 " +
 		"explicit/implicit indexes) with 120.00 GB size and throughput requirement of 5000 reads/sec and " +
@@ -946,10 +1021,10 @@ func TestGetReasoning_ColocatedAndShardedObjects(t *testing.T) {
 func TestGetReasoning_Indexes(t *testing.T) {
 	recommendation := IntermediateRecommendation{VCPUsPerInstance: 4, MemoryPerCore: 16}
 	shardedObjects := []SourceDBMetadata{
-		{Size: 200.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 6000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
+		{Size: sql.NullFloat64{Float64: 200.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 6000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000}},
 	}
 	colocatedObjects := []SourceDBMetadata{
-		{Size: 100.0, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
+		{Size: sql.NullFloat64{Float64: 100.0}, ReadsPerSec: sql.NullInt64{Valid: true, Int64: 3000}, WritesPerSec: sql.NullInt64{Valid: true, Int64: 2000}},
 	}
 	expected := "Recommended instance type with 4 vCPU and 64 GiB memory could fit 1 objects(0 tables and " +
 		"1 explicit/implicit indexes) with 100.00 GB size and throughput requirement of 3000 reads/sec and " +


### PR DESCRIPTION
- associated JIRA task: https://yugabyte.atlassian.net/browse/DB-11948
- handles null values for size_in_bytes column
- adjusted unit tests accordingly
- tested by setting null in that column.