### PR TITLE
Start Clean prompts for export-data, import-data

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -917,6 +917,11 @@ func clearMigrationStateIfRequired() {
 	exportSnapshotStatusFile := jsonfile.NewJsonFile[ExportSnapshotStatus](exportSnapshotStatusFilePath)
 	dfdFilePath := exportDir + datafile.DESCRIPTOR_PATH
 	if startClean {
+		if dataIsExported() {
+			if !utils.AskPrompt("Data is already exported. Are you sure you want to clean the data directory and start fresh?") {
+				utils.ErrExit("Export aborted.")
+			}
+		}
 		utils.CleanDir(exportDataDir)
 		utils.CleanDir(sslDir)
 		clearDataIsExported()

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -918,7 +918,7 @@ func clearMigrationStateIfRequired() {
 	dfdFilePath := exportDir + datafile.DESCRIPTOR_PATH
 	if startClean {
 		if dataIsExported() {
-			if !utils.AskPrompt("Data is already exported. Are you sure you want to clean the data directory and start fresh?") {
+			if !utils.AskPrompt("Data is already exported. Are you sure you want to clean the data directory and start afresh") {
 				utils.ErrExit("Export aborted.")
 			}
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -859,9 +859,8 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 			return nt.ForOutput()
 		})
 		utils.PrintAndLog("Non-Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
-		utils.PrintAndLog("The above list of tables on target DB are not empty; " +
-			"partial data may have been imported in a previous run. Are you sure you want to start-clean? \n" +
-			"If you wish to truncate the tables, please manually truncate them on the target DB.")
+		utils.PrintAndLog("The above list of tables on target DB are not empty. Are you sure you want to start-clean? \n" +
+			"Please manually truncate them on the target DB, before continuing.")
 		yes := utils.AskPrompt("Do you want to continue")
 		if !yes {
 			utils.ErrExit("Aborting import.")

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -858,10 +858,11 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 		nonEmptyTableNames := lo.Map(nonEmptyNts, func(nt sqlname.NameTuple, _ int) string {
 			return nt.ForOutput()
 		})
-		utils.PrintAndLog("Following tables are not empty. "+
-			"TRUNCATE them before importing data with --start-clean.\n%s",
-			strings.Join(nonEmptyTableNames, ", "))
-		yes := utils.AskPrompt("Do you want to continue without truncating these tables?")
+		utils.PrintAndLog("Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
+		utils.PrintAndLog("The above list of tables on target DB are not empty; " +
+			"partial data may have been imported in a previous run. Are you sure you want to start-clean? \n" +
+			"If you wish to truncate the tables, please manually truncate them on the target DB.")
+		yes := utils.AskPrompt("Do you want to continue")
 		if !yes {
 			utils.ErrExit("Aborting import.")
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -859,11 +859,10 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 			return nt.ForOutput()
 		})
 		utils.PrintAndLog("Non-Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
-		utils.PrintAndLog("The above list of tables on target DB are not empty. Are you sure you want to start-clean? \n" +
-			"Please manually truncate them on the target DB, before continuing.")
-		yes := utils.AskPrompt("Do you want to continue")
+		utils.PrintAndLog("The above list of tables on target DB are not empty. ")
+		yes := utils.AskPrompt("Are you sure you want to start afresh without truncating tables")
 		if !yes {
-			utils.ErrExit("Aborting import.")
+			utils.ErrExit("Aborting import. Manually truncate the tables on target DB before continuing.")
 		}
 	}
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -858,7 +858,7 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 		nonEmptyTableNames := lo.Map(nonEmptyNts, func(nt sqlname.NameTuple, _ int) string {
 			return nt.ForOutput()
 		})
-		utils.PrintAndLog("Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
+		utils.PrintAndLog("Non-Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
 		utils.PrintAndLog("The above list of tables on target DB are not empty; " +
 			"partial data may have been imported in a previous run. Are you sure you want to start-clean? \n" +
 			"If you wish to truncate the tables, please manually truncate them on the target DB.")


### PR DESCRIPTION
Added prompt in export-data : 
```
~/Documents/test/integ » yb-voyager export data from source --export-dir .  --source-db-type postgresql --source-db-host 127.0.0.1 --source-db-port 5432 --source-db-user postgres --source-db-password postgres  --source-db-schema public --send-diagnostics=false --export-type snapshot-and-changes  --source-db-name test --start-clean t --table-list 'test_simple'
Note: Using current directory as export-dir
Note: Live migration is a TECH PREVIEW feature.
export of data for source type as 'postgresql'
migrationID: b4ae9c48-2358-4491-9f36-6135d838cb93
checking postgres version
Data is already exported. Are you sure you want to clean the data directory and start fresh?? [Y/N]: n
Export aborted.
```

Modified prompt in import-data: 
```
~/Documents/test/integ » yb-voyager import data to target --export-dir .  --target-db-host 127.0.0.1 --target-db-user yugabyte     --target-db-password yugabyte  --target-db-name test --start-clean true

Note: Using current directory as export-dir
migrationID: b4ae9c48-2358-4491-9f36-6135d838cb93
Using 3 parallel jobs.
yugabytedb version: 15.2-YB-2.25.0.0-b0

import of data in "test" database started
Non-Empty tables: [public.test_simple]
The above list of tables on target DB are not empty.
Are you sure you want to start afresh without truncating tables? [Y/N]: n
Aborting import. Manually truncate the tables on target DB before continuing.
```