### PR TITLE
Fix misleading error message in live migration pointing to wrong VSN. 

### DIFF
--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -423,6 +423,14 @@ func (eb *EventBatch) ID() string {
 	return fmt.Sprintf("%d:%d", eb.Events[0].Vsn, eb.GetLastVsn())
 }
 
+func (eb *EventBatch) GetAllVsns() []int64 {
+	vsns := make([]int64, len(eb.Events))
+	for i, event := range eb.Events {
+		vsns[i] = event.Vsn
+	}
+	return vsns
+}
+
 func (eb *EventBatch) GetChannelMetadataUpdateQuery(migrationUUID uuid.UUID) string {
 	queryTemplate := `UPDATE %s 
 	SET 

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -535,9 +535,9 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
+				log.Errorf("error executing stmt for event in batch(%s): %v. Event VSNs in batch:%v", batch.ID(), err, batch.GetAllVsns())
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
+				return false, fmt.Errorf("error executing stmt for event in batch(%s): %v", batch.ID(), err)
 			}
 			switch true {
 			case res.Insert():

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -623,9 +623,9 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
+				log.Errorf("error executing stmt for event in batch(%s): %v. Event VSNs in batch:%v", batch.ID(), err, batch.GetAllVsns())
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
+				return false, fmt.Errorf("error executing stmt for event in batch(%s): %v", batch.ID(), err)
 			}
 			switch true {
 			case res.Insert():


### PR DESCRIPTION
https://yugabyte.atlassian.net/browse/DB-13350

in pgx.SendBatch, no matter which statement has an error, we get the error on BatchResults.Exec() of the first statement https://github.com/jackc/pgx/issues/872. 

Thus, there is no direct way to figure out exactly which event in the batch resulted in an error. 
`
With regards to statement parse time errors being reported on the first result regardless of which statement was unparseable... that is pretty tricky. All the parsing occurs before any of the executing. So there are no results to report. Just a single error regardless of which query was unparseable.
`
https://github.com/jackc/pgx/issues/872#issuecomment-727660378

While we come up with a proper solution for this, this PR just corrects the error message, i.e. by not pointing to a particular VSN(which will always be the first VSN in the batch). 