### PR TITLE
[DB-11620] Enhance Control Plane with SourceDB, TargetDB, and Voyager client info for yugabyted-ui

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -273,9 +273,6 @@ func assessMigration() (err error) {
 		return fmt.Errorf("failed to get migration UUID: %w", err)
 	}
 
-	startEvent := createMigrationAssessmentStartedEvent()
-	controlPlane.MigrationAssessmentStarted(startEvent)
-
 	assessmentDir := filepath.Join(exportDir, "assessment")
 	migassessment.AssessmentDir = assessmentDir
 	migassessment.SourceDBType = source.DBType
@@ -301,6 +298,9 @@ func assessMigration() (err error) {
 
 		source.DB().Disconnect()
 	}
+
+	startEvent := createMigrationAssessmentStartedEvent()
+	controlPlane.MigrationAssessmentStarted(startEvent)
 
 	initAssessmentDB() // Note: migassessment.AssessmentDir needs to be set beforehand
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -31,6 +31,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/color"
 	_ "github.com/godror/godror"
 	"github.com/google/uuid"
@@ -808,7 +809,11 @@ func initBaseSourceEvent(bev *cp.BaseEvent, eventType string) {
 		DBType:        source.DBType,
 		DatabaseName:  source.DBName,
 		SchemaNames:   cp.GetSchemaList(source.Schema),
+		HostIP:        utils.LookupIP(source.Host),
+		Port:          source.Port,
+		DBVersion:     source.DBVersion,
 	}
+	utils.PrintAndLog("[debug]base event: %s\n", spew.Sdump(bev))
 }
 
 func initBaseTargetEvent(bev *cp.BaseEvent, eventType string) {
@@ -818,6 +823,9 @@ func initBaseTargetEvent(bev *cp.BaseEvent, eventType string) {
 		DBType:        tconf.TargetDBType,
 		DatabaseName:  tconf.DBName,
 		SchemaNames:   []string{tconf.Schema},
+		HostIP:        utils.LookupIP(tconf.Host),
+		Port:          tconf.Port,
+		DBVersion:     tconf.DBVersion,
 	}
 }
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -808,9 +808,9 @@ func initBaseSourceEvent(bev *cp.BaseEvent, eventType string) {
 		DBType:        source.DBType,
 		DatabaseName:  source.DBName,
 		SchemaNames:   cp.GetSchemaList(source.Schema),
-		HostIP:        utils.LookupIP(source.Host),
+		DBIP:          utils.LookupIP(source.Host),
 		Port:          source.Port,
-		DbVersion:     source.DBVersion,
+		DBVersion:     source.DBVersion,
 	}
 }
 
@@ -821,9 +821,9 @@ func initBaseTargetEvent(bev *cp.BaseEvent, eventType string) {
 		DBType:        tconf.TargetDBType,
 		DatabaseName:  tconf.DBName,
 		SchemaNames:   []string{tconf.Schema},
-		HostIP:        utils.LookupIP(tconf.Host),
+		DBIP:          utils.LookupIP(tconf.Host),
 		Port:          tconf.Port,
-		DbVersion:     tconf.DBVersion,
+		DBVersion:     tconf.DBVersion,
 	}
 }
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -31,7 +31,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/color"
 	_ "github.com/godror/godror"
 	"github.com/google/uuid"
@@ -813,7 +812,6 @@ func initBaseSourceEvent(bev *cp.BaseEvent, eventType string) {
 		Port:          source.Port,
 		DbVersion:     source.DBVersion,
 	}
-	utils.PrintAndLog("[debug]base event: %s\n", spew.Sdump(bev))
 }
 
 func initBaseTargetEvent(bev *cp.BaseEvent, eventType string) {

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -811,7 +811,7 @@ func initBaseSourceEvent(bev *cp.BaseEvent, eventType string) {
 		SchemaNames:   cp.GetSchemaList(source.Schema),
 		HostIP:        utils.LookupIP(source.Host),
 		Port:          source.Port,
-		DBVersion:     source.DBVersion,
+		DbVersion:     source.DBVersion,
 	}
 	utils.PrintAndLog("[debug]base event: %s\n", spew.Sdump(bev))
 }
