### PR TITLE
Add truncate-tables flag to import-data-to-target

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -90,6 +90,7 @@ func validateImportFlags(cmd *cobra.Command, importerRole string) error {
 		getSourceDBPassword(cmd)
 	}
 	validateParallelismFlags()
+	validateTruncateTablesFlag()
 	return nil
 }
 
@@ -237,7 +238,7 @@ func registerImportDataToTargetFlags(cmd *cobra.Command) {
 If any table on YugabyteDB database is non-empty, it prompts whether you want to continue the import without truncating those tables; 
 If you go ahead without truncating, then yb-voyager starts ingesting the data present in the data files with upsert mode.
 Note that for the cases where a table doesn't have a primary key, this may lead to insertion of duplicate data. To avoid this, exclude the table using the --exclude-file-list or truncate those tables manually before using the start-clean flag (default false)`)
-	BoolVar(cmd.Flags(), &truncateTables, "truncate-tables", false, "Truncate tables on target YugabyteDB before importing data (default false)")
+	BoolVar(cmd.Flags(), &truncateTables, "truncate-tables", false, "Truncate tables on target YugabyteDB before importing data. Only applicable along with --start-clean true (default false)")
 }
 
 func registerImportSchemaFlags(cmd *cobra.Command) {
@@ -408,4 +409,10 @@ func validateParallelismFlags() {
 		}
 	}
 
+}
+
+func validateTruncateTablesFlag() {
+	if truncateTables && !startClean {
+		utils.ErrExit("Error: --truncate-tables true can only be specified along with --start-clean true")
+	}
 }

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -231,13 +231,13 @@ func registerImportDataCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().MarkHidden("truncate-splits")
 }
 
-func registerImportDataFlags(cmd *cobra.Command) {
+func registerImportDataToTargetFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &startClean, "start-clean", false,
 		`Starts a fresh import with exported data files present in the export-dir/data directory. 
 If any table on YugabyteDB database is non-empty, it prompts whether you want to continue the import without truncating those tables; 
 If you go ahead without truncating, then yb-voyager starts ingesting the data present in the data files with upsert mode.
 Note that for the cases where a table doesn't have a primary key, this may lead to insertion of duplicate data. To avoid this, exclude the table using the --exclude-file-list or truncate those tables manually before using the start-clean flag (default false)`)
