### PR TITLE
Fix for export-data-from-target with new YB CDC connector from Oracle source.

### DIFF
--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -566,7 +566,7 @@ func createYBReplicationSlotAndPublication(tableList []sqlname.NameTuple, leafPa
 			continue
 		}
 		// for case sensitive tables in yugabytedb, we need to use the quoted table name
-		finalTableList = append(finalTableList, table.ForKey())
+		finalTableList = append(finalTableList, table.ForUserQuery())
 	}
 
 	publicationName := "voyager_dbz_publication_" + strings.ReplaceAll(migrationUUID.String(), "-", "_")


### PR DESCRIPTION
Using `ForUserQuery` to ensure that we are using proper target names, not source table names (used by `ForKey`). 