### PR TITLE
Update default Debezium Server HTTP port from 8080 to 8181 in config file

### DIFF
--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -81,7 +81,7 @@ type Config struct {
 var baseConfigTemplate = `
 debezium.format.value=connect
 debezium.format.key=connect
-quarkus.http.port=8181
+quarkus.http.port=%d
 quarkus.log.console.json=false
 quarkus.log.level=%s
 `
@@ -296,10 +296,18 @@ func (c *Config) String() string {
 	} else {
 		log.Infof("QUEUE_SEGMENT_MAX_BYTES: %d", queueSegmentMaxBytes)
 	}
+
+	quarkusLogPort, err := utils.GetFreePort()
+	if err != nil {
+		log.Warnf("failed to get a free port for quarkus http server, falling back to 8080: %v", err)
+		quarkusLogPort = 8080
+	}
+
 	var conf string
 	switch c.SourceDBType {
 	case "postgresql":
 		conf = fmt.Sprintf(postgresConfigTemplate,
+			quarkusLogPort,
 			c.LogLevel,
 			c.Username,
 			c.SnapshotMode,
@@ -333,6 +341,7 @@ func (c *Config) String() string {
 	case "yugabytedb":
 		if !c.UseYBgRPCConnector {
 			conf = fmt.Sprintf(yugabyteLogicalReplicationConfigTemplate,
+				quarkusLogPort,
 				c.LogLevel,
 				c.Username,
 				"never",
@@ -360,6 +369,7 @@ func (c *Config) String() string {
 			}
 		} else {
 			conf = fmt.Sprintf(yugabyteConfigTemplate,
+				quarkusLogPort,
 				c.LogLevel,
 				c.Username,
 				"never",
@@ -392,6 +402,7 @@ func (c *Config) String() string {
 		}
 	case "oracle":
 		conf = fmt.Sprintf(oracleConfigTemplate,
+			quarkusLogPort,
 			c.LogLevel,
 			c.Username,
 			c.SnapshotMode,
@@ -423,6 +434,7 @@ func (c *Config) String() string {
 
 	case "mysql":
 		conf = fmt.Sprintf(mysqlConfigTemplate,
+			quarkusLogPort,
 			c.LogLevel,
 			c.Username,
 			c.SnapshotMode,

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -81,7 +81,7 @@ type Config struct {
 var baseConfigTemplate = `
 debezium.format.value=connect
 debezium.format.key=connect
-quarkus.http.log=8181
+quarkus.http.port=8181
 quarkus.log.console.json=false
 quarkus.log.level=%s
 `

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -81,6 +81,7 @@ type Config struct {
 var baseConfigTemplate = `
 debezium.format.value=connect
 debezium.format.key=connect
+quarkus.http.log=8181
 quarkus.log.console.json=false
 quarkus.log.level=%s
 `

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -302,6 +302,7 @@ func (c *Config) String() string {
 		log.Warnf("failed to get a free port for quarkus http server, falling back to 8080: %v", err)
 		quarkusLogPort = 8080
 	}
+	log.Infof("using port number %d for quarkus http server", quarkusLogPort)
 
 	var conf string
 	switch c.SourceDBType {

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -684,3 +684,17 @@ func ChangeFileExtension(filePath string, newExt string) string {
 
 	return filePath + newExt
 }
+
+// Port 0 generally returns port number in range 30xxx - 60xxx but it also depends on OS and network configuration
+func GetFreePort() (int, error) {
+	// Listen on port 0, which tells the OS to assign an available port
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, fmt.Errorf("failed to listen on a port: %v", err)
+	}
+	defer listener.Close()
+
+	// Retrieve the assigned port
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.Port, nil
+}


### PR DESCRIPTION
- 8080 is a common port and likely to conflict with existing services

Testing: Verified with resume/restart in case of postgres export data.
The events were picked up from last left, and no errors.