### PR TITLE
Added guardrails checks for db version and migration permissions for PG

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -53,6 +53,8 @@ func init() {
 func registerCommonExportFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &startClean, "start-clean", false,
 		"cleans up the project directory for schema or data files depending on the export command (default false)")
+
+	BoolVar(cmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", true, "run guardrails checks before exporting data")
 }
 
 func registerCommonSourceDBConnFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -54,7 +54,7 @@ func registerCommonExportFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &startClean, "start-clean", false,
 		"cleans up the project directory for schema or data files depending on the export command (default false)")
 
-	BoolVar(cmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", true, "run guardrails checks before exporting data")
+	BoolVar(cmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", false, "run guardrails checks before exporting data")
 }
 
 func registerCommonSourceDBConnFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -213,6 +213,11 @@ func exportData() bool {
 	}
 	defer source.DB().Disconnect()
 
+	err = source.DB().CheckSourceDBVersion()
+	if err != nil {
+		utils.ErrExit("Source DB version check failed: %s", err)
+	}
+
 	source.DBVersion = source.DB().GetVersion()
 	source.DBSize, err = source.DB().GetDatabaseSize()
 	if err != nil {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -238,12 +238,9 @@ func exportData() bool {
 			utils.ErrExit("get missing export data permissions: %v", err)
 		}
 		if len(missingPermissions) > 0 {
-			// Iterate over missing permissions and print them
 			color.Red("\nSome permissions are missing for the source database on user %s:\n", source.User)
-			for _, perm := range missingPermissions {
-				utils.PrintAndLog("%s\n", perm)
-			}
-			fmt.Println()
+			output := strings.Join(missingPermissions, "\n")
+			utils.PrintAndLog("%s\n", output)
 			utils.ErrExit("Please grant the required permissions to the user %s and try again.", source.User)
 		} else {
 			// TODO: Print this message on the console too once the code is stable

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -229,6 +229,22 @@ func exportData() bool {
 		utils.ErrExit("schema %q does not exist", source.Schema)
 	}
 
+	// Check if source DB has required permissions for export data
+	missingPermissions, err := source.DB().GetMissingExportDataPermissions(exportType)
+	if err != nil {
+		utils.ErrExit("get missing export data permissions: %v", err)
+	}
+	if len(missingPermissions) > 0 {
+		// Iterate over missing permissions and print them
+		// Print in red color
+		color.Red("\nSome permissions are missing for the source database on user %s:\n", source.User)
+		for _, perm := range missingPermissions {
+			utils.PrintAndLog("%s\n", perm)
+		}
+		fmt.Println()
+		utils.ErrExit("Please grant the required permissions to the user %s and try again.", source.User)
+	}
+
 	clearMigrationStateIfRequired()
 	checkSourceDBCharset()
 	source.DB().CheckRequiredToolsAreInstalled()

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -246,6 +246,7 @@ func exportData() bool {
 			fmt.Println()
 			utils.ErrExit("Please grant the required permissions to the user %s and try again.", source.User)
 		} else {
+			// TODO: Print this message on the console too once the code is stable
 			log.Info("All required permissions are present for the source database.")
 		}
 	}

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -130,12 +130,9 @@ func exportSchema() error {
 			return fmt.Errorf("failed to get missing migration permissions: %w", err)
 		}
 		if len(missingPerms) > 0 {
-			// Traverse the missing permissions and print them
 			color.Red("\nSome permissions are missing for the source database on user %s:\n", source.User)
-			for _, perm := range missingPerms {
-				utils.PrintAndLog("%s\n", perm)
-			}
-			fmt.Println()
+			output := strings.Join(missingPerms, "\n")
+			utils.PrintAndLog("%s\n", output)
 			return fmt.Errorf("some permissions are missing for the source database on user %s", source.User)
 		}
 	}

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -99,6 +99,11 @@ func exportSchema() error {
 	}
 	defer source.DB().Disconnect()
 
+	err = source.DB().CheckSourceDBVersion()
+	if err != nil {
+		return fmt.Errorf("source DB version check failed: %w", err)
+	}
+
 	checkSourceDBCharset()
 	source.DB().CheckRequiredToolsAreInstalled()
 	sourceDBVersion := source.DB().GetVersion()

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -131,7 +131,6 @@ func exportSchema() error {
 		}
 		if len(missingPerms) > 0 {
 			// Traverse the missing permissions and print them
-			// Print in red
 			color.Red("\nSome permissions are missing for the source database on user %s:\n", source.User)
 			for _, perm := range missingPerms {
 				utils.PrintAndLog("%s\n", perm)

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -96,7 +96,7 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &tconf.ContinueOnError, "continue-on-error", false,
 		"Ignore errors and continue with the import")
 
-	BoolVar(cmd.Flags(), &tconf.RunGuardrailsChecks, "run-guardrails-checks", true, "Run guardrails checks during import")
+	BoolVar(cmd.Flags(), &tconf.RunGuardrailsChecks, "run-guardrails-checks", false, "Run guardrails checks during import")
 }
 
 func registerTargetDBConnFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -95,6 +95,8 @@ func validateImportFlags(cmd *cobra.Command, importerRole string) error {
 func registerCommonImportFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &tconf.ContinueOnError, "continue-on-error", false,
 		"Ignore errors and continue with the import")
+
+	BoolVar(cmd.Flags(), &tconf.RunGuardrailsChecks, "run-guardrails-checks", true, "Run guardrails checks during import")
 }
 
 func registerTargetDBConnFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -128,19 +128,21 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	}
 
 	// Check if target DB has the required permissions
