### PR TITLE
Fix: datatype queries to remove the '::regtype' as its not  able to detetct the non-public schema types

### DIFF
--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -66,7 +66,7 @@ AND NOT a.attisdropped
 AND t.relkind IN ('r', 'P')
 AND seq.relkind = 'S';`
 
-const GET_TABLE_COLUMNS_QUERY_TEMPLATE_PG_AND_YB = `SELECT a.attname AS column_name, t.typname::regtype AS data_type, rol.rolname AS data_type_owner 
+const GET_TABLE_COLUMNS_QUERY_TEMPLATE_PG_AND_YB = `SELECT a.attname AS column_name, t.typname AS data_type, rol.rolname AS data_type_owner 
 FROM pg_attribute AS a 
 JOIN pg_type AS t ON t.oid = a.atttypid 
 JOIN pg_class AS c ON c.oid = a.attrelid 
@@ -593,7 +593,7 @@ func (pg *PostgreSQL) GetColumnsWithSupportedTypes(tableList []sqlname.NameTuple
 				//Using this ContainsAnyStringFromSlice as the catalog we use for fetching datatypes uses the data_type only
 				// which just contains the base type for example VARCHARs it won't include any length, precision or scale information
 				//of these types there are other columns available for these information so we just do string match of types with our list
-				//And also for geometry or complex types like if a column is defined with  public.geometry(Point,4326) then also only geometry is available 
+				//And also for geometry or complex types like if a column is defined with  public.geometry(Point,4326) then also only geometry is available
 				//in the typname column of those catalog tables  and further details (Point,4326) is managed by Postgis extension.
 				if utils.ContainsAnyStringFromSlice(PostgresUnsupportedDataTypesForDbzm, dataTypes[i]) {
 					unsupportedColumnNames = append(unsupportedColumnNames, column)

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -501,7 +501,7 @@ func (yb *YugabyteDB) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList
 	if len(unsupportedTables) > 0 {
 		unsupportedTablesStringList := make([]string, len(unsupportedTables))
 		for i, table := range unsupportedTables {
-			unsupportedTablesStringList[i] = table.String()
+			unsupportedTablesStringList[i] = table.ForMinOutput()
 		}
 
 		if !utils.AskPrompt("\nThe following tables are unsupported since they contains an array of enums:\n" + strings.Join(unsupportedTablesStringList, "\n") +

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -443,7 +443,7 @@ func (yb *YugabyteDB) getAllUserDefinedTypesInSchema(schemaName string) []string
 }
 
 func (yb *YugabyteDB) getTypesOfAllArraysInATable(schemaName, tableName string) []string {
-	query := fmt.Sprintf(`SELECT udt_name::regtype FROM information_schema.columns 
+	query := fmt.Sprintf(`SELECT udt_name FROM information_schema.columns 
 						WHERE table_schema = '%s' 
 						AND table_name='%s' 
 						AND data_type = 'ARRAY';`, schemaName, tableName)
@@ -488,7 +488,9 @@ func (yb *YugabyteDB) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList
 	outer:
 		for _, arrayType := range tableColumnArrayTypes {
 			for _, udt := range userDefinedTypes {
-				if strings.Contains(arrayType, udt) {
+				if strings.EqualFold(strings.TrimLeft(arrayType, "_"), udt) { 
+					// as the array_type is determined by an underscore at the first place
+					//ref - https://www.postgresql.org/docs/current/xtypes.html#:~:text=The%20array%20type%20typically%20has%20the%20same%20name%20as%20the%20base%20type%20with%20the%20underscore%20character%20(_)%20prepended
 					unsupportedTables = append(unsupportedTables, table)
 					break outer
 				}
@@ -570,7 +572,7 @@ func (yb *YugabyteDB) filterUnsupportedUserDefinedDatatypes(tableName sqlname.Na
 	// Currently all UDTs other than enums and domain are unsupported
 	sname, tname := tableName.ForCatalogQuery()
 	query := fmt.Sprintf(`SELECT 
-    	t.typname::regtype AS type_name,
+    	t.typname AS type_name,
 		CASE WHEN t.typtype = 'c' THEN 'Yes' ELSE 'No' END AS is_user_defined
 	FROM 
 		pg_class c


### PR DESCRIPTION
* fixed the array type detection from `strings.Contains` to proper `strings.Equalfold` detection by removing the prefixed underscore (`_`), reference pg docs for the mention that array types are determined by having underscores with the type name
https://www.postgresql.org/docs/current/xtypes.html#:~:text=The%20array%20type%20typically%20has%20the%20same%20name%20as%20the%20base%20type%20with%20the%20underscore%20character%20(_)%20prepended