### PR TITLE
Fix misleading error in batch for live migration

### DIFF
--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -423,14 +423,6 @@ func (eb *EventBatch) ID() string {
 	return fmt.Sprintf("%d:%d", eb.Events[0].Vsn, eb.GetLastVsn())
 }
 
-func (eb *EventBatch) GetAllVsns() []int64 {
-	vsns := make([]int64, len(eb.Events))
-	for i, event := range eb.Events {
-		vsns[i] = event.Vsn
-	}
-	return vsns
-}
-
 func (eb *EventBatch) GetChannelMetadataUpdateQuery(migrationUUID uuid.UUID) string {
 	queryTemplate := `UPDATE %s 
 	SET 

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -423,6 +423,14 @@ func (eb *EventBatch) ID() string {
 	return fmt.Sprintf("%d:%d", eb.Events[0].Vsn, eb.GetLastVsn())
 }
 
+func (eb *EventBatch) GetAllVsns() []int64 {
+	vsns := make([]int64, len(eb.Events))
+	for i, event := range eb.Events {
+		vsns[i] = event.Vsn
+	}
+	return vsns
+}
+
 func (eb *EventBatch) GetChannelMetadataUpdateQuery(migrationUUID uuid.UUID) string {
 	queryTemplate := `UPDATE %s 
 	SET 

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -535,9 +535,9 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event in batch(%s): %v. Event VSNs in batch:%v", batch.ID(), err, batch.GetAllVsns())
+				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event in batch(%s): %v", batch.ID(), err)
+				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
 			}
 			switch true {
 			case res.Insert():

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -535,9 +535,9 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
+				log.Errorf("error executing stmt for event in batch(%s): %v. Event VSNs in batch:%v", batch.ID(), err, batch.GetAllVsns())
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
+				return false, fmt.Errorf("error executing stmt for event in batch(%s): %v", batch.ID(), err)
 			}
 			switch true {
 			case res.Insert():

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -535,9 +535,15 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
+				errorMsg := ""
+				if i == 0 {
+					errorMsg = fmt.Sprintf("error preparing statements for events in batch (%s) or when executing event with vsn(%d)", batch.ID(), batch.Events[i].Vsn)
+				} else {
+					errorMsg = fmt.Sprintf("error executing stmt for event with vsn(%d) in batch(%s)", batch.Events[i].Vsn, batch.ID())
+				}
+				log.Errorf("%s : %v", errorMsg, err)
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
+				return false, fmt.Errorf("%s: %w", errorMsg, err)
 			}
 			switch true {
 			case res.Insert():

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -535,6 +535,16 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
+				// When using pgx SendBatch, there can be two types of errors thrown:
+				// 1. Error while preparing the statement - this is preprocessing (parsing, preparinng statements, etc)
+				//	that pgx will do before sending the batch. Examples - syntax error.
+				//  No matter which statement in the batch has an issue, the error will be thrown on calling br.Exec() for the first time.
+				// 2. Error while executing the statement - this is the actual execution of the statement, and the error comes from the DB.
+				// 	Examples - constraint violation, etc.
+				//  In this case, we get the error on the appropriate br.Exec() call associated with the statement that failed.
+				// Therefore, if error is thrown on the first br.Exec() call, it could be either of the above cases.
+				// Reference - https://github.com/jackc/pgx/issues/872
+				// This ideally needs to be fixed in pgx library.
 				errorMsg := ""
 				if i == 0 {
 					errorMsg = fmt.Sprintf("error preparing statements for events in batch (%s) or when executing event with vsn(%d)", batch.ID(), batch.Events[i].Vsn)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -636,6 +636,7 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 				errorMsg := ""
 				if i == 0 {
 					errorMsg = fmt.Sprintf("error preparing statements for events in batch (%s) or when executing event with vsn(%d)", batch.ID(), batch.Events[i].Vsn)
+					log.Errorf("Event VSNs in batch(%s): %v", batch.ID(), batch.GetAllVsns())
 				} else {
 					errorMsg = fmt.Sprintf("error executing stmt for event with vsn(%d) in batch(%s)", batch.Events[i].Vsn, batch.ID())
 				}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -623,9 +623,9 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event in batch(%s): %v. Event VSNs in batch:%v", batch.ID(), err, batch.GetAllVsns())
+				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event in batch(%s): %v", batch.ID(), err)
+				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
 			}
 			switch true {
 			case res.Insert():

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -623,6 +623,16 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
+				// When using pgx SendBatch, there can be two types of errors thrown:
+				// 1. Error while preparing the statement - this is preprocessing (parsing, preparinng statements, etc)
+				//	that pgx will do before sending the batch. Examples - syntax error.
+				//  No matter which statement in the batch has an issue, the error will be thrown on calling br.Exec() for the first time.
+				// 2. Error while executing the statement - this is the actual execution of the statement, and the error comes from the DB.
+				// 	Examples - constraint violation, etc.
+				//  In this case, we get the error on the appropriate br.Exec() call associated with the statement that failed.
+				// Therefore, if error is thrown on the first br.Exec() call, it could be either of the above cases.
+				// Reference - https://github.com/jackc/pgx/issues/872
+				// This ideally needs to be fixed in pgx library.
 				errorMsg := ""
 				if i == 0 {
 					errorMsg = fmt.Sprintf("error preparing statements for events in batch (%s) or when executing event with vsn(%d)", batch.ID(), batch.Events[i].Vsn)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -623,9 +623,9 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
+				log.Errorf("error executing stmt for event in batch(%s): %v. Event VSNs in batch:%v", batch.ID(), err, batch.GetAllVsns())
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
+				return false, fmt.Errorf("error executing stmt for event in batch(%s): %v", batch.ID(), err)
 			}
 			switch true {
 			case res.Insert():

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -623,9 +623,15 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		for i := 0; i < len(batch.Events); i++ {
 			res, err := br.Exec()
 			if err != nil {
-				log.Errorf("error executing stmt for event with vsn(%d) in batch(%s): %v", batch.Events[i].Vsn, batch.ID(), err)
+				errorMsg := ""
+				if i == 0 {
+					errorMsg = fmt.Sprintf("error preparing statements for events in batch (%s) or when executing event with vsn(%d)", batch.ID(), batch.Events[i].Vsn)
+				} else {
+					errorMsg = fmt.Sprintf("error executing stmt for event with vsn(%d) in batch(%s)", batch.Events[i].Vsn, batch.ID())
+				}
+				log.Errorf("%s : %v", errorMsg, err)
 				closeBatch()
-				return false, fmt.Errorf("error executing stmt for event with vsn(%d): %v", batch.Events[i].Vsn, err)
+				return false, fmt.Errorf("%s: %w", errorMsg, err)
 			}
 			switch true {
 			case res.Insert():


### PR DESCRIPTION
When using pgx SendBatch, there can be two types of errors thrown:
1. Error while preparing the statement - this is preprocessing (parsing, preparinng statements, etc) that pgx will do before sending the batch. Examples - syntax error.
 No matter which statement in the batch has an issue, the error will be thrown on calling br.Exec() for the first time.
2. Error while executing the statement - this is the actual execution of the statement, and the error comes from the DB.
Examples - constraint violation, etc.
In this case, we get the error on the appropriate br.Exec() call associated with the statement that failed.

Therefore, if error is thrown on the first br.Exec() call, it could be either of the above cases. Modified the logs to indicate this as part of this PR. 

Reference - https://github.com/jackc/pgx/issues/872
This ideally needs to be fixed in pgx library, and has been partially fixed in https://github.com/jackc/pgx/pull/1441 (pgx v5)