### PR TITLE
Fix: Regression cause by commit dfc43241aad44f2a4072d2f2a90f14cd1db34a96

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -272,6 +272,13 @@ func assessMigration() (err error) {
 	migassessment.AssessmentDir = assessmentDir
 	migassessment.SourceDBType = source.DBType
 
+	if source.Password == "" {
+		source.Password, err = askPassword("source DB", source.User, "SOURCE_DB_PASSWORD")
+		if err != nil {
+			return fmt.Errorf("failed to get source DB password: %w", err)
+		}
+	}
+
 	if assessmentMetadataDirFlag == "" { // only in case of source connectivity
 		err := source.DB().Connect()
 		if err != nil {
@@ -501,13 +508,6 @@ func gatherAssessmentMetadata() (err error) {
 	// setting schema objects types to export before creating the project directories
 	source.ExportObjectTypeList = utils.GetExportSchemaObjectList(source.DBType)
 	CreateMigrationProjectIfNotExists(source.DBType, exportDir)
-
-	if source.Password == "" {
-		source.Password, err = askPassword("source DB", source.User, "SOURCE_DB_PASSWORD")
-		if err != nil {
-			return fmt.Errorf("failed to get source DB password: %w", err)
-		}
-	}
 
 	utils.PrintAndLog("gathering metadata and stats from '%s' source database...", source.DBType)
 	switch source.DBType {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -73,7 +73,7 @@ func (ora *Oracle) CheckSchemaExists() bool {
 	if err == sql.ErrNoRows {
 		return false
 	} else if err != nil {
-		log.Fatalf("error in querying source database for schema %q: %v\n", schemaName, err)
+		utils.ErrExit("error in querying source database for schema %q: %v\n", schemaName, err)
 	}
 	return true
 }


### PR DESCRIPTION
This commit fixed a regression introduced in commit dfc43241aad44f2a4072d2f2a90f14cd1db34a96 because of which the assess-migration command was exiting without error msg if SOURCE_DB_PASSWORD is not provided as flag

- with this fix it will prompt for the password if not provided through flag of env var(original behaviour)