### PR TITLE
Added new steps to install the cpan modules in the airgapped script itself

### DIFF
--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -15,6 +15,7 @@ centos_yum_package_requirements=(
   "perl-App-cpanminus|min|0"
   "perl-ExtUtils-MakeMaker|min|0"
   "mysql-devel|min|0"
+  "libaio|min|0"
   "oracle-instantclient-tools|exact|21.5.0.0.0"
   "oracle-instantclient-basic|exact|21.5.0.0.0"
   "oracle-instantclient-devel|exact|21.5.0.0.0"

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -39,6 +39,13 @@ ubuntu_apt_package_requirements=(
 
 # Array with format "Module::Name|requirement_type|required_version|tarball_name"
 cpan_modules_requirements=(
+  "Compress::Raw::Bzip2|min|2.213|Compress-Raw-Bzip2-2.213.tar.gz"
+  "Compress::Raw::Zlib|min|2.213|Compress-Raw-Zlib-2.213.tar.gz"
+  "Test::Deep|min|0|Test-Deep-1.204.tar.gz"
+  "DBI::DBD|min|0|DBI-1.645.tgz"
+  "Capture::Tiny|min|0|Capture-Tiny-0.48.tar.gz"
+  "Mock::Config|min|0.02|Mock-Config-0.03.tar.gz"
+  "Devel::CheckLib|min|1.16|Devel-CheckLib-1.16.tar.gz"
   "DBD::mysql|min|5.005|DBD-mysql-5.005.tar.gz"
   "Test::NoWarnings|min|1.06|Test-NoWarnings-1.06.tar.gz"
   "DBD::Oracle|min|1.83|DBD-Oracle-1.83.tar.gz"
@@ -142,28 +149,30 @@ install_perl_module() {
     
     echo "Installing $package for module $module_name..."
     
-    # Extract the package
-    tar -xzvf "$package"
+        # Extract the package
+    tar -xzvf "$package" || { echo "Error: Failed to extract $package"; exit 1; }
     
     # Get the extracted directory name (remove the .tar.gz extension)
     local dir_name="${package%.tar.gz}"
+    # If tar zip is like .tgz then remove .tgz extension. Add a condition for that
+    dir_name="${dir_name%.tgz}"
     
     # Navigate to the extracted directory
-    cd "$dir_name" || { echo "Failed to enter directory $dir_name"; exit 1; }
+    cd "$dir_name" || { echo "Error: Failed to enter directory $dir_name"; exit 1; }
     
     # Check if Makefile.PL or Build.PL exists and run the appropriate commands
     if [[ -f Makefile.PL ]]; then
         echo "Installing $dir_name using Makefile.PL..."
-        perl Makefile.PL
-        make
-        make test
-        sudo make install
+        perl Makefile.PL || { echo "Error: perl Makefile.PL failed for $module_name"; exit 1; }
+        make || { echo "Error: make command failed for $module_name"; exit 1; }
+        make test || { echo "Error: make test failed for $module_name"; exit 1; }
+        sudo make install || { echo "Error: sudo make install failed for $module_name"; exit 1; }
     elif [[ -f Build.PL ]]; then
         echo "Installing $dir_name using Build.PL..."
-        perl Build.PL
-        ./Build
-        ./Build test
-        sudo ./Build install
+        perl Build.PL || { echo "Error: perl Build.PL failed for $module_name"; exit 1; }
+        ./Build || { echo "Error: ./Build command failed for $module_name"; exit 1; }
+        ./Build test || { echo "Error: ./Build test failed for $module_name"; exit 1; }
+        sudo ./Build install || { echo "Error: sudo ./Build install failed for $module_name"; exit 1; }
     else
         echo "Error: No Makefile.PL or Build.PL found in $dir_name, installation failed."
         exit 1


### PR DESCRIPTION
We used to ask the users to install the cpan modules themselves in an airgapped environment. We only checked whether the packages with the required versions were installed or not.
However, manually installing cpan modules can be a big task for the users. They have to first get the tar zip and then perform lengthy `make` steps.
So to automate this process for the users, we are now including the cpan tars in the airgapped  bundle and running build/installation from these tars ourselves inside the airgapped script.