### PR TITLE
Bug fix: Avoid schema registry "no such file or directory" errors in import-data

### DIFF
--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -358,17 +358,16 @@ func debeziumExportData(ctx context.Context, config *dbzm.Config, tableNameToApp
 	if err != nil {
 		return fmt.Errorf("failed to start debezium: %w", err)
 	}
-	if exporterRole == SOURCE_DB_EXPORTER_ROLE {
-		err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-			if exporterRole == SOURCE_DB_EXPORTER_ROLE {
-				record.ExportDataSourceDebeziumStarted = true
-			} else {
-				record.ExportDataTargetDebeziumStarted = true
-			}
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update migration status record: %w", err)
+
+	err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		if exporterRole == SOURCE_DB_EXPORTER_ROLE {
+			record.ExportDataSourceDebeziumStarted = true
+		} else {
+			record.ExportDataTargetDebeziumStarted = true
 		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update migration status record: %w", err)
 	}
 
 	var status *dbzm.ExportStatus

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -358,6 +358,18 @@ func debeziumExportData(ctx context.Context, config *dbzm.Config, tableNameToApp
 	if err != nil {
 		return fmt.Errorf("failed to start debezium: %w", err)
 	}
+	if exporterRole == SOURCE_DB_EXPORTER_ROLE {
+		err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+			if exporterRole == SOURCE_DB_EXPORTER_ROLE {
+				record.ExportDataSourceDebeziumStarted = true
+			} else {
+				record.ExportDataTargetDebeziumStarted = true
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update migration status record: %w", err)
+		}
+	}
 
 	var status *dbzm.ExportStatus
 	snapshotComplete := false

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -530,8 +530,9 @@ func importData(importFileTasks []*ImportFileTask) {
 		if importerRole != SOURCE_DB_IMPORTER_ROLE {
 			displayImportedRowCountSnapshot(state, importFileTasks)
 		}
-		importPhase = dbzm.MODE_STREAMING
+
 		waitForDebeziumStartIfRequired()
+		importPhase = dbzm.MODE_STREAMING
 		color.Blue("streaming changes to %s...", tconf.TargetDBType)
 
 		if err != nil {
@@ -613,6 +614,7 @@ func waitForDebeziumStartIfRequired() error {
 	// in case pg_dump was used to export snapshot data,
 	// we need to wait for export-data to have started debezium in cdc phase
 	// in order to avoid any race conditions.
+	fmt.Println("Initializing streaming phase...")
 	log.Infof("waiting for export-data to have started debezium in cdc phase")
 	for {
 		msr, err = metaDB.GetMigrationStatusRecord()

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -85,6 +85,12 @@ func (d *Debezium) Start() error {
 		return err
 	}
 
+	schemasPath := filepath.Join(d.ExportDir, "data", "schemas", d.ExporterRole)
+	err = os.MkdirAll(schemasPath, 0755)
+	if err != nil {
+		return fmt.Errorf("Error creating schemas directory: %v", err)
+	}
+
 	var YB_OR_PG_CONNECTOR_PATH string
 	if isTargetDBExporter(d.ExporterRole) {
 		if !d.Config.UseYBgRPCConnector {

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -11,43 +11,48 @@ import (
 )
 
 type MigrationStatusRecord struct {
-	MigrationUUID                                   string            `json:"MigrationUUID"`
-	VoyagerVersion                                  string            `json:"VoyagerVersion"`
-	ExportType                                      string            `json:"ExportType"`
-	ArchivingEnabled                                bool              `json:"ArchivingEnabled"`
-	FallForwardEnabled                              bool              `json:"FallForwardEnabled"`
-	FallbackEnabled                                 bool              `json:"FallbackEnabled"`
-	UseYBgRPCConnector                              bool              `json:"UseYBgRPCConnector"`
-	TargetDBConf                                    *tgtdb.TargetConf `json:"TargetDBConf"`
-	SourceReplicaDBConf                             *tgtdb.TargetConf `json:"SourceReplicaDBConf"`
-	SourceDBAsTargetConf                            *tgtdb.TargetConf `json:"SourceDBAsTargetConf"`
-	TableListExportedFromSource                     []string          `json:"TableListExportedFromSource"`
-	SourceDBConf                                    *srcdb.Source     `json:"SourceDBConf"`
-	CutoverToTargetRequested                        bool              `json:"CutoverToTargetRequested"`
-	CutoverProcessedBySourceExporter                bool              `json:"CutoverProcessedBySourceExporter"`
-	CutoverProcessedByTargetImporter                bool              `json:"CutoverProcessedByTargetImporter"`
-	ExportFromTargetFallForwardStarted              bool              `json:"ExportFromTargetFallForwardStarted"`
-	CutoverToSourceReplicaRequested                 bool              `json:"CutoverToSourceReplicaRequested"`
-	CutoverToSourceReplicaProcessedByTargetExporter bool              `json:"CutoverToSourceReplicaProcessedByTargetExporter"`
-	CutoverToSourceReplicaProcessedBySRImporter     bool              `json:"CutoverToSourceReplicaProcessedBySRImporter"`
-	ExportFromTargetFallBackStarted                 bool              `json:"ExportFromTargetFallBackStarted"`
-	CutoverToSourceRequested                        bool              `json:"CutoverToSourceRequested"`
-	CutoverToSourceProcessedByTargetExporter        bool              `json:"CutoverToSourceProcessedByTargetExporter"`
-	CutoverToSourceProcessedBySourceImporter        bool              `json:"CutoverToSourceProcessedBySourceImporter"`
-	ExportSchemaDone                                bool              `json:"ExportSchemaDone"`
-	ExportDataDone                                  bool              `json:"ExportDataDone"`
-	YBCDCStreamID                                   string            `json:"YBCDCStreamID"`
-	EndMigrationRequested                           bool              `json:"EndMigrationRequested"`
-	PGReplicationSlotName                           string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	PGPublicationName                               string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	YBReplicationSlotName                           string            `json:"YBReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	YBPublicationName                               string            `json:"YBPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	SnapshotMechanism                               string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump, ora2pg)
-	SourceRenameTablesMap                           map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
-	TargetRenameTablesMap                           map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
-	IsExportTableListSet                            bool              `json:"IsExportTableListSet"`
-	MigrationAssessmentDone                         bool              `json:"MigrationAssessmentDone"`
-	AssessmentRecommendationsApplied                bool              `json:"AssessmentRecommendationsApplied"`
+	MigrationUUID               string            `json:"MigrationUUID"`
+	VoyagerVersion              string            `json:"VoyagerVersion"`
+	ExportType                  string            `json:"ExportType"`
+	ArchivingEnabled            bool              `json:"ArchivingEnabled"`
+	FallForwardEnabled          bool              `json:"FallForwardEnabled"`
+	FallbackEnabled             bool              `json:"FallbackEnabled"`
+	UseYBgRPCConnector          bool              `json:"UseYBgRPCConnector"`
+	TargetDBConf                *tgtdb.TargetConf `json:"TargetDBConf"`
+	SourceReplicaDBConf         *tgtdb.TargetConf `json:"SourceReplicaDBConf"`
+	SourceDBAsTargetConf        *tgtdb.TargetConf `json:"SourceDBAsTargetConf"`
+	TableListExportedFromSource []string          `json:"TableListExportedFromSource"`
+	SourceDBConf                *srcdb.Source     `json:"SourceDBConf"`
+
+	CutoverToTargetRequested                        bool `json:"CutoverToTargetRequested"`
+	CutoverProcessedBySourceExporter                bool `json:"CutoverProcessedBySourceExporter"`
+	CutoverProcessedByTargetImporter                bool `json:"CutoverProcessedByTargetImporter"`
+	ExportFromTargetFallForwardStarted              bool `json:"ExportFromTargetFallForwardStarted"`
+	CutoverToSourceReplicaRequested                 bool `json:"CutoverToSourceReplicaRequested"`
+	CutoverToSourceReplicaProcessedByTargetExporter bool `json:"CutoverToSourceReplicaProcessedByTargetExporter"`
+	CutoverToSourceReplicaProcessedBySRImporter     bool `json:"CutoverToSourceReplicaProcessedBySRImporter"`
+	ExportFromTargetFallBackStarted                 bool `json:"ExportFromTargetFallBackStarted"`
+	CutoverToSourceRequested                        bool `json:"CutoverToSourceRequested"`
+	CutoverToSourceProcessedByTargetExporter        bool `json:"CutoverToSourceProcessedByTargetExporter"`
+	CutoverToSourceProcessedBySourceImporter        bool `json:"CutoverToSourceProcessedBySourceImporter"`
+
+	ExportSchemaDone                bool `json:"ExportSchemaDone"`
+	ExportDataDone                  bool `json:"ExportDataDone"` // to be interpreted as export of snapshot data from source is complete
+	ExportDataSourceDebeziumStarted bool `json:"ExportDataSourceDebeziumStarted"`
+	ExportDataTargetDebeziumStarted bool `json:"ExportDataTargetDebeziumStarted"`
+
+	YBCDCStreamID                    string            `json:"YBCDCStreamID"`
+	EndMigrationRequested            bool              `json:"EndMigrationRequested"`
+	PGReplicationSlotName            string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	PGPublicationName                string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	YBReplicationSlotName            string            `json:"YBReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	YBPublicationName                string            `json:"YBPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	SnapshotMechanism                string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump, ora2pg)
+	SourceRenameTablesMap            map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
+	TargetRenameTablesMap            map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
+	IsExportTableListSet             bool              `json:"IsExportTableListSet"`
+	MigrationAssessmentDone          bool              `json:"MigrationAssessmentDone"`
+	AssessmentRecommendationsApplied bool              `json:"AssessmentRecommendationsApplied"`
 }
 
 const MIGRATION_STATUS_KEY = "migration_status"


### PR DESCRIPTION
https://yugabyte.atlassian.net/browse/DB-12656
Race condition seen in test cases: 
Assume that the following happens chronologically.
1. start export-data PG live migration
2. start import-data 
3. pg_dump snapshot completes
4. import data snapshot import completes
5. import data tries to start CDC phase (it tries to create schema registry from the /data/schemas/source-db-exporter dir)
6. export-data starts debezium for the cdc phase
7. debezium starts up and creates schemas directory. 

Step 5 will fail because it depends on step 7. 

To solve this
1. explicitly create schemas in voyager go layer before starting debezium
2. let export-data store state of starting debezium, and have import-data wait for the state before starting cdc phase.  