### PR TITLE
YBVersion to be able to store and compare yb versions

### DIFF
--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -42,6 +42,7 @@ require (
 
 require (
 	github.com/fergusstrange/embedded-postgres v1.29.0 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/jackc/puddle v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -1260,6 +1260,8 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/yb-voyager/src/version/yb_version.go
+++ b/yb-voyager/src/version/yb_version.go
@@ -82,7 +82,7 @@ func (ybv *YBVersion) originalSegmentsLen() int {
 	return len(segments)
 }
 
-func (ybv *YBVersion) ComparePrefix(other *YBVersion) (int, error) {
+func (ybv *YBVersion) CompareCommonPrefix(other *YBVersion) (int, error) {
 	if ybv.Series() != other.Series() {
 		return 0, fmt.Errorf("Cannot compare versions with different series: %s and %s", ybv.Series(), other.Series())
 	}
@@ -101,16 +101,16 @@ func (ybv *YBVersion) ComparePrefix(other *YBVersion) (int, error) {
 	return ybvMin.Compare(otherMin), nil
 }
 
-func (ybv *YBVersion) PrefixGreaterThanOrEqual(other *YBVersion) (bool, error) {
-	res, err := ybv.ComparePrefix(other)
+func (ybv *YBVersion) CommonPrefixGreaterThanOrEqual(other *YBVersion) (bool, error) {
+	res, err := ybv.CompareCommonPrefix(other)
 	if err != nil {
 		return false, err
 	}
 	return res >= 0, nil
 }
 
-func (ybv *YBVersion) PrefixLessThan(other *YBVersion) (bool, error) {
-	res, err := ybv.ComparePrefix(other)
+func (ybv *YBVersion) CommonPrefixLessThan(other *YBVersion) (bool, error) {
+	res, err := ybv.CompareCommonPrefix(other)
 	if err != nil {
 		return false, err
 	}

--- a/yb-voyager/src/version/yb_version.go
+++ b/yb-voyager/src/version/yb_version.go
@@ -90,6 +90,11 @@ func (ybv *YBVersion) ReleaseType() string {
 	}
 }
 
+// This returns the len of the segments in the original
+// input. For instance if input is 2024.1,
+// go-version.Version.Segments() will return [2024, 1, 0, 0]
+// original = 2024.1
+// originalSegmentsLen  = 2 ([2024,1])
 func (ybv *YBVersion) originalSegmentsLen() int {
 	orig := ybv.Original()
 	segments := strings.Split(orig, ".")

--- a/yb-voyager/src/version/yb_version.go
+++ b/yb-voyager/src/version/yb_version.go
@@ -22,14 +22,16 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
+	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 )
 
-var supportedYBVersionStableSeriesOld = []string{"2.20"}
+// Reference - https://docs.yugabyte.com/preview/releases/ybdb-releases/
+var supportedYBVersionStableSeriesOld = []string{"2.14", "2.18", "2.20"}
 var supportedYBVersionStableSeries = []string{"2024.1"}
-var supportedYBVersionPreviewSeries = []string{"2.21"}
+var supportedYBVersionPreviewSeries = []string{"2.21", "2.23"}
 
-var allSupportedYBVersionSeries = append(append(supportedYBVersionStableSeries, supportedYBVersionPreviewSeries...), supportedYBVersionStableSeriesOld...)
+var allSupportedYBVersionSeries = lo.Flatten([][]string{supportedYBVersionStableSeries, supportedYBVersionPreviewSeries, supportedYBVersionStableSeriesOld})
 
 const (
 	STABLE     = "stable"
@@ -69,6 +71,8 @@ func NewYBVersion(v string) (*YBVersion, error) {
 	return ybv, nil
 }
 
+// The first two segments essentially represent the release series
+// as per https://docs.yugabyte.com/preview/releases/ybdb-releases/
 func (ybv *YBVersion) Series() string {
 	return joinIntsWith(ybv.Segments()[:2], ".")
 }

--- a/yb-voyager/src/version/yb_version.go
+++ b/yb-voyager/src/version/yb_version.go
@@ -60,11 +60,11 @@ func NewYBVersion(v string) (*YBVersion, error) {
 	ybv := &YBVersion{v1}
 	origSegLen := ybv.originalSegmentsLen()
 	if origSegLen < 2 || origSegLen > 4 {
-		return nil, fmt.Errorf("Invalid YB version: %s. Version should have between min 2 and max 4 segments (A.B.C.D). Version %s has ybv.originalSegmentsLen()", v, v)
+		return nil, fmt.Errorf("invalid YB version: %s. Version should have between min 2 and max 4 segments (A.B.C.D). Version %s has ybv.originalSegmentsLen()", v, v)
 	}
 
 	if !slices.Contains(allSupportedYBVersionSeries, ybv.Series()) {
-		return nil, fmt.Errorf("Unsupported YB version series: %s. Supported YB version series = %v", ybv.Series(), allSupportedYBVersionSeries)
+		return nil, fmt.Errorf("unsupported YB version series: %s. Supported YB version series = %v", ybv.Series(), allSupportedYBVersionSeries)
 	}
 	return ybv, nil
 }
@@ -104,7 +104,7 @@ or larger than the other version, respectively.
 */
 func (ybv *YBVersion) CompareCommonPrefix(other *YBVersion) (int, error) {
 	if ybv.Series() != other.Series() {
-		return 0, fmt.Errorf("Cannot compare versions with different series: %s and %s", ybv.Series(), other.Series())
+		return 0, fmt.Errorf("cannot compare versions with different series: %s and %s", ybv.Series(), other.Series())
 	}
 	myOriginalSegLen := ybv.originalSegmentsLen()
 	otherOriginalSegLen := other.originalSegmentsLen()

--- a/yb-voyager/src/version/yb_version.go
+++ b/yb-voyager/src/version/yb_version.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"golang.org/x/exp/slices"
+)
+
+var supportedYBVersionStableSeriesOld = []string{"2.20"}
+var supportedYBVersionStableSeries = []string{"2024.1"}
+var supportedYBVersionPreviewSeries = []string{"2.21"}
+
+var allSupportedYBVersionSeries = append(append(supportedYBVersionStableSeries, supportedYBVersionPreviewSeries...), supportedYBVersionStableSeriesOld...)
+
+const (
+	STABLE     = "stable"
+	PREVIEW    = "preview"
+	STABLE_OLD = "stable_old"
+)
+
+type YBVersion struct {
+	V *version.Version
+}
+
+func NewYBVersion(v string) (*YBVersion, error) {
+	v1, err := version.NewVersion(v)
+	if err != nil {
+		return nil, err
+	}
+
+	ybv := &YBVersion{v1}
+	origSegLen := ybv.originalSegmentsLen()
+	if origSegLen < 2 || origSegLen > 4 {
+		return nil, fmt.Errorf("Invalid YB version: %s. Version should have between min 2 and max 4 segments (A.B.C.D). Version %s has ybv.originalSegmentsLen()", v, v)
+	}
+
+	if !slices.Contains(allSupportedYBVersionSeries, ybv.Series()) {
+		return nil, fmt.Errorf("Unsupported YB version series: %s. Supported YB version series = %v", ybv.Series(), allSupportedYBVersionSeries)
+	}
+	return ybv, nil
+}
+
+func (ybv *YBVersion) Series() string {
+	return joinIntsWith(ybv.V.Segments()[:2], ".")
+}
+
+func (ybv *YBVersion) ReleaseType() string {
+	series := ybv.Series()
+	if slices.Contains(supportedYBVersionStableSeries, series) {
+		return STABLE
+	} else if slices.Contains(supportedYBVersionPreviewSeries, series) {
+		return PREVIEW
+	} else if slices.Contains(supportedYBVersionStableSeriesOld, series) {
+		return STABLE_OLD
+	} else {
+		panic("unknown release type for series: " + series)
+	}
+}
+
+func (ybv *YBVersion) originalSegmentsLen() int {
+	orig := ybv.V.Original()
+	segments := strings.Split(orig, ".")
+	return len(segments)
+}
+
+func (ybv *YBVersion) ComparePrefix(other *YBVersion) int {
+	myOriginalSegLen := ybv.originalSegmentsLen()
+	otherOriginalSegLen := other.originalSegmentsLen()
+	minSegLen := min(myOriginalSegLen, otherOriginalSegLen)
+
+	ybvMin, err := version.NewVersion(joinIntsWith(ybv.V.Segments()[:minSegLen], "."))
+	if err != nil {
+		panic(err)
+	}
+	otherMin, err := version.NewVersion(joinIntsWith(other.V.Segments()[:minSegLen], "."))
+	if err != nil {
+		panic(err)
+	}
+	return ybvMin.Compare(otherMin)
+}
+
+func (ybv *YBVersion) PrefixGreaterThanOrEqual(other *YBVersion) bool {
+	return ybv.ComparePrefix(other) >= 0
+}
+
+func (ybv *YBVersion) PrefixLessThan(other *YBVersion) bool {
+	return ybv.ComparePrefix(other) < 0
+}
+
+func (ybv *YBVersion) String() string {
+	return ybv.V.Original()
+}
+
+func joinIntsWith(ints []int, delimiter string) string {
+	strs := make([]string, len(ints))
+	for i, v := range ints {
+		strs[i] = strconv.Itoa(v)
+	}
+	return strings.Join(strs, delimiter)
+}

--- a/yb-voyager/src/version/yb_version.go
+++ b/yb-voyager/src/version/yb_version.go
@@ -112,11 +112,11 @@ func (ybv *YBVersion) CompareCommonPrefix(other *YBVersion) (int, error) {
 
 	ybvMin, err := version.NewVersion(joinIntsWith(ybv.Segments()[:minSegLen], "."))
 	if err != nil {
-		panic(err)
+		return 0, fmt.Errorf("create version from segments: %v", ybv.Segments()[:minSegLen])
 	}
 	otherMin, err := version.NewVersion(joinIntsWith(other.Segments()[:minSegLen], "."))
 	if err != nil {
-		panic(err)
+		return 0, fmt.Errorf("create version from segments: %v", other.Segments()[:minSegLen])
 	}
 	return ybvMin.Compare(otherMin), nil
 }

--- a/yb-voyager/src/version/yb_version_test.go
+++ b/yb-voyager/src/version/yb_version_test.go
@@ -91,7 +91,7 @@ func TestVersionPrefixGreaterThanOrEqual(t *testing.T) {
 		assert.NoError(t, err)
 		v2, err := NewYBVersion(v[1])
 		assert.NoError(t, err)
-		greaterThan, err := v1.PrefixGreaterThanOrEqual(v2)
+		greaterThan, err := v1.CommonPrefixGreaterThanOrEqual(v2)
 		assert.NoError(t, err)
 		assert.True(t, greaterThan, "%s >= %s", v[0], v[1])
 	}
@@ -108,7 +108,7 @@ func TestVersionPrefixLessThan(t *testing.T) {
 		assert.NoError(t, err)
 		v2, err := NewYBVersion(v[1])
 		assert.NoError(t, err)
-		lessThan, err := v1.PrefixLessThan(v2)
+		lessThan, err := v1.CommonPrefixLessThan(v2)
 		assert.NoError(t, err)
 		assert.True(t, lessThan, "%s < %s", v[0], v[1])
 	}
@@ -117,6 +117,6 @@ func TestVersionPrefixLessThan(t *testing.T) {
 func TestComparingDifferentSeriesThrowsError(t *testing.T) {
 	v1, _ := NewYBVersion("2024.1.1")
 	v2, _ := NewYBVersion("2.21.1")
-	_, err := v1.PrefixGreaterThanOrEqual(v2)
+	_, err := v1.CompareCommonPrefix(v2)
 	assert.Error(t, err)
 }

--- a/yb-voyager/src/version/yb_version_test.go
+++ b/yb-voyager/src/version/yb_version_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidNewYBVersion(t *testing.T) {
+	validVersionStrings := []string{
+		"2024.1.1",
+		"2.20",
+		"2.21.2.1",
+	}
+	for _, v := range validVersionStrings {
+		_, err := NewYBVersion(v)
+		assert.NoError(t, err)
+	}
+}
+
+func TestInvalidNewYBVersion(t *testing.T) {
+	invalidVersionStrings := []string{
+		"abc.def",        // has to be numbers
+		"2024.0.1-1",     // has to be in supported series
+		"2024",           // has to have at least 2 segments
+		"2024.1.1.1.1.1", // max 4 segments
+	}
+	for _, v := range invalidVersionStrings {
+		_, err := NewYBVersion(v)
+		assert.Error(t, err)
+	}
+}
+
+func TestStableReleaseType(t *testing.T) {
+	stableVersionStrings := []string{
+		"2024.1.1",
+		"2024.1",
+		"2024.1.1.1",
+	}
+	for _, v := range stableVersionStrings {
+		ybVersion, _ := NewYBVersion(v)
+		assert.Equal(t, STABLE, ybVersion.ReleaseType())
+	}
+}
+
+func TestPreviewReleaseType(t *testing.T) {
+	previewVersionStrings := []string{
+		"2.21.1",
+		"2.21",
+	}
+	for _, v := range previewVersionStrings {
+		ybVersion, _ := NewYBVersion(v)
+		assert.Equal(t, PREVIEW, ybVersion.ReleaseType())
+	}
+}
+
+func TestStableOldReleaseType(t *testing.T) {
+	stableOldVersionStrings := []string{
+		"2.20.1",
+		"2.20",
+	}
+	for _, v := range stableOldVersionStrings {
+		ybVersion, _ := NewYBVersion(v)
+		assert.Equal(t, STABLE_OLD, ybVersion.ReleaseType())
+	}
+}
+
+func TestVersionPrefixGreaterThanOrEqual(t *testing.T) {
+	versionsToCompare := [][]string{
+		{"2024.1.1", "2024.1.0"},
+		{"2024.1", "2024.1.4.0"}, //prefix 2024.1 == 2024.1
+	}
+	for _, v := range versionsToCompare {
+		v1, err := NewYBVersion(v[0])
+		assert.NoError(t, err)
+		v2, err := NewYBVersion(v[1])
+		assert.NoError(t, err)
+		greaterThan, err := v1.PrefixGreaterThanOrEqual(v2)
+		assert.NoError(t, err)
+		assert.True(t, greaterThan, "%s >= %s", v[0], v[1])
+	}
+}
+
+func TestVersionPrefixLessThan(t *testing.T) {
+	versionsToCompare := [][]string{
+		{"2024.1.0", "2024.1.2"},
+		{"2.21.1", "2.21.7"},
+		{"2.20.1", "2.20.7"},
+	}
+	for _, v := range versionsToCompare {
+		v1, err := NewYBVersion(v[0])
+		assert.NoError(t, err)
+		v2, err := NewYBVersion(v[1])
+		assert.NoError(t, err)
+		lessThan, err := v1.PrefixLessThan(v2)
+		assert.NoError(t, err)
+		assert.True(t, lessThan, "%s < %s", v[0], v[1])
+	}
+}
+
+func TestComparingDifferentSeriesThrowsError(t *testing.T) {
+	v1, _ := NewYBVersion("2024.1.1")
+	v2, _ := NewYBVersion("2.21.1")
+	_, err := v1.PrefixGreaterThanOrEqual(v2)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
YBVersion is a wrapper around hashicorp/go-version.Version that adds some Yugabyte-specific
functionality.
 1. It only supports versions with 2, 3, or 4 segments (A.B, A.B.C, A.B.C.D).
 2. It only accepts one of supported Yugabyte version series.
 3. It provides a method to compare versions based on common prefix of segments. This is useful in cases
    where the version is not fully specified (e.g. 2.20 vs 2.20.7.0).
    If the user specifies 2.20, a reasonable assumption is that they would be on the latest 2.20.x.y version.
    Therefore, we want only want to compare the prefix 2.20 between versions and ignore the rest.