### PR TITLE
Fix: Go static checks are failing with go version format mismatch with latest staticcheck package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,5 +36,5 @@ jobs:
     - name: Run staticcheck
       run: |
         cd yb-voyager
-        go install honnef.co/go/tools/cmd/staticcheck@latest
+        go install honnef.co/go/tools/cmd/staticcheck@2023.1.7
         staticcheck ./...


### PR DESCRIPTION
Go `Run staticcheck` is failing with latest `go/tools/cmd/staticcheck` package with an error - 
```
go: honnef.co/go/tools/cmd/staticcheck@latest (in honnef.co/go/tools@v0.5.0): go.mod:3: invalid go version '1.22.1': must match format 1.23
```
which seems to be not working with current go version we use, so restricting the static check package to use the last release before the latest i.e. [2023.1.7](https://github.com/dominikh/go-tools/releases/tag/2023.1.7)

