### PR TITLE
Removed start clean from the automation commands

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -236,7 +236,6 @@ export_schema() {
  		--source-db-password ${SOURCE_DB_PASSWORD}
 		--source-db-name ${SOURCE_DB_NAME}
 		--send-diagnostics=false --yes
-		--start-clean t
 	"
 	if [ "${source_db_schema}" != "" ]
 	then
@@ -280,7 +279,6 @@ export_data() {
 		--disable-pb=true
 		--send-diagnostics=false
 		--yes
-		--start-clean 1
 	"
 	if [ "${TABLE_LIST}" != "" ]
 	then
@@ -371,7 +369,6 @@ import_schema() {
 		--target-db-name ${TARGET_DB_NAME}	
 		--yes
 		--send-diagnostics=false
-		--start-clean 1
 		"
 
 		if [ "${SOURCE_DB_TYPE}" != "postgresql" ]
@@ -392,7 +389,6 @@ import_data() {
 		--target-db-name ${TARGET_DB_NAME}
 		--disable-pb true
 		--send-diagnostics=false 
-		--start-clean 1
 		--truncate-splits true
 		--max-retries 1
 		"
@@ -436,7 +432,6 @@ import_data_to_source_replica() {
 	--source-replica-db-user ${SOURCE_REPLICA_DB_USER} 
 	--source-replica-db-name ${SOURCE_REPLICA_DB_NAME} 
 	--source-replica-db-password ${SOURCE_REPLICA_DB_PASSWORD} 
-	--start-clean true
 	--disable-pb true
 	--send-diagnostics=false
 	--parallel-jobs 3
@@ -762,7 +757,6 @@ assess_migration() {
 		--source-db-password ${SOURCE_DB_PASSWORD}
 		--source-db-name ${SOURCE_DB_NAME}
 		--send-diagnostics=false --yes
-		--start-clean t
 		--iops-capture-interval 0
 	"
 	if [ "${SOURCE_DB_SCHEMA}" != "" ]

--- a/migtests/scripts/run-schema-migration.sh
+++ b/migtests/scripts/run-schema-migration.sh
@@ -118,6 +118,7 @@ main() {
         mv "${EXPORT_DIR}/schema/failed.sql" "${EXPORT_DIR}/schema/failed.sql.bak"
         #replace_files
         replace_files "${TEST_DIR}/replacement_dir" "${EXPORT_DIR}/schema"
+		# --start-clean is required here since we are running the import command for the second time
         import_schema --start-clean t
 
         if [ -f "${EXPORT_DIR}/schema/failed.sql" ]

--- a/migtests/scripts/run-schema-migration.sh
+++ b/migtests/scripts/run-schema-migration.sh
@@ -118,7 +118,7 @@ main() {
         mv "${EXPORT_DIR}/schema/failed.sql" "${EXPORT_DIR}/schema/failed.sql.bak"
         #replace_files
         replace_files "${TEST_DIR}/replacement_dir" "${EXPORT_DIR}/schema"
-        import_schema
+        import_schema --start-clean t
 
         if [ -f "${EXPORT_DIR}/schema/failed.sql" ]
         then

--- a/migtests/tests/import-file/run-import-file-test
+++ b/migtests/tests/import-file/run-import-file-test
@@ -41,9 +41,11 @@ main() {
 
 	export TARGET_DB_SCHEMA='non_public'
 
+# Kept --start-clean here to test the command for import data file. Can add proper validations for it once --truncate-tables is introduced here
+
 	step "Import data file: SMSA.txt -> smsa in a non-public schema"
 	import_data_file --data-dir ${TEST_DIR} --format text --delimiter '\t' \
-			--file-table-map "SMSA.txt:smsa"
+			--file-table-map "SMSA.txt:smsa" --start-clean true
 	
 	#clean up the export dir as we will have public schema from this test which should be on fresh export-dir 
 	rm -rf ${EXPORT_DIR}

--- a/migtests/tests/import-file/run-import-file-test
+++ b/migtests/tests/import-file/run-import-file-test
@@ -43,7 +43,7 @@ main() {
 
 	step "Import data file: SMSA.txt -> smsa in a non-public schema"
 	import_data_file --data-dir ${TEST_DIR} --format text --delimiter '\t' \
-			--file-table-map "SMSA.txt:smsa"  --start-clean true
+			--file-table-map "SMSA.txt:smsa"
 	
 	#clean up the export dir as we will have public schema from this test which should be on fresh export-dir 
 	rm -rf ${EXPORT_DIR}
@@ -53,7 +53,7 @@ main() {
 	#Default BATCH_SIZE_BYTES
 	step "Import data file: OneMRows.text -> one_m_rows"
 	import_data_file --data-dir ${TEST_DIR} --format text --delimiter '|' \
-		--file-table-map "OneMRows.text:one_m_rows" --start-clean true 
+		--file-table-map "OneMRows.text:one_m_rows"
 
 	
 	export MAX_BATCH_SIZE_BYTES=345643 #~300KB 
@@ -276,7 +276,7 @@ main() {
 	if [ "${RUN_LARGE_IMPORT_DATA_FILE_TEST}" = true ] ; then
 
 		step "Run large sized import data file test"
-		import_data_file --data-dir "s3://yb-voyager-test-data" --delimiter "\t" --format "text" --file-table-map "accounts_350m_data.sql:accounts_large" --start-clean true --yes
+		import_data_file --data-dir "s3://yb-voyager-test-data" --delimiter "\t" --format "text" --file-table-map "accounts_350m_data.sql:accounts_large" --yes
 
 	fi
 


### PR DESCRIPTION
We were adding the --start-clean flag to almost all the commands we were running in the automation.
This is not required since we aren't doing any restarts. 