### PR TITLE
[Callhome] Added CommandLineArgs field in the phase payload to send the cli arguments changed in the command 

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -152,6 +152,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		TableSizingStats:     callhome.MarshalledJsonString(tableSizingStats),
 		IndexSizingStats:     callhome.MarshalledJsonString(indexSizingStats),
 		SchemaSummary:        callhome.MarshalledJsonString(schemaSummaryCopy),
+		CommandLineArgs:      cliArgsString,
 	}
 	if status == ERROR {
 		assessPayload.Error = errMsg

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1049,10 +1049,10 @@ func (ar *AssessmentReport) GetClusterSizingRecommendation() string {
 func createCallhomePayload() callhome.Payload {
 	var payload callhome.Payload
 	payload.MigrationUUID = migrationUUID
-	payload.PhaseStartTime = startTime.UTC().Format("2006-01-02T15:04:05.999999")
+	payload.PhaseStartTime = startTime.UTC().Format("2006-01-02 15:04:05.999999")
 	payload.YBVoyagerVersion = utils.YB_VOYAGER_VERSION
 	payload.TimeTakenSec = int(math.Ceil(time.Since(startTime).Seconds()))
-	payload.CollectedAt = time.Now().UTC().Format("2006-01-02T15:04:05.999999")
+	payload.CollectedAt = time.Now().UTC().Format("2006-01-02 15:04:05.999999")
 
 	return payload
 }

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -104,6 +104,10 @@ func packAndSendEndMigrationPayload(status string) {
 		return
 	}
 	payload := createCallhomePayload()
+	payload.MigrationType = OFFLINE
+	if streamChangesMode {
+		payload.MigrationType = LIVE_MIGRATION
+	}
 	payload.MigrationPhase = END_MIGRATION_PHASE
 	endMigrationPayload := callhome.EndMigrationPhasePayload{
 		CommandLineArgs: cliArgsString,

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -106,10 +106,7 @@ func packAndSendEndMigrationPayload(status string) {
 	payload := createCallhomePayload()
 	payload.MigrationPhase = END_MIGRATION_PHASE
 	endMigrationPayload := callhome.EndMigrationPhasePayload{
-		BackupLogFiles:       bool(backupLogFiles),
-		BackupSchemaFiles:    bool(backupSchemaFiles),
-		BackupDataFiles:      bool(backupDataFiles),
-		SaveMigrationReports: bool(saveMigrationReports),
+		CommandLineArgs: cliArgsString,
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(endMigrationPayload)
 	payload.Status = status

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -180,11 +180,16 @@ func packAndSendExportDataPayload(status string) {
 
 	payload.MigrationPhase = EXPORT_DATA_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs: int64(source.NumConnections),
-		StartClean:   bool(startClean),
+		ParallelJobs:    int64(source.NumConnections),
+		StartClean:      bool(startClean),
+		CommandLineArgs: cliArgsString,
 	}
 
 	updateExportSnapshotDataStatsInPayload(&exportDataPayload)
+
+	if exportDataPayload.ExportSnapshotMechanism == "debezium" {
+		exportDataPayload.ParallelJobs = 1 //In case of debezium parallel-jobs is not used as such
+	}
 
 	exportDataPayload.Phase = exportPhase
 	if exportPhase != dbzm.MODE_SNAPSHOT {

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -127,8 +127,9 @@ func packAndSendExportDataFromTargetPayload(status string) {
 
 	payload.MigrationPhase = EXPORT_DATA_FROM_TARGET_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs: int64(source.NumConnections),
-		StartClean:   bool(startClean),
+		ParallelJobs:    int64(source.NumConnections),
+		StartClean:      bool(startClean),
+		CommandLineArgs: cliArgsString,
 	}
 
 	exportDataPayload.Phase = exportPhase

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -157,6 +157,7 @@ func packAndSendExportSchemaPayload(status string) {
 	exportSchemaPayload := callhome.ExportSchemaPhasePayload{
 		StartClean:             bool(startClean),
 		AppliedRecommendations: assessmentRecommendationsApplied,
+		CommandLineArgs:        cliArgsString,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(exportSchemaPayload)

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -303,7 +303,7 @@ func getSourceReplicaDBPassword(cmd *cobra.Command) {
 	var err error
 	tconf.Password, err = getPassword(cmd, "source-replica-db-password", "SOURCE_REPLICA_DB_PASSWORD")
 	if err != nil {
-		utils.ErrExit("error while getting ff-db-password: %w", err)
+		utils.ErrExit("error while getting source-replica-db-password: %w", err)
 	}
 }
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -605,8 +605,9 @@ func packAndSendImportDataPayload(status string) {
 	payload.TargetDBDetails = callhome.MarshalledJsonString(targetDBDetails)
 	payload.MigrationPhase = IMPORT_DATA_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs: int64(tconf.Parallelism),
-		StartClean:   bool(startClean),
+		ParallelJobs:    int64(tconf.Parallelism),
+		StartClean:      bool(startClean),
+		CommandLineArgs: cliArgsString,
 	}
 
 	//Getting the imported snapshot details

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -107,6 +107,8 @@ var importDataToTargetCmd = &cobra.Command{
 }
 
 func importDataCommandFn(cmd *cobra.Command, args []string) {
+
+	importPhase = dbzm.MODE_SNAPSHOT
 	ExitIfAlreadyCutover(importerRole)
 	reportProgressInBytes = false
 	tconf.ImportMode = true
@@ -159,8 +161,6 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	} else {
 		importFileTasks = applyTableListFilter(importFileTasks)
 	}
-
-	importPhase = dbzm.MODE_SNAPSHOT
 
 	importData(importFileTasks)
 	tdb.Finalize()
@@ -625,7 +625,7 @@ func packAndSendImportDataPayload(status string) {
 
 	importDataPayload.Phase = importPhase
 
-	if importPhase != dbzm.MODE_SNAPSHOT {
+	if importPhase != dbzm.MODE_SNAPSHOT && statsReporter != nil {
 		importDataPayload.EventsImportRate = statsReporter.EventsImportRateLast3Min
 		importDataPayload.TotalImportedEvents = statsReporter.TotalEventsImported
 	}

--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -103,9 +103,10 @@ func packAndSendImportDataToSourcePayload(status string) {
 
 	payload.MigrationPhase = IMPORT_DATA_SOURCE_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs: int64(tconf.Parallelism),
-		StartClean:   bool(startClean),
+		ParallelJobs:     int64(tconf.Parallelism),
+		StartClean:       bool(startClean),
 		LiveWorkflowType: FALL_BACK,
+		CommandLineArgs:  cliArgsString,
 	}
 
 	importDataPayload.Phase = importPhase

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -108,6 +108,7 @@ func packAndSendImportDataToSrcReplicaPayload(status string) {
 		ParallelJobs:     int64(tconf.Parallelism),
 		StartClean:       bool(startClean),
 		LiveWorkflowType: FALL_FORWARD,
+		CommandLineArgs:  cliArgsString,
 	}
 	importRowsMap, err := getImportedSnapshotRowsMap("source-replica")
 	if err != nil {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -158,26 +158,26 @@ func importSchema() error {
 		}
 		skipFn := isSkipStatement
 		err = importSchemaInternal(exportDir, objectList, skipFn)
-    if err != nil {
-      return err
-    }
+		if err != nil {
+			return err
+		}
 
 		// Import the skipped ALTER TABLE statements from sequence.sql and table.sql if it exists
 		skipFn = func(objType, stmt string) bool {
 			return !isSkipStatement(objType, stmt)
 		}
 		if slices.Contains(objectList, "SEQUENCE") {
-      err = importSchemaInternal(exportDir, []string{"SEQUENCE"}, skipFn)
-      if err != nil {
-        return err
-      }
-    }
-    if slices.Contains(objectList, "TABLE") {
-      err = importSchemaInternal(exportDir, []string{"TABLE"}, skipFn)
-      if err != nil {
-        return err
-      }
-    }
+			err = importSchemaInternal(exportDir, []string{"SEQUENCE"}, skipFn)
+			if err != nil {
+				return err
+			}
+		}
+		if slices.Contains(objectList, "TABLE") {
+			err = importSchemaInternal(exportDir, []string{"TABLE"}, skipFn)
+			if err != nil {
+				return err
+			}
+		}
 
 		importDeferredStatements()
 		log.Info("Schema import is complete.")
@@ -230,6 +230,7 @@ func packAndSendImportSchemaPayload(status string, errMsg string) {
 		Errors:             errorsList,
 		PostSnapshotImport: bool(flagPostSnapshotImport),
 		StartClean:         bool(startClean),
+		CommandLineArgs:    cliArgsString,
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(importSchemaPayload)
 	err := callhome.SendPayload(&payload)

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -112,7 +112,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 func createCLIArgsString(cmd *cobra.Command) {
 	var flagStrings []string
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-		if flag.Changed && !strings.Contains(flag.Name, "password") {
+		if flag.Changed && !slices.Contains(callhome.DoNotStoreFlags, flag.Name) {
 			flagStrings = append(flagStrings, fmt.Sprintf("--%s=%s", flag.Name, flag.Value))
 		}
 	})

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -51,6 +52,7 @@ var (
 	controlPlane                       cp.ControlPlane
 	currentCommand                     string
 	callHomeErrorOrCompletePayloadSent bool
+	cliArgsString                      string
 )
 
 var rootCmd = &cobra.Command{
@@ -75,6 +77,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 		startTime = time.Now()
 
 		if callhome.SendDiagnostics {
+			createCLIArgsString(cmd)
 			go sendCallhomePayloadAtIntervals()
 		}
 
@@ -104,6 +107,16 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 		}
 		atexit.Exit(0)
 	},
+}
+
+func createCLIArgsString(cmd *cobra.Command) {
+	var flagStrings []string
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed && !strings.Contains(flag.Name, "password") {
+			flagStrings = append(flagStrings, fmt.Sprintf("--%s=%s", flag.Name, flag.Value))
+		}
+	})
+	cliArgsString = strings.Join(flagStrings, " ")
 }
 
 func startPprofServer() {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -177,6 +177,13 @@ type EndMigrationPhasePayload struct {
 	CommandLineArgs string `json:"command_line_args"`
 }
 
+var DoNotStoreFlags = []string{
+	"source-db-password",
+	"target-db-password",
+	"source-replica-db-password",
+	"export-dir",
+}
+
 func MarshalledJsonString[T any](value T) string {
 	bytes, err := json.Marshal(value)
 	if err != nil {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -99,6 +99,7 @@ type AssessMigrationPhasePayload struct {
 	IndexSizingStats     string `json:"index_sizing_stats"`
 	SchemaSummary        string `json:"schema_summary"`
 	SourceConnectivity   bool   `json:"source_connectivity"`
+	CommandLineArgs      string `json:"command_line_args"`
 }
 
 type ObjectSizingStats struct {
@@ -110,8 +111,9 @@ type ObjectSizingStats struct {
 }
 
 type ExportSchemaPhasePayload struct {
-	StartClean             bool `json:"start_clean"`
-	AppliedRecommendations bool `json:"applied_recommendations"`
+	StartClean             bool   `json:"start_clean"`
+	AppliedRecommendations bool   `json:"applied_recommendations"`
+	CommandLineArgs        string `json:"command_line_args"`
 }
 
 type AnalyzePhasePayload struct {
@@ -129,6 +131,7 @@ type ExportDataPhasePayload struct {
 	TotalExportedEvents int64  `json:"total_exported_events,omitempty"`
 	EventsExportRate    int64  `json:"events_export_rate_3m,omitempty"`
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
+	CommandLineArgs     string `json:"command_line_args,omitempty"`
 }
 
 type ImportSchemaPhasePayload struct {
@@ -136,6 +139,7 @@ type ImportSchemaPhasePayload struct {
 	Errors             []string `json:"errors"`
 	PostSnapshotImport bool     `json:"post_snapshot_import"`
 	StartClean         bool     `json:"start_clean"`
+	CommandLineArgs    string   `json:"command_line_args"`
 }
 
 type ImportDataPhasePayload struct {
@@ -148,6 +152,7 @@ type ImportDataPhasePayload struct {
 	TotalImportedEvents int64  `json:"total_imported_events,omitempty"`
 	EventsImportRate    int64  `json:"events_import_rate_3m,omitempty"`
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
+	CommandLineArgs     string `json:"command_line_args"`
 }
 
 type ImportDataFilePhasePayload struct {
@@ -169,10 +174,7 @@ type DataFileParameters struct {
 }
 
 type EndMigrationPhasePayload struct {
-	BackupLogFiles       bool `json:"backup_log_files"`
-	BackupDataFiles      bool `json:"backup_data_files"`
-	BackupSchemaFiles    bool `json:"backup_schema_files"`
-	SaveMigrationReports bool `json:"save_migration_reports"`
+	CommandLineArgs string `json:"command_line_args"`
 }
 
 func MarshalledJsonString[T any](value T) string {


### PR DESCRIPTION
1. Added CommandLineArgs field in the phase payload to send the cli arguments changes in the command 
2. Misc Callhome fixes-
       - Nil pointer handling for statsReporter in import data payloads
       - In case of debezium export data parallel-jobs should be stored as 1.
       - Populated MigrationType field for end-migration
       - Populated `node_count` and `total_cores` in import schema 