### PR TITLE
Fix: changing SCHEMA_CHANGES_HIGH_THRESHOLD to maxInt32 instead of infinity 

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -975,7 +975,7 @@ var (
 	UNSUPPORTED_DATATYPE_XID_ISSUE  = fmt.Sprintf("%s - xid", UNSUPPORTED_DATATYPE)
 	APP_CHANGES_HIGH_THRESHOLD      = 5
 	APP_CHANGES_MEDIUM_THRESHOLD    = 1
-	SCHEMA_CHANGES_HIGH_THRESHOLD   = int(math.Inf(1))
+	SCHEMA_CHANGES_HIGH_THRESHOLD   = 1000 // not adding infinity as converting is getting overflow negative number
 	SCHEMA_CHANGES_MEDIUM_THRESHOLD = 20
 )
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -975,7 +975,7 @@ var (
 	UNSUPPORTED_DATATYPE_XID_ISSUE  = fmt.Sprintf("%s - xid", UNSUPPORTED_DATATYPE)
 	APP_CHANGES_HIGH_THRESHOLD      = 5
 	APP_CHANGES_MEDIUM_THRESHOLD    = 1
-	SCHEMA_CHANGES_HIGH_THRESHOLD   = 1000 // not adding infinity as converting is getting overflow negative number
+	SCHEMA_CHANGES_HIGH_THRESHOLD   = math.MaxInt32
 	SCHEMA_CHANGES_MEDIUM_THRESHOLD = 20
 )
 


### PR DESCRIPTION
Changing this threshold to `math.MaxInt32` as infinity to int conversion is getting overflowed to some negative number and even for 2 schema changes, it was giving HIGH  migration complexity.