### PR TITLE
Fix Table Inheritance handling and consider them as normal tables in the workflow

### DIFF
--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -36,8 +36,8 @@
 			},
 			{
 				"ObjectType": "TABLE",
-				"TotalCount": 63,
-				"ObjectNames": "public.\"Case_Sensitive_Columns\", public.\"Mixed_Case_Table_Name_Test\", public.\"Recipients\", public.\"WITH\", public.audit, public.sales_region, public.boston, public.c, public.parent_table, public.child_table, public.citext_type, public.combined_tbl, public.documents, public.employees2, public.ext_test, public.foo, public.inet_type, public.london, public.mixed_data_types_table1, public.mixed_data_types_table2, public.orders, public.orders2, public.products, public.session_log, public.session_log1, public.session_log2, public.sydney, public.test_exclude_basic, public.test_jsonb, public.test_xml_type, public.ts_query_table, public.tt, public.with_example1, public.with_example2, schema2.\"Case_Sensitive_Columns\", schema2.\"Mixed_Case_Table_Name_Test\", schema2.\"Recipients\", schema2.\"WITH\", schema2.audit, schema2.sales_region, schema2.boston, schema2.c, schema2.parent_table, schema2.child_table, schema2.employees2, schema2.ext_test, schema2.foo, schema2.london, schema2.mixed_data_types_table1, schema2.mixed_data_types_table2, schema2.orders, schema2.orders2, schema2.products, schema2.session_log, schema2.session_log1, schema2.session_log2, schema2.sydney, schema2.test_xml_type, schema2.tt, schema2.with_example1, schema2.with_example2, test_views.view_table1, test_views.view_table2"
+				"TotalCount": 67,
+				"ObjectNames": "public.cities, public.capitals, schema2.cities, schema2.capitals, public.\"Case_Sensitive_Columns\", public.\"Mixed_Case_Table_Name_Test\", public.\"Recipients\", public.\"WITH\", public.audit, public.sales_region, public.boston, public.c, public.parent_table, public.child_table, public.citext_type, public.combined_tbl, public.documents, public.employees2, public.ext_test, public.foo, public.inet_type, public.london, public.mixed_data_types_table1, public.mixed_data_types_table2, public.orders, public.orders2, public.products, public.session_log, public.session_log1, public.session_log2, public.sydney, public.test_exclude_basic, public.test_jsonb, public.test_xml_type, public.ts_query_table, public.tt, public.with_example1, public.with_example2, schema2.\"Case_Sensitive_Columns\", schema2.\"Mixed_Case_Table_Name_Test\", schema2.\"Recipients\", schema2.\"WITH\", schema2.audit, schema2.sales_region, schema2.boston, schema2.c, schema2.parent_table, schema2.child_table, schema2.employees2, schema2.ext_test, schema2.foo, schema2.london, schema2.mixed_data_types_table1, schema2.mixed_data_types_table2, schema2.orders, schema2.orders2, schema2.products, schema2.session_log, schema2.session_log1, schema2.session_log2, schema2.sydney, schema2.test_xml_type, schema2.tt, schema2.with_example1, schema2.with_example2, test_views.view_table1, test_views.view_table2"
 			},
 			{
 				"ObjectType": "INDEX",
@@ -103,6 +103,10 @@
 				"public.child_table",
 				"public.parent_table",
 				"public.documents",
+				"public.cities",
+				"public.capitals",
+				"schema2.cities",
+				"schema2.capitals",
 				"schema2.child_table",
 				"schema2.parent_table",
 				"schema2.tbl_unlogged",
@@ -152,7 +156,7 @@
 				"test_views.abc_mview",
 				"test_views.view_table1"
 			],
