### PR TITLE
Altered password for test_schema

### DIFF
--- a/migtests/scripts/oracle/create_oracle_user
+++ b/migtests/scripts/oracle/create_oracle_user
@@ -15,6 +15,7 @@ begin
   end if;
 end;
 /
+ALTER USER TEST_SCHEMA IDENTIFIED BY password;
 EOF
 
 run_sqlplus_as_sys ${SOURCE_DB_NAME} "oracle-create-user.sql"


### PR DESCRIPTION
TEST_SCHEMA is used in Oracle to run the tests on in Jenkins. This is a pre-created schema in the AMI.
The password gets expired after some time. Adding an alter statement to the create user step to avoid the situation.
We can look for a better fix later if required.