### PR TITLE
Do not detect the DML issues on MVIEW/VIEW object in GetDMLIssues()

### DIFF
--- a/yb-voyager/src/queryissue/queryissue.go
+++ b/yb-voyager/src/queryissue/queryissue.go
@@ -95,6 +95,9 @@ func (p *ParserIssueDetector) GetDMLIssues(query string) ([]issue.IssueInstance,
 	if err != nil {
 		return nil, fmt.Errorf("error parsing query: %w", err)
 	}
+	if queryparser.IsViewObject(parseTree) || queryparser.IsMviewObject(parseTree) {
+		return nil, nil
+	}
 	var result []issue.IssueInstance
 	var unsupportedConstructs []string
 	visited := make(map[protoreflect.Message]bool)


### PR DESCRIPTION
https://yugabyte.atlassian.net/browse/DB-14204

We should not detect issues on CREATE MVIEw/VIEw queries coming from pgss to `GetDMLIssues` as we are already detecting them in PL/pgSQL section. 