### PR TITLE
Fix: changed ContainsAnySubstringFromSlice to ContainsAnyStringFromSlice for Unsupported datatypes handling

### DIFF
--- a/migtests/tests/pg/basic-non-public-live-test/snapshot_data.sql
+++ b/migtests/tests/pg/basic-non-public-live-test/snapshot_data.sql
@@ -12,3 +12,8 @@ INSERT INTO user_table (email) VALUES
     ('user6@example.com'),
     ('user7@example.com'),
     ('user8@example.com');
+
+INSERT INTO test_enum values(1, 'duplicate_payment_method');
+INSERT INTO test_enum values(2, 'server_failure');
+INSERT INTO test_enum values(3, 'server_failure');
+INSERT INTO test_enum values(4, 'duplicate_payment_method');

--- a/migtests/tests/pg/basic-non-public-live-test/snapshot_schema.sql
+++ b/migtests/tests/pg/basic-non-public-live-test/snapshot_schema.sql
@@ -8,3 +8,12 @@ CREATE TABLE user_table (
     status VARCHAR(50) DEFAULT 'active'
 );
 
+CREATE TYPE decline_reason AS ENUM (
+    'duplicate_payment_method',
+    'server_failure'
+);
+
+CREATE TABLE test_enum (
+    id int PRIMARY KEY,
+    reason decline_reason
+);

--- a/migtests/tests/pg/basic-non-public-live-test/source_delta.sql
+++ b/migtests/tests/pg/basic-non-public-live-test/source_delta.sql
@@ -28,3 +28,11 @@ UPDATE user_table SET email = 'user4@example.com' WHERE id = 6;
 
 -- events with NULL value for unique key columns
 UPDATE user_table SET status = 'inactive' where id > 0;
+
+--events for test_enum table 
+INSERT INTO test_enum values(5, 'duplicate_payment_method');
+INSERT INTO test_enum values(6, 'server_failure');
+
+UPDATE test_enum set reason = 'server_failure' where id = 4;
+
+DELETE from test_enum where id = 2;

--- a/migtests/tests/pg/basic-non-public-live-test/target_delta.sql
+++ b/migtests/tests/pg/basic-non-public-live-test/target_delta.sql
@@ -28,3 +28,11 @@ UPDATE user_table SET email = 'user4@example.com' WHERE id = 4;
 
 -- events with NULL value for unique key columns
 UPDATE user_table SET status = 'active' where id > 0;
+
+--events for test_enum table 
+INSERT INTO test_enum values(7, 'duplicate_payment_method');
+INSERT INTO test_enum values(8, 'server_failure');
+
+UPDATE test_enum set reason = 'server_failure' where id = 6;
+
+DELETE from test_enum where id = 5;

--- a/migtests/tests/pg/basic-non-public-live-test/validate
+++ b/migtests/tests/pg/basic-non-public-live-test/validate
@@ -36,7 +36,7 @@ EXPECTED_DATA_TYPES = {
 	},
 	'test_enum': {
 		'id': 'integer',
-		'reason': 'decline_reason'
+		'reason': 'USER-DEFINED'
 	}
 }
 

--- a/migtests/tests/pg/basic-non-public-live-test/validate
+++ b/migtests/tests/pg/basic-non-public-live-test/validate
@@ -20,7 +20,8 @@ def main():
 
 EXPECTED_ROW_COUNT = {
 	'x':3,
- 	'user_table': 8
+ 	'user_table': 8,
+	'test_enum':4
 }
 
 EXPECTED_DATA_TYPES = {
@@ -32,6 +33,10 @@ EXPECTED_DATA_TYPES = {
 		'id': 'integer',
 		'email': 'character varying',
 		'status': 'character varying'
+	},
+	'test_enum': {
+		'id': 'integer',
+		'reason': 'decline_reason'
 	}
 }
 
@@ -42,6 +47,9 @@ EXPECTED_SUM_OF_COLUMN = {
 	},
 	'user_table': {
 		'id': '36',
+	},
+	'test_enum':{
+		'id':'10'
 	}
 }
 

--- a/migtests/tests/pg/basic-non-public-live-test/validateAfterChanges
+++ b/migtests/tests/pg/basic-non-public-live-test/validateAfterChanges
@@ -22,7 +22,8 @@ def main():
 
 EXPECTED_ROW_COUNT = {
 	'x':5,
-	'user_table': 8
+	'user_table': 8,
+	'test_enum': 5
 }
 
 EXPECTED_DATA_TYPES = {
@@ -34,6 +35,10 @@ EXPECTED_DATA_TYPES = {
 		'id': 'integer',
 		'email': 'character varying',
 		'status': 'character varying'
+	},
+	'test_enum': {
+		'id': 'integer',
+		'reason': 'decline_reason'
 	}
 }
 
