### PR TITLE
Make adaptive parallelism parallel jobs error message more descriptive

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -397,19 +397,15 @@ func validateFFDBSchemaFlag() {
 }
 
 func validateParallelismFlags() {
-	if importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE {
-		if tconf.EnableYBAdaptiveParallelism {
-			if tconf.Parallelism > 0 {
-				utils.ErrExit("Error: --parallel-jobs flag cannot be used with --enable-adaptive-parallelism flag")
-			}
+	if tconf.EnableYBAdaptiveParallelism {
+		if tconf.Parallelism > 0 {
+			utils.ErrExit("Error: --parallel-jobs flag cannot be used with --enable-adaptive-parallelism true. If you wish to set the number of parallel jobs explicitly, disable adaptive parallelism using --enable-adaptive-parallelism false")
 		}
-		if tconf.MaxParallelism > 0 {
-			if !tconf.EnableYBAdaptiveParallelism {
-				utils.ErrExit("Error: --adaptive-parallelism-max flag can only be used with --enable-adaptive-parallelism true")
-			}
-		}
-	} else {
-		// not relevant for source-replica and source
-		tconf.EnableYBAdaptiveParallelism = false
 	}
+	if tconf.MaxParallelism > 0 {
+		if !tconf.EnableYBAdaptiveParallelism {
+			utils.ErrExit("Error: --adaptive-parallelism-max flag can only be used with --enable-adaptive-parallelism true")
+		}
+	}
+
 }

--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -40,6 +40,7 @@ var importDataToSourceCmd = &cobra.Command{
 		if err != nil {
 			utils.ErrExit("failed to setup target conf from source conf in MSR: %v", err)
 		}
+		tconf.EnableYBAdaptiveParallelism = false
 		importDataCmd.PreRun(cmd, args)
 		importDataCmd.Run(cmd, args)
 	},

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -51,6 +51,7 @@ func setTargetConfSpecifics(cmd *cobra.Command) {
 	}
 	sconf := msr.SourceDBConf
 	tconf.TargetDBType = sconf.DBType
+	tconf.EnableYBAdaptiveParallelism = false
 	if tconf.TargetDBType == POSTGRESQL {
 		if cmd.Flags().Lookup("source-replica-db-schema").Changed {
 			utils.ErrExit("cannot specify --source-replica-db-schema for PostgreSQL source")


### PR DESCRIPTION
- Make adaptive parallelism parallel jobs error message more descriptive
- Also set adaptive parallelism to false explicitly in `import-data-to-source-replica` and `import-data-to-source` functions rather than in the validate function. 