### PR TITLE
Bug fix: Check for TargetDB colocation only when assessment recommendations are applied, otherwise ignore.

### DIFF
--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -78,6 +78,7 @@ func exportSchema() error {
 				utils.CleanDir(filepath.Join(exportDir, dirName))
 			}
 			clearSchemaIsExported()
+			clearAssessmentRecommendationsApplied()
 		} else {
 			fmt.Fprintf(os.Stderr, "Schema is already exported. "+
 				"Use --start-clean flag to export schema again -- "+
@@ -273,9 +274,11 @@ func applyMigrationAssessmentRecommendations() error {
 			return fmt.Errorf("failed to apply colocated vs sharded table recommendation: %w", err)
 		}
 	}
+	
 	assessmentRecommendationsApplied = true
-	utils.PrintAndLog("Applied assessment recommendations.")
+	SetAssessmentRecommendationsApplied()
 
+	utils.PrintAndLog("Applied assessment recommendations.")
 	return nil
 }
 
@@ -455,4 +458,22 @@ func createExportSchemaCompletedEvent() cp.ExportSchemaCompletedEvent {
 	result := cp.ExportSchemaCompletedEvent{}
 	initBaseSourceEvent(&result.BaseEvent, "EXPORT SCHEMA")
 	return result
+}
+
+func SetAssessmentRecommendationsApplied() {
+	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		record.AssessmentRecommendationsApplied = true
+	})
+	if err != nil {
+		utils.ErrExit("failed to update migration status record with assessment recommendations applied flag: %w", err)
+	}
+}
+
+func clearAssessmentRecommendationsApplied() {
+	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		record.AssessmentRecommendationsApplied = false
+	})
+	if err != nil {
+		utils.ErrExit("clear assessment recommendations applied: update migration status record: %s", err)
+	}	
 }

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -44,6 +44,7 @@ type MigrationStatusRecord struct {
 	TargetRenameTablesMap                           map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
 	IsExportTableListSet                            bool              `json:"IsExportTableListSet"`
 	MigrationAssessmentDone                         bool              `json:"MigrationAssessmentDone"`
+	AssessmentRecommendationsApplied                bool              `json:"AssessmentRecommendationsApplied"`
 }
 
 const MIGRATION_STATUS_KEY = "migration_status"


### PR DESCRIPTION
- assume a case where user didn't apply recommendations and doesn't want to have target db colocated also, then this prompt is of no use.