### PR TITLE
Incorrect statements after adding mviews to the sizing calculations

### DIFF
--- a/yb-voyager/cmd/exportSchema_test.go
+++ b/yb-voyager/cmd/exportSchema_test.go
@@ -31,8 +31,8 @@ func TestShardingRecommendations(t *testing.T) {
 	}
 	sqlInfo_mview2 := sqlInfo{
 		objName:       "m1",
-		stmt:          "CREATE MATERIALIZED VIEW m1 AS SELECT * FROM t1 WHERE a = 3 with no data",
-		formattedStmt: "CREATE MATERIALIZED VIEW m1 AS SELECT * FROM t1 WHERE a = 3 with no data",
+		stmt:          "CREATE MATERIALIZED VIEW m1 AS SELECT * FROM t1 WHERE a = 3 with no data;",
+		formattedStmt: "CREATE MATERIALIZED VIEW m1 AS SELECT * FROM t1 WHERE a = 3 with no data;",
 		fileName:      "",
 	}
 	sqlInfo_mview3 := sqlInfo{
@@ -53,7 +53,7 @@ func TestShardingRecommendations(t *testing.T) {
 	assert.Equal(t, match, true)
 
 	modifiedSqlStmt, match, _ = applyShardingRecommendationIfMatching(&sqlInfo_mview2, []string{"m1_notfound"}, MVIEW)
-	assert.Equal(t, modifiedSqlStmt, "CREATE MATERIALIZED VIEW m1 AS SELECT * FROM t1 WHERE a = 3 with no data")
+	assert.Equal(t, modifiedSqlStmt, sqlInfo_mview2.stmt)
 	assert.Equal(t, match, false)
 
 	modifiedSqlStmt, match, _ = applyShardingRecommendationIfMatching(&sqlInfo_mview3, []string{"m1"}, MVIEW)
@@ -70,14 +70,14 @@ func TestShardingRecommendations(t *testing.T) {
 	}
 	sqlInfo_table2 := sqlInfo{
 		objName:       "m1",
-		stmt:          "create table a (a int, b int) WITH (fillfactor=70)",
-		formattedStmt: "create table a (a int, b int) WITH (fillfactor=70)",
+		stmt:          "create table a (a int, b int) WITH (fillfactor=70);",
+		formattedStmt: "create table a (a int, b int) WITH (fillfactor=70);",
 		fileName:      "",
 	}
 	sqlInfo_table3 := sqlInfo{
 		objName:       "m1",
-		stmt:          "alter table a add col text",
-		formattedStmt: "alter table a add col text",
+		stmt:          "alter table a add col text;",
+		formattedStmt: "alter table a add col text;",
 		fileName:      "",
 	}
 	modifiedTableStmt, matchTable, _ := applyShardingRecommendationIfMatching(&sqlInfo_table1, []string{"a"}, TABLE)
@@ -91,11 +91,11 @@ func TestShardingRecommendations(t *testing.T) {
 	assert.Equal(t, matchTable, true)
 
 	modifiedSqlStmt, matchTable, _ = applyShardingRecommendationIfMatching(&sqlInfo_table2, []string{"m1_notfound"}, TABLE)
-	assert.Equal(t, modifiedSqlStmt, "create table a (a int, b int) WITH (fillfactor=70)")
+	assert.Equal(t, modifiedSqlStmt, sqlInfo_table2.stmt)
 	assert.Equal(t, matchTable, false)
 
 	modifiedTableStmt, matchTable, _ = applyShardingRecommendationIfMatching(&sqlInfo_table3, []string{"a"}, TABLE)
 	assert.Equal(t, strings.ToLower(modifiedTableStmt),
-		strings.ToLower("alter table a add col text"))
+		strings.ToLower(sqlInfo_table3.stmt))
 	assert.Equal(t, matchTable, false)
 }


### PR DESCRIPTION
- Fix for "Export schema CLI output contains incorrect / additional statements after MViews sizing implementation". See [DB](https://yugabyte.atlassian.net/browse/DB-13079)
- Added tests for Mviews that already have storage parameters. 
- Added tests for alter table in the exportSchema