### PR TITLE
[DB-12268/12271/12272] CONVERSION object type categorising and report, Multi-column gin index and Add PK to partitioned table issues reporting in Assess

### DIFF
--- a/migtests/scripts/run-validate-assessment-report.sh
+++ b/migtests/scripts/run-validate-assessment-report.sh
@@ -75,6 +75,7 @@ main() {
 		echo "Comparing Report contents"
         expected_file="${TEST_DIR}/expectedAssessmentReport.json"
         actual_file="${EXPORT_DIR}/assessment/reports/assessmentReport.json"
+		cat ${actual_file} # just for testing oracle assessment and get its report to update expected report
 	    compare_assessment_reports ${expected_file} ${actual_file}
 	else
 		echo "Error: Assessment reports were not created successfully."

--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/conversions/conversion.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/conversions/conversion.sql
@@ -1,0 +1,6 @@
+
+
+--conversion not supported
+CREATE CONVERSION myconv FOR 'UTF8' TO 'LATIN1' FROM myfunc;
+
+ALTER CONVERSION myconv rename to my_conv_1;

--- a/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
+++ b/migtests/tests/analyze-schema/dummy-export-dir/schema/tables/table.sql
@@ -111,11 +111,6 @@ CREATE TABLE test_9 (
 	PRIMARY KEY (order_id,order_mode,order_date,order_total,sales_rep_id)
 ) PARTITION BY RANGE (order_total, order_date, sales_rep_id) ;
 
---conversion not supported
-CREATE CONVERSION myconv FOR 'UTF8' TO 'LATIN1' FROM myfunc;
-
-ALTER CONVERSION myconv for  'UTF8' TO 'LATIN1' FROM myfunc1;
-
 --Reindexing not supported
 REINDEX TABLE my_table;
 

--- a/migtests/tests/analyze-schema/expected_issues.json
+++ b/migtests/tests/analyze-schema/expected_issues.json
@@ -90,7 +90,7 @@
         {
             "ObjectType": "CONVERSION",
             "ObjectName": "myconv",
-            "Reason": "CONVERSION type is not supported in YugabyteDB",
+            "Reason": "CREATE CONVERSION is not supported yet",
             "SqlStatement": "CREATE CONVERSION myconv FOR 'UTF8' TO 'LATIN1' FROM myfunc;",
             "Suggestion": "Remove it from the exported schema",
             "GH": "https://github.com/yugabyte/yugabyte-db/issues/10866"
@@ -98,7 +98,7 @@
         {
             "ObjectType": "CONVERSION",
             "ObjectName": "myconv",
-            "Reason": "ALTER CONVERSION is not supported in YugabyteDB",
+            "Reason": "ALTER CONVERSION is not supported yet",
             "SqlStatement": "ALTER CONVERSION myconv rename to my_conv_1;",
             "Suggestion": "Remove it from the exported schema",
             "GH": "https://github.com/YugaByte/yugabyte-db/issues/10866"

--- a/migtests/tests/analyze-schema/expected_issues.json
+++ b/migtests/tests/analyze-schema/expected_issues.json
@@ -90,17 +90,17 @@
         {
             "ObjectType": "CONVERSION",
             "ObjectName": "myconv",
-            "Reason": "CREATE CONVERSION not supported yet",
+            "Reason": "CONVERSION type is not supported in YugabyteDB",
             "SqlStatement": "CREATE CONVERSION myconv FOR 'UTF8' TO 'LATIN1' FROM myfunc;",
-            "Suggestion": "",
-            "GH": "https://github.com/YugaByte/yugabyte-db/issues/10866"
+            "Suggestion": "Remove it from the exported schema",
+            "GH": "https://github.com/yugabyte/yugabyte-db/issues/10866"
         },
         {
             "ObjectType": "CONVERSION",
             "ObjectName": "myconv",
-            "Reason": "ALTER CONVERSION not supported yet",
-            "SqlStatement": "ALTER CONVERSION myconv for  'UTF8' TO 'LATIN1' FROM myfunc1;",
-            "Suggestion": "",
+            "Reason": "ALTER CONVERSION is not supported in YugabyteDB",
+            "SqlStatement": "ALTER CONVERSION myconv rename to my_conv_1;",
+            "Suggestion": "Remove it from the exported schema",
             "GH": "https://github.com/YugaByte/yugabyte-db/issues/10866"
         },
         {

--- a/migtests/tests/analyze-schema/summary.json
+++ b/migtests/tests/analyze-schema/summary.json
@@ -47,6 +47,12 @@
                 "TotalCount": 3,
                 "InvalidCount": 3,
                 "ObjectNames": "transfer_insert, emp_trig, test"
+            },
+            {
+                "ObjectType": "CONVERSION",
+                "TotalCount": 1,
+                "InvalidCount": 1,
+                "ObjectNames": "myconv"
             }
         ]
 }

--- a/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
@@ -178,44 +178,72 @@
 	"UnsupportedFeatures": [
 		{
 			"FeatureName": "Compound Triggers",
-			"ObjectNames": [
-				"trg_simple_insert"
-			],
-			"DDLs": null
+			"Objects": [
+				{
+					"ObjectName": "trg_simple_insert",
+					"SqlStatement": "CREATE TRIGGER trg_simple_insert\n\tCOMPOUND INSERT ON simple_table FOR EACH ROW\n\tEXECUTE PROCEDURE trigger_fct_trg_simple_insert();"
+				}
+			]
 		},
 		{
 			"FeatureName": "Unsupported Indexes",
-			"ObjectNames": [
-				"Index Name: TEXT_INDEX, Index Type=DOMAIN INDEX",
-				"Index Name: IDX_EMP_DEPT_CLUSTER, Index Type=CLUSTER INDEX",
-				"Index Name: REV_INDEX, Index Type=NORMAL/REV INDEX",
-				"Index Name: FUNC_REV_INDEX, Index Type=FUNCTION-BASED NORMAL/REV INDEX",
-				"Index Name: PK_IOT_TABLE, Index Type=IOT - TOP INDEX"
-			],
-			"DDLs": null
+			"Objects": [
+				{
+					"ObjectName": "Index Name: TEXT_INDEX, Index Type=DOMAIN INDEX",
+					"SqlStatement": ""
+				},
+				{
+					"ObjectName": "Index Name: IDX_EMP_DEPT_CLUSTER, Index Type=CLUSTER INDEX",
+					"SqlStatement": ""
+				},
+				{
+					"ObjectName": "Index Name: FUNC_REV_INDEX, Index Type=FUNCTION-BASED NORMAL/REV INDEX",
+					"SqlStatement": ""
+				},
+				{
+					"ObjectName": "Index Name: PK_IOT_TABLE, Index Type=IOT - TOP INDEX",
+					"SqlStatement": ""
+				},
+				{
+					"ObjectName": "Index Name: REV_INDEX, Index Type=NORMAL/REV INDEX",
+					"SqlStatement": ""
+				}
+			]
 		},
 		{
 			"FeatureName": "Virtual Columns",
-			"ObjectNames": [
-				"XML_TABLE.DATA",
-				"GENERATED_COLUMN_TABLE.TOTAL_PRICE"
-			],
-			"DDLs": null
+			"Objects": [
+				{
+					"ObjectName": "XML_TABLE.DATA",
+					"SqlStatement": ""
+				},
+				{
+					"ObjectName": "GENERATED_COLUMN_TABLE.TOTAL_PRICE",
+					"SqlStatement": ""
+				}
+			]
 		},
 		{
 			"FeatureName": "Inherited Types",
-			"ObjectNames": [
-				"SIMPLE_CAR_TYPE"
-			],
-			"DDLs": null
+			"Objects": [
+				{
+					"ObjectName": "SIMPLE_CAR_TYPE",
+					"SqlStatement": ""
+				}
+			]
 		},
 		{
 			"FeatureName": "Unsupported Partitioning Methods",
-			"ObjectNames": [
-				"Table Name: SALES, Partition Method: SYSTEM PARTITION",
-				"Table Name: EMPLOYEES2, Partition Method: REFERENCE PARTITION"
-			],
-			"DDLs": null
+			"Objects": [
+				{
+					"ObjectName": "Table Name: EMPLOYEES2, Partition Method: REFERENCE PARTITION",
+					"SqlStatement": ""
+				},
+				{
+					"ObjectName": "Table Name: SALES, Partition Method: SYSTEM PARTITION",
+					"SqlStatement": ""
+				}
+			]
 		}
 	],
 	"UnsupportedFeaturesDesc": "Features of the source database that are not supported on the target YugabyteDB.",

--- a/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
@@ -180,7 +180,8 @@
 			"FeatureName": "Compound Triggers",
 			"ObjectNames": [
 				"trg_simple_insert"
-			]
+			],
+			"DDLs": null
 		},
 		{
 			"FeatureName": "Unsupported Indexes",
@@ -190,27 +191,31 @@
 				"Index Name: REV_INDEX, Index Type=NORMAL/REV INDEX",
 				"Index Name: FUNC_REV_INDEX, Index Type=FUNCTION-BASED NORMAL/REV INDEX",
 				"Index Name: PK_IOT_TABLE, Index Type=IOT - TOP INDEX"
-			]
+			],
+			"DDLs": null
 		},
 		{
 			"FeatureName": "Virtual Columns",
 			"ObjectNames": [
 				"XML_TABLE.DATA",
 				"GENERATED_COLUMN_TABLE.TOTAL_PRICE"
-			]
+			],
+			"DDLs": null
 		},
 		{
 			"FeatureName": "Inherited Types",
 			"ObjectNames": [
 				"SIMPLE_CAR_TYPE"
-			]
+			],
+			"DDLs": null
 		},
 		{
 			"FeatureName": "Unsupported Partitioning Methods",
 			"ObjectNames": [
 				"Table Name: SALES, Partition Method: SYSTEM PARTITION",
 				"Table Name: EMPLOYEES2, Partition Method: REFERENCE PARTITION"
-			]
+			],
+			"DDLs": null
 		}
 	],
 	"UnsupportedFeaturesDesc": "Features of the source database that are not supported on the target YugabyteDB.",

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -35,8 +35,8 @@
 			},
 			{
 				"ObjectType": "TABLE",
-				"TotalCount": 46,
-				"ObjectNames": "public.mixed_data_types_table1, public.session_log, schema2.\"WITH\", schema2.products, public.audit, public.foo, schema2.ext_test, schema2.tt, test_views.view_table1, public.with_example1, public.with_example2, schema2.audit, public.\"Mixed_Case_Table_Name_Test\", public.c, public.orders2, public.products, public.tt, schema2.session_log1, schema2.orders, schema2.orders2, schema2.with_example2, public.\"Case_Sensitive_Columns\", public.\"WITH\", schema2.\"Recipients\", schema2.parent_table, schema2.child_table, test_views.view_table2, public.ext_test, public.orders, schema2.employees2, schema2.with_example1, public.employees2, public.session_log2, schema2.\"Case_Sensitive_Columns\", schema2.mixed_data_types_table1, schema2.mixed_data_types_table2, schema2.session_log, public.parent_table, public.mixed_data_types_table2, public.session_log1, schema2.\"Mixed_Case_Table_Name_Test\", schema2.foo, public.\"Recipients\", public.child_table, schema2.c, schema2.session_log2"
+				"TotalCount": 54,
+				"ObjectNames": "public.sydney, schema2.ext_test, public.session_log2, schema2.audit, public.\"Recipients\", schema2.boston, schema2.mixed_data_types_table2, public.mixed_data_types_table2, schema2.\"Case_Sensitive_Columns\", schema2.employees2, schema2.sydney, schema2.session_log1, schema2.tt, public.audit, public.ext_test, public.session_log1, schema2.child_table, schema2.orders, schema2.products, public.\"Mixed_Case_Table_Name_Test\", public.session_log, public.tt, public.with_example1, schema2.\"Mixed_Case_Table_Name_Test\", schema2.c, public.mixed_data_types_table1, schema2.parent_table, public.employees2, schema2.\"WITH\", schema2.session_log2, schema2.with_example2, public.parent_table, schema2.session_log, public.\"WITH\", public.london, schema2.sales_region, schema2.london, public.products, schema2.foo, public.boston, public.foo, public.orders, schema2.with_example1, test_views.view_table1, public.\"Case_Sensitive_Columns\", public.sales_region, public.child_table, public.orders2, schema2.\"Recipients\", test_views.view_table2, public.c, public.with_example2, schema2.mixed_data_types_table1, schema2.orders2"
 			},
 			{
 				"ObjectType": "INDEX",
@@ -129,14 +129,20 @@
 				"schema2.audit",
 				"schema2.c",
 				"test_views.view_table2",
-				"test_views.view_table1"
+				"test_views.view_table1",
+				"public.boston",
+				"public.london",
+				"public.sydney",
+				"schema2.london",
+				"schema2.boston",
+				"schema2.sydney"
 			],
