### PR TITLE
[DB-13347] Implement callhome for Unsupported Query Constructs feature

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -172,7 +172,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		})),
 		UnsupportedQueryConstructs: callhome.MarshalledJsonString(countByConstructType),
 		UnsupportedDatatypes:       callhome.MarshalledJsonString(unsupportedDatatypesList),
-		MigrationCaveats: callhome.MarshalledJsonString(lo.Map(assessmentReport.UnsupportedFeatures, func(feature UnsupportedFeature, _ int) callhome.UnsupportedFeature {
+		MigrationCaveats: callhome.MarshalledJsonString(lo.Map(assessmentReport.MigrationCaveats, func(feature UnsupportedFeature, _ int) callhome.UnsupportedFeature {
 			return callhome.UnsupportedFeature{
 				FeatureName: feature.FeatureName,
 				ObjectCount: len(feature.Objects),

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -144,7 +144,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		}
 	}
 	schemaSummaryCopy := utils.SchemaSummary{
-		Notes:               assessmentReport.SchemaSummary.Notes,
+		Notes: assessmentReport.SchemaSummary.Notes,
 		DBObjects: lo.Map(schemaAnalysisReport.SchemaSummary.DBObjects, func(dbObject utils.DBObject, _ int) utils.DBObject {
 			dbObject.ObjectNames = ""
 			return dbObject
@@ -155,6 +155,13 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		return datatype.DataType
 	})
 
+	groupedByConstructType := lo.GroupBy(assessmentReport.UnsupportedQueryConstructs, func(q utils.UnsupportedQueryConstruct) string {
+		return q.ConstructType
+	})
+	countByConstructType := lo.MapValues(groupedByConstructType, func(constructs []utils.UnsupportedQueryConstruct, _ string) int {
+		return len(constructs)
+	})
+
 	assessPayload := callhome.AssessMigrationPhasePayload{
 		MigrationComplexity: assessmentReport.MigrationComplexity,
 		UnsupportedFeatures: callhome.MarshalledJsonString(lo.Map(assessmentReport.UnsupportedFeatures, func(feature UnsupportedFeature, _ int) callhome.UnsupportedFeature {
@@ -163,11 +170,12 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 				ObjectCount: len(feature.Objects),
 			}
 		})),
-		UnsupportedDatatypes: callhome.MarshalledJsonString(unsupportedDatatypesList),
-		TableSizingStats:     callhome.MarshalledJsonString(tableSizingStats),
-		IndexSizingStats:     callhome.MarshalledJsonString(indexSizingStats),
-		SchemaSummary:        callhome.MarshalledJsonString(schemaSummaryCopy),
-		IopsInterval:         intervalForCapturingIOPS,
+		UnsupportedQueryConstructs: callhome.MarshalledJsonString(countByConstructType),
+		UnsupportedDatatypes:       callhome.MarshalledJsonString(unsupportedDatatypesList),
+		TableSizingStats:           callhome.MarshalledJsonString(tableSizingStats),
+		IndexSizingStats:           callhome.MarshalledJsonString(indexSizingStats),
+		SchemaSummary:              callhome.MarshalledJsonString(schemaSummaryCopy),
+		IopsInterval:               intervalForCapturingIOPS,
 	}
 	if status == ERROR {
 		assessPayload.Error = "ERROR" // removing error for now, TODO to see if we want to keep it
@@ -185,7 +193,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(assessPayload)
 	payload.Status = status
-
+	utils.PrintAndLog("sending payload for callhome assess: %s\n", payload.PhasePayload)
 	err := callhome.SendPayload(&payload)
 	if err == nil && (status == COMPLETE || status == ERROR) {
 		callHomeErrorOrCompletePayloadSent = true

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -101,6 +101,7 @@ type AssessMigrationPhasePayload struct {
 	UnsupportedFeatures        string `json:"unsupported_features"`
 	UnsupportedDatatypes       string `json:"unsupported_datatypes"`
 	UnsupportedQueryConstructs string `json:"unsupported_query_constructs"`
+	MigrationCaveats           string `json:"migration_caveats"`
 	Error                      string `json:"error,omitempty"` // Removed it for now, TODO
 	TableSizingStats           string `json:"table_sizing_stats"`
 	IndexSizingStats           string `json:"index_sizing_stats"`

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -97,19 +97,20 @@ type UnsupportedFeature struct {
 }
 
 type AssessMigrationPhasePayload struct {
-	MigrationComplexity  string `json:"migration_complexity"`
-	UnsupportedFeatures  string `json:"unsupported_features"`
-	UnsupportedDatatypes string `json:"unsupported_datatypes"`
-	Error                string `json:"error,omitempty"` // Removed it for now, TODO
-	TableSizingStats     string `json:"table_sizing_stats"`
-	IndexSizingStats     string `json:"index_sizing_stats"`
-	SchemaSummary        string `json:"schema_summary"`
-	SourceConnectivity   bool   `json:"source_connectivity"`
-	IopsInterval         int64  `json:"iops_interval"`
+	MigrationComplexity        string `json:"migration_complexity"`
+	UnsupportedFeatures        string `json:"unsupported_features"`
+	UnsupportedDatatypes       string `json:"unsupported_datatypes"`
+	UnsupportedQueryConstructs string `json:"unsupported_query_constructs"`
+	Error                      string `json:"error,omitempty"` // Removed it for now, TODO
+	TableSizingStats           string `json:"table_sizing_stats"`
+	IndexSizingStats           string `json:"index_sizing_stats"`
+	SchemaSummary              string `json:"schema_summary"`
+	SourceConnectivity         bool   `json:"source_connectivity"`
+	IopsInterval               int64  `json:"iops_interval"`
 }
 
 type AssessMigrationBulkPhasePayload struct {
-	FleetConfigCount int `json:"fleet_config_count"` // Not storing any source infor just the count of db configs passed to bulk cmd
+	FleetConfigCount int `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
 }
 
 type ObjectSizingStats struct {


### PR DESCRIPTION
[DB-13917] Add Migration Caveats also in assessment callhome payload


Testing: Verified the payload by receiving it on a local call home end point.