### PR TITLE
Fix: Let upsert mode warning show up in import-data-file workflow 

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -394,7 +394,10 @@ func importData(importFileTasks []*ImportFileTask) {
 	}
 
 	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && (tconf.EnableUpsert) {
-		utils.PrintAndLog(color.RedString("WARNING: Ensure that tables on target YugabyteDB do not have secondary indexes. If a table has secondary indexes, setting --enable-upsert to true may lead to corruption of the indexes."))
+		if !utils.AskPrompt(color.RedString("WARNING: Ensure that tables on target YugabyteDB do not have secondary indexes. " +
+			"If a table has secondary indexes, setting --enable-upsert to true may lead to corruption of the indexes. Are you sure you want to proceed?")) {
+			utils.ErrExit("Aborting import.")
+		}
 	}
 
 	if importerRole == TARGET_DB_IMPORTER_ROLE {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -133,10 +133,6 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 		utils.ErrExit("initialize name registry: %v", err)
 	}
 
-	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && (tconf.EnableUpsert) {
-		utils.PrintAndLog(color.RedString("WARNING: Ensure that tables on target YugabyteDB do not have secondary indexes. If a table has secondary indexes, setting --enable-upsert to true may lead to corruption of the indexes."))
-	}
-
 	dataStore = datastore.NewDataStore(filepath.Join(exportDir, "data"))
 	dataFileDescriptor = datafile.OpenDescriptor(exportDir)
 	// TODO: handle case-sensitive in table names with oracle ff-db
@@ -395,6 +391,10 @@ func importData(importFileTasks []*ImportFileTask) {
 	err := retrieveMigrationUUID()
 	if err != nil {
 		utils.ErrExit("failed to get migration UUID: %w", err)
+	}
+
+	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && (tconf.EnableUpsert) {
+		utils.PrintAndLog(color.RedString("WARNING: Ensure that tables on target YugabyteDB do not have secondary indexes. If a table has secondary indexes, setting --enable-upsert to true may lead to corruption of the indexes."))
 	}
 
 	if importerRole == TARGET_DB_IMPORTER_ROLE {


### PR DESCRIPTION
Move error msg to importData function so that it is applicable to both import data as well as import-data-file