-			"ColocatedReasoning": "Recommended instance type with 4 vCPU and 16 GiB memory could fit 69 objects (61 tables/materialized views and 8 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Rest 24 objects (5 tables/materialized views and 19 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec need to be migrated as range partitioned tables. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.",
+			"ColocatedReasoning": "Recommended instance type with 4 vCPU and 16 GiB memory could fit 73 objects (65 tables/materialized views and 8 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Rest 24 objects (5 tables/materialized views and 19 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec need to be migrated as range partitioned tables. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.",
 			"ShardedTables": [
 				"public.combined_tbl",
 				"public.citext_type",
@@ -275,6 +279,14 @@
 		{
 			"FeatureName": "Inherited tables",
 			"Objects": [
+				{
+					"ObjectName": "public.capitals",
+					"SqlStatement": "CREATE TABLE public.capitals (     state character(2) NOT NULL ) INHERITS (public.cities);"
+				},
+				{
+					"ObjectName": "schema2.capitals",
+					"SqlStatement": "CREATE TABLE schema2.capitals (     state character(2) NOT NULL ) INHERITS (schema2.cities);"
+				},
 				{
 					"ObjectName": "public.child_table",
 					"SqlStatement": "CREATE TABLE public.child_table (\n    specific_column1 date\n)\nINHERITS (public.parent_table);"
@@ -710,6 +722,62 @@
 			"ObjectType": "",
 			"ParentTableName": null,
 			"SizeInBytes": 0
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "capitals",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 7,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "schema2",
+			"ObjectName": "capitals",
+			"RowCount": 0,
+			"ColumnCount": 4,
+			"Reads": 0,
+			"Writes": 7,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "cities",
+			"RowCount": 0,
+			"ColumnCount": 3,
+			"Reads": 0,
+			"Writes": 7,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "schema2",
+			"ObjectName": "cities",
+			"RowCount": 0,
+			"ColumnCount": 3,
+			"Reads": 0,
+			"Writes": 7,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
 		},
 		{
 			"SchemaName": "public",

--- a/migtests/tests/pg/misc-objects-2/fix-schema
+++ b/migtests/tests/pg/misc-objects-2/fix-schema
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+sed -i  's/CREATE TABLE public.capitals (/CREATE TABLE public.capitals (\n    name TEXT,\n    population REAL,\n    elevation INT,/g' $TEST_DIR/export-dir/schema/tables/table.sql
+sed -i  's/INHERITS (public.cities)/ /g' $TEST_DIR/export-dir/schema/tables/table.sql

--- a/migtests/tests/pg/misc-objects-2/pg_misc_objects2.sql
+++ b/migtests/tests/pg/misc-objects-2/pg_misc_objects2.sql
@@ -178,3 +178,35 @@ INSERT INTO foo (id, value) VALUES (31, E'Text with \r\nText with \\r\\nText wit
 INSERT INTO foo (id, value) VALUES (32, E'\n\rText with \r');
 INSERT INTO foo (id, value) VALUES (33, E'Text with \n\r');
 INSERT INTO foo (id, value) VALUES (34, E'Text with \r\nText with \n\r');
+
+
+CREATE TABLE cities (
+    name       TEXT,
+    population REAL,
+    elevation  INT
+);
+ 
+CREATE TABLE capitals (
+    state CHAR(2) NOT NULL
+) INHERITS (cities);
+
+-- Inserting into the parent table
+INSERT INTO cities (name, population, elevation) VALUES 
+('San Francisco', 884363, 16),
+('Denver', 704621, 1609),
+('Los Angeles', 3980400, 71),
+('Chicago', 2716000, 594),
+('Miami', 467963, 2),
+('Seattle', 744955, 184),
+('Boston', 694583, 43);
+
+
+-- Inserting into the child table (capital)
+INSERT INTO capitals (name, population, elevation, state) VALUES 
+('Sacramento', 508529, 9, 'CA'),
+('Denver', 704621, 1609, 'CO'),
+('Phoenix', 1660272, 331, 'AZ'),
+('Austin', 964254, 149, 'TX'),
+('Tallahassee', 191049, 62, 'FL'),
+('Olympia', 52389, 95, 'WA'),
+('Boston', 694583, 43, 'MA');

--- a/migtests/tests/pg/misc-objects-2/validate
+++ b/migtests/tests/pg/misc-objects-2/validate
@@ -14,6 +14,8 @@ EXPECTED_ROW_COUNT = {
 	'audit': 4,
 	'c':12,
 	'foo': 34,
+	'cities': 7,
+	'capitals':7
 }
 
 EXPECTED_TEXT_LENGTHS = {
@@ -60,7 +62,7 @@ def YB_specific_checks(tgt):
 def migration_completed_checks(tgt):
 	table_list = tgt.get_table_names("public")
 	print("table_list:", table_list)
-	assert len(table_list) == 5 
+	assert len(table_list) == 7 
 
 	got_row_count = tgt.row_count_of_all_tables("public")
 	for table_name, row_count in EXPECTED_ROW_COUNT.items():

--- a/migtests/tests/pg/misc-objects-2/validate
+++ b/migtests/tests/pg/misc-objects-2/validate
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import yb
 
 def main():
@@ -55,6 +56,8 @@ EXPECTED_TEXT_LENGTHS = {
     34: 24,
 }
 
+if os.environ.get("BETA_FAST_DATA_EXPORT") == '1':
+	EXPECTED_ROW_COUNT["cities"] = 14
 
 def YB_specific_checks(tgt):
 	yb.verify_colocation(tgt, "postgresql")

--- a/migtests/tests/pg/misc-objects-2/validate-schema
+++ b/migtests/tests/pg/misc-objects-2/validate-schema
@@ -13,7 +13,7 @@ EXPECTED_TRIGGER_LIST = ["audit_trigger",]
 def migration_completed_checks(tgt):
 	table_list = tgt.get_table_names("public")
 	print("table_list:", table_list)
-	assert len(table_list) == 5 
+	assert len(table_list) == 7
 
 	fetched_triggers = tgt.fetch_all_triggers("public")
 	print(f"fetched triggers list: {fetched_triggers}\n Expected triggers: {EXPECTED_TRIGGER_LIST}")

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -635,7 +635,7 @@ func (pg *PostgreSQL) GetColumnsWithSupportedTypes(tableList []sqlname.NameTuple
 func (pg *PostgreSQL) ParentTableOfPartition(table sqlname.NameTuple) string {
 	var parentTable string
 	// For this query in case of case sensitive tables, minquoting is required
-	query := fmt.Sprintf(` SELECT c.relname, p.relname AS parent_table
+	query := fmt.Sprintf(` SELECT p.relname AS parent_table
 		FROM pg_catalog.pg_class c
 		JOIN pg_catalog.pg_inherits i ON c.oid = i.inhrelid
 		JOIN pg_catalog.pg_class p ON i.inhparent = p.oid
@@ -738,7 +738,7 @@ func (pg *PostgreSQL) GetPartitions(tableName sqlname.NameTuple) []string {
 	sname, tname := tableName.ForCatalogQuery()
 	query := fmt.Sprintf(`SELECT
     nmsp_child.nspname  AS child_schema,
-    child.relname       AS child
+    child.relname       AS child_table
 	FROM pg_inherits
 		JOIN pg_class parent            ON pg_inherits.inhparent = parent.oid
 		JOIN pg_class child             ON pg_inherits.inhrelid   = child.oid

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -635,11 +635,11 @@ func (pg *PostgreSQL) GetColumnsWithSupportedTypes(tableList []sqlname.NameTuple
 func (pg *PostgreSQL) ParentTableOfPartition(table sqlname.NameTuple) string {
 	var parentTable string
 	// For this query in case of case sensitive tables, minquoting is required
-	query := fmt.Sprintf(` SELECT p.relname AS parent_table
+	query := fmt.Sprintf(` SELECT i.inhparent::pg_catalog.regclass AS parent_table
 		FROM pg_catalog.pg_class c
 		JOIN pg_catalog.pg_inherits i ON c.oid = i.inhrelid
 		JOIN pg_catalog.pg_class p ON i.inhparent = p.oid
-		JOIN pg_catalog.pg_partitioned_table pt ON p.oid = pt.partrelid  -- This ensures it's a partitioned table
+		JOIN pg_catalog.pg_partitioned_table pt ON p.oid = pt.partrelid  -- this clause ensures it filters only partitioned table
 		WHERE c.oid = '%s'::regclass::oid;`, table.ForOutput())
 
 	err := pg.db.QueryRow(query).Scan(&parentTable)


### PR DESCRIPTION
1. Added an end-to-end test for inherited tables, migrating them as normal tables 
005a188a6f01820b2551ed00f338d67d6106eaea this commit adds test which fails in import-data phase.
```
if required quote column names: quote attribute name for "state" in table [CurrentName=(cities) SourceName=(cities) TargetName=(cities)]: find best matching column name for "state" in table [CurrentName=(cities) SourceName=(cities) TargetName=(cities)]: column "state" not found amongst table columns [population elevation name]
```
2. Modifying the `GetPartitions` and `ParentTableOfPartition` function's queries to only considers partitioned tables, not inherited ones.