### PR TITLE
Added a new const PREVIOUS_BREAKING_CHANGE_VERSION  and implemented version compatibility checks using it

### DIFF
--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -698,3 +698,23 @@ func GetFreePort() (int, error) {
 	addr := listener.Addr().(*net.TCPAddr)
 	return addr.Port, nil
 }
+
+func GetFinalReleaseVersionFromRCVersion(msrVoyagerFinalVersion string) (string, error) {
+	// RC version will be like 0rc1.1.8.6
+	// We need to extract 1.8.6 from it
+	// Compring with this 1.8.6 should be enough to check if the version is compatible with the current version
+	// Split the string at "rc" to isolate the part after it
+	parts := strings.Split(msrVoyagerFinalVersion, "rc")
+	if len(parts) > 1 {
+		// Further split the remaining part by '.' and remove the first segment
+		versionParts := strings.Split(parts[1], ".")
+		if len(versionParts) > 1 {
+			msrVoyagerFinalVersion = strings.Join(versionParts[1:], ".") // Join the parts after the first one
+		} else {
+			return "", fmt.Errorf("unexpected version format %q", msrVoyagerFinalVersion)
+		}
+	} else {
+		return "", fmt.Errorf("unexpected version format %q", msrVoyagerFinalVersion)
+	}
+	return msrVoyagerFinalVersion, nil
+}

--- a/yb-voyager/src/utils/version.go
+++ b/yb-voyager/src/utils/version.go
@@ -19,6 +19,9 @@ const (
 	// This constant must be updated on every release.
 	YB_VOYAGER_VERSION = "main"
 
+	// This constant must be updated after every breaking change.
+	PREVIOUS_BREAKING_CHANGE_VERSION = "1.8.5"
+
 	// @Refer: https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/
 	GIT_COMMIT_HASH = "$Format:%H$"
 )


### PR DESCRIPTION
- Added a new constant `PREVIOUS_BREAKING_CHANGE_VERSION` and set it to `1.8.5` for now. This needs to be changed every time we make a breaking release.
- Added logic to check the Voyager version used to create the export directory against the breaking change version.
- Ensured compatibility checks handle scenarios where the export directory was created using:
  - The `main` branch.
  - An older Voyager version without version information in msr.
  - A specific Voyager version.