### PR TITLE
Addded Guardrails check for pg_stat_statements in assess migration cmd

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -336,7 +336,7 @@ func assessMigration() (err error) {
 		// Check if source db has permissions to assess migration
 		if source.RunGuardrailsChecks {
 			checkIfSchemasHaveUsagePermissions()
-			missingPerms, err := source.DB().GetMissingExportSchemaPermissions()
+			missingPerms, err := source.DB().GetMissingAssessMigrationPermissions()
 			if err != nil {
 				return fmt.Errorf("failed to get missing assess migration permissions: %w", err)
 			}

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -1196,7 +1196,7 @@ func (pg *PostgreSQL) checkPgStatStatementsSetup() (string, error) {
 	} else {
 		schemaList := lo.Union(pg.getTrimmedSchemaList(), []string{"public"})
 		if !slices.Contains(schemaList, pgssExtSchema) {
-			return fmt.Sprintf("pg_stat_statements extension schema %q is not in the schema list (%s)",
+			return fmt.Sprintf("pg_stat_statements extension schema %q is not in the schema list (%s), required for detecting Unsupported Query Constructs",
 				pgssExtSchema, strings.Join(schemaList, ", ")), nil
 		}
 	}
@@ -1210,7 +1210,7 @@ func (pg *PostgreSQL) checkPgStatStatementsSetup() (string, error) {
 		log.Warnf("failed to check if pg_stat_statements extension is properly loaded on source DB: %v", err)
 	}
 	if !slices.Contains(strings.Split(sharedPreloadLibraries, ","), PG_STAT_STATEMENTS) {
-		return "pg_stat_statements is not loaded via shared_preload_libraries", nil
+		return "pg_stat_statements is not loaded via shared_preload_libraries, required for detecting Unsupported Query Constructs", nil
 	}
 
 	// 3. User has permission to read from pg_stat_statements table

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -46,6 +46,7 @@ const MAX_SUPPORTED_PG_VERSION = "16"
 const MISSING = "MISSING"
 const GRANTED = "GRANTED"
 const NO_USAGE_PERMISSION = "NO USAGE PERMISSION"
+const PG_STAT_STATEMENTS = "pg_stat_statements"
 
 var pg_catalog_tables_required = []string{"regclass", "pg_class", "pg_inherits", "setval", "pg_index", "pg_relation_size", "pg_namespace", "pg_tables", "pg_sequences", "pg_roles", "pg_database", "pg_extension"}
 var information_schema_tables_required = []string{"schemata", "tables", "columns", "key_column_usage", "sequences"}
@@ -1202,6 +1203,9 @@ func (pg *PostgreSQL) checkPgStatStatementsSetup() (string, error) {
 	err = pg.db.QueryRow(querySharedPreloadLibraries).Scan(&sharedPreloadLibraries)
 	if err != nil {
 		log.Warnf("failed to check if pg_stat_statements extension is properly loaded on source DB: %w", err)
+	}
+	if !slices.Contains(strings.Split(sharedPreloadLibraries, ","), PG_STAT_STATEMENTS) {
+		return "pg_stat_statements is not loaded via shared_preload_libraries", nil
 	}
 
 	// 3. User has permission to read from pg_stat_statements table


### PR DESCRIPTION
Note: checking if pgss is properly installed or not (via shared_preload_libraries) is not possible, needs `pg_read_all_settings` grant to the user.
Feels unnecessary to add this to our grant script just for a check.
So it will best effort, if it able to fetch the libraries then we check in the list, otherwise just add warn to the logs and assess-migration command will fail at the step of db_queries_summary metadata script execution.

Cases this new guardrails check detects:
![image](https://github.com/user-attachments/assets/d0cc8416-a721-494c-bf02-8784afcced92)


https://yugabyte.atlassian.net/browse/DB-14108
https://yugabyte.atlassian.net/browse/DB-13678