-	missingPermissions, err := tdb.GetMissingImportDataPermissions()
-	if err != nil {
-		utils.ErrExit("Failed to get missing import data permissions: %s", err)
-	}
-	if len(missingPermissions) > 0 {
-		utils.PrintAndLog(color.RedString("The target database is missing the following permissions required for importing data:"))
-		// Iterate over the missing permissions and print them
-		for _, permission := range missingPermissions {
-			utils.PrintAndLog(permission)
+	if tconf.RunGuardrailsChecks {
+		missingPermissions, err := tdb.GetMissingImportDataPermissions()
+		if err != nil {
+			utils.ErrExit("Failed to get missing import data permissions: %s", err)
 		}
-		utils.ErrExit("Please grant the required permissions and retry the import.")
-	} else {
-		utils.PrintAndLog("The target database has the required permissions for importing data.")
+		if len(missingPermissions) > 0 {
+			utils.PrintAndLog(color.RedString("The target database is missing the following permissions required for importing data:"))
+			// Iterate over the missing permissions and print them
+			for _, permission := range missingPermissions {
+				utils.PrintAndLog(permission)
+			}
+			utils.ErrExit("Please grant the required permissions and retry the import.")
+		} else {
+			log.Info("The target database has the required permissions for importing data.")
+		}
 	}
 
 	targetDBDetails = tdb.GetCallhomeTargetDBInfo()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -135,10 +135,8 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 		}
 		if len(missingPermissions) > 0 {
 			utils.PrintAndLog(color.RedString("The target database is missing the following permissions required for importing data:"))
-			// Iterate over the missing permissions and print them
-			for _, permission := range missingPermissions {
-				utils.PrintAndLog(permission)
-			}
+			output := strings.Join(missingPermissions, "\n")
+			utils.PrintAndLog(output)
 			utils.ErrExit("Please grant the required permissions and retry the import.")
 		} else {
 			log.Info("The target database has the required permissions for importing data.")

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -126,6 +126,23 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	if err != nil {
 		utils.ErrExit("Failed to initialize the target DB: %s", err)
 	}
+
+	// Check if target DB has the required permissions
+	missingPermissions, err := tdb.GetMissingImportDataPermissions()
+	if err != nil {
+		utils.ErrExit("Failed to get missing import data permissions: %s", err)
+	}
+	if len(missingPermissions) > 0 {
+		utils.PrintAndLog(color.RedString("The target database is missing the following permissions required for importing data:"))
+		// Iterate over the missing permissions and print them
+		for _, permission := range missingPermissions {
+			utils.PrintAndLog(permission)
+		}
+		utils.ErrExit("Please grant the required permissions and retry the import.")
+	} else {
+		utils.PrintAndLog("The target database has the required permissions for importing data.")
+	}
+
 	targetDBDetails = tdb.GetCallhomeTargetDBInfo()
 
 	// we don't want to re-register in case import data to source/source-replica

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -105,6 +105,10 @@ func (ms *MySQL) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {
 	return approxRowCount.Int64
 }
 
+func (ms *MySQL) CheckSourceDBVersion() error {
+	return nil
+}
+
 func (ms *MySQL) GetVersion() string {
 	if ms.source.DBVersion != "" {
 		return ms.source.DBVersion

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -109,6 +109,14 @@ func (ms *MySQL) CheckSourceDBVersion() error {
 	return nil
 }
 
+func (ms *MySQL) GetMissingExportSchemaPermissions() ([]string, error) {
+	return nil, nil
+}
+
+func (ms *MySQL) GetMissingExportDataPermissions(exportType string) ([]string, error) {
+	return nil, nil
+}
+
 func (ms *MySQL) GetVersion() string {
 	if ms.source.DBVersion != "" {
 		return ms.source.DBVersion

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -116,6 +116,14 @@ func (ora *Oracle) CheckSourceDBVersion() error {
 	return nil
 }
 
+func (ora *Oracle) GetMissingExportSchemaPermissions() ([]string, error) {
+	return nil, nil
+}
+
+func (ora *Oracle) GetMissingExportDataPermissions(exportType string) ([]string, error) {
+	return nil, nil
+}
+
 func (ora *Oracle) GetVersion() string {
 	if ora.source.DBVersion != "" {
 		return ora.source.DBVersion

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -112,6 +112,10 @@ func (ora *Oracle) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {
 	return approxRowCount.Int64
 }
 
+func (ora *Oracle) CheckSourceDBVersion() error {
+	return nil
+}
+
 func (ora *Oracle) GetVersion() string {
 	if ora.source.DBVersion != "" {
 		return ora.source.DBVersion

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -1244,12 +1244,12 @@ func (pg *PostgreSQL) listTablesMissingReplicaIdentityFull() ([]string, error) {
 	CASE 
 		WHEN c.relreplident <> 'f' 
 		THEN '%s' 
-		ELSE 'Correct' 
+		ELSE '%s' 
 	END AS status
 	FROM pg_class c
 	JOIN pg_namespace n ON c.relnamespace = n.oid
 	WHERE quote_ident(n.nspname) IN (%s)
-	AND c.relkind IN ('r', 'p');`, MISSING, querySchemaList)
+	AND c.relkind IN ('r', 'p');`, MISSING, GRANTED, querySchemaList)
 	rows, err := pg.db.Query(checkTableReplicaIdentityQuery)
 	if err != nil {
 		return nil, fmt.Errorf("error in querying(%q) source database for checking table replica identity: %w", checkTableReplicaIdentityQuery, err)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -152,8 +152,8 @@ func (pg *PostgreSQL) GetMissingExportDataPermissions(exportType string) ([]stri
 	}
 
 	// For live migration
-	// Check wal_level is set to logical
 	if exportType == utils.CHANGES_ONLY || exportType == utils.SNAPSHOT_AND_CHANGES {
+		// Check wal_level is set to logical
 		correctlySet := pg.checkWalLevel()
 		if !correctlySet {
 			combinedResult = append(combinedResult, "wal_level is not set to logical")

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -359,12 +359,6 @@ WHERE n.nspname IN (%s)
 }
 
 func (pg *PostgreSQL) checkWalLevel() bool {
-	// 	# Check wal level
-	// SELECT
-	//     CASE WHEN current_setting('wal_level') = 'logical'
-	//          THEN true
-	//          ELSE false
-	//     END AS wal_level_status_correct;
 	query := `SELECT
 	CASE WHEN current_setting('wal_level') = 'logical'
 		THEN true

--- a/yb-voyager/src/srcdb/source.go
+++ b/yb-voyager/src/srcdb/source.go
@@ -57,6 +57,7 @@ type Source struct {
 	DBSize                   int64         `json:"db_size"`
 	StrExportObjectTypeList  string        `json:"str_export_object_type_list"`
 	StrExcludeObjectTypeList string        `json:"str_exclude_object_type_list"`
+	RunGuardrailsChecks      utils.BoolStr `json:"run_guardrails_checks"`
 
 	ExportObjectTypeList []string `json:"-"`
 	sourceDB             SourceDB `json:"-"`

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -57,6 +57,8 @@ type SourceDB interface {
 	ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error
 	GetDatabaseSize() (int64, error)
 	CheckSourceDBVersion() error
+	GetMissingExportSchemaPermissions() ([]string, error)
+	GetMissingExportDataPermissions(exportType string) ([]string, error)
 }
 
 func newSourceDB(source *Source) SourceDB {

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -56,6 +56,7 @@ type SourceDB interface {
 	GetNonPKTables() ([]string, error)
 	ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error
 	GetDatabaseSize() (int64, error)
+	CheckSourceDBVersion() error
 }
 
 func newSourceDB(source *Source) SourceDB {

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -100,6 +100,10 @@ func (yb *YugabyteDB) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 
 	return approxRowCount.Int64
 }
 
+func (yb *YugabyteDB) CheckSourceDBVersion() error {
+	return nil
+}
+
 func (yb *YugabyteDB) GetVersion() string {
 	if yb.source.DBVersion != "" {
 		return yb.source.DBVersion

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -104,6 +104,14 @@ func (yb *YugabyteDB) CheckSourceDBVersion() error {
 	return nil
 }
 
+func (yb *YugabyteDB) GetMissingExportSchemaPermissions() ([]string, error) {
+	return nil, nil
+}
+
+func (yb *YugabyteDB) GetMissingExportDataPermissions(exportType string) ([]string, error) {
+	return nil, nil
+}
+
 func (yb *YugabyteDB) GetVersion() string {
 	if yb.source.DBVersion != "" {
 		return yb.source.DBVersion

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -714,3 +714,7 @@ func (tdb *TargetOracleDB) ClearMigrationState(migrationUUID uuid.UUID, exportDi
 	DROP USER %s CASCADE`, schema, tdb.tconf.Host, schema)
 	return nil
 }
+
+func (tdb *TargetOracleDB) GetMissingImportDataPermissions() ([]string, error) {
+	return nil, nil
+}

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -786,3 +786,117 @@ func (pg *TargetPostgreSQL) ClearMigrationState(migrationUUID uuid.UUID, exportD
 
 	return nil
 }
+
+func (pg *TargetPostgreSQL) GetMissingImportDataPermissions() ([]string, error) {
+	// Check if db_user has SELECT, INSERT, UPDATE, DELETE permissions on schemas tables
+	missingPermissions, err := pg.checkWhichTablesHaveMissingSelectInsertUpdateDeletePermissions()
+	if err != nil {
+		return nil, err
+	}
+	var missingPermissionsList []string
+	for permission, tables := range missingPermissions {
+		if permission == "USAGE" {
+			missingPermissionsList = append(missingPermissionsList, fmt.Sprintf("Missing USAGE permissions on the schemas of tables: %v", tables))
+			continue
+		}
+		missingPermissionsList = append(missingPermissionsList, fmt.Sprintf("Missing %s permissions on tables: %v", permission, tables))
+	}
+
+	return missingPermissionsList, nil
+}
+
+func (pg *TargetPostgreSQL) checkWhichTablesHaveMissingSelectInsertUpdateDeletePermissions() (map[string][]string, error) {
+	querySchemaList := pg.getSchemaList()
+	// querySchemaList := strings.Join(schemaList, "','") // a','b','c
+	fmt.Println("Schema list: ", querySchemaList)
+
+	query := fmt.Sprintf(`WITH table_privileges AS (
+		SELECT
+			schemaname AS schema_name,
+			tablename AS table_name,
+			CASE
+				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+					CASE
+						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'SELECT') THEN 'Granted'
+						ELSE 'Missing'
+					END
+				ELSE 'No USAGE privilege on schema'
+			END AS select_status,
+			CASE
+				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+					CASE
+						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'INSERT') THEN 'Granted'
+						ELSE 'Missing'
+					END
+				ELSE 'No USAGE privilege on schema'
+			END AS insert_status,
+			CASE
+				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+					CASE
+						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'UPDATE') THEN 'Granted'
+						ELSE 'Missing'
+					END
+				ELSE 'No USAGE privilege on schema'
+			END AS update_status,
+			CASE
+				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+					CASE
+						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'DELETE') THEN 'Granted'
+						ELSE 'Missing'
+					END
+				ELSE 'No USAGE privilege on schema'
+			END AS delete_status
+		FROM pg_tables
+		WHERE schemaname = ANY(string_to_array('%s', ','))
+	)
+	SELECT
+		schema_name,
+		table_name,
+		select_status,
+		insert_status,
+		update_status,
+		delete_status
+	FROM table_privileges;`,
+		pg.tconf.User, pg.tconf.User, pg.tconf.User, pg.tconf.User, pg.tconf.User, pg.tconf.User, pg.tconf.User, pg.tconf.User, querySchemaList)
+	rows, err := pg.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("run query %q on target %q: %w", query, pg.tconf.Host, err)
+	}
+	defer rows.Close()
+	missingPermissions := make(map[string][]string)
+	for rows.Next() {
+		var schemaName, tableName, selectStatus, insertStatus, updateStatus, deleteStatus string
+		err = rows.Scan(&schemaName, &tableName, &selectStatus, &insertStatus, &updateStatus, &deleteStatus)
+		if err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		// status is 'Missing' then add to key missingSelect etc
+		// status is 'No USAGE privilege on schema' then add to key missingUsage
+		if selectStatus == "Missing" {
+			missingPermissions["SELECT"] = append(missingPermissions["SELECT"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		} else if selectStatus == "No USAGE privilege on schema" {
+			missingPermissions["USAGE"] = append(missingPermissions["USAGE"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		}
+		if insertStatus == "Missing" {
+			missingPermissions["INSERT"] = append(missingPermissions["INSERT"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		} else if insertStatus == "No USAGE privilege on schema" {
+			missingPermissions["USAGE"] = append(missingPermissions["USAGE"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		}
+		if updateStatus == "Missing" {
+			missingPermissions["UPDATE"] = append(missingPermissions["UPDATE"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		} else if updateStatus == "No USAGE privilege on schema" {
+			missingPermissions["USAGE"] = append(missingPermissions["USAGE"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		}
+		if deleteStatus == "Missing" {
+			missingPermissions["DELETE"] = append(missingPermissions["DELETE"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		} else if deleteStatus == "No USAGE privilege on schema" {
+			missingPermissions["USAGE"] = append(missingPermissions["USAGE"], fmt.Sprintf("%s.%s", schemaName, tableName))
+		}
+	}
+	return missingPermissions, nil
+}
+
+func (pg *TargetPostgreSQL) getSchemaList() []string {
+	schemas := strings.Split(pg.tconf.Schema, ",")
+	return schemas
+}

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -789,7 +789,7 @@ func (pg *TargetPostgreSQL) ClearMigrationState(migrationUUID uuid.UUID, exportD
 
 func (pg *TargetPostgreSQL) GetMissingImportDataPermissions() ([]string, error) {
 	// Check if db_user has SELECT, INSERT, UPDATE, DELETE permissions on schemas tables
-	missingPermissions, err := pg.checkWhichTablesHaveMissingSelectInsertUpdateDeletePermissions()
+	missingPermissions, err := pg.listTablesMissingSelectInsertUpdateDeletePermissions()
 	if err != nil {
 		return nil, err
 	}
@@ -805,12 +805,11 @@ func (pg *TargetPostgreSQL) GetMissingImportDataPermissions() ([]string, error) 
 	return missingPermissionsList, nil
 }
 
-func (pg *TargetPostgreSQL) checkWhichTablesHaveMissingSelectInsertUpdateDeletePermissions() (map[string][]string, error) {
+func (pg *TargetPostgreSQL) listTablesMissingSelectInsertUpdateDeletePermissions() (map[string][]string, error) {
 	querySchemaList := pg.getSchemaList()
-	// querySchemaList := strings.Join(schemaList, "','") // a','b','c
-	fmt.Println("Schema list: ", querySchemaList)
 
-	query := fmt.Sprintf(`WITH table_privileges AS (
+	query := fmt.Sprintf(`
+	WITH table_privileges AS (
 		SELECT
 			quote_ident(schemaname) AS schema_name,
 			quote_ident(tablename) AS table_name,

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -812,42 +812,42 @@ func (pg *TargetPostgreSQL) checkWhichTablesHaveMissingSelectInsertUpdateDeleteP
 
 	query := fmt.Sprintf(`WITH table_privileges AS (
 		SELECT
-			schemaname AS schema_name,
-			tablename AS table_name,
+			quote_ident(schemaname) AS schema_name,
+			quote_ident(tablename) AS table_name,
 			CASE
-				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+				WHEN has_schema_privilege('%s', quote_ident(schemaname), 'USAGE') THEN
 					CASE
-						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'SELECT') THEN 'Granted'
+						WHEN has_table_privilege('%s', quote_ident(schemaname) || '.' || quote_ident(tablename), 'SELECT') THEN 'Granted'
 						ELSE 'Missing'
 					END
 				ELSE 'No USAGE privilege on schema'
 			END AS select_status,
 			CASE
-				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+				WHEN has_schema_privilege('%s', quote_ident(schemaname), 'USAGE') THEN
 					CASE
-						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'INSERT') THEN 'Granted'
+						WHEN has_table_privilege('%s', quote_ident(schemaname) || '.' || quote_ident(tablename), 'INSERT') THEN 'Granted'
 						ELSE 'Missing'
 					END
 				ELSE 'No USAGE privilege on schema'
 			END AS insert_status,
 			CASE
-				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+				WHEN has_schema_privilege('%s', quote_ident(schemaname), 'USAGE') THEN
 					CASE
-						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'UPDATE') THEN 'Granted'
+						WHEN has_table_privilege('%s', quote_ident(schemaname) || '.' || quote_ident(tablename), 'UPDATE') THEN 'Granted'
 						ELSE 'Missing'
 					END
 				ELSE 'No USAGE privilege on schema'
 			END AS update_status,
 			CASE
-				WHEN has_schema_privilege('%s', schemaname, 'USAGE') THEN
+				WHEN has_schema_privilege('%s', quote_ident(schemaname), 'USAGE') THEN
 					CASE
-						WHEN has_table_privilege('%s', schemaname || '.' || tablename, 'DELETE') THEN 'Granted'
+						WHEN has_table_privilege('%s', quote_ident(schemaname) || '.' || quote_ident(tablename), 'DELETE') THEN 'Granted'
 						ELSE 'Missing'
 					END
 				ELSE 'No USAGE privilege on schema'
 			END AS delete_status
 		FROM pg_tables
-		WHERE schemaname = ANY(string_to_array('%s', ','))
+		WHERE quote_ident(schemaname) = ANY(string_to_array('%s', ','))
 	)
 	SELECT
 		schema_name,

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -57,6 +57,7 @@ type TargetDB interface {
 	QueryRow(query string) *sql.Row
 	Exec(query string) (int64, error)
 	WithTx(fn func(tx *sql.Tx) error) error
+	GetMissingImportDataPermissions() ([]string, error)
 }
 
 //=============================================================

--- a/yb-voyager/src/tgtdb/tconf.go
+++ b/yb-voyager/src/tgtdb/tconf.go
@@ -48,6 +48,7 @@ type TargetConf struct {
 	ImportObjects        string        `json:"import_objects"`
 	ExcludeImportObjects string        `json:"exclude_import_objects"`
 	DBVersion            string        `json:"db_version"`
+	RunGuardrailsChecks  utils.BoolStr `json:"run_guardrails_checks"`
 
 	TargetEndpoints            string        `json:"target_endpoints"`
 	UsePublicIP                utils.BoolStr `json:"use_public_ip"`

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1216,3 +1216,7 @@ func (yb *TargetYugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportD
 
 	return nil
 }
+
+func (yb *TargetYugabyteDB) GetMissingImportDataPermissions() ([]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Added source db version checks and migration permission checks:

- Added source db version checks for postgres in export schema and export data
- Added migration permission checks for postgres in export schema and export data
- Added migration permission checks for postgres in import data
- Added a flag --run-guardrails-checks to switch on or off the above checks. Default is true rn.

Jenkins tests:
[https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/3657/](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/3657/)
[https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/3658/](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/3658/)
