### PR TITLE
Fix for import-data-to-source-replica clearing out yb table names in name registry

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -128,7 +128,9 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	}
 	targetDBDetails = tdb.GetCallhomeTargetDBInfo()
 
-	err = InitNameRegistry(exportDir, importerRole, nil, nil, &tconf, tdb, bool(startClean))
+	// we don't want to re-register in case import data to source/source-replica
+	reregisterYBNames := importerRole == TARGET_DB_IMPORTER_ROLE && bool(startClean)
+	err = InitNameRegistry(exportDir, importerRole, nil, nil, &tconf, tdb, reregisterYBNames)
 	if err != nil {
 		utils.ErrExit("initialize name registry: %v", err)
 	}


### PR DESCRIPTION
https://yugabyte.atlassian.net/browse/DB-12600

We introduce the ability to re-register YB table names in name registry to support start-clean. 
But this should only be performed for TARGET_DB_IMPORTER, not SOURCE_REPLICA_DB_IMPORTER or SOURCE_DB_IMPORTER.