### PR TITLE
Partial fix for [export-data errors out if background metadata queries (count*) are still running when pg_dump completes.]

### DIFF
--- a/yb-voyager/cmd/exportDataStatus.go
+++ b/yb-voyager/cmd/exportDataStatus.go
@@ -102,7 +102,7 @@ func initializeExportTableMetadata(tableList []sqlname.NameTuple) {
 			ExportedRowCountSnapshot: int64(0),
 		}
 		if source.DBType == POSTGRESQL {
-			//for Postgresql rename the table leaf table names to root table 
+			//for Postgresql rename the table leaf table names to root table
 			renamedTable, isRenamed := renameTableIfRequired(key)
 			if isRenamed {
 				exportSnapshotStatus.Tables[key].TableName = renamedTable
@@ -203,7 +203,11 @@ func startExportPB(progressContainer *mpb.Progress, mapKey string, quitChan chan
 
 	// parallel goroutine to calculate and set total to actual row count
 	go func() {
-		actualRowCount := source.DB().GetTableRowCount(tableMetadata.TableName)
+		actualRowCount, err := source.DB().GetTableRowCount(tableMetadata.TableName)
+		if err != nil {
+			log.Warnf("could not get actual row count for table=%s: %v", tableMetadata.TableName, err)
+			return
+		}
 		log.Infof("Replacing actualRowCount=%d inplace of expectedRowCount=%d for table=%s",
 			actualRowCount, tableMetadata.CountTotalRows, tableMetadata.TableName.ForUserQuery())
 		pbr.SetTotalRowCount(actualRowCount, false)

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -47,7 +47,7 @@ func newMySQL(s *Source) *MySQL {
 
 func (ms *MySQL) Connect() error {
 	db, err := sql.Open("mysql", ms.getConnectionUri())
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(ms.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	ms.db = db
 	return err

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -75,17 +75,17 @@ func (ms *MySQL) CheckRequiredToolsAreInstalled() {
 	checkTools("ora2pg")
 }
 
-func (ms *MySQL) GetTableRowCount(tableName sqlname.NameTuple) int64 {
+func (ms *MySQL) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.AsQualifiedCatalogName())
 
 	log.Infof("Querying row count of table %s", tableName)
 	err := ms.db.QueryRow(query).Scan(&rowCount)
 	if err != nil {
-		utils.ErrExit("Failed to query %q for row count of %q: %s", query, tableName, err)
+		return 0, fmt.Errorf("query %q for row count of %q: %w", query, tableName, err)
 	}
 	log.Infof("Table %q has %v rows.", tableName, rowCount)
-	return rowCount
+	return rowCount, nil
 }
 
 func (ms *MySQL) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -82,17 +82,17 @@ func (ora *Oracle) CheckRequiredToolsAreInstalled() {
 	checkTools("ora2pg", "sqlplus")
 }
 
-func (ora *Oracle) GetTableRowCount(tableName sqlname.NameTuple) int64 {
+func (ora *Oracle) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.ForUserQuery())
 
 	log.Infof("Querying row count of table %q", tableName)
 	err := ora.db.QueryRow(query).Scan(&rowCount)
 	if err != nil {
-		utils.ErrExit("Failed to query %q for row count of %q: %s", query, tableName, err)
+		return 0, fmt.Errorf("query %q for row count of %q: %w", query, tableName, err)
 	}
 	log.Infof("Table %q has %v rows.", tableName, rowCount)
-	return rowCount
+	return rowCount, nil
 }
 
 func (ora *Oracle) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -47,7 +47,7 @@ func newOracle(s *Source) *Oracle {
 
 func (ora *Oracle) Connect() error {
 	db, err := sql.Open("godror", ora.getConnectionUri())
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(ora.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	ora.db = db
 	return err

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -109,7 +109,7 @@ func newPostgreSQL(s *Source) *PostgreSQL {
 
 func (pg *PostgreSQL) Connect() error {
 	db, err := sql.Open("pgx", pg.getConnectionUri())
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(pg.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	pg.db = db
 	return err

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -143,16 +143,16 @@ func (pg *PostgreSQL) CheckRequiredToolsAreInstalled() {
 	checkTools("strings")
 }
 
-func (pg *PostgreSQL) GetTableRowCount(tableName sqlname.NameTuple) int64 {
+func (pg *PostgreSQL) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.ForUserQuery())
 	log.Infof("Querying row count of table %q", tableName)
 	err := pg.db.QueryRow(query).Scan(&rowCount)
 	if err != nil {
-		utils.ErrExit("Failed to query %q for row count of %q: %s", query, tableName, err)
+		return 0, fmt.Errorf("query %q for row count of %q: %w", query, tableName, err)
 	}
 	log.Infof("Table %q has %v rows.", tableName, rowCount)
-	return rowCount
+	return rowCount, nil
 }
 
 func (pg *PostgreSQL) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -31,7 +31,7 @@ type SourceDB interface {
 	Disconnect()
 	CheckSchemaExists() bool
 	GetConnectionUriWithoutPassword() string
-	GetTableRowCount(tableName sqlname.NameTuple) int64
+	GetTableRowCount(tableName sqlname.NameTuple) (int64, error)
 	GetTableApproxRowCount(tableName sqlname.NameTuple) int64
 	CheckRequiredToolsAreInstalled()
 	GetVersion() string

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -74,16 +74,16 @@ func (yb *YugabyteDB) CheckRequiredToolsAreInstalled() {
 	checkTools("strings")
 }
 
-func (yb *YugabyteDB) GetTableRowCount(tableName sqlname.NameTuple) int64 {
+func (yb *YugabyteDB) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.ForUserQuery())
 	log.Infof("Querying row count of table %q", tableName)
 	err := yb.db.QueryRow(query).Scan(&rowCount)
 	if err != nil {
-		utils.ErrExit("Failed to query %q for row count of %q: %s", query, tableName, err)
+		return 0, fmt.Errorf("query %q for row count of %q: %w", query, tableName, err)
 	}
 	log.Infof("Table %q has %v rows.", tableName, rowCount)
-	return rowCount
+	return rowCount, nil
 }
 
 func (yb *YugabyteDB) GetTableApproxRowCount(tableName sqlname.NameTuple) int64 {

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -52,7 +52,7 @@ func newYugabyteDB(s *Source) *YugabyteDB {
 
 func (yb *YugabyteDB) Connect() error {
 	db, err := sql.Open("pgx", yb.getConnectionUri())
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(yb.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	yb.db = db
 	return err


### PR DESCRIPTION
Implements fixes 1,3 in https://github.com/yugabyte/yb-voyager/issues/1920 : 
When goroutines A,B,C,D encounter an error, they should not bring down the process, they should silently log the error and continue, as this is not a critical process.