### PR TITLE
Fix: template rendering extra spaces after Unsupported PL/pgSQL objects section heading

### DIFF
--- a/yb-voyager/cmd/templates/migration_assessment_report.template
+++ b/yb-voyager/cmd/templates/migration_assessment_report.template
@@ -303,38 +303,38 @@
                     <th>Statement</th>
                     <th>Details</th>
                 </tr>
-               {{ range  .UnsupportedPlPgSqlObjects }}
-                <!-- Feature Row with rowspan for grouping -->
-                <tr>
-                    {{ $objectsGroupByObjectType := groupByObjectType .Objects}}
-                    {{ $numUniqueObjectNamesOfAllTypes := totalUniqueObjectNamesOfAllTypes $objectsGroupByObjectType}}
+                {{ range  .UnsupportedPlPgSqlObjects }}
+                    <!-- Feature Row with rowspan for grouping -->
+                    <tr>
+                    {{ $objectsGroupByObjectType := groupByObjectType .Objects }}
+                    {{ $numUniqueObjectNamesOfAllTypes := totalUniqueObjectNamesOfAllTypes $objectsGroupByObjectType }}
                     {{ $docsLink := .DocsLink }}
-                    <td rowspan={{$numUniqueObjectNamesOfAllTypes}}><strong>{{ .FeatureName }}</strong></td>
+                    <td rowspan={{ $numUniqueObjectNamesOfAllTypes }}><strong>{{ .FeatureName }}</strong></td>
                     {{ $isNextRowRequiredForObjectType := false }}
                     {{ range $type, $objectsByType := $objectsGroupByObjectType }}
                         {{ $objectGroupByObjectName := groupByObjectName $objectsByType }}
                         {{ $numUniqueObjectNames := numKeysInMapStringObjectInfo $objectGroupByObjectName }}
                         {{ if $isNextRowRequiredForObjectType }}
-                           <tr>
+                            <tr>
                         {{ end }}
-                        <td rowspan={{$numUniqueObjectNames}} >{{$type}}</td>
+                        <td rowspan={{ $numUniqueObjectNames }} >{{ $type }}</td>
                         {{ $isNextRowRequiredForObjectName := false }}
                         {{ range $name, $objectsByName := $objectGroupByObjectName }}
                             {{ if $isNextRowRequiredForObjectName }}
-                              <tr>
+                                <tr>
                             {{ end }}
-                            <td>{{ $name }}</td> 
+                            <td>{{ $name }}</td>
                             <td>
                                 <div class="scrollable-div">
                                     <ul>
-                                        {{ range $objectsByName }}
-                                            <li class="list_item"><pre>{{ .SqlStatement }}</pre></li>
-                                        {{ end }}
+                                    {{ range $objectsByName }}
+                                        <li class="list_item"><pre>{{ .SqlStatement }}</pre></li>
+                                    {{ end }}
                                     </ul>
                                 </div>
                             </td>
                             {{ if not $isNextRowRequiredForObjectType }}
-                                <td rowspan={{$numUniqueObjectNamesOfAllTypes}}><a href="{{ $docsLink }}" target="_blank">Link</a></td>
+                                <td rowspan={{ $numUniqueObjectNamesOfAllTypes }}><a href="{{ $docsLink }}" target="_blank">Link</a></td>
                             {{ end }}
                             {{ $isNextRowRequiredForObjectName = true }}
                             {{ $isNextRowRequiredForObjectType = true }}


### PR DESCRIPTION
The issue in the `Unsupported PL/pgSQL objects` section showing extra spaces before the table -
In chrome -
![Screenshot 2024-11-15 at 4 58 45 PM](https://github.com/user-attachments/assets/9a5a1d15-0807-4aed-9d56-c7b1c1589c33)

In Safari, it is showing weird character `Â` (StackOverflow [link](https://stackoverflow.com/questions/1461907/html-encoding-issues-%C3%82-character-showing-up-instead-of-nbsp) where `&nbsp;` is encoded to this char)
<img width="923" alt="Screenshot 2024-11-26 at 11 41 28 AM" src="https://github.com/user-attachments/assets/f0a5ad98-946f-418c-a372-cb846d4ea205">

This patches remove these extra spaces - 
![Screenshot 2024-11-26 at 11 43 19 AM](https://github.com/user-attachments/assets/65d4ace2-e9cd-40f4-8d79-9f13f6de5106)

Fixes - https://yugabyte.atlassian.net/browse/DB-14237