### PR TITLE
Using table list in guardrails queries related to checking permission of tables on the export side

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -336,7 +336,7 @@ func assessMigration() (err error) {
 		// Check if source db has permissions to assess migration
 		if source.RunGuardrailsChecks {
 			checkIfSchemasHaveUsagePermissions()
-			missingPerms, err := source.DB().GetMissingExportSchemaPermissions()
+			missingPerms, err := source.DB().GetMissingAssessMigrationPermissions()
 			if err != nil {
 				return fmt.Errorf("failed to get missing assess migration permissions: %w", err)
 			}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -261,7 +261,7 @@ func exportData() bool {
 
 	// Check if source DB has required permissions for export data
 	if source.RunGuardrailsChecks {
-		checkExportDataPermissions()
+		checkExportDataPermissions(finalTableList)
 	}
 
 	// finalize table list and column list
@@ -445,7 +445,7 @@ func exportData() bool {
 	}
 }
 
-func checkExportDataPermissions() {
+func checkExportDataPermissions(finalTableList []sqlname.NameTuple) {
 	// If source is PostgreSQL or YB, check if the number of existing replicaton slots is less than the max allowed
 	if (source.DBType == POSTGRESQL && changeStreamingIsEnabled(exportType)) ||
 		(source.DBType == YUGABYTEDB && !bool(useYBgRPCConnector)) {
@@ -463,7 +463,7 @@ func checkExportDataPermissions() {
 		}
 	}
 
-	missingPermissions, err := source.DB().GetMissingExportDataPermissions(exportType)
+	missingPermissions, err := source.DB().GetMissingExportDataPermissions(exportType, finalTableList)
 	if err != nil {
 		utils.ErrExit("get missing export data permissions: %v", err)
 	}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -348,10 +348,6 @@ func exportData() bool {
 			// 2. export snapshot corresponding to replication slot by passing it to pg_dump
 			// 3. start debezium with configration to read changes from the created replication slot, publication.
 
-			err := source.DB().ValidateTablesReadyForLiveMigration(finalTableList)
-			if err != nil {
-				utils.ErrExit("error: validate if tables are ready for live migration: %v", err)
-			}
 			if !dataIsExported() { // if snapshot is not already done...
 				err = exportPGSnapshotWithPGdump(ctx, cancel, finalTableList, tablesColumnList, leafPartitions)
 				if err != nil {

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -135,7 +135,7 @@ func exportSchema() error {
 	// Check if the source database has the required permissions for exporting schema.
 	if source.RunGuardrailsChecks {
 		checkIfSchemasHaveUsagePermissions()
-		missingPerms, err := source.DB().GetMissingExportSchemaPermissions()
+		missingPerms, err := source.DB().GetMissingExportSchemaPermissions("")
 		if err != nil {
 			return fmt.Errorf("failed to get missing migration permissions: %w", err)
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -217,11 +217,12 @@ func checkImportDataPermissions() {
 		utils.PrintAndLog(output)
 
 		var link string
-		if importerRole == SOURCE_REPLICA_DB_IMPORTER_ROLE {
+		switch importerRole {
+		case SOURCE_REPLICA_DB_IMPORTER_ROLE:
 			link = "https://docs.yugabyte.com/preview/yugabyte-voyager/migrate/live-fall-forward/#prepare-source-replica-database"
-		} else if importerRole == SOURCE_DB_IMPORTER_ROLE {
+		case SOURCE_DB_IMPORTER_ROLE:
 			link = "https://docs.yugabyte.com/preview/yugabyte-voyager/migrate/live-fall-back/#prepare-the-source-database"
-		} else {
+		default:
 			if changeStreamingIsEnabled(importType) {
 				link = "https://docs.yugabyte.com/preview/yugabyte-voyager/migrate/live-migrate/#prepare-the-target-database"
 			} else {
@@ -231,11 +232,9 @@ func checkImportDataPermissions() {
 		fmt.Println("\nCheck the documentation to prepare the database for migration:", color.BlueString(link))
 
 		// Prompt user to continue if missing permissions only if fk and triggers check did not fail
-		if !fkAndTriggersCheckFailed {
-			if !utils.AskPrompt("\nDo you want to continue anyway") {
-				utils.ErrExit("Please grant the required permissions and retry the import.")
-			}
-		} else {
+		if fkAndTriggersCheckFailed {
+			utils.ErrExit("Please grant the required permissions and retry the import.")
+		} else if !utils.AskPrompt("\nDo you want to continue anyway") {
 			utils.ErrExit("Please grant the required permissions and retry the import.")
 		}
 	} else {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -239,7 +239,12 @@ func checkImportDataPermissions() {
 			utils.ErrExit("Please grant the required permissions and retry the import.")
 		}
 	} else {
-		log.Info("The target database has the required permissions for importing data.")
+		// If only fk and triggers check failed just simply error out
+		if fkAndTriggersCheckFailed {
+			utils.ErrExit("")
+		} else {
+			log.Info("The target database has the required permissions for importing data.")
+		}
 	}
 }
 

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -375,10 +375,6 @@ func (ms *MySQL) ParentTableOfPartition(table sqlname.NameTuple) string {
 	panic("not implemented")
 }
 
-func (ms *MySQL) ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error {
-	panic("not implemented")
-}
-
 /*
 Only valid case is when the table has a auto increment column
 Note: a mysql table can have only one auto increment column

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -534,11 +534,11 @@ func (ms *MySQL) CheckSourceDBVersion(exportType string) error {
 	return nil
 }
 
-func (ms *MySQL) GetMissingExportSchemaPermissions() ([]string, error) {
+func (ms *MySQL) GetMissingExportSchemaPermissions(queryTableList string) ([]string, error) {
 	return nil, nil
 }
 
-func (ms *MySQL) GetMissingExportDataPermissions(exportType string) ([]string, error) {
+func (ms *MySQL) GetMissingExportDataPermissions(exportType string, finalTableList []sqlname.NameTuple) ([]string, error) {
 	return nil, nil
 }
 

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -434,10 +434,6 @@ func (ora *Oracle) ParentTableOfPartition(table sqlname.NameTuple) string {
 	panic("not implemented")
 }
 
-func (ora *Oracle) ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error {
-	panic("not implemented")
-}
-
 /*
 GetColumnToSequenceMap returns a map of column name to sequence name for all identity columns in the given list of tables.
 Note: There can be only one identity column per table in Oracle

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -717,11 +717,11 @@ func (ora *Oracle) CheckSourceDBVersion(exportType string) error {
 	return nil
 }
 
-func (ora *Oracle) GetMissingExportSchemaPermissions() ([]string, error) {
+func (ora *Oracle) GetMissingExportSchemaPermissions(queryTableList string) ([]string, error) {
 	return nil, nil
 }
 
-func (ora *Oracle) GetMissingExportDataPermissions(exportType string) ([]string, error) {
+func (ora *Oracle) GetMissingExportDataPermissions(exportType string, finalTableList []sqlname.NameTuple) ([]string, error) {
 	return nil, nil
 }
 

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -975,43 +975,6 @@ func (pg *PostgreSQL) GetNonPKTables() ([]string, error) {
 	return nonPKTables, nil
 }
 
-func (pg *PostgreSQL) ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error {
-	var tablesWithReplicaIdentityNotFull []string
-	var qualifiedTableNames []string
-	for _, table := range tableList {
-		sname, tname := table.ForCatalogQuery()
-		qualifiedTableNames = append(qualifiedTableNames, fmt.Sprintf("'%s.%s'", sname, tname))
-	}
-	query := fmt.Sprintf(`SELECT n.nspname || '.' || c.relname AS table_name_with_schema
-    FROM pg_class AS c
-    JOIN pg_namespace AS n ON c.relnamespace = n.oid
-    WHERE (n.nspname || '.' || c.relname) IN (%s)
-    AND c.relkind = 'r'
-    AND c.relreplident <> 'f';`, strings.Join(qualifiedTableNames, ","))
-	rows, err := pg.db.Query(query)
-	if err != nil {
-		return fmt.Errorf("error in querying(%q) source database for replica identity: %v", query, err)
-	}
-	defer func() {
-		closeErr := rows.Close()
-		if closeErr != nil {
-			log.Warnf("close rows for query %q: %v", query, closeErr)
-		}
-	}()
-	for rows.Next() {
-		var tableWithSchema string
-		err := rows.Scan(&tableWithSchema)
-		if err != nil {
-			return fmt.Errorf("error in scanning query rows for replica identity: %v", err)
-		}
-		tablesWithReplicaIdentityNotFull = append(tablesWithReplicaIdentityNotFull, tableWithSchema)
-	}
-	if len(tablesWithReplicaIdentityNotFull) > 0 {
-		return fmt.Errorf("tables %v do not have REPLICA IDENTITY FULL\nPlease ALTER the tables and set their REPLICA IDENTITY to FULL", tablesWithReplicaIdentityNotFull)
-	}
-	return nil
-}
-
 // =============================== Guardrails ===============================
 
 func (pg *PostgreSQL) CheckSourceDBVersion(exportType string) error {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -276,7 +276,7 @@ func (pg *PostgreSQL) GetAllTableNames() []*sqlname.SourceName {
 		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 	WHERE 
 		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
-		AND n.nspname IN ('%s');  
+		AND n.nspname IN (%s);  
 	`, querySchemaList)
 
 	rows, err := pg.db.Query(query)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -235,7 +235,7 @@ func (pg *PostgreSQL) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 	WHERE 
 		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
-		AND n.nspname IN (%s); 
+		AND n.nspname = '%s'; 
 	`, schemaName)
 
 	rows, err := pg.db.Query(query)
@@ -276,7 +276,7 @@ func (pg *PostgreSQL) GetAllTableNames() []*sqlname.SourceName {
 		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 	WHERE 
 		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
-		AND n.nspname IN (%s);  
+		AND n.nspname IN ('%s');  
 	`, querySchemaList)
 
 	rows, err := pg.db.Query(query)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -227,7 +227,6 @@ func (pg *PostgreSQL) checkSchemasExists() []string {
 func (pg *PostgreSQL) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 	query := fmt.Sprintf(`
 	SELECT 
-		n.nspname AS table_schema,
 		c.relname AS table_name
 	FROM 
 		pg_catalog.pg_class c
@@ -268,7 +267,6 @@ func (pg *PostgreSQL) GetAllTableNames() []*sqlname.SourceName {
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
 	query := fmt.Sprintf(`
 	SELECT 
-		n.nspname AS table_schema,
 		c.relname AS table_name
 	FROM 
 		pg_catalog.pg_class c

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -187,17 +187,6 @@ func (pg *PostgreSQL) GetVersion() string {
 
 func (pg *PostgreSQL) CheckSchemaExists() bool {
 	schemaList := pg.checkSchemasExists()
-
-	if pg.source.RunGuardrailsChecks {
-		// Check if schemas have USAGE permission
-		missingSchemas, err := pg.listSchemasMissingUsagePermission()
-		if err != nil {
-			utils.ErrExit("error checking schema usage permissions: %v", err)
-		}
-		if len(missingSchemas) > 0 {
-			utils.ErrExit("\n%s[%s]", color.RedString(fmt.Sprintf("Missing USAGE permission for user %s on Schemas: ", pg.source.User)), strings.Join(missingSchemas, ", "))
-		}
-	}
 	return schemaList != nil
 }
 

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -267,6 +267,7 @@ func (pg *PostgreSQL) GetAllTableNames() []*sqlname.SourceName {
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
 	query := fmt.Sprintf(`
 	SELECT 
+		n.nspname AS table_schema,
 		c.relname AS table_name
 	FROM 
 		pg_catalog.pg_class c

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -225,10 +225,18 @@ func (pg *PostgreSQL) checkSchemasExists() []string {
 }
 
 func (pg *PostgreSQL) GetAllTableNamesRaw(schemaName string) ([]string, error) {
-	query := fmt.Sprintf(`SELECT table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema = '%s';`, schemaName)
+	query := fmt.Sprintf(`
+	SELECT 
+		n.nspname AS table_schema,
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname IN (%s); 
+	`, schemaName)
 
 	rows, err := pg.db.Query(query)
 	if err != nil {
@@ -258,10 +266,18 @@ func (pg *PostgreSQL) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 func (pg *PostgreSQL) GetAllTableNames() []*sqlname.SourceName {
 	schemaList := pg.checkSchemasExists()
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
-	query := fmt.Sprintf(`SELECT table_schema, table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema IN (%s);`, querySchemaList)
+	query := fmt.Sprintf(`
+	SELECT 
+		n.nspname AS table_schema,
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname IN (%s);  
+	`, querySchemaList)
 
 	rows, err := pg.db.Query(query)
 	if err != nil {
@@ -656,9 +672,17 @@ func (pg *PostgreSQL) ParentTableOfPartition(table sqlname.NameTuple) string {
 	var parentTable string
 
 	// For this query in case of case sensitive tables, minquoting is required
-	query := fmt.Sprintf(`SELECT inhparent::pg_catalog.regclass
-	FROM pg_catalog.pg_class c JOIN pg_catalog.pg_inherits ON c.oid = inhrelid
-	WHERE c.oid = '%s'::regclass::oid`, table.ForOutput())
+	query := fmt.Sprintf(`SELECT
+	inhparent::pg_catalog.regclass AS parent_table
+	FROM
+	pg_catalog.pg_inherits
+	JOIN
+	pg_catalog.pg_class AS child ON pg_inherits.inhrelid = child.oid
+	JOIN
+	pg_catalog.pg_namespace AS nsp_child ON child.relnamespace = nsp_child.oid
+	WHERE
+	child.relname = '%s'
+	AND nsp_child.nspname = '%s';`, table.CurrentName.Unqualified.MinQuoted, table.CurrentName.SchemaName)
 
 	err := pg.db.QueryRow(query).Scan(&parentTable)
 	if err != sql.ErrNoRows && err != nil {

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -1324,19 +1324,6 @@ func (pg *PostgreSQL) checkReplicationPermission() (bool, error) {
 	return hasPermission, nil
 }
 
-// SELECT
-//     n.nspname AS schema_name,
-//     c.relname AS table_name,
-//     c.relreplident AS replica_identity,
-//     CASE
-//         WHEN c.relreplident <> 'f' THEN 'GRANTED'
-//         ELSE 'MISSING'
-//     END AS status
-// FROM pg_class c
-// JOIN pg_namespace n ON c.relnamespace = n.oid
-// WHERE (n.nspname || '.' || c.relname) IN ('schema1.table1', 'schema2.table2', 'schema3.table3')
-// AND c.relkind IN ('r', 'p');
-
 func (pg *PostgreSQL) listTablesMissingReplicaIdentityFull(queryTableList string) ([]string, error) {
 	checkTableReplicaIdentityQuery := fmt.Sprintf(`
 	SELECT

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -225,10 +225,17 @@ func (pg *PostgreSQL) checkSchemasExists() []string {
 }
 
 func (pg *PostgreSQL) GetAllTableNamesRaw(schemaName string) ([]string, error) {
-	query := fmt.Sprintf(`SELECT table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema = '%s';`, schemaName)
+	query := fmt.Sprintf(`
+	SELECT 
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname = '%s'; 
+	`, schemaName)
 
 	rows, err := pg.db.Query(query)
 	if err != nil {
@@ -258,10 +265,18 @@ func (pg *PostgreSQL) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 func (pg *PostgreSQL) GetAllTableNames() []*sqlname.SourceName {
 	schemaList := pg.checkSchemasExists()
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
-	query := fmt.Sprintf(`SELECT table_schema, table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema IN (%s);`, querySchemaList)
+	query := fmt.Sprintf(`
+	SELECT 
+		n.nspname AS table_schema,
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname IN (%s);  
+	`, querySchemaList)
 
 	rows, err := pg.db.Query(query)
 	if err != nil {
@@ -656,9 +671,17 @@ func (pg *PostgreSQL) ParentTableOfPartition(table sqlname.NameTuple) string {
 	var parentTable string
 
 	// For this query in case of case sensitive tables, minquoting is required
-	query := fmt.Sprintf(`SELECT inhparent::pg_catalog.regclass
-	FROM pg_catalog.pg_class c JOIN pg_catalog.pg_inherits ON c.oid = inhrelid
-	WHERE c.oid = '%s'::regclass::oid`, table.ForOutput())
+	query := fmt.Sprintf(`SELECT
+	inhparent::pg_catalog.regclass AS parent_table
+	FROM
+	pg_catalog.pg_inherits
+	JOIN
+	pg_catalog.pg_class AS child ON pg_inherits.inhrelid = child.oid
+	JOIN
+	pg_catalog.pg_namespace AS nsp_child ON child.relnamespace = nsp_child.oid
+	WHERE
+	child.relname = '%s'
+	AND nsp_child.nspname = '%s';`, table.CurrentName.Unqualified.MinQuoted, table.CurrentName.SchemaName)
 
 	err := pg.db.QueryRow(query).Scan(&parentTable)
 	if err != sql.ErrNoRows && err != nil {
@@ -1016,11 +1039,11 @@ Returns:
   - []string: A slice of strings describing the missing permissions, if any.
   - error: An error if any issues occur during the permission checks.
 */
-func (pg *PostgreSQL) GetMissingExportSchemaPermissions() ([]string, error) {
+func (pg *PostgreSQL) GetMissingExportSchemaPermissions(queryTableList string) ([]string, error) {
 	var combinedResult []string
 
 	// Check if tables have SELECT permission
-	missingTables, err := pg.listTablesMissingSelectPermission()
+	missingTables, err := pg.listTablesMissingSelectPermission(queryTableList)
 	if err != nil {
 		return nil, fmt.Errorf("error checking table select permissions: %w", err)
 	}
@@ -1057,8 +1080,13 @@ The function performs the following checks:
   - Checks if the user has create permission on the database.
   - Checks if the user has ownership over all tables.
 */
-func (pg *PostgreSQL) GetMissingExportDataPermissions(exportType string) ([]string, error) {
+func (pg *PostgreSQL) GetMissingExportDataPermissions(exportType string, finalTableList []sqlname.NameTuple) ([]string, error) {
 	var combinedResult []string
+	var qualifiedQuotedTableList []string
+	for _, table := range finalTableList {
+		qualifiedQuotedTableList = append(qualifiedQuotedTableList, table.ForOutput())
+	}
+	queryTableList := "'" + strings.Join(qualifiedQuotedTableList, "','") + "'"
 
 	// For live migration
 	if exportType == utils.CHANGES_ONLY || exportType == utils.SNAPSHOT_AND_CHANGES {
@@ -1094,16 +1122,16 @@ func (pg *PostgreSQL) GetMissingExportDataPermissions(exportType string) ([]stri
 		}
 
 		// Check replica identity of tables
-		// missingTables, err := pg.listTablesMissingReplicaIdentityFull()
-		// if err != nil {
-		// 	return nil, fmt.Errorf("error in checking table replica identity: %w", err)
-		// }
-		// if len(missingTables) > 0 {
-		// 	combinedResult = append(combinedResult, fmt.Sprintf("\n%s[%s]", color.RedString("Tables missing replica identity full: "), strings.Join(missingTables, ", ")))
-		// }
+		missingTables, err := pg.listTablesMissingReplicaIdentityFull(queryTableList)
+		if err != nil {
+			return nil, fmt.Errorf("error in checking table replica identity: %w", err)
+		}
+		if len(missingTables) > 0 {
+			combinedResult = append(combinedResult, fmt.Sprintf("\n%s[%s]", color.RedString("Tables missing replica identity full: "), strings.Join(missingTables, ", ")))
+		}
 
 		// Check if user has ownership over all tables
-		missingTables, err := pg.listTablesMissingOwnerPermission()
+		missingTables, err = pg.listTablesMissingOwnerPermission(queryTableList)
 		if err != nil {
 			return nil, fmt.Errorf("error in checking table owner permissions: %w", err)
 		}
@@ -1122,7 +1150,7 @@ func (pg *PostgreSQL) GetMissingExportDataPermissions(exportType string) ([]stri
 	} else {
 		// For offline migration
 		// Check if schemas have USAGE permission and check if tables in the provided schemas have SELECT permission
-		res, err := pg.GetMissingExportSchemaPermissions()
+		res, err := pg.GetMissingExportSchemaPermissions(queryTableList)
 		if err != nil {
 			return nil, fmt.Errorf("error in getting missing export data permissions: %w", err)
 		}
@@ -1145,7 +1173,7 @@ func (pg *PostgreSQL) GetMissingAssessMigrationPermissions() ([]string, error) {
 	var combinedResult []string
 
 	// Check if tables have SELECT permission
-	missingTables, err := pg.listTablesMissingSelectPermission()
+	missingTables, err := pg.listTablesMissingSelectPermission("")
 	if err != nil {
 		return nil, fmt.Errorf("error checking table select permissions: %w", err)
 	}
@@ -1181,10 +1209,7 @@ func (pg *PostgreSQL) isMigrationUserASuperUser() (bool, error) {
 	return isSuperUser, nil
 }
 
-func (pg *PostgreSQL) listTablesMissingOwnerPermission() ([]string, error) {
-	trimmedSchemaList := pg.getTrimmedSchemaList()
-	querySchemaList := "'" + strings.Join(trimmedSchemaList, "','") + "'"
-
+func (pg *PostgreSQL) listTablesMissingOwnerPermission(queryTableList string) ([]string, error) {
 	checkTableOwnerPermissionQuery := fmt.Sprintf(`
 	WITH table_ownership AS (
 		SELECT
@@ -1193,8 +1218,8 @@ func (pg *PostgreSQL) listTablesMissingOwnerPermission() ([]string, error) {
 			pg_get_userbyid(c.relowner) AS owner_name
 		FROM pg_class c
 		JOIN pg_namespace n ON c.relnamespace = n.oid
-		WHERE c.relkind IN ('r', 'p') -- 'r' indicates a table 'p' indicates a partitioned table
-		AND n.nspname IN (%s)
+		WHERE c.relkind IN ('r', 'p') -- 'r' indicates a table, 'p' indicates a partitioned table
+		  AND (n.nspname || '.' || c.relname) IN (%s)
 	)
 	SELECT
 		schema_name,
@@ -1211,7 +1236,7 @@ func (pg *PostgreSQL) listTablesMissingOwnerPermission() ([]string, error) {
 			) THEN true
 			ELSE false
 		END AS has_ownership
-	FROM table_ownership;`, querySchemaList, pg.source.User, pg.source.User)
+	FROM table_ownership;`, queryTableList, pg.source.User, pg.source.User)
 
 	rows, err := pg.db.Query(checkTableOwnerPermissionQuery)
 	if err != nil {
@@ -1299,54 +1324,68 @@ func (pg *PostgreSQL) checkReplicationPermission() (bool, error) {
 	return hasPermission, nil
 }
 
-// func (pg *PostgreSQL) listTablesMissingReplicaIdentityFull() ([]string, error) {
-// 	trimmedSchemaList := pg.getTrimmedSchemaList()
-// 	querySchemaList := "'" + strings.Join(trimmedSchemaList, "','") + "'"
-// 	checkTableReplicaIdentityQuery := fmt.Sprintf(`SELECT
-// 	n.nspname AS schema_name,
-// 	c.relname AS table_name,
-// 	c.relreplident AS replica_identity,
-// 	CASE
-// 		WHEN c.relreplident <> 'f'
-// 		THEN '%s'
-// 		ELSE '%s'
-// 	END AS status
-// 	FROM pg_class c
-// 	JOIN pg_namespace n ON c.relnamespace = n.oid
-// 	WHERE quote_ident(n.nspname) IN (%s)
-// 	AND c.relkind IN ('r', 'p');`, MISSING, GRANTED, querySchemaList)
-// 	rows, err := pg.db.Query(checkTableReplicaIdentityQuery)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("error in querying(%q) source database for checking table replica identity: %w", checkTableReplicaIdentityQuery, err)
-// 	}
-// 	defer func() {
-// 		closeErr := rows.Close()
-// 		if closeErr != nil {
-// 			log.Warnf("close rows for query %q: %v", checkTableReplicaIdentityQuery, closeErr)
-// 		}
-// 	}()
+// SELECT
+//     n.nspname AS schema_name,
+//     c.relname AS table_name,
+//     c.relreplident AS replica_identity,
+//     CASE
+//         WHEN c.relreplident <> 'f' THEN 'GRANTED'
+//         ELSE 'MISSING'
+//     END AS status
+// FROM pg_class c
+// JOIN pg_namespace n ON c.relnamespace = n.oid
+// WHERE (n.nspname || '.' || c.relname) IN ('schema1.table1', 'schema2.table2', 'schema3.table3')
+// AND c.relkind IN ('r', 'p');
 
-// 	var missingTables []string
-// 	var tableSchemaName, tableName, replicaIdentity, status string
+func (pg *PostgreSQL) listTablesMissingReplicaIdentityFull(queryTableList string) ([]string, error) {
+	checkTableReplicaIdentityQuery := fmt.Sprintf(`
+	SELECT
+		n.nspname AS schema_name,
+		c.relname AS table_name,
+		c.relreplident AS replica_identity,
+		CASE
+			WHEN c.relreplident <> 'f'
+			THEN '%s'
+			ELSE '%s'
+		END AS status
+	FROM pg_class c
+	JOIN pg_namespace n ON c.relnamespace = n.oid
+	WHERE (n.nspname || '.' || c.relname) IN (%s)
+	AND c.relkind IN ('r', 'p');
+	`, MISSING, GRANTED, queryTableList)
 
-// 	for rows.Next() {
-// 		err = rows.Scan(&tableSchemaName, &tableName, &replicaIdentity, &status)
-// 		if err != nil {
-// 			return nil, fmt.Errorf("error in scanning query rows for table names: %w", err)
-// 		}
-// 		if status == MISSING {
-// 			// quote table name as it can be case sensitive
-// 			missingTables = append(missingTables, fmt.Sprintf(`%s."%s"`, tableSchemaName, tableName))
-// 		}
-// 	}
+	rows, err := pg.db.Query(checkTableReplicaIdentityQuery)
+	if err != nil {
+		return nil, fmt.Errorf("error in querying(%q) source database for checking table replica identity: %w", checkTableReplicaIdentityQuery, err)
+	}
+	defer func() {
+		closeErr := rows.Close()
+		if closeErr != nil {
+			log.Warnf("close rows for query %q: %v", checkTableReplicaIdentityQuery, closeErr)
+		}
+	}()
 
-// 	// Check for errors during row iteration
-// 	if err = rows.Err(); err != nil {
-// 		return nil, fmt.Errorf("error iterating over query rows: %w", err)
-// 	}
+	var missingTables []string
+	var tableSchemaName, tableName, replicaIdentity, status string
 
-// 	return missingTables, nil
-// }
+	for rows.Next() {
+		err = rows.Scan(&tableSchemaName, &tableName, &replicaIdentity, &status)
+		if err != nil {
+			return nil, fmt.Errorf("error in scanning query rows for table names: %w", err)
+		}
+		if status == MISSING {
+			// quote table name as it can be case sensitive
+			missingTables = append(missingTables, fmt.Sprintf(`%s."%s"`, tableSchemaName, tableName))
+		}
+	}
+
+	// Check for errors during row iteration
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating over query rows: %w", err)
+	}
+
+	return missingTables, nil
+}
 
 func (pg *PostgreSQL) checkWalLevel() (msg string) {
 	query := `SELECT current_setting('wal_level') AS wal_level;`
@@ -1434,43 +1473,61 @@ func (pg *PostgreSQL) listSequencesMissingSelectPermission() (sequencesWithMissi
 	return sequencesWithMissingPerm, nil
 }
 
-func (pg *PostgreSQL) listTablesMissingSelectPermission() (tablesWithMissingPerm []string, err error) {
+func (pg *PostgreSQL) listTablesMissingSelectPermission(queryTableList string) (tablesWithMissingPerm []string, err error) {
 	// Users only need SELECT permissions on the tables of the schema they want to export for export schema
-	trimmedSchemaList := pg.getTrimmedSchemaList()
-	trimmedSchemaList = append(trimmedSchemaList, "pg_catalog", "information_schema")
-	querySchemaList := "'" + strings.Join(trimmedSchemaList, "','") + "'"
+	checkTableSelectPermissionQuery := ""
+	if queryTableList == "" {
 
-	checkTableSelectPermissionQuery := fmt.Sprintf(`
-	WITH schema_list AS (
-		SELECT unnest(ARRAY[%s]) AS schema_name
-	),
-	accessible_schemas AS (
-		SELECT schema_name
-		FROM schema_list
-		WHERE has_schema_privilege('%s', quote_ident(schema_name), 'USAGE')
-	)
-	SELECT
-		t.schemaname AS schema_name,
-		t.tablename AS table_name,
-		CASE 
-			WHEN has_table_privilege('%s', quote_ident(t.schemaname) || '.' || quote_ident(t.tablename), 'SELECT') 
-			THEN '%s' 
-			ELSE '%s' 
-		END AS status
-	FROM pg_tables t
-	JOIN accessible_schemas a ON t.schemaname = a.schema_name
-	UNION ALL
-	SELECT
-		t.schemaname AS schema_name,
-		t.tablename AS table_name,
-		'%s' AS status
-	FROM pg_tables t
-	WHERE t.schemaname IN (SELECT schema_name FROM schema_list)
-	AND NOT EXISTS (
-		SELECT 1
-		FROM accessible_schemas a
-		WHERE t.schemaname = a.schema_name
-	);`, querySchemaList, pg.source.User, pg.source.User, GRANTED, MISSING, NO_USAGE_PERMISSION)
+		trimmedSchemaList := pg.getTrimmedSchemaList()
+		trimmedSchemaList = append(trimmedSchemaList, "pg_catalog", "information_schema")
+		querySchemaList := "'" + strings.Join(trimmedSchemaList, "','") + "'"
+
+		checkTableSelectPermissionQuery = fmt.Sprintf(`
+		WITH schema_list AS (
+			SELECT unnest(ARRAY[%s]) AS schema_name
+		),
+		accessible_schemas AS (
+			SELECT schema_name
+			FROM schema_list
+			WHERE has_schema_privilege('%s', quote_ident(schema_name), 'USAGE')
+		)
+		SELECT
+			t.schemaname AS schema_name,
+			t.tablename AS table_name,
+			CASE 
+				WHEN has_table_privilege('%s', quote_ident(t.schemaname) || '.' || quote_ident(t.tablename), 'SELECT') 
+				THEN '%s' 
+				ELSE '%s' 
+			END AS status
+		FROM pg_tables t
+		JOIN accessible_schemas a ON t.schemaname = a.schema_name
+		UNION ALL
+		SELECT
+			t.schemaname AS schema_name,
+			t.tablename AS table_name,
+			'%s' AS status
+		FROM pg_tables t
+		WHERE t.schemaname IN (SELECT schema_name FROM schema_list)
+		AND NOT EXISTS (
+			SELECT 1
+			FROM accessible_schemas a
+			WHERE t.schemaname = a.schema_name
+		);`, querySchemaList, pg.source.User, pg.source.User, GRANTED, MISSING, NO_USAGE_PERMISSION)
+	} else {
+		checkTableSelectPermissionQuery = fmt.Sprintf(`
+		SELECT
+            quote_ident(split_part(t.schemaname || '.' || t.tablename, '.', 1)) AS schema_name,
+            quote_ident(split_part(t.schemaname || '.' || t.tablename, '.', 2)) AS table_name,
+            CASE 
+                WHEN has_table_privilege('%s', t.schemaname || '.' || t.tablename, 'SELECT') 
+                THEN '%s' 
+                ELSE '%s' 
+            END AS status
+        FROM pg_tables t
+        WHERE t.schemaname || '.' || t.tablename IN (%s);
+	`, pg.source.User, GRANTED, MISSING, queryTableList)
+	}
+
 	rows, err := pg.db.Query(checkTableSelectPermissionQuery)
 	if err != nil {
 		return nil, fmt.Errorf("error in querying(%q) source database for checking table select permission: %w", checkTableSelectPermissionQuery, err)

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -54,7 +54,6 @@ type SourceDB interface {
 	GetTableToUniqueKeyColumnsMap(tableList []sqlname.NameTuple) (map[string][]string, error)
 	ClearMigrationState(migrationUUID uuid.UUID, exportDir string) error
 	GetNonPKTables() ([]string, error)
-	ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error
 	GetDatabaseSize() (int64, error)
 	CheckSourceDBVersion(exportType string) error
 	GetMissingExportSchemaPermissions(queryTableList string) ([]string, error)

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -57,8 +57,8 @@ type SourceDB interface {
 	ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error
 	GetDatabaseSize() (int64, error)
 	CheckSourceDBVersion(exportType string) error
-	GetMissingExportSchemaPermissions() ([]string, error)
-	GetMissingExportDataPermissions(exportType string) ([]string, error)
+	GetMissingExportSchemaPermissions(queryTableList string) ([]string, error)
+	GetMissingExportDataPermissions(exportType string, finalTableList []sqlname.NameTuple) ([]string, error)
 	GetMissingAssessMigrationPermissions() ([]string, error)
 	CheckIfReplicationSlotsAreAvailable() (isAvailable bool, usedCount int, maxCount int, err error)
 	GetSchemasMissingUsagePermissions() ([]string, error)

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -164,7 +164,6 @@ func (yb *YugabyteDB) checkSchemasExists() []string {
 func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 	query := fmt.Sprintf(`
 	SELECT 
-		n.nspname AS table_schema,
 		c.relname AS table_name
 	FROM 
 		pg_catalog.pg_class c
@@ -172,7 +171,7 @@ func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 	WHERE 
 		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
-		AND n.nspname '%s';  
+		AND n.nspname = '%s'; 
 	`, schemaName)
 
 	rows, err := yb.db.Query(query)
@@ -205,7 +204,6 @@ func (yb *YugabyteDB) GetAllTableNames() []*sqlname.SourceName {
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
 	query := fmt.Sprintf(`
 	SELECT 
-		n.nspname AS table_schema,
 		c.relname AS table_name
 	FROM 
 		pg_catalog.pg_class c
@@ -213,7 +211,7 @@ func (yb *YugabyteDB) GetAllTableNames() []*sqlname.SourceName {
 		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 	WHERE 
 		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
-		AND n.nspname IN (%s); 
+		AND n.nspname IN (%s);  
 	`, querySchemaList)
 
 	rows, err := yb.db.Query(query)

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -204,6 +204,7 @@ func (yb *YugabyteDB) GetAllTableNames() []*sqlname.SourceName {
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
 	query := fmt.Sprintf(`
 	SELECT 
+		n.nspname AS table_schema,
 		c.relname AS table_name
 	FROM 
 		pg_catalog.pg_class c

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -172,7 +172,7 @@ func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 	WHERE 
 		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
-		AND n.nspname IN (%s);  
+		AND n.nspname '%s';  
 	`, schemaName)
 
 	rows, err := yb.db.Query(query)

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -162,10 +162,17 @@ func (yb *YugabyteDB) checkSchemasExists() []string {
 }
 
 func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
-	query := fmt.Sprintf(`SELECT table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema = '%s';`, schemaName)
+	query := fmt.Sprintf(`
+	SELECT 
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname = '%s'; 
+	`, schemaName)
 
 	rows, err := yb.db.Query(query)
 	if err != nil {
@@ -195,10 +202,18 @@ func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 func (yb *YugabyteDB) GetAllTableNames() []*sqlname.SourceName {
 	schemaList := yb.checkSchemasExists()
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
-	query := fmt.Sprintf(`SELECT table_schema, table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema IN (%s);`, querySchemaList)
+	query := fmt.Sprintf(`
+	SELECT 
+		n.nspname AS table_schema,
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname IN (%s);  
+	`, querySchemaList)
 
 	rows, err := yb.db.Query(query)
 	if err != nil {
@@ -1033,11 +1048,11 @@ func (yb *YugabyteDB) CheckSourceDBVersion(exportType string) error {
 	return nil
 }
 
-func (yb *YugabyteDB) GetMissingExportSchemaPermissions() ([]string, error) {
+func (yb *YugabyteDB) GetMissingExportSchemaPermissions(queryTableList string) ([]string, error) {
 	return nil, nil
 }
 
-func (yb *YugabyteDB) GetMissingExportDataPermissions(exportType string) ([]string, error) {
+func (yb *YugabyteDB) GetMissingExportDataPermissions(exportType string, finalTableList []sqlname.NameTuple) ([]string, error) {
 	return nil, nil
 }
 

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -283,10 +283,6 @@ func (yb *YugabyteDB) ExportSchema(exportDir string, schemaDir string) {
 	panic("not implemented")
 }
 
-func (yb *YugabyteDB) ValidateTablesReadyForLiveMigration(tableList []sqlname.NameTuple) error {
-	panic("not implemented")
-}
-
 func (yb *YugabyteDB) GetIndexesInfo() []utils.IndexInfo {
 	return nil
 }

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -162,6 +162,8 @@ func (yb *YugabyteDB) checkSchemasExists() []string {
 }
 
 func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
+	// Information schema requires select permission on the tables to query the tables. However, pg_catalog does not require any permission.
+	// So, we are using pg_catalog to get the table names.
 	query := fmt.Sprintf(`
 	SELECT 
 		c.relname AS table_name
@@ -202,6 +204,8 @@ func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 func (yb *YugabyteDB) GetAllTableNames() []*sqlname.SourceName {
 	schemaList := yb.checkSchemasExists()
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
+	// Information schema requires select permission on the tables to query the tables. However, pg_catalog does not require any permission.
+	// So, we are using pg_catalog to get the table names.
 	query := fmt.Sprintf(`
 	SELECT 
 		n.nspname AS table_schema,

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -162,10 +162,18 @@ func (yb *YugabyteDB) checkSchemasExists() []string {
 }
 
 func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
-	query := fmt.Sprintf(`SELECT table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema = '%s';`, schemaName)
+	query := fmt.Sprintf(`
+	SELECT 
+		n.nspname AS table_schema,
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname IN (%s);  
+	`, schemaName)
 
 	rows, err := yb.db.Query(query)
 	if err != nil {
@@ -195,10 +203,18 @@ func (yb *YugabyteDB) GetAllTableNamesRaw(schemaName string) ([]string, error) {
 func (yb *YugabyteDB) GetAllTableNames() []*sqlname.SourceName {
 	schemaList := yb.checkSchemasExists()
 	querySchemaList := "'" + strings.Join(schemaList, "','") + "'"
-	query := fmt.Sprintf(`SELECT table_schema, table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema IN (%s);`, querySchemaList)
+	query := fmt.Sprintf(`
+	SELECT 
+		n.nspname AS table_schema,
+		c.relname AS table_name
+	FROM 
+		pg_catalog.pg_class c
+	JOIN 
+		pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE 
+		c.relkind IN ('r', 'p')  -- 'r' for regular tables, 'p' for partitioned tables
+		AND n.nspname IN (%s); 
+	`, querySchemaList)
 
 	rows, err := yb.db.Query(query)
 	if err != nil {


### PR DESCRIPTION
- Building on the changes in PR:
https://github.com/yugabyte/yb-voyager/pull/1824
- Added `queryTableList` instead of `querySchemaList` in all the guardrails queries related to tables on the export side
- Removed 'ValidateTablesReadyForLiveMigration' since it was already getting covered in guardrails