### PR TITLE
Misc changes to adaptive parallelism 

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -462,7 +462,7 @@ func importData(importFileTasks []*ImportFileTask) {
 		}
 		go func() {
 			err := adaptiveparallelism.AdaptParallelism(yb)
-			if errors.Is(err, adaptiveparallelism.AdaptiveParallelismNotSupportedError) {
+			if errors.Is(err, adaptiveparallelism.ErrAdaptiveParallelismNotSupported) {
 				utils.PrintAndLog(color.YellowString("Disabling adaptive parallelism as it is not supported in this version of YugabyteDB"))
 			} else {
 				log.Errorf("adaptive parallelism error: %v", err)

--- a/yb-voyager/src/adaptiveparallelism/adaptive_parallelism.go
+++ b/yb-voyager/src/adaptiveparallelism/adaptive_parallelism.go
@@ -39,9 +39,11 @@ type TargetYugabyteDBWithConnectionPool interface {
 	UpdateNumConnectionsInPool(int) error // (delta)
 }
 
+var AdaptiveParallelismNotSupportedError = fmt.Errorf("adaptive parallelism not supported in target YB database")
+
 func AdaptParallelism(yb TargetYugabyteDBWithConnectionPool) error {
 	if !yb.IsAdaptiveParallelismSupported() {
-		return fmt.Errorf("adaptive parallelism not supported in target YB database")
+		return AdaptiveParallelismNotSupportedError
 	}
 	for {
 		time.Sleep(ADAPTIVE_PARALLELISM_FREQUENCY)

--- a/yb-voyager/src/adaptiveparallelism/adaptive_parallelism.go
+++ b/yb-voyager/src/adaptiveparallelism/adaptive_parallelism.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 )
 
 const (
@@ -33,7 +34,7 @@ const (
 
 type TargetYugabyteDBWithConnectionPool interface {
 	IsAdaptiveParallelismSupported() bool
-	GetClusterMetrics() (map[string]map[string]string, error) // node_uuid:metric_name:metric_value
+	GetClusterMetrics() (map[string]tgtdb.NodeMetrics, error) // node_uuid:metric_name:metric_value
 	GetNumConnectionsInPool() int
 	GetNumMaxConnectionsInPool() int
 	UpdateNumConnectionsInPool(int) error // (delta)
@@ -71,6 +72,9 @@ func fetchClusterMetricsAndUpdateParallelism(yb TargetYugabyteDBWithConnectionPo
 	if err != nil {
 		return fmt.Errorf("getting max cpu usage in cluster: %w", err)
 	}
+	if maxCpuUsage < 0 {
+		log.Warnf("adaptive: Ignoring update as max cpu usage in cluster is negative: %d", maxCpuUsage)
+	}
 	log.Infof("adaptive: max cpu usage in cluster = %d", maxCpuUsage)
 
 	if maxCpuUsage > MAX_CPU_THRESHOLD {
@@ -89,14 +93,17 @@ func fetchClusterMetricsAndUpdateParallelism(yb TargetYugabyteDBWithConnectionPo
 	return nil
 }
 
-func getMaxCpuUsageInCluster(clusterMetrics map[string]map[string]string) (int, error) {
-	var maxCpuPct int
+func getMaxCpuUsageInCluster(clusterMetrics map[string]tgtdb.NodeMetrics) (int, error) {
+	maxCpuPct := -1
 	for _, nodeMetrics := range clusterMetrics {
-		cpuUsageUser, err := strconv.ParseFloat(nodeMetrics[CPU_USAGE_USER], 64)
+		if nodeMetrics.Status != "OK" {
+			continue
+		}
+		cpuUsageUser, err := strconv.ParseFloat(nodeMetrics.Metrics[CPU_USAGE_USER], 64)
 		if err != nil {
 			return -1, fmt.Errorf("parsing cpu usage user as float: %w", err)
 		}
-		cpuUsageSystem, err := strconv.ParseFloat(nodeMetrics[CPU_USAGE_SYSTEM], 64)
+		cpuUsageSystem, err := strconv.ParseFloat(nodeMetrics.Metrics[CPU_USAGE_SYSTEM], 64)
 		if err != nil {
 			return -1, fmt.Errorf("parsing cpu usage system as float: %w", err)
 		}

--- a/yb-voyager/src/adaptiveparallelism/adaptive_parallelism.go
+++ b/yb-voyager/src/adaptiveparallelism/adaptive_parallelism.go
@@ -40,11 +40,11 @@ type TargetYugabyteDBWithConnectionPool interface {
 	UpdateNumConnectionsInPool(int) error // (delta)
 }
 
-var AdaptiveParallelismNotSupportedError = fmt.Errorf("adaptive parallelism not supported in target YB database")
+var ErrAdaptiveParallelismNotSupported = fmt.Errorf("adaptive parallelism not supported in target YB database")
 
 func AdaptParallelism(yb TargetYugabyteDBWithConnectionPool) error {
 	if !yb.IsAdaptiveParallelismSupported() {
-		return AdaptiveParallelismNotSupportedError
+		return ErrAdaptiveParallelismNotSupported
 	}
 	for {
 		time.Sleep(ADAPTIVE_PARALLELISM_FREQUENCY)

--- a/yb-voyager/src/adaptiveparallelism/adaptive_parallelism_test.go
+++ b/yb-voyager/src/adaptiveparallelism/adaptive_parallelism_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 )
 
 type dummyTargetYugabyteDB struct {
@@ -35,14 +36,29 @@ func (d *dummyTargetYugabyteDB) IsAdaptiveParallelismSupported() bool {
 	return true
 }
 
-func (d *dummyTargetYugabyteDB) GetClusterMetrics() (map[string]map[string]string, error) {
-	result := make(map[string]map[string]string)
-	result["node1"] = make(map[string]string)
-	result["node1"]["cpu_usage_user"] = strconv.FormatFloat(d.cpuUsageUser1, 'f', -1, 64)
-	result["node1"]["cpu_usage_system"] = strconv.FormatFloat(d.cpuUsageSys1, 'f', -1, 64)
-	result["node2"] = make(map[string]string)
-	result["node2"]["cpu_usage_user"] = strconv.FormatFloat(d.cpuUsageUser2, 'f', -1, 64)
-	result["node2"]["cpu_usage_system"] = strconv.FormatFloat(d.cpuUsageSys2, 'f', -1, 64)
+func (d *dummyTargetYugabyteDB) GetClusterMetrics() (map[string]tgtdb.NodeMetrics, error) {
+	result := make(map[string]tgtdb.NodeMetrics)
+	metrics1 := make(map[string]string)
+	metrics1["cpu_usage_user"] = strconv.FormatFloat(d.cpuUsageUser1, 'f', -1, 64)
+	metrics1["cpu_usage_system"] = strconv.FormatFloat(d.cpuUsageSys1, 'f', -1, 64)
+
+	result["node1"] = tgtdb.NodeMetrics{
+		Metrics: metrics1,
+		UUID:    "node1",
+		Status:  "OK",
+		Error:   "",
+	}
+
+	metrics2 := make(map[string]string)
+	metrics2["cpu_usage_user"] = strconv.FormatFloat(d.cpuUsageUser2, 'f', -1, 64)
+	metrics2["cpu_usage_system"] = strconv.FormatFloat(d.cpuUsageSys2, 'f', -1, 64)
+
+	result["node2"] = tgtdb.NodeMetrics{
+		Metrics: metrics2,
+		UUID:    "node2",
+		Status:  "OK",
+		Error:   "",
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
- if DB version  does not support adaptive parallelism, warn user, and fall-back to default behavior. 
- GetClusterMetrics should return STATUS, ERROR as well. adaptive parallelism can make use of this information in the future. 
- make parameters configurable by env var.