### PR TITLE
[DB-12491] Add validation and enhancements to assess-migration-bulk command

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -185,7 +185,7 @@ func buildCommandArguments(dbConfig AssessMigrationDBConfig, exportDirPath strin
 		args = append(args, "--source-db-name", dbConfig.DbName)
 	} else {
 		// special handling due to issue https://yugabyte.atlassian.net/browse/DB-12481
-		args = append(args, "--source-db-name", `""`)
+		args = append(args, "--source-db-name", "")
 	}
 	if dbConfig.TnsAlias != "" {
 		args = append(args, "--oracle-tns-alias", dbConfig.TnsAlias)

--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -186,7 +185,7 @@ func buildCommandArguments(dbConfig AssessMigrationDBConfig, exportDirPath strin
 		args = append(args, "--source-db-name", dbConfig.DbName)
 	} else {
 		// special handling due to issue https://yugabyte.atlassian.net/browse/DB-12481
-		args = append(args, `--source-db-name ""`)
+		args = append(args, "--source-db-name", `""`)
 	}
 	if dbConfig.TnsAlias != "" {
 		args = append(args, "--oracle-tns-alias", dbConfig.TnsAlias)
@@ -204,7 +203,11 @@ func buildCommandArguments(dbConfig AssessMigrationDBConfig, exportDirPath strin
 	// Always safe to use --start-clean to cleanup if there is some state from previous runs in export-dir
 	// since bulk command has separate check to decide beforehand whether the report exists or assessment needs to be performed.
 	args = append(args, "--start-clean", "true")
-	args = append(args, "--yes", lo.Ternary(utils.DoNotPrompt, "true", "false"))
+
+	if utils.DoNotPrompt {
+		args = append(args, "--yes")
+	}
+
 	return args
 }
 

--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -273,6 +273,11 @@ func createDBConfigFromRecord(record []string, header []string) (*AssessMigratio
 		return nil, fmt.Errorf("mandatory fields missing in the record: '%s'", strings.Join(missingFields, "', '"))
 	}
 
+	// Check if the source-db-type is supported (only 'oracle' allowed)
+	if dbType, ok := configMap[SOURCE_DB_TYPE]; ok && strings.ToLower(dbType) != ORACLE {
+		return nil, fmt.Errorf("unsupported/invalid source-db-type: '%s'. Only '%s' is supported", dbType, ORACLE)
+	}
+
 	return &AssessMigrationDBConfig{
 		DbType:   configMap[SOURCE_DB_TYPE],
 		Host:     configMap[SOURCE_DB_HOST],

--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -65,6 +65,11 @@ Mandatory: 'source-db-type', 'source-db-user', 'source-db-schema', and one of ['
 Guidelines:
 	- The first line must be a header row.
 	- Ensure mandatory fields are included and correctly spelled.
+
+Sample fleet_config_file:
+	source-db-type,source-db-host,source-db-port,source-db-name,oracle-db-sid,oracle-tns-alias,source-db-user,source-db-password,source-db-schema
+	oracle,localhost,1521,orclpdb,,,user1,password1,schema1
+	oracle,localhost,1521,,orclsid,,user2,password2,schema2
 `
 
 	// defining flags

--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -201,7 +201,7 @@ func buildCommandArguments(dbConfig AssessMigrationDBConfig, exportDirPath strin
 	}
 
 	// Always safe to use --start-clean and --yes to cleanup if there is some state from previous runs in export-dir
-	// since bulk command has separate check to decide beforehand whether the existing report or need to be executed
+	// since bulk command has separate check to decide beforehand whether the report exists or assessment needs to be performed.
 	args = append(args, "--start-clean", "true",
 		"--yes", "true")
 	return args

--- a/yb-voyager/cmd/assessMigrationCommandBulk.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk.go
@@ -57,6 +57,7 @@ var assessMigrationBulkCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(assessMigrationBulkCmd)
+	registerCommonGlobalFlags(assessMigrationBulkCmd)
 
 	const fleetConfigFileHelp = `
 Path to the CSV file with connection parameters for schema(s) to be assessed.

--- a/yb-voyager/cmd/assessMigrationCommandBulk_test.go
+++ b/yb-voyager/cmd/assessMigrationCommandBulk_test.go
@@ -39,9 +39,11 @@ Unit tests
     1. Invalid length header [length more than the total] or less than the minimum
     2. Missing each of the mandatory args from [source-db-type, source-db-user, source-db-schema, one of [source-db-name, oracle-db-sid, oracle-tns-alias]]
     3. No line after header
+	4. Invalid source db type
 3. Multi line config [generate below case, differently for each line]
     1. Invalid length header [length more than the total] or less than the minimum
     2. Missing each of the mandatory args from [source-db-type, source-db-user, source-db-schema, one of [source-db-name, oracle-db-sid, oracle-tns-alias]]
+	3. Invalid source db type
 4. Passing tests
     1. Minimum header
     2. Single line entry after header
@@ -176,6 +178,12 @@ oracle,,,dms`,
 oracle,,,`,
 			expectedErrSuffix: "failed to create config for line 2 in fleet config file: mandatory fields missing in the record: 'source-db-user', 'source-db-schema', 'one of [source-db-name, oracle-db-sid, oracle-tns-alias]'",
 		},
+		{
+			name: "Invalid source-db-type in Single Record",
+			fileContent: `source-db-type,source-db-user,source-db-schema,source-db-name
+mysql,user1,schema1,db1`,
+			expectedErrSuffix: "failed to create config for line 2 in fleet config file: unsupported/invalid source-db-type: 'mysql'. Only 'oracle' is supported",
+		},
 		// Multiple line Record Tests
 		{
 			name: "Multi-Line Config - Missing Mandatory Field on Third Line",
@@ -192,6 +200,14 @@ oracle,user1,schema1,db1
 oracle,user2,schema2,db2
 oracle,user3,schema3,`,
 			expectedErrSuffix: "failed to create config for line 4 in fleet config file: mandatory fields missing in the record: 'one of [source-db-name, oracle-db-sid, oracle-tns-alias]'",
+		},
+		{
+			name: "Multi-Line Config - Invalid source-db-type on Third Line",
+			fileContent: `source-db-type,source-db-user,source-db-schema,source-db-name
+oracle,user1,schema1,db1
+postgresql,user2,schema2,db2
+oracle,user3,schema3,db3`,
+			expectedErrSuffix: "failed to create config for line 3 in fleet config file: unsupported/invalid source-db-type: 'postgresql'. Only 'oracle' is supported",
 		},
 	}
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1095,6 +1095,8 @@ func (dbConfig *AssessMigrationDBConfig) GetJsonAssessmentReportPath() string {
 	return filepath.Join(exportDir, "assessment", "reports", "assessmentReport.json")
 }
 
+// path to the assessment report without extension(like .json or .html).
+// example: bulkAssessmentDir/assessment/reports/assessmentReport
 func (dbConfig *AssessMigrationDBConfig) GetAssessmentReportBasePath() string {
 	exportDir := dbConfig.GetAssessmentExportDirPath()
 	return filepath.Join(exportDir, "assessment", "reports", "assessmentReport")

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1085,9 +1085,19 @@ func (dbConfig *AssessMigrationDBConfig) GetAssessmentExportDirPath() string {
 	return fmt.Sprintf("%s/%s-%s-export-dir", bulkAssessmentDir, dbConfig.GetDatabaseIdentifier(), dbConfig.Schema)
 }
 
-func (dbConfig *AssessMigrationDBConfig) GetAssessmentReportPath() string {
+func (dbConfig *AssessMigrationDBConfig) GetHtmlAssessmentReportPath() string {
 	exportDir := dbConfig.GetAssessmentExportDirPath()
 	return filepath.Join(exportDir, "assessment", "reports", "assessmentReport.html")
+}
+
+func (dbConfig *AssessMigrationDBConfig) GetJsonAssessmentReportPath() string {
+	exportDir := dbConfig.GetAssessmentExportDirPath()
+	return filepath.Join(exportDir, "assessment", "reports", "assessmentReport.json")
+}
+
+func (dbConfig *AssessMigrationDBConfig) GetAssessmentReportBasePath() string {
+	exportDir := dbConfig.GetAssessmentExportDirPath()
+	return filepath.Join(exportDir, "assessment", "reports", "assessmentReport")
 }
 
 func (dbConfig *AssessMigrationDBConfig) GetAssessmentLogFilePath() string {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -337,7 +337,6 @@ func validateOracleParams() {
 	}
 
 }
-
 func getAndStoreSourceDBPasswordInSourceConf(cmd *cobra.Command) {
 	var err error
 	source.Password, err = getPassword(cmd, "source-db-password", "SOURCE_DB_PASSWORD")

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -599,3 +599,16 @@ func SafeDereferenceInt64(ptr *int64) int64 {
 	}
 	return 0
 }
+
+func ChangeFileExtension(filePath string, newExt string) string {
+	ext := filepath.Ext(filePath)
+	if ext != "" {
+		filePath = strings.TrimSuffix(filePath, ext)
+	}
+
+	if !strings.HasPrefix(newExt, ".") {
+		newExt = "." + newExt
+	}
+
+	return filePath + newExt
+}


### PR DESCRIPTION
- Implemented checks for both JSON and HTML reports to decide whether the assessment for that schema is done or not.
- Added a sample fleet configuration file in the help message for better user guidance.
- Introduced global flags `--yes` and `--send-diagnostics` to the bulk assessment command for consistent flag usage across commands.
- Added validation for `source-db-type` in the fleet configuration file, restricting it to 'oracle' only.
- Included unit tests to verify proper validation of `source-db-type` in both single and multi-line config file.