### PR TITLE
sizing calc: DB-11954: added constant to prefer_remote_file, set to false by default

### DIFF
--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -1315,7 +1315,7 @@ func createConnectionToExperimentData() (*sql.DB, error) {
 
 func getExperimentFile() (string, error) {
 	fetchedFromRemote := false
-	if checkInternetAccess() && PREFER_REMOTE_EXPERIMENT_DB {
+	if PREFER_REMOTE_EXPERIMENT_DB && checkInternetAccess() {
 		existsOnRemote, err := checkAndDownloadFileExistsOnRemoteRepo()
 		if err != nil {
 			return "", err

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -115,6 +115,7 @@ const (
 	HIGH_PHASE_SIZE_THRESHOLD_GB  = 10
 	FINAL_PHASE_SIZE_THRESHOLD_GB = 100
 	MAX_TABLETS_PER_TABLE         = 256
+	PREFER_REMOTE_EXPERIMENT_DB   = false
 )
 
 func getExperimentDBPath() string {
@@ -1314,7 +1315,7 @@ func createConnectionToExperimentData() (*sql.DB, error) {
 
 func getExperimentFile() (string, error) {
 	fetchedFromRemote := false
-	if checkInternetAccess() {
+	if checkInternetAccess() && PREFER_REMOTE_EXPERIMENT_DB {
 		existsOnRemote, err := checkAndDownloadFileExistsOnRemoteRepo()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
- associated JIRA task: https://yugabyte.atlassian.net/browse/DB-11954
- added a constant to prefer using remote file or not. By default it is set to false, meaning that it will use the local file.
- In future, it needed, we will just have to change the constant value.