### PR TITLE
 Fix: datatype queries to remove the '::regtype' as its not  able to detetct the non-public schema types  (#1677)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [main]
+    branches: [main, '1.8-dev']
   pull_request:
-    branches: [main]
+    branches: [main, '1.8-dev']
 
 jobs:
 

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -2,9 +2,9 @@ name: "MySQL: Migration Tests"
 
 on:
   push:
-    branches: ['main']
+    branches: ['main', '1.8-dev']
   pull_request:
-    branches: ['main']
+    branches: ['main', '1.8-dev']
 
 jobs:
   run-mysql-migration-tests:

--- a/.github/workflows/pg-9-migtests.yml
+++ b/.github/workflows/pg-9-migtests.yml
@@ -2,9 +2,9 @@ name: "PG 9: Migration Tests"
 
 on:
   push:
-    branches: ['main']
+    branches: ['main', '1.8-dev']
   pull_request:
-    branches: ['main']
+    branches: ['main', '1.8-dev']
 
 jobs:
   run-pg-migration-tests:

--- a/.github/workflows/pg-migtests.yml
+++ b/.github/workflows/pg-migtests.yml
@@ -2,9 +2,9 @@ name: "PG 13: Migration Tests"
 
 on:
   push:
-    branches: ['main']
+    branches: ['main', '1.8-dev']
   pull_request:
-    branches: ['main']
+    branches: ['main', '1.8-dev']
 
 jobs:
   run-pg-migration-tests:

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -202,12 +202,12 @@ main() {
     fi
 	done
 	
-	sleep 60
+	sleep 120
 
 	step "Inserting new events to YB"
 	ysql_import_file ${TARGET_DB_NAME} target_delta.sql
 
-	sleep 60
+	sleep 120
 
 	step "Resetting the trap command"
 	trap - SIGINT SIGTERM EXIT SIGSEGV SIGHUP
@@ -232,7 +232,7 @@ main() {
 
 	run_ysql ${TARGET_DB_NAME} "\di"
 	run_ysql ${TARGET_DB_NAME} "\dft" 
-
+	
 	step "Run final validations."
 	if [ -x "${TEST_DIR}/validateAfterChanges" ]
 	then

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -66,7 +66,7 @@ AND NOT a.attisdropped
 AND t.relkind IN ('r', 'P')
 AND seq.relkind = 'S';`
 
-const GET_TABLE_COLUMNS_QUERY_TEMPLATE_PG_AND_YB = `SELECT a.attname AS column_name, t.typname::regtype AS data_type, rol.rolname AS data_type_owner 
+const GET_TABLE_COLUMNS_QUERY_TEMPLATE_PG_AND_YB = `SELECT a.attname AS column_name, t.typname AS data_type, rol.rolname AS data_type_owner 
 FROM pg_attribute AS a 
 JOIN pg_type AS t ON t.oid = a.atttypid 
 JOIN pg_class AS c ON c.oid = a.attrelid 
@@ -593,7 +593,7 @@ func (pg *PostgreSQL) GetColumnsWithSupportedTypes(tableList []sqlname.NameTuple
 				//Using this ContainsAnyStringFromSlice as the catalog we use for fetching datatypes uses the data_type only
 				// which just contains the base type for example VARCHARs it won't include any length, precision or scale information
 				//of these types there are other columns available for these information so we just do string match of types with our list
-				//And also for geometry or complex types like if a column is defined with  public.geometry(Point,4326) then also only geometry is available 
+				//And also for geometry or complex types like if a column is defined with  public.geometry(Point,4326) then also only geometry is available
 				//in the typname column of those catalog tables  and further details (Point,4326) is managed by Postgis extension.
 				if utils.ContainsAnyStringFromSlice(PostgresUnsupportedDataTypesForDbzm, dataTypes[i]) {
 					unsupportedColumnNames = append(unsupportedColumnNames, column)


### PR DESCRIPTION
Also, fixed the array type detection from `strings.Contains` to proper `strings.Equalfold` detection by removing the prefixed underscore (`_`), reference pg docs for the mention that array types are determined by having underscores with the type name https://www.postgresql.org/docs/current/xtypes.html#:~:text=The%20array%20type%20typically%20has%20the%20same%20name%20as%20the%20base%20type%20with%20the%20underscore%20character%20(_)%20prepended

* increase sleep in live-migraion-fallb-run-test.sh script for fixing the timing issue with yb debezium in export-data-from-target