### PR TITLE
Miscellaneous changes in the air gapped installation script

### DIFF
--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -186,8 +186,6 @@ check_cpan_dependencies() {
 }
 
 check_binutils_version() {
-    echo ""
-	output "Checking binutils version."
 	min_required_version='2.25'
 
 	# Example output of "ld -v" on CentOS/RHEL:
@@ -209,6 +207,9 @@ check_binutils_version() {
 		echo -e "\e[31mERROR: unsupported binutils version ${version}. Update to binutils version > ${min_required_version}.\e[0m"
 		binutils_wrong_version=1
 	fi
+
+    echo ""
+    output "Found sufficient binutils version = ${version}."
 }
 
 # https://stackoverflow.com/a/4025065

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -352,7 +352,16 @@ centos_main() {
         fi
     else
         echo ""
-        echo -e "\e[33mForce install option is passed. Skipping dependency checks and proceeding with installation.\e[0m"
+        echo -e "\e[33mForce install option is passed. Skipping dependency checks.\e[0m"
+    fi
+
+    # Prompt the user for permission to install the packages
+    read -p "Do you want to proceed with the installation of packages (ora2pg, debezium, yb-voyager)? (y/n): " choice
+
+    if [[ "$choice" != "y" && "$choice" != "Y" ]]; then
+        echo ""
+        echo "Installation cancelled."
+        exit 0
     fi
 
     echo ""
@@ -462,11 +471,11 @@ ubuntu_main() {
         fi
     else 
         echo ""
-        echo -e "\e[33mForce install option is passed. Skipping dependency checks and proceeding with installation.\e[0m"
+        echo -e "\e[33mForce install option is passed. Skipping dependency checks.\e[0m"
     fi
 
     # Prompt the user for permission to install the packages
-    read -p "Do you want to install ora2pg? (y/n): " choice
+    read -p "Do you want to proceed with the installation of packages (ora2pg, debezium, yb-voyager)? (y/n): " choice
 
     if [[ "$choice" != "y" && "$choice" != "Y" ]]; then
         echo ""

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -356,13 +356,19 @@ centos_main() {
     fi
 
     # Prompt the user for permission to install the packages
-    read -p "Do you want to proceed with the installation of packages (ora2pg, debezium, yb-voyager)? (y/n): " choice
-
-    if [[ "$choice" != "y" && "$choice" != "Y" ]]; then
+    while true; do
         echo ""
-        echo "Installation cancelled."
-        exit 0
-    fi
+	    echo -n "Do you want to proceed with the installation of packages (ora2pg, debezium, yb-voyager)? (y/n):"
+	    read yn
+	    case $yn in
+		[Yy]* )
+			break;;
+		[Nn]* )
+			echo "Installation cancelled."
+            exit 0;;
+		* ) ;;
+	    esac
+	done
 
     echo ""
     echo "Installing ora2pg..."
@@ -475,13 +481,19 @@ ubuntu_main() {
     fi
 
     # Prompt the user for permission to install the packages
-    read -p "Do you want to proceed with the installation of packages (ora2pg, debezium, yb-voyager)? (y/n): " choice
-
-    if [[ "$choice" != "y" && "$choice" != "Y" ]]; then
+    while true; do
         echo ""
-        echo "Installation cancelled."
-        exit 0
-    fi
+	    echo -n "Do you want to proceed with the installation of packages (ora2pg, debezium, yb-voyager)? (y/n):"
+	    read yn
+	    case $yn in
+		[Yy]* )
+			break;;
+		[Nn]* )
+			echo "Installation cancelled."
+            exit 0;;
+		* ) ;;
+	    esac
+	done
 
     echo ""
     echo "Installing ora2pg..."

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -403,6 +403,7 @@ centos_main() {
         echo ""
         echo -e "\e[33mCPAN modules:\e[0m"
         print_dependencies "${cpan_modules_requirements[@]}"
+        print_steps_to_install_oic_on_centos
         exit 0
     fi
 
@@ -479,6 +480,28 @@ centos_main() {
     set +x 
 }
 
+print_steps_to_install_oic_on_centos() {
+    echo ""
+    echo -e "\e[33mOracle Instant Client installation help for Centos/RHEL:\e[0m"
+    echo ""
+    echo "You can download the oracle instant client rpms from the following links:"
+    echo ""
+    echo -e "\e[33moracle-instantclient-tools:\e[0m"
+    echo "https://download.oracle.com/otn_software/linux/instantclient/215000/oracle-instantclient-tools-21.5.0.0.0-1.x86_64.rpm"
+    echo ""
+    echo -e "\e[33moracle-instantclient-basic:\e[0m"
+    echo "https://download.oracle.com/otn_software/linux/instantclient/215000/oracle-instantclient-basic-21.5.0.0.0-1.x86_64.rpm"
+    echo ""
+    echo -e "\e[33moracle-instantclient-devel:\e[0m"
+    echo "https://download.oracle.com/otn_software/linux/instantclient/215000/oracle-instantclient-devel-21.5.0.0.0-1.x86_64.rpm"
+    echo ""
+    echo -e "\e[33moracle-instantclient-jdbc:\e[0m"
+    echo "https://download.oracle.com/otn_software/linux/instantclient/215000/oracle-instantclient-jdbc-21.5.0.0.0-1.x86_64.rpm"
+    echo ""
+    echo -e "\e[33moracle-instantclient-sqlplus:\e[0m"
+    echo "https://download.oracle.com/otn_software/linux/instantclient/215000/oracle-instantclient-sqlplus-21.5.0.0.0-1.x86_64.rpm"
+}
+
 check_yum_package_version() {
     local package=$1
     local version_type=$2
@@ -552,6 +575,7 @@ ubuntu_main() {
         echo ""
         echo -e "\e[33mCPAN modules:\e[0m"
         print_dependencies "${cpan_modules_requirements[@]}"
+        print_steps_to_install_oic_on_ubuntu
         exit 0
     fi
 
@@ -624,6 +648,28 @@ ubuntu_main() {
     echo "Installation completed."
 
     set +x
+}
+
+print_steps_to_install_oic_on_ubuntu() {
+    echo ""
+    echo -e "\e[33mOracle Instant Client installation help for Ubuntu:\e[0m"
+    echo ""
+    echo "You can download the oracle instant client debs from the following links:"
+    echo ""
+    echo -e "\e[33moracle-instantclient-tools:\e[0m"
+    echo "https://s3.us-west-2.amazonaws.com/downloads.yugabyte.com/repos/apt/pool/main/oracle-instantclient-tools_21.5.0.0.0-1_amd64.deb"
+    echo ""
+    echo -e "\e[33moracle-instantclient-basic:\e[0m"
+    echo "https://s3.us-west-2.amazonaws.com/downloads.yugabyte.com/repos/apt/pool/main/oracle-instantclient-basic_21.5.0.0.0-1_amd64.deb"
+    echo ""
+    echo -e "\e[33moracle-instantclient-devel:\e[0m"
+    echo "https://s3.us-west-2.amazonaws.com/downloads.yugabyte.com/repos/apt/pool/main/oracle-instantclient-devel_21.5.0.0.0-1_amd64.deb"
+    echo ""
+    echo -e "\e[33moracle-instantclient-jdbc:\e[0m"
+    echo "https://s3.us-west-2.amazonaws.com/downloads.yugabyte.com/repos/apt/pool/main/oracle-instantclient-jdbc_21.5.0.0.0-1_amd64.deb"
+    echo ""
+    echo -e "\e[33moracle-instantclient-sqlplus:\e[0m"
+    echo "https://s3.us-west-2.amazonaws.com/downloads.yugabyte.com/repos/apt/pool/main/oracle-instantclient-sqlplus_21.5.0.0.0-1_amd64.deb"
 }
 
 check_apt_dependencies() {

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -465,6 +465,15 @@ ubuntu_main() {
         echo -e "\e[33mForce install option is passed. Skipping dependency checks and proceeding with installation.\e[0m"
     fi
 
+    # Prompt the user for permission to install the packages
+    read -p "Do you want to install ora2pg? (y/n): " choice
+
+    if [[ "$choice" != "y" && "$choice" != "Y" ]]; then
+        echo ""
+        echo "Installation cancelled."
+        exit 0
+    fi
+
     echo ""
     echo "Installing ora2pg..."
     sudo apt install -y -q ./ora2pg*all.deb 1>&2

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -141,7 +141,18 @@ check_cpan_module() {
   local installed_version=$(perl -M"$module" -e 'print $'"$module"'::VERSION' 2>/dev/null)
 
   if [ -z "$installed_version" ]; then
-    missing_cpan_modules+=("$module is not installed.")
+    case "$version_type" in
+      min)
+        if [ "$required_version" != "0" ]; then
+          missing_cpan_modules+=("$module with minimum version $required_version is not installed.")
+        else
+          missing_cpan_modules+=("$module is not installed.")
+        fi
+        ;;
+      exact)
+        missing_cpan_modules+=("$module with exact version $required_version is not installed.")
+        ;;
+    esac
   else
     case "$version_type" in
       min)
@@ -410,7 +421,18 @@ check_yum_package_version() {
     local installed_version=$(yum list installed "$package" 2>/dev/null | awk '/^Installed Packages/ {getline; print $2}' | cut -d- -f1)
 
     if [ -z "$installed_version" ]; then
-        centos_missing_yum_packages+=("$package is not installed.")
+        case $version_type in
+            min)
+                if [ "$required_version" != "0" ]; then
+                    centos_missing_yum_packages+=("$package with minimum version $required_version is not installed.")
+                else 
+                    centos_missing_yum_packages+=("$package is not installed.")
+                fi
+                ;;
+            exact)
+                centos_missing_yum_packages+=("$package with exact version $required_version is not installed.")
+                ;;
+        esac 
     else
         case "$version_type" in
         min)
@@ -550,7 +572,18 @@ check_apt_package_version() {
     local installed_version=$(dpkg-query -f '${Version}' -W "$package" 2>/dev/null)
 
     if [ -z "$installed_version" ]; then
-        ubuntu_missing_apt_packages+=("$package is not installed.")
+        case "$version_type" in
+            min)
+                if [ "$required_version" != "0" ]; then
+                    ubuntu_missing_apt_packages+=("$package with minimum version $required_version is not installed.")
+                else 
+                    ubuntu_missing_apt_packages+=("$package is not installed.")
+                fi
+                ;;
+            exact)
+                ubuntu_missing_apt_packages+=("$package with exact version $required_version is not installed.")
+                ;;
+        esac
     else
         case "$version_type" in
         min)

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -197,6 +197,12 @@ check_binutils_version() {
 	# Example output of "ld -v" on Ubuntu:
 	# GNU ld (GNU Binutils for Ubuntu) 2.38
 	version=$(ld -v | awk '{print $NF}' | awk -F '-' '{print $1}')
+    if [ -z "$version" ]; then
+        echo ""
+        echo -e "\e[31mERROR: binutils not found. Please install binutils version > ${min_required_version}.\e[0m"
+        binutils_wrong_version=1
+        return
+    fi
 
 	version_ok=$(version_satisfied "$min_required_version" "$version")
 	if [[ $version_ok -eq 0 ]]

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -583,6 +583,12 @@ check_binutils_version() {
 	# Example output of "ld -v" on Ubuntu:
 	# GNU ld (GNU Binutils for Ubuntu) 2.38
 	version=$(ld -v | awk '{print $NF}' | awk -F '-' '{print $1}')
+	if [ -z "$version" ]; then
+        echo ""
+        echo -e "\e[31mERROR: binutils not found. Please install binutils version > ${min_required_version}.\e[0m"
+        binutils_wrong_version=1
+        return
+    fi
 
 	version_ok=$(version_satisfied "$min_required_version" "$version")
 	if [[ $version_ok -eq 0 ]]


### PR DESCRIPTION
- Added --help flag to list out all the dependencies required on the system and also list the links from which oracle instant clients can be downloaded
- Bug fixed: If binutils was not installed then the script displayed that the minimum required version for binutils was not found. Fixed it to display binutils not installed.
- If a package is not found installed then the version of the required package is also printed
- Added a prompt to ask for the user's consent before starting to install the packages.