### PR TITLE
Added READ permissions on pg_stat_statements in grant script for assessment (#1800)

### DIFF
--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -112,6 +112,12 @@ SELECT 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA ' || schema_name || ' TO ' || :'
 FROM information_schema.schemata
 \gexec
 
+-- Grant READ on the pg_stat_statments for Assessing the source 
+\echo ''
+\echo '--- Granting READ Permission on the pg_stat_statments for Assessing the source database'
+GRANT pg_read_all_stats to :voyager_user;
+
+
 -- Change the replica identity of all tables to FULL
 \if :is_live_migration
     \echo ''


### PR DESCRIPTION
This will be the error message on PG9
```
--- Granting READ Permission on the pg_stat_statments for Assessing the source database
psql:/opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql:118: ERROR:  role "pg_read_all_stats" does not exist
```
and the script will move on in such case to grant further privileges.