### PR TITLE
Bug Fix: remove from conflict cache when ignoring event 

### DIFF
--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -59,8 +59,7 @@ event4: INSERT INTO users (id, email) VALUES (3, 'abc@example.com');
 6. event4 is applied successfully.
 7. event2 is retried but still fails (because now event4 is already applied).
 
-If you think about the end state, we should have only one row in the target table with id=3 (id=2 will be eventually deleted)
-However, event2 will keep failing because of unique key constraint error.
+Here, event2 will continue to fail even after multiple retries because event4 is already applied.
 --------------------------------------
 
 There can be total 4 types of conflicts:

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -35,8 +35,7 @@ func (myb *mockYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *tgtdb.Ev
 
 func TestProcessEventsBasic(t *testing.T) {
 	evChan := make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE)
-	var lastAppliedVsn int64
-	lastAppliedVsn = 0
+	lastAppliedVsn := int64(0)
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
 	state := NewImportDataState(exportDir)
@@ -59,8 +58,7 @@ func TestProcessEventsBasic(t *testing.T) {
 
 func TestProcessEventsRemovesEventFromConflicDetectionCache(t *testing.T) {
 	evChan := make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE)
-	var lastAppliedVsn int64
-	lastAppliedVsn = 0
+	lastAppliedVsn := int64(0)
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
 	state := NewImportDataState(exportDir)
@@ -97,8 +95,7 @@ func TestProcessEventsRemovesIgnoredEventFromConflicDetectionCache(t *testing.T)
 	// all events that are not from the target db exporter.
 	importerRole = SOURCE_DB_IMPORTER_ROLE
 	evChan := make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE)
-	var lastAppliedVsn int64
-	lastAppliedVsn = 100 // so that event with vsn 1 is ignored.
+	lastAppliedVsn := int64(100) // so that event with vsn 1 is ignored.
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
 	state := NewImportDataState(exportDir)

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	reporter "github.com/yugabyte/yb-voyager/yb-voyager/src/reporter/stats"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
+)
+
+type mockYugabyteDB struct {
+	tgtdb.TargetYugabyteDB // to satisfy interface
+}
+
+func (myb *mockYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *tgtdb.EventBatch) error {
+	return nil
+}
+
+func TestProcessEventsBasic(t *testing.T) {
+	evChan := make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE)
+	var lastAppliedVsn int64
+	lastAppliedVsn = 0
+	doneChan := make(chan bool, 1)
+	statsReporter := &reporter.StreamImportStatsReporter{}
+	state := NewImportDataState(exportDir)
+	tdb = &mockYugabyteDB{}
+	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []string](), []chan *tgtdb.Event{evChan}, "postgresql")
+
+	oname := sqlname.NewObjectName("yugabytedb", "public", "public", "users")
+	evChan <- &tgtdb.Event{
+		Vsn: 1,
+		Op:  "c",
+		TableNameTup: sqlname.NameTuple{
+			CurrentName: oname,
+			TargetName:  oname,
+		},
+		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+	}
+	evChan <- END_OF_QUEUE_SEGMENT_EVENT
+	processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
+}
+
+func TestProcessEventsRemovesEventFromConflicDetectionCache(t *testing.T) {
+	evChan := make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE)
+	var lastAppliedVsn int64
+	lastAppliedVsn = 0
+	doneChan := make(chan bool, 1)
+	statsReporter := &reporter.StreamImportStatsReporter{}
+	state := NewImportDataState(exportDir)
+	tdb = &mockYugabyteDB{}
+	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []string](), []chan *tgtdb.Event{evChan}, "postgresql")
+
+	oname := sqlname.NewObjectName("yugabytedb", "public", "public", "users")
+	e := &tgtdb.Event{
+		Vsn: 1,
+		Op:  "c",
+		TableNameTup: sqlname.NameTuple{
+			CurrentName: oname,
+			TargetName:  oname,
+		},
+		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+	}
+
+	conflictDetectionCache.Put(e)
+	evChan <- e
+	evChan <- END_OF_QUEUE_SEGMENT_EVENT
+	processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
+
+	// Check that the event was removed from the cache
+	if _, ok := conflictDetectionCache.m[e.Vsn]; ok {
+		t.Errorf("Event not removed from conflict detection cache")
+	}
+}
+
+// Even if event is ignored,
+// (because vsn is less than lastAppliedVsn or it is source_db_importer and event is not from target_db_importer_fb),
+// it should be removed from conflict detection cache
+func TestProcessEventsRemovesIgnoredEventFromConflicDetectionCache(t *testing.T) {
+	// to simulate the case where source db importer ignores
+	// all events that are not from the target db exporter.
+	importerRole = SOURCE_DB_IMPORTER_ROLE
+	evChan := make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE)
+	var lastAppliedVsn int64
+	lastAppliedVsn = 100 // so that event with vsn 1 is ignored.
+	doneChan := make(chan bool, 1)
+	statsReporter := &reporter.StreamImportStatsReporter{}
+	state := NewImportDataState(exportDir)
+	tdb = &mockYugabyteDB{}
+	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []string](), []chan *tgtdb.Event{evChan}, "postgresql")
+
+	oname := sqlname.NewObjectName("yugabytedb", "public", "public", "users")
+	e1 := &tgtdb.Event{
+		Vsn: 1, // so that it is less than lastAppliedVsn and ignored.
+		Op:  "c",
+		TableNameTup: sqlname.NameTuple{
+			CurrentName: oname,
+			TargetName:  oname,
+		},
+		ExporterRole: TARGET_DB_EXPORTER_FB_ROLE, // so that it is not ignored because importerRole is SOURCE_DB_IMPORTER_ROLE
+	}
+
+	e2 := &tgtdb.Event{
+		Vsn: 200, // vsn greater than lastAppliedVSn so that is not ignored
+		Op:  "c",
+		TableNameTup: sqlname.NameTuple{
+			CurrentName: oname,
+			TargetName:  oname,
+		},
+		ExporterRole: SOURCE_DB_EXPORTER_ROLE, // not TARGET_DB_EXPORTER_FB_ROLE so that it is ignored.
+	}
+
+	conflictDetectionCache.Put(e1)
+	conflictDetectionCache.Put(e2)
+	evChan <- e1
+	evChan <- e2
+	evChan <- END_OF_QUEUE_SEGMENT_EVENT
+	processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
+
+	// Check that the event was removed from the cache
+	if _, ok := conflictDetectionCache.m[e1.Vsn]; ok {
+		t.Errorf("Event %v not removed from conflict detection cache", e1)
+	}
+	if _, ok := conflictDetectionCache.m[e2.Vsn]; ok {
+		t.Errorf("Event %v not removed from conflict detection cache", e2)
+	}
+}


### PR DESCRIPTION
In live migration phase, for every event, we 
1. add to conflictDetectionCache if applicable
2. process event
3. remove from conflictDetectionCache if applicable

The issue: 
As part of step2, we can either add the event to batch and apply it on target DB OR we can ignore the event (because we had already applied it, for example). Step3 is only being executed if we add the event to the batch. In case the event is ignored, it remains in the conflict detection cache forever, causing import-data to wait hang and wait forever. 

The fix: 
Run step3 even in cases where we ignore the event.