### PR TITLE
Fix for GIN indexes in Assessment Report

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -214,6 +214,7 @@ const (
 	STORED_GENERATED_COLUMN_ISSUE_REASON = "Stored generated columns are not supported."
 
 	GIST_INDEX_ISSUE_REASON = "Schema contains GIST index which is not supported."
+	GIN_INDEX_DETAILS       = "There are some GIN indexes present in the schema, but GIN indexes are partially supported in YugabyteDB as mentioned in (https://github.com/yugabyte/yugabyte-db/issues/7850) so take a look and modify them if not supported."
 )
 
 // Reports one case in JSON
@@ -332,7 +333,7 @@ func checkGin(sqlInfoArr []sqlInfo, fpath string) {
 			}
 		}
 		if strings.Contains(strings.ToLower(sqlInfo.stmt), "using gin") {
-			summaryMap["INDEX"].details["There are some GIN indexes present in the schema, but GIN indexes are partially supported in YugabyteDB as mentioned in (https://github.com/yugabyte/yugabyte-db/issues/7850) so take a look and modify them if not supported."] = true
+			summaryMap["INDEX"].details[GIN_INDEX_DETAILS] = true
 		}
 	}
 }

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -900,7 +900,7 @@ func addNotesToAssessmentReport() {
 		// checking if gin indexes are present.
 		for _, dbObj := range schemaAnalysisReport.SchemaSummary.DBObjects {
 			if dbObj.ObjectType == "INDEX" {
-				if strings.Contains(dbObj.Details, "gin indexes present") {
+				if strings.Contains(dbObj.Details, GIN_INDEX_DETAILS) {
 					assessmentReport.Notes = append(assessmentReport.Notes, GIN_INDEXES)
 					break
 				}


### PR DESCRIPTION
There was a case mismatch in string comparision that was leading to gin indexes not being reported in assessment report. 