### PR TITLE
Added jq installation in the dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update && apt-get install -y curl perl make libdbi-perl locales && \
     curl -L https://cpanmin.us | perl - --self-upgrade && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    apt-get install -y tzdata wget rsync openjdk-17-jre git sudo gcc && \
+    apt-get install -y tzdata wget rsync openjdk-17-jre git sudo gcc jq && \
     apt-get upgrade -y binutils && \
     curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
     git clone https://github.com/yugabyte/yb-voyager.git && \


### PR DESCRIPTION
The update in the installer script to fetch latest version from GH api requires jq to process the json responses. It is not installed by default on the ubuntu image we are using in the Dockerfile. Hence, installing it before running the installer script.