### PR TITLE
Fix import data streaming logic

### DIFF
--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -57,7 +57,11 @@ var exportDataStatusCmd = &cobra.Command{
 		if err != nil {
 			utils.ErrExit("initializing name registry: %v", err)
 		}
-		useDebezium = dbzm.IsDebeziumForDataExport(exportDir)
+		msr, err := metaDB.GetMigrationStatusRecord()
+		if err != nil {
+			utils.ErrExit("Failed to get migration status record: %s", err)
+		}
+		useDebezium = msr.IsSnapshotExportedViaDebezium()
 		var rows []*exportTableMigStatusOutputRow
 		if useDebezium {
 			rows, err = runExportDataStatusCmdDbzm(streamChanges)

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -322,7 +322,7 @@ func addRowInTheTable(uitbl *uitable.Table, row rowData, nameTup sqlname.NameTup
 
 func updateExportedSnapshotRowsInTheRow(msr *metadb.MigrationStatusRecord, row *rowData, nameTup sqlname.NameTuple, dbzmSnapshotRowCount *utils.StructMap[sqlname.NameTuple, int64], exportedSnapshotPGRowsMap *utils.StructMap[sqlname.NameTuple, int64]) error {
 	// TODO: read only from one place(data file descriptor). Right now, data file descriptor does not store schema names.
-	if msr.SnapshotMechanism == "debezium" {
+	if msr.IsSnapshotExportedViaDebezium() {
 		row.ExportedSnapshotRows, _ = dbzmSnapshotRowCount.Get(nameTup)
 	} else {
 		row.ExportedSnapshotRows, _ = exportedSnapshotPGRowsMap.Get(nameTup)
@@ -367,7 +367,7 @@ func updateImportedEventsCountsInTheRow(row *rowData, tableNameTup sqlname.NameT
 	if importerRole == SOURCE_REPLICA_DB_IMPORTER_ROLE {
 		var err error
 		tblName := tableNameTup.ForKey()
-		//In case of source-replica role namereg is the map of target->source-replica name 
+		//In case of source-replica role namereg is the map of target->source-replica name
 		//and hence ForKey() returns source-relica name so we need to get that from reg
 		tableNameTup, err = nameRegistryForSourceReplicaRole.LookupTableName(tblName)
 		if err != nil {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -407,7 +407,7 @@ func importData(importFileTasks []*ImportFileTask) {
 		utils.ErrExit("Failed to get migration status record: %s", err)
 	}
 
-	if msr.SnapshotMechanism == "debezium" {
+	if msr.IsSnapshotExportedViaDebezium() {
 		valueConverter, err = dbzm.NewValueConverter(exportDir, tdb, tconf, importerRole, msr.SourceDBConf.DBType)
 	} else {
 		valueConverter, err = dbzm.NewNoOpValueConverter()
@@ -560,7 +560,7 @@ func importData(importFileTasks []*ImportFileTask) {
 			color.CyanString("yb-voyager get data-migration-report --export-dir %q", exportDir))
 	} else {
 		// offline migration; either using dbzm or pg_dump/ora2pg
-		if !dbzm.IsDebeziumForDataExport(exportDir) {
+		if !msr.IsSnapshotExportedViaDebezium() {
 			errImport := executePostSnapshotImportSqls()
 			if errImport != nil {
 				utils.ErrExit("Error in importing post-snapshot-import sql: %v", err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -522,49 +522,50 @@ func importData(importFileTasks []*ImportFileTask) {
 		utils.PrintAndLog("snapshot data import complete\n\n")
 	}
 
-	if !dbzm.IsDebeziumForDataExport(exportDir) {
-		errImport := executePostSnapshotImportSqls()
-		if errImport != nil {
-			utils.ErrExit("Error in importing post-snapshot-import sql: %v", err)
+	if changeStreamingIsEnabled(importType) {
+		if importerRole != SOURCE_DB_IMPORTER_ROLE {
+			displayImportedRowCountSnapshot(state, importFileTasks)
 		}
-		displayImportedRowCountSnapshot(state, importFileTasks)
+		importPhase = dbzm.MODE_STREAMING
+		color.Blue("streaming changes to %s...", tconf.TargetDBType)
+
+		if err != nil {
+			utils.ErrExit("failed to get table unique key columns map: %s", err)
+		}
+		valueConverter, err = dbzm.NewValueConverter(exportDir, tdb, tconf, importerRole, source.DBType)
+		if err != nil {
+			utils.ErrExit("Failed to create value converter: %s", err)
+		}
+		err = streamChanges(state, importTableList)
+		if err != nil {
+			utils.ErrExit("Failed to stream changes to %s: %s", tconf.TargetDBType, err)
+		}
+
+		status, err := dbzm.ReadExportStatus(filepath.Join(exportDir, "data", "export_status.json"))
+		if err != nil {
+			utils.ErrExit("failed to read export status for restore sequences: %s", err)
+		}
+		// in case of live migration sequences are restored after cutover
+		err = tdb.RestoreSequences(status.Sequences)
+		if err != nil {
+			utils.ErrExit("failed to restore sequences: %s", err)
+		}
+
+		utils.PrintAndLog("Completed streaming all relevant changes to %s", tconf.TargetDBType)
+		err = markCutoverProcessed(importerRole)
+		if err != nil {
+			utils.ErrExit("failed to mark cutover as processed: %s", err)
+		}
+		utils.PrintAndLog("\nRun the following command to get the current report of the migration:\n" +
+			color.CyanString("yb-voyager get data-migration-report --export-dir %q", exportDir))
 	} else {
-		if changeStreamingIsEnabled(importType) {
-			if importerRole != SOURCE_DB_IMPORTER_ROLE {
-				displayImportedRowCountSnapshot(state, importFileTasks)
+		// offline migration; either using dbzm or pg_dump/ora2pg
+		if !dbzm.IsDebeziumForDataExport(exportDir) {
+			errImport := executePostSnapshotImportSqls()
+			if errImport != nil {
+				utils.ErrExit("Error in importing post-snapshot-import sql: %v", err)
 			}
-			importPhase = dbzm.MODE_STREAMING
-			color.Blue("streaming changes to %s...", tconf.TargetDBType)
-
-			if err != nil {
-				utils.ErrExit("failed to get table unique key columns map: %s", err)
-			}
-			valueConverter, err = dbzm.NewValueConverter(exportDir, tdb, tconf, importerRole, source.DBType)
-			if err != nil {
-				utils.ErrExit("Failed to create value converter: %s", err)
-			}
-			err = streamChanges(state, importTableList)
-			if err != nil {
-				utils.ErrExit("Failed to stream changes to %s: %s", tconf.TargetDBType, err)
-			}
-
-			status, err := dbzm.ReadExportStatus(filepath.Join(exportDir, "data", "export_status.json"))
-			if err != nil {
-				utils.ErrExit("failed to read export status for restore sequences: %s", err)
-			}
-			// in case of live migration sequences are restored after cutover
-			err = tdb.RestoreSequences(status.Sequences)
-			if err != nil {
-				utils.ErrExit("failed to restore sequences: %s", err)
-			}
-
-			utils.PrintAndLog("Completed streaming all relevant changes to %s", tconf.TargetDBType)
-			err = markCutoverProcessed(importerRole)
-			if err != nil {
-				utils.ErrExit("failed to mark cutover as processed: %s", err)
-			}
-			utils.PrintAndLog("\nRun the following command to get the current report of the migration:\n" +
-				color.CyanString("yb-voyager get data-migration-report --export-dir %q", exportDir))
+			displayImportedRowCountSnapshot(state, importFileTasks)
 		} else {
 			status, err := dbzm.ReadExportStatus(filepath.Join(exportDir, "data", "export_status.json"))
 			if err != nil {

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -39,7 +39,7 @@ type MigrationStatusRecord struct {
 	EndMigrationRequested                           bool              `json:"EndMigrationRequested"`
 	PGReplicationSlotName                           string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
 	PGPublicationName                               string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	SnapshotMechanism                               string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump)
+	SnapshotMechanism                               string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump, ora2pg)
 	SourceRenameTablesMap                           map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
 	TargetRenameTablesMap                           map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
 	IsExportTableListSet                            bool              `json:"IsExportTableListSet"`
@@ -76,4 +76,8 @@ func (m *MetaDB) InitMigrationStatusRecord() error {
 		record.MigrationUUID = uuid.New().String()
 		record.ExportType = utils.SNAPSHOT_ONLY
 	})
+}
+
+func (msr *MigrationStatusRecord) IsSnapshotExportedViaDebezium() bool {
+	return msr.SnapshotMechanism == "debezium"
 }


### PR DESCRIPTION
Fixed import data logic. 
After import data snapshot phase, we were assuming that `no debezium =>  offline migration with pg_dump/ora2pg`. This assumption is wrong because for live migration from postgres source, we use pg_dump for the snapshot phase. 

While this might not affect real-world scenarios, because by the time import-data snapshot is complete, export-data streaming phase would have started (i.e. debezium would have started). However, this logic is wrong. Moreover, this was leading to intermittent failures in test runs (where import-data snapshot import finished before export-data started debezium, leading to import-data assuming that it is offline migration)  

Testing:
- Manually tested export data status for regression (pg, oracle with and w/o debezium)
- Current test automation pipelines should be enough to validate live migration correctness. In fact, intermittent failures should not be observed after this PR is merged. 