### PR TITLE
Using parser for Partition table cases in analyze-schema such as insufficient PK as per partition columns

### DIFF
--- a/migtests/tests/analyze-schema/expected_issues.json
+++ b/migtests/tests/analyze-schema/expected_issues.json
@@ -298,8 +298,18 @@
         {
             "IssueType": "unsupported_features",
             "ObjectType": "TABLE",
+            "ObjectName": "test_2",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (country_code, record_type)",
+            "SqlStatement": "CREATE TABLE test_2 (\n\tid numeric NOT NULL PRIMARY KEY,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50)\n) PARTITION BY LIST (country_code, record_type) ;",
+            "Suggestion": "Add all Partition columns to Primary Key",
+            "GH": "https://github.com/yugabyte/yb-voyager/issues/578",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns"
+        },
+        {
+            "IssueType": "unsupported_features",
+            "ObjectType": "TABLE",
             "ObjectName": "test_5",
-            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (country_code, record_type)",
             "SqlStatement": "CREATE TABLE test_5 (\n\tid numeric NOT NULL,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50),\n\tPRIMARY KEY (id)\n) PARTITION BY RANGE (country_code, record_type) ;",
             "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns",
             "Suggestion": "Add all Partition columns to Primary Key",
@@ -309,7 +319,7 @@
             "IssueType": "unsupported_features",
             "ObjectType": "TABLE",
             "ObjectName": "test_6",
-            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (record_type)",
             "SqlStatement": "CREATE TABLE test_6 (\n\tid numeric NOT NULL,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50),\n\tPRIMARY KEY (id,country_code)\n) PARTITION BY RANGE (country_code, record_type) ;",
             "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns",
             "Suggestion": "Add all Partition columns to Primary Key",
@@ -319,7 +329,7 @@
             "IssueType": "unsupported_features",
             "ObjectType": "TABLE",
             "ObjectName": "test_7",
-            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (descriptions, record_type)",
             "SqlStatement": "CREATE TABLE test_7 (\n\tid numeric NOT NULL,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50),\n\tPRIMARY KEY (id,country_code)\n) PARTITION BY RANGE (descriptions, record_type) ;",
             "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns",
             "Suggestion": "Add all Partition columns to Primary Key",
@@ -329,7 +339,7 @@
             "IssueType": "unsupported_features",
             "ObjectType": "TABLE",
             "ObjectName": "test_8",
-            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (promotion_id, order_date)",
             "SqlStatement": "CREATE TABLE test_8 (\n\torder_id bigint NOT NULL,\n\torder_date timestamp,\n\torder_mode varchar(8),\n\tcustomer_id integer,\n\torder_mode smallint,\n\torder_total double precision,\n\tsales_rep_id integer,\n\tpromotion_id integer,\n\tPRIMARY KEY (order_id,order_mode,customer_id,order_total,sales_rep_id)\n) PARTITION BY RANGE (promotion_id, order_date, sales_rep_id) ;",
             "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns",
             "Suggestion": "Add all Partition columns to Primary Key",
@@ -344,6 +354,16 @@
             "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/mysql/#multi-column-partition-by-list-is-not-supported",
             "Suggestion": "Make it a single column partition by list or choose other supported Partitioning methods",
             "GH": "https://github.com/yugabyte/yb-voyager/issues/699"
+        },
+        {
+            "IssueType": "unsupported_features",
+            "ObjectType": "TABLE",
+            "ObjectName": "test_non_pk_multi_column_list",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (country_code, record_type)",
+            "SqlStatement": "CREATE TABLE test_non_pk_multi_column_list (\n\tid numeric NOT NULL PRIMARY KEY,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50)\n) PARTITION BY LIST (country_code, record_type) ;",
+            "Suggestion": "Add all Partition columns to Primary Key",
+            "GH": "https://github.com/yugabyte/yb-voyager/issues/578",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns"
         },
         {
             "IssueType": "unsupported_features",
@@ -1037,8 +1057,18 @@
         {
             "IssueType": "unsupported_features",
             "ObjectType": "TABLE",
+            "ObjectName": "test_1",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (country_code, record_type)",
+            "SqlStatement": "CREATE TABLE test_1 (\n\tid numeric NOT NULL,\n\tcountry_code varchar(3),\n\trecord_type varchar(5),\n\tdescriptions varchar(50),\n\tPRIMARY KEY (id)\n) PARTITION BY LIST (country_code, record_type) ;",
+            "Suggestion": "Add all Partition columns to Primary Key",
+            "GH": "https://github.com/yugabyte/yb-voyager/issues/578",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns"
+        },
+        {
+            "IssueType": "unsupported_features",
+            "ObjectType": "TABLE",
             "ObjectName": "sales_data",
-            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE",
+            "Reason": "insufficient columns in the PRIMARY KEY constraint definition in CREATE TABLE - (sales_date)",
             "SqlStatement": "CREATE TABLE sales_data (\n        sales_id numeric NOT NULL,\n        sales_date timestamp,\n        sales_amount numeric,\n        PRIMARY KEY (sales_id)\n) PARTITION BY RANGE (sales_date) ;",
             "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/oracle/#partition-key-column-not-part-of-primary-key-columns",
             "Suggestion": "Add all Partition columns to Primary Key",

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -61,14 +61,13 @@ var (
 	ws         = `[\s\n\t]+`
 	optionalWS = `[\s\n\t]*` //optional white spaces
 	//TODO: fix this ident regex for the proper PG identifiers syntax - refer: https://github.com/yugabyte/yb-voyager/pull/1547#discussion_r1629282309
-	ident                        = `[a-zA-Z0-9_."-]+`
-	ifExists                     = opt("IF", "EXISTS")
-	ifNotExists                  = opt("IF", "NOT", "EXISTS")
-	optionalCommaSeperatedTokens = `[^,]+(?:,[^,]+){0,}`
-	commaSeperatedTokens         = `[^,]+(?:,[^,]+){1,}`
-	unqualifiedIdent             = `[a-zA-Z0-9_]+`
-	commonClause                 = `[a-zA-Z]+`
-	supportedExtensionsOnYB      = []string{
+	ident                   = `[a-zA-Z0-9_."-]+`
+	ifExists                = opt("IF", "EXISTS")
+	ifNotExists             = opt("IF", "NOT", "EXISTS")
+	commaSeperatedTokens    = `[^,]+(?:,[^,]+){1,}`
+	unqualifiedIdent        = `[a-zA-Z0-9_]+`
+	commonClause            = `[a-zA-Z]+`
+	supportedExtensionsOnYB = []string{
 		"adminpack", "amcheck", "autoinc", "bloom", "btree_gin", "btree_gist", "citext", "cube",
 		"dblink", "dict_int", "dict_xsyn", "earthdistance", "file_fdw", "fuzzystrmatch", "hll", "hstore",
 		"hypopg", "insert_username", "intagg", "intarray", "isn", "lo", "ltree", "moddatetime",
@@ -114,9 +113,10 @@ func re(tokens ...string) *regexp.Regexp {
 	return regexp.MustCompile(s)
 }
 
-func parenth(s string) string {
-	return `\(` + s + `\)`
-}
+//commenting it as currently not used.
+// func parenth(s string) string {
+// 	return `\(` + s + `\)`
+// }
 
 var (
 	analyzeSchemaReportFormat string
@@ -420,13 +420,13 @@ func reportAlterAddPKOnPartition(alterTableNode *pg_query.Node_AlterTableStmt, s
 
 	alterCmd := alterTableNode.AlterTableStmt.Cmds[0].GetAlterTableCmd()
 	/*
-	e.g.  
-	ALTER TABLE example2 
- 		ADD CONSTRAINT example2_pkey PRIMARY KEY (id);
-	tmts:{stmt:{alter_table_stmt:{relation:{relname:"example2"  inh:true  relpersistence:"p"  location:693}  
-	cmds:{alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_PRIMARY  conname:"example2_pkey"  
-	location:710  keys:{string:{sval:"id"}}}}  behavior:DROP_RESTRICT}}  objtype:OBJECT_TABLE}}  stmt_location:679  stmt_len:72}
-	
+			e.g.
+			ALTER TABLE example2
+		 		ADD CONSTRAINT example2_pkey PRIMARY KEY (id);
+			tmts:{stmt:{alter_table_stmt:{relation:{relname:"example2"  inh:true  relpersistence:"p"  location:693}
+			cmds:{alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_PRIMARY  conname:"example2_pkey"
+			location:710  keys:{string:{sval:"id"}}}}  behavior:DROP_RESTRICT}}  objtype:OBJECT_TABLE}}  stmt_location:679  stmt_len:72}
+
 	*/
 
 	constraint := alterCmd.GetDef().GetConstraint()
@@ -436,7 +436,7 @@ func reportAlterAddPKOnPartition(alterTableNode *pg_query.Node_AlterTableStmt, s
 			reportCase(fpath, ADDING_PK_TO_PARTITIONED_TABLE_ISSUE_REASON,
 				"https://github.com/yugabyte/yugabyte-db/issues/10074", "", "TABLE", fullyQualifiedName, sqlStmtInfo.formattedStmt, MIGRATION_CAVEATS, ADDING_PK_TO_PARTITIONED_TABLE_DOC_LINK)
 		} else {
-			primaryConsInAlter[fullyQualifiedName] = &sqlStmtInfo 
+			primaryConsInAlter[fullyQualifiedName] = &sqlStmtInfo
 		}
 	}
 }
@@ -448,24 +448,24 @@ func reportPartitionsRelatedIssues(createTableNode *pg_query.Node_CreateStmt, sq
 	fullyQualifiedName := lo.Ternary(schemaName != "", schemaName+"."+tableName, tableName)
 
 	/*
-	e.g. In case if PRIMARY KEY is included in column definition 
-	 CREATE TABLE example2 (
-	 	id numeric NOT NULL PRIMARY KEY,
-		country_code varchar(3),
-		record_type varchar(5)
-	) PARTITION BY RANGE (country_code, record_type) ;
-	stmts:{stmt:{create_stmt:{relation:{relname:"example2"  inh:true  relpersistence:"p"  location:193}  table_elts:{column_def:{colname:"id"  
-	type_name:{names:{string:{sval:"pg_catalog"}}  names:{string:{sval:"numeric"}}  typemod:-1  location:208}  is_local:true  
-	constraints:{constraint:{contype:CONSTR_NOTNULL  location:216}}  constraints:{constraint:{contype:CONSTR_PRIMARY  location:225}}  
-	location:205}}  ...  partspec:{strategy:PARTITION_STRATEGY_RANGE  
-	part_params:{partition_elem:{name:"country_code"  location:310}}  part_params:{partition_elem:{name:"record_type"  location:324}}  
-	location:290}  oncommit:ONCOMMIT_NOOP}}  stmt_location:178  stmt_len:159}
-	
-	In case if PRIMARY KEY in column list CREATE TABLE example1 (..., PRIMARY KEY(id,country_code) ) PARTITION BY RANGE (country_code, record_type);
-	stmts:{stmt:{create_stmt:{relation:{relname:"example1"  inh:true  relpersistence:"p"  location:15}  table_elts:{column_def:{colname:"id"  
-	type_name:{names:{string:{sval:"pg_catalog"}}  names:{string:{sval:"numeric"}}  ... table_elts:{constraint:{contype:CONSTR_PRIMARY  
-	location:98  keys:{string:{sval:"id"}} keys:{string:{sval:"country_code"}}}}  partspec:{strategy:PARTITION_STRATEGY_RANGE  
-	part_params:{partition_elem:{name:"country_code" location:150}}  part_params:{partition_elem:{name:"record_type"  ...
+		e.g. In case if PRIMARY KEY is included in column definition
+		 CREATE TABLE example2 (
+		 	id numeric NOT NULL PRIMARY KEY,
+			country_code varchar(3),
+			record_type varchar(5)
+		) PARTITION BY RANGE (country_code, record_type) ;
+		stmts:{stmt:{create_stmt:{relation:{relname:"example2"  inh:true  relpersistence:"p"  location:193}  table_elts:{column_def:{colname:"id"
+		type_name:{names:{string:{sval:"pg_catalog"}}  names:{string:{sval:"numeric"}}  typemod:-1  location:208}  is_local:true
+		constraints:{constraint:{contype:CONSTR_NOTNULL  location:216}}  constraints:{constraint:{contype:CONSTR_PRIMARY  location:225}}
+		location:205}}  ...  partspec:{strategy:PARTITION_STRATEGY_RANGE
+		part_params:{partition_elem:{name:"country_code"  location:310}}  part_params:{partition_elem:{name:"record_type"  location:324}}
+		location:290}  oncommit:ONCOMMIT_NOOP}}  stmt_location:178  stmt_len:159}
+
+		In case if PRIMARY KEY in column list CREATE TABLE example1 (..., PRIMARY KEY(id,country_code) ) PARTITION BY RANGE (country_code, record_type);
+		stmts:{stmt:{create_stmt:{relation:{relname:"example1"  inh:true  relpersistence:"p"  location:15}  table_elts:{column_def:{colname:"id"
+		type_name:{names:{string:{sval:"pg_catalog"}}  names:{string:{sval:"numeric"}}  ... table_elts:{constraint:{contype:CONSTR_PRIMARY
+		location:98  keys:{string:{sval:"id"}} keys:{string:{sval:"country_code"}}}}  partspec:{strategy:PARTITION_STRATEGY_RANGE
+		part_params:{partition_elem:{name:"country_code" location:150}}  part_params:{partition_elem:{name:"record_type"  ...
 	*/
 	if createTableNode.CreateStmt.GetPartspec() == nil {
 		//If not partition table then no need to proceed
@@ -473,7 +473,7 @@ func reportPartitionsRelatedIssues(createTableNode *pg_query.Node_CreateStmt, sq
 	}
 
 	if primaryConsInAlter[fullyQualifiedName] != nil {
-		//reporting the ALTER TABLE ADD PK on partition table here in case the order is different if ALTER is before the CREATE 
+		//reporting the ALTER TABLE ADD PK on partition table here in case the order is different if ALTER is before the CREATE
 		alterTableSqlInfo := primaryConsInAlter[fullyQualifiedName]
 		reportCase(alterTableSqlInfo.fileName, ADDING_PK_TO_PARTITIONED_TABLE_ISSUE_REASON,
 			"https://github.com/yugabyte/yugabyte-db/issues/10074", "", "TABLE", fullyQualifiedName, alterTableSqlInfo.formattedStmt, MIGRATION_CAVEATS, ADDING_PK_TO_PARTITIONED_TABLE_DOC_LINK)

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -540,7 +540,7 @@ func reportPartitionsRelatedIssues(createTableNode *pg_query.Node_CreateStmt, sq
 	}
 
 	partitionColumnsNotInPK, _ := lo.Difference(partitionColumns, primaryKeyColumns)
-	if len(primaryKeyColumns) > 0 && len(partitionColumnsNotInPK) > 0 {
+	if len(partitionColumnsNotInPK) > 0 {
 		summaryMap["TABLE"].invalidCount[fullyQualifiedName] = true
 		reportCase(fpath, fmt.Sprintf("%s - (%s)", INSUFFICIENT_COLUMNS_IN_PK_FOR_PARTITION, strings.Join(partitionColumnsNotInPK, ", ")),
 			"https://github.com/yugabyte/yb-voyager/issues/578", "Add all Partition columns to Primary Key", "TABLE", fullyQualifiedName, sqlStmtInfo.formattedStmt, UNSUPPORTED_FEATURES, PARTITION_KEY_NOT_PK_DOC_LINK)


### PR DESCRIPTION
Modifying the following cases of analyze-schema to be reported using pg-parser:
1. List partitioned table can't have multi-column partitions
2. Expression partitioned table can't have Primary key / Unique columns
3. The partition key on the partitioned table should have all the columns included in PK.
4. Alter table ADD PK on a partitioned table.

https://yugabyte.atlassian.net/browse/DB-13266