### PR TITLE
Bug fix[DB-12536]: With bulk assessment cmd, if dbname and tns_alias both are provided then export-dir is getting created with dbname but actual assessment is done using tns_alias

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1065,12 +1065,12 @@ type AssessMigrationDBConfig struct {
 
 func (dbConfig *AssessMigrationDBConfig) GetDatabaseIdentifier() string {
 	switch {
-	case dbConfig.SID != "":
-		return dbConfig.SID
-	case dbConfig.DbName != "":
-		return dbConfig.DbName
 	case dbConfig.TnsAlias != "":
 		return dbConfig.TnsAlias
+	case dbConfig.DbName != "":
+		return dbConfig.DbName
+	case dbConfig.SID != "":
+		return dbConfig.SID
 	default:
 		return ""
 	}


### PR DESCRIPTION
- using the same priority order of export/assess cmds: tns-alias > dbname > dbsid