### PR TITLE
Fix token too long in export-data-from-target when log-level is debug

### DIFF
--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -227,7 +227,7 @@ func registerCommonGlobalFlags(cmd *cobra.Command) {
 
 	registerExportDirFlag(cmd)
 
-	cmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "debug",
+	cmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
 		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
 
 	cmd.PersistentFlags().BoolVarP(&utils.DoNotPrompt, "yes", "y", false,

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -227,7 +227,7 @@ func registerCommonGlobalFlags(cmd *cobra.Command) {
 
 	registerExportDirFlag(cmd)
 
-	cmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
+	cmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "debug",
 		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
 
 	cmd.PersistentFlags().BoolVarP(&utils.DoNotPrompt, "yes", "y", false,


### PR DESCRIPTION
Fix for https://github.com/yugabyte/yb-voyager/issues/1786

Using [Reader](https://pkg.go.dev/bufio#Reader) instead of [Scanner](https://pkg.go.dev/bufio#Scanner) which does not suffer from the "token too long" errors. 