@@ -44,12 +49,16 @@ EXPECTED_SUM_OF_COLUMN = {
 	},
 	'user_table': {
 		'id': '51',
+	},
+	'test_enum': {
+		'id':'19',
 	}
 }
 
 EXPECTED_ROW_COUNT_FF = {
 	'x':7,
-	'user_table': 8
+	'user_table': 8,
+	'test_enum': 6
 }
 
 EXPECTED_SUM_OF_COLUMN_FF = {
@@ -59,6 +68,9 @@ EXPECTED_SUM_OF_COLUMN_FF = {
 	},
 	'user_table': {
 		'id': '49',
+	},
+	'test_enum':{
+		'id':'29'
 	}
 }
 

--- a/migtests/tests/pg/basic-non-public-live-test/validateAfterChanges
+++ b/migtests/tests/pg/basic-non-public-live-test/validateAfterChanges
@@ -38,7 +38,7 @@ EXPECTED_DATA_TYPES = {
 	},
 	'test_enum': {
 		'id': 'integer',
-		'reason': 'decline_reason'
+		'reason': 'USER-DEFINED'
 	}
 }
 

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -923,10 +923,13 @@ func fetchColumnsWithUnsupportedDataTypes() ([]utils.TableColumnsDataTypes, []ut
 
 	// filter columns with unsupported data types using sourceUnsupportedDataTypes
 	for i := 0; i < len(allColumnsDataTypes); i++ {
-		if utils.ContainsAnySubstringFromSlice(sourceUnsupportedDataTypes, allColumnsDataTypes[i].DataType) {
+		//Using this ContainsAnyStringFromSlice as the catalog we use for fetching datatypes uses the data_type only
+		// which just contains the base type for example VARCHARs it won't include any length, precision or scale information 
+		//of these types there are other columns available for these information so we just do string match of types with our list
+		if utils.ContainsAnyStringFromSlice(sourceUnsupportedDataTypes, allColumnsDataTypes[i].DataType) {
 			unsupportedDataTypes = append(unsupportedDataTypes, allColumnsDataTypes[i])
 		}
-		if utils.ContainsAnySubstringFromSlice(liveMigrationUnsupportedDataTypes, allColumnsDataTypes[i].DataType) {
+		if utils.ContainsAnyStringFromSlice(liveMigrationUnsupportedDataTypes, allColumnsDataTypes[i].DataType) {
 			unsupportedDataTypesForLiveMigration = append(unsupportedDataTypesForLiveMigration, allColumnsDataTypes[i])
 		}
 	}

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -344,7 +344,10 @@ func (ms *MySQL) GetColumnsWithSupportedTypes(tableList []sqlname.NameTuple, use
 		_, tname := tableName.ForCatalogQuery()
 		var unsupportedColumnNames []string
 		for i := 0; i < len(columns); i++ {
-			if utils.ContainsAnySubstringFromSlice(mysqlUnsupportedDataTypes, dataTypes[i]) {
+			//Using this ContainsAnyStringFromSlice as the catalog we use for fetching datatypes uses the data_type only
+			// which just contains the base type for example VARCHARs it won't include any length, precision or scale information
+			//of these types there are other columns available for these information so we just do string match of types with our list
+			if utils.ContainsAnyStringFromSlice(mysqlUnsupportedDataTypes, dataTypes[i]) {
 				log.Infof("Skipping unsupproted column %s.%s of type %s", tname, columns[i], dataTypes[i])
 				unsupportedColumnNames = append(unsupportedColumnNames, fmt.Sprintf("%s.%s of type %s", tname, columns[i], dataTypes[i]))
 			} else {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -536,7 +536,10 @@ func (ora *Oracle) GetColumnsWithSupportedTypes(tableList []sqlname.NameTuple, u
 		var unsupportedColumnNames []string
 		for i := 0; i < len(columns); i++ {
 			isUdtWithDebezium := (dataTypesOwner[i] == sname) && useDebezium // datatype owner check is for UDT type detection as VARRAY are created using UDT
-			if isUdtWithDebezium || utils.ContainsAnySubstringFromSlice(OracleUnsupportedDataTypes, dataTypes[i]) {
+			//Using this ContainsAnyStringFromSlice as the catalog we use for fetching datatypes uses the data_type only
+			// which just contains the base type for example VARCHARs it won't include any length, precision or scale information
+			//of these types there are other columns available for these information so we just do string match of types with our list
+			if isUdtWithDebezium || utils.ContainsAnyStringFromSlice(OracleUnsupportedDataTypes, dataTypes[i]) {
 				log.Infof("Skipping unsupproted column %s.%s of type %s", tname, columns[i], dataTypes[i])
 				unsupportedColumnNames = append(unsupportedColumnNames, fmt.Sprintf("%s.%s of type %s", tname, columns[i], dataTypes[i]))
 			} else {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -586,7 +586,12 @@ func (pg *PostgreSQL) GetColumnsWithSupportedTypes(tableList []sqlname.NameTuple
 		var supportedColumnNames []string
 		for i, column := range columns {
 			if useDebezium || isStreamingEnabled {
-				if utils.ContainsAnySubstringFromSlice(PostgresUnsupportedDataTypesForDbzm, dataTypes[i]) {
+				//Using this ContainsAnyStringFromSlice as the catalog we use for fetching datatypes uses the data_type only
+				// which just contains the base type for example VARCHARs it won't include any length, precision or scale information
+				//of these types there are other columns available for these information so we just do string match of types with our list
+				//And also for geometry or complex types like if a column is defined with  public.geometry(Point,4326) then also only geometry is available 
+				//in the typname column of those catalog tables  and further details (Point,4326) is managed by Postgis extension.
+				if utils.ContainsAnyStringFromSlice(PostgresUnsupportedDataTypesForDbzm, dataTypes[i]) {
 					unsupportedColumnNames = append(unsupportedColumnNames, column)
 				} else {
 					supportedColumnNames = append(supportedColumnNames, column)

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -344,6 +344,15 @@ func ContainsAnySubstringFromSlice(slice []string, s string) bool {
 	return false
 }
 
+func ContainsAnyStringFromSlice(slice []string, s string) bool {
+	for i := 0; i < len(slice); i++ {
+		if strings.EqualFold(s, slice[i]) {
+			return true
+		}
+	}
+	return false
+}
+
 func WaitForLineInLogFile(filePath string, message string, timeoutDuration time.Duration) error {
 	// Wait for log file to be created
 	timeout := time.After(timeoutDuration)


### PR DESCRIPTION
Fixes the issue where some user-defined type name can have a substring of any unsupported type.
https://yugabyte.atlassian.net/browse/DB-12623

Verified for all the source types that string full match is fine as other information for types like length, precision, and scale for column type is not present in the `Data_Type`/ `typname` column of the catalog queries we use.
Note: just for Oracle, timestamp and interval can just these information in the column but we don't have any of these as unsupported.
```
//Mysql
mysql> SELECT COLUMN_NAME,column_type, DATA_TYPE from INFORMATION_SCHEMA.COLUMNS where table_schema = 'datatypes' and table_name='test_type_name';
+-------------+--------------+-----------+
| COLUMN_NAME | COLUMN_TYPE  | DATA_TYPE |
+-------------+--------------+-----------+
| id          | int          | int       |
| val         | varchar(220) | varchar   |
+-------------+--------------+-----------+
2 rows in set (0.29 sec)

//ORACLE
SQL> SELECT COLUMN_NAME, DATA_TYPE, DATA_LENGTH, DATA_PRECISION, DATA_SCALE, CHAR_LENGTH, DATA_TYPE_OWNER FROM ALL_TAB_COLUMNS WHERE OWNER = 'ADMIN';

COLUMN_NAME       DATA_TYPE                               DATA_LENGTH    DATA_PRECISION    DATA_SCALE    CHAR_LENGTH DATA_TYPE_OWNER    
_________________ ____________________________________ ______________ _________________ _____________ ______________ __________________ 
V1                VARRAY_TYPE                                     421                                              0 ADMIN              
COL1              MY_TAB_T                                         16                                              0 ADMIN              
ID                NUMBER                                           22                               0              0                    
NUM_VAL           NUMBER                                           22                                              0                    
FLOAT_VAL         FLOAT                                            22                 5                            0                    
BIN_FLOAT_VAL     BINARY_FLOAT                                      4                                              0                    
BIN_DOUBLE_VAL    BINARY_DOUBLE                                     8                                              0                    
ID                NUMBER                                           22                               0              0                    
DATE_VAL          DATE                                              7                                              0                    
TIMESTAMP_VAL     TIMESTAMP(6)                                     11                               6              0       

//PG
postgres=> SELECT a.attname AS column_name, a.attlen as char_length , a.atttypmod as type_precision , t.typname::regtype AS data_type, rol.rolname AS data_type_owner                                                                                                       FROM pg_attribute AS a                                                                                                                                                                                            JOIN pg_type AS t ON t.oid = a.atttypid                                                                                                                                                                           JOIN pg_class AS c ON c.oid = a.attrelid                                                                                                                                                                          JOIN pg_namespace AS n ON n.oid = c.relnamespace                                                                                                                                                                  JOIN pg_roles AS rol ON rol.oid = t.typowner                                                                                                                                                                      WHERE c.relname = 'locations' AND n.nspname = 'public' AND a.attname NOT IN ('tableoid', 'cmax', 'xmax', 'cmin', 'xmin', 'ctid');
 column_name | char_length | type_precision |     data_type     | data_type_owner 
-------------+-------------+----------------+-------------------+-----------------
 id          |           4 |             -1 | integer           | rdsadmin
 name        |          -1 |            104 | character varying | rdsadmin
 geom        |          -1 |        1107460 | geometry          | rdsadmin
(3 rows)
```


Tests:
Added automation for this case of type name in `basic-non-public-live-test` for all workflows.