### PR TITLE
Bug Fix[DB-12388]: Bulk Assessment command continues even after child process (assess-migration) is interrupted

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -115,8 +114,9 @@ func assessMigrationBulk() {
 
 		if ProcessShutdownRequested {
 			log.Info("Shutting down as SIGINT/SIGTERM received...")
-			log.Infof("sleep for 10 seconds for exit handlers to execute")
-			time.Sleep(time.Second * 10)
+			// log.Infof("sleep for 10 seconds for exit handlers to execute")
+			// time.Sleep(time.Second * 10)
+			fmt.Print("returning.....\n")
 			return
 		}
 	}

--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -113,10 +113,7 @@ func assessMigrationBulk() {
 		}
 
 		if ProcessShutdownRequested {
-			log.Info("Shutting down as SIGINT/SIGTERM received...")
-			// log.Infof("sleep for 10 seconds for exit handlers to execute")
-			// time.Sleep(time.Second * 10)
-			fmt.Print("returning.....\n")
+			log.Info("Exiting from assess-migration-bulk. Further assessments will not be executed due to a shutdown request.")
 			return
 		}
 	}

--- a/yb-voyager/main.go
+++ b/yb-voyager/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -40,6 +41,10 @@ func main() {
 	atexit.Register(restoreTerminalState) // ensure terminal is always restored
 	cmd.Execute()
 	cmd.PrintElapsedDuration()
+	if cmd.ProcessShutdownRequested {
+		utils.PrintAndLog("waiting for exit handlers to complete the cleanup")
+		time.Sleep(time.Second * 120) // using here larger value than what we have for debezium(100sec)
+	}
 }
 
 func registerSignalHandlers() {
@@ -60,7 +65,7 @@ func registerSignalHandlers() {
 		}
 		// Ensure we restore the terminal even if everything goes well
 		restoreTerminalState()
-		atexit.Exit(0)
+		atexit.Exit(1)
 	}()
 }
 


### PR DESCRIPTION
-  added sleep of 120sec in main() in case of ProcessShutdownRequested to handle the race condition
- changed exit code from 0 -> 1 in at.Exit(1), so that if there is a script or parent process calling a voyager cmd, then in case of SIGINT/SIGTERM it should error out.