### PR TITLE
 Fixed analyze-schema issues in summary part to include the partitions in table object for Oracle, and table DDLs in type.sql

### DIFF
--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/types/type.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/types/type.sql
@@ -2,3 +2,8 @@
 ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
 
 ALTER TYPE compfoo ADD ATTRIBUTE f3 int;
+
+
+CREATE TABLE test_table_in_type_file(
+    id int PRIMARY KEY
+);

--- a/migtests/tests/analyze-schema/summary.json
+++ b/migtests/tests/analyze-schema/summary.json
@@ -19,9 +19,9 @@
             },
             {
                 "ObjectType": "TABLE",
-                "TotalCount": 25,
+                "TotalCount": 26,
                 "InvalidCount": 22,
-                "ObjectNames": "sales, test_2, test_7, test_8, table_abc, table_1, test_interval, sales_data, test_6, order_details, public.employees4, table_test, xyz, anydata_test, anytype_test, salaries2, test_3, uritype_test, test_1, test_non_pk_multi_column_list, test_4, test_5, test_9, table_xyz, anydataset_test"
+                "ObjectNames": "test_table_in_type_file, sales, test_2, test_7, test_8, table_abc, table_1, test_interval, sales_data, test_6, order_details, public.employees4, table_test, xyz, anydata_test, anytype_test, salaries2, test_3, uritype_test, test_1, test_non_pk_multi_column_list, test_4, test_5, test_9, table_xyz, anydataset_test"
             },
             {
                 "ObjectType": "INDEX",

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -734,6 +734,9 @@ func getCreateObjRegex(objType string) (*regexp.Regexp, int) {
 	} else if objType == "INDEX" || objType == "PARTITION_INDEX" || objType == "FTS_INDEX" {
 		createObjRegex = re("CREATE", opt("UNIQUE"), "INDEX", ifNotExists, capture(ident))
 		objNameIndex = 3
+	} else if objType == "TABLE" || objType == "PARTITION" {
+		createObjRegex = re("CREATE", opt("OR REPLACE"), "TABLE", ifNotExists, capture(ident))
+		objNameIndex = 3
 	} else { //TODO: check syntaxes for other objects and add more cases if required
 		createObjRegex = re("CREATE", opt("OR REPLACE"), objType, ifNotExists, capture(ident))
 		objNameIndex = 3
@@ -751,9 +754,16 @@ func processCollectedSql(fpath string, stmt string, formattedStmt string, objTyp
 	if createObjStmt != nil {
 		objName = createObjStmt[objNameIndex]
 
-		if summaryMap != nil && summaryMap[objType] != nil { //when just createSqlStrArray() is called from someother file, then no summaryMap exists
-			summaryMap[objType].totalCount += 1
-			summaryMap[objType].objSet[objName] = true
+		if objType == "PARTITION" || objType == "TABLE" {
+			if summaryMap != nil && summaryMap["TABLE"] != nil {
+				summaryMap["TABLE"].totalCount += 1
+				summaryMap["TABLE"].objSet[objName] = true
+			}
+		} else {
+			if summaryMap != nil && summaryMap[objType] != nil { //when just createSqlStrArray() is called from someother file, then no summaryMap exists
+				summaryMap[objType].totalCount += 1
+				summaryMap[objType].objSet[objName] = true
+			}
 		}
 	}
 

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -765,8 +765,22 @@ func processCollectedSql(fpath string, stmt string, formattedStmt string, objTyp
 				summaryMap[objType].objSet[objName] = true
 			}
 		}
+	} else {
+		if objType == "TYPE" {
+			//in case of oracle there are some inherited types which can be exported as inherited tables but will be dumped in type.sql
+			createObjRegex, objNameIndex = getCreateObjRegex("TABLE")
+			createObjStmt = createObjRegex.FindStringSubmatch(formattedStmt)
+			if createObjStmt != nil {
+				objName = createObjStmt[objNameIndex]
+				if summaryMap != nil && summaryMap["TABLE"] != nil {
+					summaryMap["TABLE"].totalCount += 1
+					summaryMap["TABLE"].objSet[objName] = true
+				}
+			}
+		}	
 	}
 
+	
 	if *reportNextSql > 0 && (summaryMap != nil && summaryMap[objType] != nil) {
 		reportBasedOnComment(*reportNextSql, fpath, "", "", objName, objType, formattedStmt)
 		*reportNextSql = 0 //reset flag


### PR DESCRIPTION
1. Fixed Oracle analyze report's summary to include partition tables in the total table object summary
2. Fixed the issue where if oracle source has some inherited types that can be converted to inherited tables in pg it will exported in `type.sql` 

Tests: 
1. Manual - tested both work fine now
2. Automation added for 2nd fix, can't add for first right now as it will require to run analyze-schema when source-db-type is Oracle, so will have to add export-dir for it. Will take it up later. 

Jenkins Oracle tests 
https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/2837/