### PR TITLE
Bug Fix[DB-12365]: Validate Schema Existence Before Migration Assessment and Export Schema/Data

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -211,12 +211,19 @@ func exportData() bool {
 	if err != nil {
 		utils.ErrExit("Failed to connect to the source db: %s", err)
 	}
+	defer source.DB().Disconnect()
+
 	source.DBVersion = source.DB().GetVersion()
 	source.DBSize, err = source.DB().GetDatabaseSize()
 	if err != nil {
 		log.Errorf("error getting database size: %v", err) //can just log as this is used for call-home only
 	}
-	defer source.DB().Disconnect()
+
+	res := source.DB().CheckSchemaExists()
+	if !res {
+		utils.ErrExit("schema %q does not exist", source.Schema)
+	}
+
 	clearMigrationStateIfRequired()
 	checkSourceDBCharset()
 	source.DB().CheckRequiredToolsAreInstalled()

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -96,8 +96,8 @@ func exportSchema() error {
 		log.Errorf("failed to connect to the source db: %s", err)
 		return fmt.Errorf("failed to connect to the source db: %w", err)
 	}
-
 	defer source.DB().Disconnect()
+
 	checkSourceDBCharset()
 	source.DB().CheckRequiredToolsAreInstalled()
 	sourceDBVersion := source.DB().GetVersion()
@@ -107,6 +107,12 @@ func exportSchema() error {
 		log.Errorf("error getting database size: %v", err) //can just log as this is used for call-home only
 	}
 	utils.PrintAndLog("%s version: %s\n", source.DBType, sourceDBVersion)
+
+	res := source.DB().CheckSchemaExists()
+	if !res {
+		return fmt.Errorf("schema %q does not exist", source.Schema)
+	}
+
 	err = retrieveMigrationUUID()
 	if err != nil {
 		log.Errorf("failed to get migration UUID: %v", err)

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -65,6 +65,12 @@ func (ms *MySQL) Disconnect() {
 	}
 }
 
+func (ms *MySQL) CheckSchemaExists() bool {
+	// no concept of schema in MySQL, only database
+	// also if Connect() passed already that means database is present
+	return true
+}
+
 func (ms *MySQL) CheckRequiredToolsAreInstalled() {
 	checkTools("ora2pg")
 }

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -65,6 +65,19 @@ func (ora *Oracle) Disconnect() {
 	}
 }
 
+func (ora *Oracle) CheckSchemaExists() bool {
+	schemaName := ora.source.Schema
+	query := fmt.Sprintf(`SELECT username FROM ALL_USERS WHERE username = '%s'`, strings.ToUpper(schemaName))
+	var schema string
+	err := ora.db.QueryRow(query).Scan(&schema)
+	if err == sql.ErrNoRows {
+		return false
+	} else if err != nil {
+		log.Fatalf("error in querying source database for schema %q: %v\n", schemaName, err)
+	}
+	return true
+}
+
 func (ora *Oracle) CheckRequiredToolsAreInstalled() {
 	checkTools("ora2pg", "sqlplus")
 }

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -145,6 +145,11 @@ func (pg *PostgreSQL) GetVersion() string {
 	return version
 }
 
+func (pg *PostgreSQL) CheckSchemaExists() bool {
+	schemaList := pg.checkSchemasExists()
+	return schemaList != nil
+}
+
 func (pg *PostgreSQL) checkSchemasExists() []string {
 	list := strings.Split(pg.source.Schema, "|")
 	var trimmedList []string

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -29,6 +29,7 @@ import (
 type SourceDB interface {
 	Connect() error
 	Disconnect()
+	CheckSchemaExists() bool
 	GetConnectionUriWithoutPassword() string
 	GetTableRowCount(tableName sqlname.NameTuple) int64
 	GetTableApproxRowCount(tableName sqlname.NameTuple) int64

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -109,6 +109,11 @@ func (yb *YugabyteDB) GetVersion() string {
 	return version
 }
 
+func (yb *YugabyteDB) CheckSchemaExists() bool {
+	schemaList := yb.checkSchemasExists()
+	return schemaList != nil
+}
+
 func (yb *YugabyteDB) checkSchemasExists() []string {
 	list := strings.Split(yb.source.Schema, "|")
 	var trimmedList []string


### PR DESCRIPTION
https://yugabyte.atlassian.net/issues/DB-12365

- Assess Migration: Fixed unclear output displaying that metadata is collected when schema is missing.
- Export Schema [Oracle]: Improved error message for nonexistent schema.
- Export Data [Oracle]: Prevented misleading 'no tables present to export, exiting...' message by checking schema existence first.

Ensures early schema validation, clearer error messages, and avoids unnecessary operations.


Previously this is how it looked in case of `export data` command for oracle source, in case of invalid schemaname:
1. Before 
```
ubuntu@ip-10-9-15-212:~/vol1/export-dirs/oracle-sakila-migration$ export SOURCE_DB_SCHEMA=SAKILA2
ubuntu@ip-10-9-15-212:~/vol1/export-dirs/oracle-sakila-migration$ yb-voyager  export data --source-db-type $SOURCE_DB_TYPE --source-db-user $SOURCE_DB_USER --source-db-password $SOURCE_DB_PASSWORD --source-db-name $SOURCE_DB_NAME --source-db-host $SOURCE_DB_HOST --source-db-schema $SOURCE_DB_SCHEMA --start-clean true --export-dir .
Note: Using current directory as export-dir
Using DB Name for export.
export of data for source type as 'oracle'
migrationID: cc265c64-0349-49c2-834c-41f57b03b520
no tables present to export, exiting...
```

2. Now
```
ubuntu@ip-10-9-15-212:~/vol1/export-dirs/oracle-sakila-migration$ yb-voyager  export data --source-db-type $SOURCE_DB_TYPE --source-db-user $SOURCE_DB_USER --source-db-password $SOURCE_DB_PASSWORD --source-db-name $SOURCE_DB_NAME --source-db-host $SOURCE_DB_HOST --source-db-schema $SOURCE_DB_SCHEMA --start-clean true --export-dir .
Note: Using current directory as export-dir
Using DB Name for export.
export of data for source type as 'oracle'
migrationID: cc265c64-0349-49c2-834c-41f57b03b520
schema "SAKILA2" does not exist
```