-			"ColocatedReasoning": "Recommended instance type with 4 vCPU and 16 GiB memory could fit 52 objects (46 tables and 6 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.",
+			"ColocatedReasoning": "Recommended instance type with 4 vCPU and 16 GiB memory could fit 58 objects (52 tables and 6 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.",
 			"ShardedTables": null,
 			"NumNodes": 3,
 			"VCPUsPerInstance": 4,
 			"MemoryPerInstance": 16,
-			"OptimalSelectConnectionsPerNode": 10,
+			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
 			"EstimatedTimeInMinForImport": 0,
 			"ParallelVoyagerJobs": 1
@@ -278,7 +284,10 @@
 		{
 			"FeatureName": "Unsupported DDL operations",
 			"ObjectNames": null,
-			"DDLs": []
+			"DDLs": [
+				"ALTER TABLE ONLY public.sales_region\n    ADD CONSTRAINT sales_region_pkey PRIMARY KEY (id, region);",
+				"ALTER TABLE ONLY schema2.sales_region\n    ADD CONSTRAINT sales_region_pkey PRIMARY KEY (id, region);"
+			]
 		}
 	],
 	"UnsupportedFeaturesDesc": "Features of the source database that are not supported on the target YugabyteDB.",
@@ -1010,6 +1019,90 @@
 			"ObjectType": "",
 			"ParentTableName": "schema2.orders2",
 			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "boston",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 0,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 0
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "london",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 0,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 0
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "sydney",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 0,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 0
+		},
+		{
+			"SchemaName": "schema2",
+			"ObjectName": "london",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 0,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 0
+		},
+		{
+			"SchemaName": "schema2",
+			"ObjectName": "boston",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 0,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 0
+		},
+		{
+			"SchemaName": "schema2",
+			"ObjectName": "sydney",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 0,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 0
 		}
 	],
 	"Notes": null

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -239,7 +239,7 @@
 	"UnsupportedFeatures": [
 		{
 			"FeatureName": "GIST indexes",
-			"ObjectInfo": [
+			"Objects": [
 				{
 					"ObjectName": "idx_box_data",
 					"SqlStatement": "CREATE INDEX idx_box_data ON public.mixed_data_types_table1 USING gist (box_data);"
@@ -260,7 +260,7 @@
 		},
 		{
 			"FeatureName": "Constraint triggers",
-			"ObjectInfo": [
+			"Objects": [
 				{
 					"ObjectName": "enforce_shipped_date_constraint",
 					"SqlStatement": "CREATE CONSTRAINT TRIGGER enforce_shipped_date_constraint AFTER UPDATE ON public.orders2 NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW WHEN ((((new.status)::text = 'shipped'::text) AND (new.shipped_date IS NULL))) EXECUTE FUNCTION public.prevent_update_shipped_without_date();"
@@ -273,7 +273,7 @@
 		},
 		{
 			"FeatureName": "Inherited tables",
-			"ObjectInfo": [
+			"Objects": [
 				{
 					"ObjectName": "public.child_table",
 					"SqlStatement": "CREATE TABLE public.child_table (\n    specific_column1 date\n)\nINHERITS (public.parent_table);"
@@ -286,7 +286,7 @@
 		},
 		{
 			"FeatureName": "Tables with Stored generated columns",
-			"ObjectInfo": [
+			"Objects": [
 				{
 					"ObjectName": "public.employees2",
 					"SqlStatement": "CREATE TABLE public.employees2 (\n    id integer NOT NULL,\n    first_name character varying(50) NOT NULL,\n    last_name character varying(50) NOT NULL,\n    full_name character varying(101) GENERATED ALWAYS AS ((((first_name)::text || ' '::text) || (last_name)::text)) STORED\n);"
@@ -299,15 +299,15 @@
 		},
 		{
 			"FeatureName": "Conversion objects",
-			"ObjectInfo": []
+			"Objects": []
 		},
 		{
 			"FeatureName": "Gin Indexes on Multi-columns",
-			"ObjectInfo": []
+			"Objects": []
 		},
 		{
 			"FeatureName": "Unsupported DDL operations",
-			"ObjectInfo": [
+			"Objects": [
 				{
 					"ObjectName": "public.sales_region",
 					"SqlStatement": "ALTER TABLE ONLY public.sales_region\n    ADD CONSTRAINT sales_region_pkey PRIMARY KEY (id, region);"

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -239,54 +239,83 @@
 	"UnsupportedFeatures": [
 		{
 			"FeatureName": "GIST indexes",
-			"ObjectNames": [
-				"idx_box_data",
-				"idx_point_data",
-				"idx_box_data",
-				"idx_point_data"
-			],
-			"DDLs": null
+			"ObjectInfo": [
+				{
+					"ObjectName": "idx_box_data",
+					"SqlStatement": "CREATE INDEX idx_box_data ON public.mixed_data_types_table1 USING gist (box_data);"
+				},
+				{
+					"ObjectName": "idx_point_data",
+					"SqlStatement": "CREATE INDEX idx_point_data ON public.mixed_data_types_table1 USING gist (point_data);"
+				},
+				{
+					"ObjectName": "idx_box_data",
+					"SqlStatement": "CREATE INDEX idx_box_data ON schema2.mixed_data_types_table1 USING gist (box_data);"
+				},
+				{
+					"ObjectName": "idx_point_data",
+					"SqlStatement": "CREATE INDEX idx_point_data ON schema2.mixed_data_types_table1 USING gist (point_data);"
+				}
+			]
 		},
 		{
 			"FeatureName": "Constraint triggers",
-			"ObjectNames": [
-				"enforce_shipped_date_constraint",
-				"enforce_shipped_date_constraint"
-			],
-			"DDLs": null
+			"ObjectInfo": [
+				{
+					"ObjectName": "enforce_shipped_date_constraint",
+					"SqlStatement": "CREATE CONSTRAINT TRIGGER enforce_shipped_date_constraint AFTER UPDATE ON public.orders2 NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW WHEN ((((new.status)::text = 'shipped'::text) AND (new.shipped_date IS NULL))) EXECUTE FUNCTION public.prevent_update_shipped_without_date();"
+				},
+				{
+					"ObjectName": "enforce_shipped_date_constraint",
+					"SqlStatement": "CREATE CONSTRAINT TRIGGER enforce_shipped_date_constraint AFTER UPDATE ON schema2.orders2 NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW WHEN ((((new.status)::text = 'shipped'::text) AND (new.shipped_date IS NULL))) EXECUTE FUNCTION schema2.prevent_update_shipped_without_date();"
+				}
+			]
 		},
 		{
 			"FeatureName": "Inherited tables",
-			"ObjectNames": [
-				"public.child_table",
-				"schema2.child_table"
-			],
-			"DDLs": null
+			"ObjectInfo": [
+				{
+					"ObjectName": "public.child_table",
+					"SqlStatement": "CREATE TABLE public.child_table (\n    specific_column1 date\n)\nINHERITS (public.parent_table);"
+				},
+				{
+					"ObjectName": "schema2.child_table",
+					"SqlStatement": "CREATE TABLE schema2.child_table (\n    specific_column1 date\n)\nINHERITS (schema2.parent_table);"
+				}
+			]
 		},
 		{
 			"FeatureName": "Tables with Stored generated columns",
-			"ObjectNames": [
-				"public.employees2",
-				"schema2.employees2"
-			],
-			"DDLs": null
+			"ObjectInfo": [
+				{
+					"ObjectName": "public.employees2",
+					"SqlStatement": "CREATE TABLE public.employees2 (\n    id integer NOT NULL,\n    first_name character varying(50) NOT NULL,\n    last_name character varying(50) NOT NULL,\n    full_name character varying(101) GENERATED ALWAYS AS ((((first_name)::text || ' '::text) || (last_name)::text)) STORED\n);"
+				},
+				{
+					"ObjectName": "schema2.employees2",
+					"SqlStatement": "CREATE TABLE schema2.employees2 (\n    id integer NOT NULL,\n    first_name character varying(50) NOT NULL,\n    last_name character varying(50) NOT NULL,\n    full_name character varying(101) GENERATED ALWAYS AS ((((first_name)::text || ' '::text) || (last_name)::text)) STORED\n);"
+				}
+			]
 		},
 		{
 			"FeatureName": "Conversion objects",
-			"ObjectNames": [],
-			"DDLs": null
+			"ObjectInfo": []
 		},
 		{
 			"FeatureName": "Gin Indexes on Multi-columns",
-			"ObjectNames": [],
-			"DDLs": null
+			"ObjectInfo": []
 		},
 		{
 			"FeatureName": "Unsupported DDL operations",
-			"ObjectNames": null,
-			"DDLs": [
-				"ALTER TABLE ONLY public.sales_region\n    ADD CONSTRAINT sales_region_pkey PRIMARY KEY (id, region);",
-				"ALTER TABLE ONLY schema2.sales_region\n    ADD CONSTRAINT sales_region_pkey PRIMARY KEY (id, region);"
+			"ObjectInfo": [
+				{
+					"ObjectName": "public.sales_region",
+					"SqlStatement": "ALTER TABLE ONLY public.sales_region\n    ADD CONSTRAINT sales_region_pkey PRIMARY KEY (id, region);"
+				},
+				{
+					"ObjectName": "schema2.sales_region",
+					"SqlStatement": "ALTER TABLE ONLY schema2.sales_region\n    ADD CONSTRAINT sales_region_pkey PRIMARY KEY (id, region);"
+				}
 			]
 		}
 	],

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -272,7 +272,7 @@
 			"DDLs": null
 		},
 		{
-			"FeatureName": "Conversion types",
+			"FeatureName": "Conversion objects",
 			"ObjectNames": [],
 			"DDLs": null
 		},

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -238,28 +238,47 @@
 				"idx_point_data",
 				"idx_box_data",
 				"idx_point_data"
-			]
+			],
+			"DDLs": null
 		},
 		{
 			"FeatureName": "Constraint triggers",
 			"ObjectNames": [
 				"enforce_shipped_date_constraint",
 				"enforce_shipped_date_constraint"
-			]
+			],
+			"DDLs": null
 		},
 		{
 			"FeatureName": "Inherited tables",
 			"ObjectNames": [
 				"public.child_table",
 				"schema2.child_table"
-			]
+			],
+			"DDLs": null
 		},
 		{
 			"FeatureName": "Tables with Stored generated columns",
 			"ObjectNames": [
-				"schema2.employees2",
-				"public.employees2"
-			]
+				"public.employees2",
+				"schema2.employees2"
+			],
+			"DDLs": null
+		},
+		{
+			"FeatureName": "Conversion types",
+			"ObjectNames": [],
+			"DDLs": null
+		},
+		{
+			"FeatureName": "Gin Indexes on Multi-columns",
+			"ObjectNames": [],
+			"DDLs": null
+		},
+		{
+			"FeatureName": "Unsupported DDL operations",
+			"ObjectNames": null,
+			"DDLs": []
 		}
 	],
 	"UnsupportedFeaturesDesc": "Features of the source database that are not supported on the target YugabyteDB.",

--- a/migtests/tests/pg/assessment-report-test/pg_assessment_report.sql
+++ b/migtests/tests/pg/assessment-report-test/pg_assessment_report.sql
@@ -61,3 +61,9 @@ CREATE TABLE employees2 (
     last_name VARCHAR(50) NOT NULL,
     full_name VARCHAR(101) GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
 );
+
+--For the ALTER TABLE ADD PK on partitioned DDL in schema
+CREATE TABLE sales_region (id int, amount int, branch text, region text, PRIMARY KEY(id, region)) PARTITION BY LIST (region);
+CREATE TABLE Boston PARTITION OF sales_region FOR VALUES IN ('Boston');
+CREATE TABLE London PARTITION OF sales_region FOR VALUES IN ('London');
+CREATE TABLE Sydney PARTITION OF sales_region FOR VALUES IN ('Sydney');

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -207,7 +207,7 @@ var (
 )
 
 const (
-	CONVERSION_ISSUE_REASON                     = "CONVERSION type is not supported in YugabyteDB"
+	CONVERSION_ISSUE_REASON                     = "CREATE CONVERSION is not supported yet"
 	GIN_INDEX_MULTI_COLUMN_ISSUE_REASON         = "Schema contains gin index on multi column which is not supported."
 	ADDING_PK_TO_PARTITIONED_TABLE_ISSUE_REASON = "Adding primary key to a partitioned table is not yet implemented."
 	INHERITANCE_ISSUE_REASON                    = "TABLE INHERITANCE not supported in YugabyteDB"
@@ -1046,7 +1046,7 @@ func checkConversions(sqlInfoArr []sqlInfo, filePath string) {
 		} else {
 			//pg_query doesn't seem to have a Node type of AlterConversionStmt so using regex for now
 			if stmt := alterConvRegex.FindStringSubmatch(sqlStmtInfo.stmt); stmt != nil {
-				reportCase(filePath, "ALTER CONVERSION is not supported in YugabyteDB", "https://github.com/YugaByte/yugabyte-db/issues/10866",
+				reportCase(filePath, "ALTER CONVERSION is not supported yet", "https://github.com/YugaByte/yugabyte-db/issues/10866",
 					"Remove it from the exported schema", "CONVERSION", stmt[1], sqlStmtInfo.formattedStmt)
 			}
 		}

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1034,13 +1034,13 @@ func checkConversions(sqlInfoArr []sqlInfo, filePath string) {
 		createConvNode, ok := parseTree.Stmts[0].Stmt.Node.(*pg_query.Node_CreateConversionStmt)
 		if ok {
 			createConvStmt := createConvNode.CreateConversionStmt
-			//Conversion name here is a list of items which are '.' separated 
+			//Conversion name here is a list of items which are '.' separated
 			//so 0th and 1st indexes are Schema and conv name respectively
 			nameList := createConvStmt.GetConversionName()
 			convName := nameList[0].GetString_().Sval
 			if len(nameList) > 1 {
 				convName = fmt.Sprintf("%s.%s", convName, nameList[1].GetString_().Sval)
-			} 
+			}
 			reportCase(filePath, CONVERSION_ISSUE_REASON, "https://github.com/yugabyte/yugabyte-db/issues/10866",
 				"Remove it from the exported schema", "CONVERSION", convName, sqlStmtInfo.formattedStmt)
 		} else {

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1034,11 +1034,13 @@ func checkConversions(sqlInfoArr []sqlInfo, filePath string) {
 		createConvNode, ok := parseTree.Stmts[0].Stmt.Node.(*pg_query.Node_CreateConversionStmt)
 		if ok {
 			createConvStmt := createConvNode.CreateConversionStmt
+			//Conversion name here is a list of items which are '.' separated 
+			//so 0th and 1st indexes are Schema and conv name respectively
 			nameList := createConvStmt.GetConversionName()
 			convName := nameList[0].GetString_().Sval
-			if len(nameList) > 0 {
+			if len(nameList) > 1 {
 				convName = fmt.Sprintf("%s.%s", convName, nameList[1].GetString_().Sval)
-			}
+			} 
 			reportCase(filePath, CONVERSION_ISSUE_REASON, "https://github.com/yugabyte/yugabyte-db/issues/10866",
 				"Remove it from the exported schema", "CONVERSION", convName, sqlStmtInfo.formattedStmt)
 		} else {

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -207,10 +207,12 @@ var (
 )
 
 const (
-	CONVERSION_ISSUE_REASON         = "CONVERSION type is not supported in YugabyteDB"
-	INHERITANCE_ISSUE_REASON        = "TABLE INHERITANCE not supported in YugabyteDB"
-	CONSTRAINT_TRIGGER_ISSUE_REASON = "CONSTRAINT TRIGGER not supported yet."
-	COMPOUND_TRIGGER_ISSUE_REASON   = "COMPOUND TRIGGER not supported in YugabyteDB."
+	CONVERSION_ISSUE_REASON                     = "CONVERSION type is not supported in YugabyteDB"
+	GIN_INDEX_MULTI_COLUMN_ISSUE_REASON         = "Schema contains gin index on multi column which is not supported."
+	ADDING_PK_TO_PARTITIONED_TABLE_ISSUE_REASON = "Adding primary key to a partitioned table is not yet implemented."
+	INHERITANCE_ISSUE_REASON                    = "TABLE INHERITANCE not supported in YugabyteDB"
+	CONSTRAINT_TRIGGER_ISSUE_REASON             = "CONSTRAINT TRIGGER not supported yet."
+	COMPOUND_TRIGGER_ISSUE_REASON               = "COMPOUND TRIGGER not supported in YugabyteDB."
 
 	STORED_GENERATED_COLUMN_ISSUE_REASON = "Stored generated columns are not supported."
 
@@ -1040,7 +1042,7 @@ func checkConversions(sqlInfoArr []sqlInfo, filePath string) {
 			reportCase(filePath, CONVERSION_ISSUE_REASON, "https://github.com/yugabyte/yugabyte-db/issues/10866",
 				"Remove it from the exported schema", "CONVERSION", convName, sqlStmtInfo.formattedStmt)
 		} else {
-			//pg_query doesn't seem to a Node type of AlterConversionStmt so using regex for now
+			//pg_query doesn't seem to have a Node type of AlterConversionStmt so using regex for now
 			if stmt := alterConvRegex.FindStringSubmatch(sqlStmtInfo.stmt); stmt != nil {
 				reportCase(filePath, "ALTER CONVERSION is not supported in YugabyteDB", "https://github.com/YugaByte/yugabyte-db/issues/10866",
 					"Remove it from the exported schema", "CONVERSION", stmt[1], sqlStmtInfo.formattedStmt)

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -67,7 +67,7 @@ var sourceConnectionFlags = []string{
 
 type UnsupportedFeature struct {
 	FeatureName string       `json:"FeatureName"`
-	Objects     []ObjectInfo `json:"ObjectInfo"`
+	Objects     []ObjectInfo `json:"Objects"`
 }
 
 type ObjectInfo struct {

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -800,7 +800,7 @@ func fetchUnsupportedPGFeaturesFromSchemaReport(schemaAnalysisReport utils.Schem
 	filterIssuesWithObjectNamesForUnsupportedFeature("Constraint triggers", CONSTRAINT_TRIGGER_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	filterIssuesWithObjectNamesForUnsupportedFeature("Inherited tables", INHERITANCE_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	filterIssuesWithObjectNamesForUnsupportedFeature("Tables with Stored generated columns", STORED_GENERATED_COLUMN_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
-	filterIssuesWithObjectNamesForUnsupportedFeature("Conversion types", CONVERSION_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
+	filterIssuesWithObjectNamesForUnsupportedFeature("Conversion objects", CONVERSION_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	filterIssuesWithObjectNamesForUnsupportedFeature("Gin Indexes on Multi-columns", GIN_INDEX_MULTI_COLUMN_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	filterIssuesWithDDLsForUnsupportedFeature("Unsupported DDL operations", ADDING_PK_TO_PARTITIONED_TABLE_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	return unsupportedFeatures, nil

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -788,6 +788,7 @@ func fetchUnsupportedPGFeaturesFromSchemaReport(schemaAnalysisReport utils.Schem
 	filterIssuesForUnsupportedFeature("Constraint triggers", CONSTRAINT_TRIGGER_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	filterIssuesForUnsupportedFeature("Inherited tables", INHERITANCE_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	filterIssuesForUnsupportedFeature("Tables with Stored generated columns", STORED_GENERATED_COLUMN_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
+	filterIssuesForUnsupportedFeature("Conversion types", CONVERSION_ISSUE_REASON, schemaAnalysisReport, &unsupportedFeatures)
 	return unsupportedFeatures, nil
 }
 

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -68,7 +68,7 @@ var sourceConnectionFlags = []string{
 type UnsupportedFeature struct {
 	FeatureName string   `json:"FeatureName"`
 	ObjectNames []string `json:"ObjectNames"`
-	DDls        []string `json:"DDLs"`
+	DDLs        []string `json:"DDLs"`
 }
 
 var assessMigrationCmd = &cobra.Command{

--- a/yb-voyager/cmd/templates/assessmentReport.template
+++ b/yb-voyager/cmd/templates/assessmentReport.template
@@ -175,6 +175,17 @@
                     </ul>
                 </div>
             {{end}}
+            {{if .DDLs}} <!-- Check if DDLs is not empty -->
+                {{ $hasUnsupportedFeatures = true }}
+                <h3>{{.FeatureName}}</h3>
+                <div class="scrollable-div">
+                    <ul>
+                        {{range .DDLs}}
+                            <li>{{.}}</li>
+                        {{end}}
+                    </ul>
+                </div>
+            {{end}}
         {{end}}
         {{if not $hasUnsupportedFeatures}} <!-- Check if no unsupported features were found -->
             <p>No unsupported features were present among the ones assessed.</p>

--- a/yb-voyager/cmd/templates/assessmentReport.template
+++ b/yb-voyager/cmd/templates/assessmentReport.template
@@ -164,27 +164,27 @@
         <p>{{.UnsupportedFeaturesDesc}}</p>
         {{ $hasUnsupportedFeatures := false }}
         {{range .UnsupportedFeatures}}
-            {{if .ObjectNames}} <!-- Check if ObjectNames is not empty -->
+            {{if .Objects}} <!-- Check if Objects is not empty -->
                 {{ $hasUnsupportedFeatures = true }}
-                <h3>{{.FeatureName}}</h3>
-                <div class="scrollable-div">
-                    <ul>
-                        {{range .ObjectNames}}
-                            <li>{{.}}</li>
-                        {{end}}
-                    </ul>
-                </div>
-            {{end}}
-            {{if .DDLs}} <!-- Check if DDLs is not empty -->
-                {{ $hasUnsupportedFeatures = true }}
-                <h3>{{.FeatureName}}</h3>
-                <div class="scrollable-div">
-                    <ul>
-                        {{range .DDLs}}
-                            <li>{{.}}</li>
-                        {{end}}
-                    </ul>
-                </div>
+                {{if eq .FeatureName "Unsupported DDL operations"}} <!-- for this feature we are displaying the DDLs-->
+                    <h3>{{.FeatureName}}</h3>
+                    <div class="scrollable-div">
+                        <ul>
+                            {{range .Objects}}
+                                <li>{{.SqlStatement}}</li>
+                            {{end}}
+                        </ul>
+                    </div>
+                {{else}}
+                    <h3>{{.FeatureName}}</h3>
+                    <div class="scrollable-div">
+                        <ul>
+                            {{range .Objects}}
+                                <li>{{.ObjectName}}</li>
+                            {{end}}
+                        </ul>
+                    </div>
+                {{end}}
             {{end}}
         {{end}}
         {{if not $hasUnsupportedFeatures}} <!-- Check if no unsupported features were found -->

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -141,6 +141,8 @@ func parseSchemaFile(exportDir string, schemaDir string, exportObjectTypesList [
 				alterAttachPartition.WriteString(stmts)
 			case "MATERIALIZED VIEW":
 				objSqlStmts["MVIEW"].WriteString(stmts)
+			case "CONVERSION":
+				objSqlStmts["CONVERSION"].WriteString(stmts)
 			default:
 				uncategorizedSqls.WriteString(stmts)
 			}

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -60,7 +60,7 @@ var oracleSchemaObjectListForExport = []string{"TYPE", "SEQUENCE", "TABLE", "PAC
 var postgresSchemaObjectList = []string{"SCHEMA", "COLLATION", "EXTENSION", "TYPE", "DOMAIN", "SEQUENCE",
 	"TABLE", "INDEX", "FUNCTION", "AGGREGATE", "PROCEDURE", "VIEW", "TRIGGER",
 	"MVIEW", "RULE", "COMMENT" /* GRANT, ROLE*/, "CONVERSION"}
-var postgresSchemaObjectListForExport = []string{"TYPE", "DOMAIN", "SEQUENCE", "TABLE", "FUNCTION", "PROCEDURE", "AGGREGATE", "VIEW", "MVIEW", "TRIGGER", "COMMENT"}
+var postgresSchemaObjectListForExport = []string{"TYPE", "DOMAIN", "SEQUENCE", "TABLE", "FUNCTION", "PROCEDURE", "AGGREGATE", "VIEW", "MVIEW", "TRIGGER", "COMMENT", "CONVERSION"}
 
 // In MYSQL, TYPE and SEQUENCE are not supported
 var mysqlSchemaObjectList = []string{"TABLE", "PARTITION", "INDEX", "VIEW", /*"GRANT*/

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -59,7 +59,7 @@ var oracleSchemaObjectListForExport = []string{"TYPE", "SEQUENCE", "TABLE", "PAC
 // In PG, PARTITION are exported along with TABLE
 var postgresSchemaObjectList = []string{"SCHEMA", "COLLATION", "EXTENSION", "TYPE", "DOMAIN", "SEQUENCE",
 	"TABLE", "INDEX", "FUNCTION", "AGGREGATE", "PROCEDURE", "VIEW", "TRIGGER",
-	"MVIEW", "RULE", "COMMENT" /* GRANT, ROLE*/}
+	"MVIEW", "RULE", "COMMENT" /* GRANT, ROLE*/, "CONVERSION"}
 var postgresSchemaObjectListForExport = []string{"TYPE", "DOMAIN", "SEQUENCE", "TABLE", "FUNCTION", "PROCEDURE", "AGGREGATE", "VIEW", "MVIEW", "TRIGGER", "COMMENT"}
 
 // In MYSQL, TYPE and SEQUENCE are not supported


### PR DESCRIPTION
**Description:**

There are multiple fixes and enhancements  - 
1. Categorizing and reporting the CREATE CONVERSION DDL in PG migrations unsupported in target.
![Screenshot 2024-08-07 at 11 42 19 AM](https://github.com/user-attachments/assets/d0261d68-a0fe-403e-b4ec-8401e9746174)

2. Reporting Multi-column GIN index in Assess-migration report.
4. Reporting ALTER TABLE ADD PK to the partitioned table in Assess migration under a feature name called "Unsupported DDL operations" to show all the unsupported DDLs under this bucket.
![Screenshot 2024-08-07 at 11 35 56 AM](https://github.com/user-attachments/assets/d78d53cd-2194-48e5-a3da-29ebf254e4ff)
5. Fixed automation tests and added automation for ALTER TABLE one to detect.

Added docs in doc - https://docs.google.com/document/d/1vLmV72lsWz9868VjPSit-KYmzpc_fkas9s_I9T9BnFE/edit 
 
Fixes all these -
a. https://yugabyte.atlassian.net/browse/DB-12268
b. https://yugabyte.atlassian.net/browse/DB-12271
c. https://yugabyte.atlassian.net/browse/DB-12272

Jenkins -
1. Oracle tests - https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/3096