-	BoolVar(cmd.Flags(), &truncateTables, "truncate-tables", false, "Truncate tables before importing data (default false)")
+	BoolVar(cmd.Flags(), &truncateTables, "truncate-tables", false, "Truncate tables on target YugabyteDB before importing data (default false)")
 }
 
 func registerImportSchemaFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -237,7 +237,7 @@ func registerImportDataFlags(cmd *cobra.Command) {
 If any table on YugabyteDB database is non-empty, it prompts whether you want to continue the import without truncating those tables; 
 If you go ahead without truncating, then yb-voyager starts ingesting the data present in the data files with upsert mode.
 Note that for the cases where a table doesn't have a primary key, this may lead to insertion of duplicate data. To avoid this, exclude the table using the --exclude-file-list or truncate those tables manually before using the start-clean flag (default false)`)
-
+	BoolVar(cmd.Flags(), &truncateTables, "truncate-tables", false, "Truncate tables before importing data (default false)")
 }
 
 func registerImportSchemaFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -926,16 +926,18 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 		})
 		if importerRole == TARGET_DB_IMPORTER_ROLE && truncateTables {
 			// truncate tables only supported for import-data-to-target.
-			utils.PrintAndLog("Truncating non-empty tables on target DB : %v", nonEmptyTableNames)
+			utils.PrintAndLog("Truncating non-empty tables on DB: %v", nonEmptyTableNames)
 			err := tdb.TruncateTables(nonEmptyNts)
 			if err != nil {
 				utils.ErrExit("failed to truncate tables: %s", err)
 			}
 		} else {
 			utils.PrintAndLog("Non-Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
-			utils.PrintAndLog("The above list of tables on target DB are not empty.")
+			utils.PrintAndLog("The above list of tables on DB are not empty.")
 			if importerRole == TARGET_DB_IMPORTER_ROLE {
 				utils.PrintAndLog("If you wish to truncate them, re-run the import command with --truncate-tables true")
+			} else {
+				utils.PrintAndLog("If you wish to truncate them, re-run the import command after manually truncating the tables on DB.")
 			}
 			yes := utils.AskPrompt("Do you want to start afresh without truncating tables")
 			if !yes {

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -70,6 +70,7 @@ func init() {
 	registerStartCleanFlag(importDataToSourceReplicaCmd)
 	registerImportDataCommonFlags(importDataToSourceReplicaCmd)
 	hideImportFlagsInFallForwardOrBackCmds(importDataToSourceReplicaCmd)
+	BoolVar(importDataToSourceReplicaCmd.Flags(), &truncateTables, "truncate-tables", false, "Truncate tables on source-replica before importing data (default false)")
 }
 
 func registerStartCleanFlag(cmd *cobra.Command) {

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -70,7 +70,6 @@ func init() {
 	registerStartCleanFlag(importDataToSourceReplicaCmd)
 	registerImportDataCommonFlags(importDataToSourceReplicaCmd)
 	hideImportFlagsInFallForwardOrBackCmds(importDataToSourceReplicaCmd)
-	BoolVar(importDataToSourceReplicaCmd.Flags(), &truncateTables, "truncate-tables", false, "Truncate tables on source-replica before importing data (default false)")
 }
 
 func registerStartCleanFlag(cmd *cobra.Command) {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -45,6 +45,7 @@ var (
 	exportDir                          string
 	schemaDir                          string
 	startClean                         utils.BoolStr
+	truncateTables                     utils.BoolStr
 	lockFile                           *lockfile.Lockfile
 	migrationUUID                      uuid.UUID
 	perfProfile                        utils.BoolStr

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
@@ -194,16 +193,7 @@ func (tdb *TargetOracleDB) GetNonEmptyTables(tables []sqlname.NameTuple) []sqlna
 }
 
 func (tdb *TargetOracleDB) TruncateTables(tables []sqlname.NameTuple) error {
-	tableNames := lo.Map(tables, func(nt sqlname.NameTuple, _ int) string {
-		return nt.ForUserQuery()
-	})
-	commaSeparatedTableNames := strings.Join(tableNames, ", ")
-	query := fmt.Sprintf("TRUNCATE TABLE %s", commaSeparatedTableNames)
-	_, err := tdb.Exec(query)
-	if err != nil {
-		return fmt.Errorf("truncate tables with query %q: %w", query, err)
-	}
-	return nil
+	return fmt.Errorf("truncate tables not implemented for oracle")
 }
 
 func (tdb *TargetOracleDB) IsNonRetryableCopyError(err error) bool {

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -36,6 +36,7 @@ type TargetDB interface {
 	GetVersion() string
 	CreateVoyagerSchema() error
 	GetNonEmptyTables(tableNames []sqlname.NameTuple) []sqlname.NameTuple
+	TruncateTables(tableNames []sqlname.NameTuple) error
 	IsNonRetryableCopyError(err error) bool
 	ImportBatch(batch Batch, args *ImportBatchArgs, exportDir string, tableSchema map[string]map[string]string) (int64, error)
 	QuoteAttributeNames(tableNameTup sqlname.NameTuple, columns []string) ([]string, error)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -82,7 +82,7 @@ func (yb *TargetYugabyteDB) Exec(query string) (int64, error) {
 		var pgErr *pgconn5.PgError
 		if errors.As(err, &pgErr) {
 			if pgErr.Hint != "" || pgErr.Detail != "" {
-				return rowsAffected, fmt.Errorf("run query %q on target %q: %w \nHINT:%q\nDETAIL:%q", query, yb.tconf.Host, err, pgErr.Hint, pgErr.Detail)
+				return rowsAffected, fmt.Errorf("run query %q on target %q: %w \nHINT: %s\nDETAIL: %s", query, yb.tconf.Host, err, pgErr.Hint, pgErr.Detail)
 			}
 		}
 		return rowsAffected, fmt.Errorf("run query %q on target %q: %w", query, yb.tconf.Host, err)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -82,7 +82,7 @@ func (yb *TargetYugabyteDB) Exec(query string) (int64, error) {
 		var pgErr *pgconn5.PgError
 		if errors.As(err, &pgErr) {
 			if pgErr.Hint != "" || pgErr.Detail != "" {
-				return rowsAffected, fmt.Errorf("run query %q on target %q: %w HINT:%q DETAIL:%q", query, yb.tconf.Host, err, pgErr.Hint, pgErr.Detail)
+				return rowsAffected, fmt.Errorf("run query %q on target %q: %w \nHINT:%q\nDETAIL:%q", query, yb.tconf.Host, err, pgErr.Hint, pgErr.Detail)
 			}
 		}
 		return rowsAffected, fmt.Errorf("run query %q on target %q: %w", query, yb.tconf.Host, err)


### PR DESCRIPTION
- `--truncate-tables` allows the user to truncate the tables before starting-clean. 
- Only applicable along with `--start-clean true`.
- only implemented for import-data-to-target, not import-data-to-source-replica, import-data-file
- caveats: 
1. In case CDC is enabled for those tables, it may fail as such: 
`
failed to truncate tables: truncate tables with query "TRUNCATE TABLE public.\"u\", public.\"fkt\", public.\"tfkt\", public.\"test_simple\", public.\"te\"": run query "TRUNCATE TABLE public.\"u\", public.\"fkt\", public.\"tfkt\", public.\"test_simple\", public.\"te\"" on target "127.0.0.1": ERROR: Invalid table definition: Error creating table test.u on the master: cannot rewrite a table that is a part of CDC or XCluster replication. See https://github.com/yugabyte/yugabyte-db/issues/16625. (SQLSTATE XX000)
`



When some tables are not empty: 
<img width="837" alt="image" src="https://github.com/user-attachments/assets/f7a1d816-1065-4a9a-91c0-6ae7ab2305ff">

When passing --truncate-tables true
<img width="806" alt="image" src="https://github.com/user-attachments/assets/b32fcff0-8c0f-4044-b31c-a86d01f1c29a">
