### PR TITLE
[DB-13765] Added Docslink in Assessment report for UnsupportedQueryConstructs

### DIFF
--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -162,7 +162,7 @@ const (
 )
 
 /*
-List of all the features we are reporting as part of Unsupported features and Migration caveats 
+List of all the features we are reporting as part of Unsupported features and Migration caveats
 */
 const (
 	//Unsupported Features

--- a/yb-voyager/cmd/templates/migration_assessment_report.template
+++ b/yb-voyager/cmd/templates/migration_assessment_report.template
@@ -205,7 +205,7 @@
                         </ul>
                     </div>
                 {{end}}
-                 {{if .DocsLink}}
+                {{if .DocsLink}}
                     <p id="refer-p"><a href="{{.DocsLink}}" target="_blank">Details</a></p>
                 {{end}} 
             {{end}}
@@ -258,7 +258,12 @@
                             </ul>
                         </div>
                     </td>
-                    </tr>
+                    {{ if .DocsLink }}
+                    <td><a href="{{.DocsLink}}" target="_blank">Learn More</a></td>
+                    {{ else }}
+                    <td>N/A</td>
+                    {{ end }}
+                </tr>
                 {{ end }}
             </table>
         {{end}}

--- a/yb-voyager/cmd/templates/migration_assessment_report.template
+++ b/yb-voyager/cmd/templates/migration_assessment_report.template
@@ -234,7 +234,7 @@
                 <tr>
                     <th>Construct Type</th>
                     <th>Queries</th>
-                    <th>Documentation</th>
+                    <th>Details</th>
                 </tr>
                 {{ $currentType := "" }}
                 {{ $docsLink := "" }}
@@ -246,7 +246,7 @@
                         </td>
                         <td>
                             {{ if $docsLink }}
-                                <a href="{{ $docsLink }}" target="_blank">Learn More</a>
+                                <a href="{{ $docsLink }}" target="_blank">Link</a>
                             {{ else }}
                                 N/A
                             {{ end }}
@@ -270,7 +270,7 @@
                 </td>
                 <td>
                     {{ if $docsLink }}
-                        <a href="{{ $docsLink }}" target="_blank">Learn More</a>
+                        <a href="{{ $docsLink }}" target="_blank">Link</a>
                     {{ else }}
                         Not Available
                     {{ end }}

--- a/yb-voyager/cmd/templates/migration_assessment_report.template
+++ b/yb-voyager/cmd/templates/migration_assessment_report.template
@@ -227,46 +227,60 @@
             </div>
         {{end}}
 
+        <h2>Unsupported Query Constructs</h2>
         {{ if .UnsupportedQueryConstructs}}
-            <h2>Unsupported  Query Constructs</h2>
-            <p>Source database queries not supported in YugabyteDB, identified by scanning system tables.:</p>
+            <p>Source database queries not supported in YugabyteDB, identified by scanning system tables:</p>
             <table>
                 <tr>
                     <th>Construct Type</th>
                     <th>Queries</th>
+                    <th>Documentation</th>
                 </tr>
                 {{ $currentType := "" }}
+                {{ $docsLink := "" }}
                 {{ range $i, $construct := .UnsupportedQueryConstructs }}
                     {{ if ne $construct.ConstructType $currentType }}
                         {{ if ne $currentType "" }}
                                 </ul>
                             </div>
                         </td>
+                        <td>
+                            {{ if $docsLink }}
+                                <a href="{{ $docsLink }}" target="_blank">Learn More</a>
+                            {{ else }}
+                                N/A
+                            {{ end }}
+                        </td>
                         </tr>
                         {{ end }}
+                        {{ $docsLink = $construct.DocsLink }}
                         <tr>
                             <td><strong>{{ $construct.ConstructType }}</strong></td>
                             <td>
                                 <div class="scrollable-div">
                                     <ul>
-                    {{ $currentType = $construct.ConstructType }}
+                        {{ $currentType = $construct.ConstructType }}
                     {{ end }}
                     <li class="list_item">{{ $construct.Query }}</li>
                 {{ end }}
                 <!-- Close the last construct type -->
                 {{ if ne $currentType "" }}
-                            </ul>
-                        </div>
-                    </td>
-                    {{ if .DocsLink }}
-                    <td><a href="{{.DocsLink}}" target="_blank">Learn More</a></td>
+                        </ul>
+                    </div>
+                </td>
+                <td>
+                    {{ if $docsLink }}
+                        <a href="{{ $docsLink }}" target="_blank">Learn More</a>
                     {{ else }}
-                    <td>N/A</td>
+                        Not Available
                     {{ end }}
+                </td>
                 </tr>
                 {{ end }}
             </table>
-        {{end}}
+        {{ else }}
+            <p>No unsupported query constructs found in the source database for target YugabyteDB.</p>
+        {{ end }}
 
         {{ if .MigrationCaveats}}
             {{ $hasMigrationCaveats := false }}

--- a/yb-voyager/src/queryparser/helpers.go
+++ b/yb-voyager/src/queryparser/helpers.go
@@ -4,6 +4,14 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+const (
+	DOCS_LINK_PREFIX        = "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/"
+	POSTGRESQL_PREFIX       = "postgresql/"
+	ADVISORY_LOCKS_DOC_LINK = DOCS_LINK_PREFIX + POSTGRESQL_PREFIX + "#advisory-locks"
+	SYSTEM_COLUMNS_DOC_LINK = DOCS_LINK_PREFIX + POSTGRESQL_PREFIX + "#system-columns"
+	XML_FUNCTIONS_DOC_LINK  = DOCS_LINK_PREFIX + POSTGRESQL_PREFIX + "#xml-functions"
+)
+
 // Refer: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
 var unsupportedAdvLockFuncs = []string{
 	"pg_advisory_lock", "pg_advisory_lock_shared",

--- a/yb-voyager/src/queryparser/query_parser.go
+++ b/yb-voyager/src/queryparser/query_parser.go
@@ -85,8 +85,22 @@ func (qp *QueryParser) GetUnsupportedQueryConstructs() ([]utils.UnsupportedQuery
 		result = append(result, utils.UnsupportedQueryConstruct{
 			ConstructType: unsupportedConstruct,
 			Query:         qp.QueryString,
+			DocsLink:      getDocsLink(unsupportedConstruct),
 		})
 	}
 
 	return result, nil
+}
+
+func getDocsLink(constructType string) string {
+	switch constructType {
+	case ADVISORY_LOCKS:
+		return ADVISORY_LOCKS_DOC_LINK
+	case SYSTEM_COLUMNS:
+		return SYSTEM_COLUMNS_DOC_LINK
+	case XML_FUNCTIONS:
+		return XML_FUNCTIONS_DOC_LINK
+	default:
+		panic(fmt.Sprintf("construct type %q not supported", constructType))
+	}
 }

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -126,6 +126,7 @@ type TableColumnsDataTypes struct {
 type UnsupportedQueryConstruct struct {
 	ConstructType string
 	Query         string
+	DocsLink      string
 }
 
 // ================== Segment ==============================


### PR DESCRIPTION
Sample Report

1. Links in case of uqc present
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/e1afa049-5b6f-41ae-bc6b-27226fec0611">

2. In case of no uqc present
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/23c0c98a-4134-44cd-8590-8fb09da32ae8">

https://yugabyte.atlassian.net/browse/DB-13765