@@ -825,7 +825,7 @@ func initBaseTargetEvent(bev *cp.BaseEvent, eventType string) {
 		SchemaNames:   []string{tconf.Schema},
 		HostIP:        utils.LookupIP(tconf.Host),
 		Port:          tconf.Port,
-		DBVersion:     tconf.DBVersion,
+		DbVersion:     tconf.DBVersion,
 	}
 }
 

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -101,7 +101,8 @@ const (
 	UNSUPPORTED_FEATURES  = "unsupported_features"
 	UNSUPPORTED_DATATYPES = "unsupported_datatypes"
 
-	TABLE = "TABLE"
+	TABLE     = "TABLE"
+	YUGABYTED = "yugabyted"
 
 	// assess-migration-bulk
 	SOURCE_DB_TYPE     = "source-db-type"

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -431,7 +431,6 @@ func importData(importFileTasks []*ImportFileTask) {
 	utils.PrintAndLog("Using %d parallel jobs.", tconf.Parallelism)
 
 	targetDBVersion := tdb.GetVersion()
-
 	fmt.Printf("%s version: %s\n", tconf.TargetDBType, targetDBVersion)
 
 	err = tdb.CreateVoyagerSchema()
@@ -1246,18 +1245,14 @@ func createSnapshotImportStartedEvent() cp.SnapshotImportStartedEvent {
 }
 
 func createSnapshotImportCompletedEvent() cp.SnapshotImportCompletedEvent {
-
 	result := cp.SnapshotImportCompletedEvent{}
 	initBaseTargetEvent(&result.BaseEvent, "IMPORT DATA")
 	return result
 }
 
 func createInitialImportDataTableMetrics(tasks []*ImportFileTask) []*cp.UpdateImportedRowCountEvent {
-
 	result := []*cp.UpdateImportedRowCountEvent{}
-
 	for _, task := range tasks {
-
 		var schemaName, tableName string
 		schemaName, tableName = cp.SplitTableNameForPG(task.TableNameTup.ForKey())
 		tableMetrics := cp.UpdateImportedRowCountEvent{

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -85,7 +85,7 @@ func importSchema() error {
 	}
 	tconf.Schema = strings.ToLower(tconf.Schema)
 
-	if callhome.SendDiagnostics {
+	if callhome.SendDiagnostics || getControlPlaneType() == YUGABYTED {
 		tdb = tgtdb.NewTargetDB(&tconf)
 		err := tdb.Init()
 		if err != nil {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -81,7 +81,8 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			if perfProfile {
 				go startPprofServer()
 			}
-			setControlPlane()
+			// no info/payload is collected/supported for assess-migration-bulk
+			setControlPlane("")
 		} else {
 			validateExportDirFlag()
 			schemaDir = filepath.Join(exportDir, "schema")
@@ -105,7 +106,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			if perfProfile {
 				go startPprofServer()
 			}
-			setControlPlane()
+			setControlPlane(getControlPlaneType())
 		}
 	},
 
@@ -299,8 +300,7 @@ func metaDBIsCreated(exportDir string) bool {
 	return utils.FileOrFolderExists(filepath.Join(exportDir, "metainfo", "meta.db"))
 }
 
-func setControlPlane() {
-	cpType := getControlPlaneType()
+func setControlPlane(cpType string) {
 	switch cpType {
 	case "":
 		log.Infof("'CONTROL_PLANE_TYPE' environment variable not set. Setting cp to NoopControlPlane.")

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -300,13 +300,12 @@ func metaDBIsCreated(exportDir string) bool {
 }
 
 func setControlPlane() {
-	cpType := os.Getenv("CONTROL_PLANE_TYPE")
-
+	cpType := getControlPlaneType()
 	switch cpType {
 	case "":
 		log.Infof("'CONTROL_PLANE_TYPE' environment variable not set. Setting cp to NoopControlPlane.")
 		controlPlane = noopcp.New()
-	case "yugabyted":
+	case YUGABYTED:
 		ybdConnString := os.Getenv("YUGABYTED_DB_CONN_STRING")
 		if ybdConnString == "" {
 			utils.ErrExit("'YUGABYTED_DB_CONN_STRING' environment variable needs to be set if 'CONTROL_PLANE_TYPE' is 'yugabyted'.")
@@ -318,4 +317,8 @@ func setControlPlane() {
 			utils.ErrExit("ERROR: Failed to initialize the target DB for visualization. %s", err)
 		}
 	}
+}
+
+func getControlPlaneType() string {
+	return os.Getenv("CONTROL_PLANE_TYPE")
 }

--- a/yb-voyager/src/cp/control_plane.go
+++ b/yb-voyager/src/cp/control_plane.go
@@ -16,7 +16,9 @@ limitations under the License.
 package cp
 
 import (
+	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/google/uuid"
 
@@ -66,12 +68,24 @@ func SplitTableNameForPG(tableName string) (string, string) {
 	return splitTableName[0], splitTableName[1]
 }
 
+func GetAvailableDiskSpace(exportDir string) (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(exportDir, &stat); err != nil {
+		return 0, fmt.Errorf("error getting disk space for directory %s: %w", exportDir, err)
+	}
+	// Available blocks * size per block to get available space in bytes
+	return stat.Bavail * uint64(stat.Bsize), nil
+}
+
 type BaseEvent struct {
 	EventType     string
 	MigrationUUID uuid.UUID
 	DBType        string
 	DatabaseName  string
 	SchemaNames   []string
+	HostIP        []string
+	Port          int
+	DBVersion     string
 }
 
 type BaseUpdateRowCountEvent struct {

--- a/yb-voyager/src/cp/control_plane.go
+++ b/yb-voyager/src/cp/control_plane.go
@@ -16,9 +16,7 @@ limitations under the License.
 package cp
 
 import (
-	"fmt"
 	"strings"
-	"syscall"
 
 	"github.com/google/uuid"
 
@@ -66,15 +64,6 @@ func GetSchemaList(schema string) []string {
 func SplitTableNameForPG(tableName string) (string, string) {
 	splitTableName := strings.Split(tableName, ".")
 	return splitTableName[0], splitTableName[1]
-}
-
-func GetAvailableDiskSpace(exportDir string) (uint64, error) {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(exportDir, &stat); err != nil {
-		return 0, fmt.Errorf("error getting disk space for directory %s: %w", exportDir, err)
-	}
-	// Available blocks * size per block to get available space in bytes
-	return stat.Bavail * uint64(stat.Bsize), nil
 }
 
 type BaseEvent struct {

--- a/yb-voyager/src/cp/control_plane.go
+++ b/yb-voyager/src/cp/control_plane.go
@@ -85,7 +85,7 @@ type BaseEvent struct {
 	SchemaNames   []string
 	HostIP        []string
 	Port          int
-	DBVersion     string
+	DbVersion     string
 }
 
 type BaseUpdateRowCountEvent struct {

--- a/yb-voyager/src/cp/control_plane.go
+++ b/yb-voyager/src/cp/control_plane.go
@@ -72,9 +72,9 @@ type BaseEvent struct {
 	DBType        string
 	DatabaseName  string
 	SchemaNames   []string
-	HostIP        []string
+	DBIP          []string
 	Port          int
-	DbVersion     string
+	DBVersion     string
 }
 
 type BaseUpdateRowCountEvent struct {
@@ -83,6 +83,13 @@ type BaseUpdateRowCountEvent struct {
 	Status            string
 	TotalRowCount     int64
 	CompletedRowCount int64
+}
+
+type VoyagerInstance struct {
+	IP                 string
+	OperatingSystem    string
+	DiskSpaceAvailable uint64 // Available disk space in bytes
+	ExportDirectory    string
 }
 
 type ExportSchemaStartedEvent struct {

--- a/yb-voyager/src/cp/yugabyted/yugabyted.go
+++ b/yb-voyager/src/cp/yugabyted/yugabyted.go
@@ -88,10 +88,10 @@ func prepareVoyagerInstance(exportDir string) *VoyagerInstance {
 }
 
 // getAvailableDiskSpace returns the available disk space in bytes in the specified directory.
-func getAvailableDiskSpace(exportDir string) (uint64, error) {
+func getAvailableDiskSpace(dirPath string) (uint64, error) {
 	var stat syscall.Statfs_t
-	if err := syscall.Statfs(exportDir, &stat); err != nil {
-		return 0, fmt.Errorf("error getting disk space for directory %s: %w", exportDir, err)
+	if err := syscall.Statfs(dirPath, &stat); err != nil {
+		return 0, fmt.Errorf("error getting disk space for directory %q: %w", dirPath, err)
 	}
 	// Available blocks * size per block to get available space in bytes
 	return stat.Bavail * uint64(stat.Bsize), nil

--- a/yb-voyager/src/cp/yugabyted/yugabyted.go
+++ b/yb-voyager/src/cp/yugabyted/yugabyted.go
@@ -67,15 +67,13 @@ func prepareVoyagerInstance(exportDir string) *VoyagerInstance {
 	ip, err := utils.GetLocalIP()
 	log.Infof("voyager machine ip: %s\n", ip)
 	if err != nil {
-		// TODO: exit in case of error or just log-and-continue
-		log.Fatalf("failed to obtain local IP address: %v", err)
+		log.Warnf("failed to obtain local IP address: %v", err)
 	}
 
 	diskSpace, err := getAvailableDiskSpace(exportDir)
 	log.Infof("voyager disk space available: %d\n", diskSpace)
 	if err != nil {
-		// TODO: exit in case of error or just log-and-continue
-		log.Fatalf("failed to determine available disk space: %v", err)
+		log.Warnf("failed to determine available disk space: %v", err)
 	}
 
 	return &VoyagerInstance{

--- a/yb-voyager/src/cp/yugabyted/yugabytedPayload.go
+++ b/yb-voyager/src/cp/yugabyted/yugabytedPayload.go
@@ -24,6 +24,9 @@ type MigrationEvent struct {
 	MigrationDirectory  string    `json:"migration_dir"`
 	DatabaseName        string    `json:"database_name"`
 	SchemaName          string    `json:"schema_name"`
+	HostIP              string    `json:"host_ip"`
+	Port                int       `json:"port"`
+	DbVersion           string    `json:"db_version"`
 	Payload             string    `json:"payload"`
 	DBType              string    `json:"db_type"`
 	Status              string    `json:"status"`

--- a/yb-voyager/src/cp/yugabyted/yugabytedPayload.go
+++ b/yb-voyager/src/cp/yugabyted/yugabytedPayload.go
@@ -24,9 +24,9 @@ type MigrationEvent struct {
 	MigrationDirectory  string    `json:"migration_dir"`
 	DatabaseName        string    `json:"database_name"`
 	SchemaName          string    `json:"schema_name"`
-	HostIP              string    `json:"host_ip"`
+	DBIP                string    `json:"db_ip"`
 	Port                int       `json:"port"`
-	DbVersion           string    `json:"db_version"`
+	DBVersion           string    `json:"db_version"`
 	Payload             string    `json:"payload"`
 	VoyagerInfo         string    `json:"voyager_info"`
 	DBType              string    `json:"db_type"`
@@ -41,4 +41,12 @@ var MIGRATION_PHASE_MAP = map[string]int{
 	"EXPORT DATA":      4,
 	"IMPORT SCHEMA":    5,
 	"IMPORT DATA":      6,
+}
+
+func isExportPhase(eventType string) bool {
+	return MIGRATION_PHASE_MAP[eventType] <= 4
+}
+
+func isImportPhase(eventType string) bool {
+	return MIGRATION_PHASE_MAP[eventType] > 4
 }

--- a/yb-voyager/src/cp/yugabyted/yugabytedPayload.go
+++ b/yb-voyager/src/cp/yugabyted/yugabytedPayload.go
@@ -28,6 +28,7 @@ type MigrationEvent struct {
 	Port                int       `json:"port"`
 	DbVersion           string    `json:"db_version"`
 	Payload             string    `json:"payload"`
+	VoyagerInfo         string    `json:"voyager_info"`
 	DBType              string    `json:"db_type"`
 	Status              string    `json:"status"`
 	InvocationTimestamp string    `json:"invocation_timestamp"`

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -106,6 +106,10 @@ func (ms *MySQL) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {
 }
 
 func (ms *MySQL) GetVersion() string {
+	if ms.source.DBVersion != "" {
+		return ms.source.DBVersion
+	}
+
 	var version string
 	query := "SELECT VERSION()"
 	err := ms.db.QueryRow(query).Scan(&version)

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -113,6 +113,10 @@ func (ora *Oracle) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {
 }
 
 func (ora *Oracle) GetVersion() string {
+	if ora.source.DBVersion != "" {
+		return ora.source.DBVersion
+	}
+
 	var version string
 	query := "SELECT BANNER FROM V$VERSION"
 	// query sample output: Oracle Database 19c Enterprise Edition Release 19.0.0.0.0 - Production

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -135,6 +135,10 @@ func (pg *PostgreSQL) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 
 }
 
 func (pg *PostgreSQL) GetVersion() string {
+	if pg.source.DBVersion != "" {
+		return pg.source.DBVersion
+	}
+
 	var version string
 	query := "SELECT setting from pg_settings where name = 'server_version'"
 	err := pg.db.QueryRow(query).Scan(&version)

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -99,6 +99,10 @@ func (yb *YugabyteDB) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 
 }
 
 func (yb *YugabyteDB) GetVersion() string {
+	if yb.source.DBVersion != "" {
+		return yb.source.DBVersion
+	}
+
 	var version string
 	query := "SELECT setting from pg_settings where name = 'server_version'"
 	err := yb.db.QueryRow(query).Scan(&version)

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -38,7 +38,6 @@ import (
 )
 
 var DoNotPrompt bool
-var localIP string
 
 func Wait(args ...string) {
 	var successMsg, failureMsg string


### PR DESCRIPTION
- BaseEvent Struct: Now includes essential hostIP and database details for both source and target
- Voyager Client Details: New fields capture local IP, OS details, and available disk space


For source(export) cmds - source_db_details + voyager_info
For target(import) cmds - target_db_details + voyager_info
voyager_info will come with every event.
Currently for yugabytedb, we will only get the node ip provided by user, we can later extend it to send all nodes of the cluster
OS info will be like linux darwin windows , it won't be send info like linux distribution(ubuntu, centos etc).. let me know if that is required