### PR TITLE
[DB-12635] Mishandling of NULL types in pg_database_size query during export data from target

### DIFF
--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -258,14 +258,14 @@ func (ms *MySQL) GetCharset() (string, error) {
 }
 
 func (ms *MySQL) GetDatabaseSize() (int64, error) {
-	var dbSize int64
+	var dbSize sql.NullInt64
 	query := fmt.Sprintf("SELECT SUM(data_length + index_length) FROM information_schema.tables WHERE table_schema = '%s'", ms.source.DBName)
 	err := ms.db.QueryRow(query).Scan(&dbSize)
 	if err != nil {
 		return 0, fmt.Errorf("error in querying database encoding: %w", err)
 	}
-	log.Infof("Total Database size of MySQL sourceDB: %v", dbSize)
-	return dbSize, nil
+	log.Infof("Total Database size of MySQL sourceDB: %d", dbSize.Int64)
+	return dbSize.Int64, nil
 }
 
 func (ms *MySQL) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList []sqlname.NameTuple, useDebezium bool) ([]sqlname.NameTuple, []sqlname.NameTuple) {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -311,14 +311,14 @@ func (ora *Oracle) GetCharset() (string, error) {
 }
 
 func (ora *Oracle) GetDatabaseSize() (int64, error) {
-	var dbSize int64
+	var dbSize sql.NullInt64
 	query := fmt.Sprintf("SELECT SUM(BYTES) FROM DBA_SEGMENTS WHERE OWNER = '%s'", ora.source.Schema)
 	err := ora.db.QueryRow(query).Scan(&dbSize)
 	if err != nil {
 		return 0, fmt.Errorf("error in querying database encoding: %w", err)
 	}
-	log.Infof("Total Database size of Oracle sourceDB: %v", dbSize)
-	return dbSize, nil
+	log.Infof("Total Database size of Oracle sourceDB: %d", dbSize.Int64)
+	return dbSize.Int64, nil
 }
 
 func (ora *Oracle) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList []sqlname.NameTuple, useDebezium bool) ([]sqlname.NameTuple, []sqlname.NameTuple) {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -484,7 +484,7 @@ func (pg *PostgreSQL) GetCharset() (string, error) {
 }
 
 func (pg *PostgreSQL) GetDatabaseSize() (int64, error) {
-	var totalSchemasSize, totalSize int64
+	var totalSchemasSize int64
 	schemaList := strings.Replace(pg.source.Schema, "|", "','", -1)
 	query := fmt.Sprintf(`SELECT
     nspname AS schema_name,
@@ -510,17 +510,18 @@ GROUP BY
 	}()
 
 	var schemaName string
+	var totalSize sql.NullInt64
 	for rows.Next() {
 		err = rows.Scan(&schemaName, &totalSize)
 		if err != nil {
 			return -1, fmt.Errorf("error in scanning query rows for schemas ('%s'): %v", schemaList, err)
 		}
-		totalSchemasSize += totalSize
+		totalSchemasSize += totalSize.Int64
 	}
 	if rows.Err() != nil {
 		return -1, fmt.Errorf("error in scanning query rows for schemas('%s'): %v", schemaList, rows.Err())
 	}
-	log.Infof("Total size of all PG sourceDB schemas ('%s'): %v", schemaList, totalSchemasSize)
+	log.Infof("Total size of all PG sourceDB schemas ('%s'): %d", schemaList, totalSchemasSize)
 	return totalSchemasSize, nil
 }
 

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -395,14 +395,14 @@ func (yb *YugabyteDB) GetCharset() (string, error) {
 }
 
 func (yb *YugabyteDB) GetDatabaseSize() (int64, error) {
-	var dbSize int64
+	var dbSize sql.NullInt64
 	query := fmt.Sprintf("select pg_database_size('%s'); ", yb.source.DBName)
 	err := yb.db.QueryRow(query).Scan(&dbSize)
 	if err != nil {
 		return 0, fmt.Errorf("error in querying database encoding: %w", err)
 	}
-	log.Infof("Total Database size of YugabyteDB sourceDB: %v", dbSize)
-	return dbSize, nil
+	log.Infof("Total Database size of YugabyteDB sourceDB: %d", dbSize.Int64)
+	return dbSize.Int64, nil
 }
 
 func (yb *YugabyteDB) getAllUserDefinedTypesInSchema(schemaName string) []string {


### PR DESCRIPTION
- use sql.NullInt64 datatype to store instead of int64