### PR TITLE
[DB-13912]: Filter database name from YUGABYTED_DB_CONN_STRING string if present

### DIFF
--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -322,9 +324,15 @@ func setControlPlane(cpType string) {
 		if ybdConnString == "" {
 			utils.ErrExit("'YUGABYTED_DB_CONN_STRING' environment variable needs to be set if 'CONTROL_PLANE_TYPE' is 'yugabyted'.")
 		}
-		controlPlane = yugabyted.New(exportDir)
+
+		ybdConnString, err := normalizeYugabytedDBConnString(ybdConnString)
+		if err != nil {
+			utils.ErrExit("%s", err.Error())
+		}
+
+		controlPlane = yugabyted.New(exportDir, ybdConnString)
 		log.Infof("Migration UUID %s", migrationUUID)
-		err := controlPlane.Init()
+		err = controlPlane.Init()
 		if err != nil {
 			utils.ErrExit("ERROR: Failed to initialize the target DB for visualization. %s", err)
 		}
@@ -333,4 +341,32 @@ func setControlPlane(cpType string) {
 
 func getControlPlaneType() string {
 	return os.Getenv("CONTROL_PLANE_TYPE")
+}
+
+func normalizeYugabytedDBConnString(connStr string) (string, error) {
+	if !strings.HasPrefix(connStr, "postgresql://") {
+		return "", fmt.Errorf("Invalid format: YUGABYTED_DB_CONN_STRING must start with 'postgresql://'")
+	}
+
+	u, err := url.Parse(connStr)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse YUGABYTED_DB_CONN_STRING: %w", err)
+	}
+
+	if u.User.Username() == "" {
+		return "", fmt.Errorf("Username not provided in YUGABYTED_DB_CONN_STRING: %s", utils.GetRedactedURLs(connStr)[0])
+	}
+	if _, passwordSet := u.User.Password(); !passwordSet {
+		return "", fmt.Errorf("Password not provided in YUGABYTED_DB_CONN_STRING: %s", utils.GetRedactedURLs(connStr)[0])
+	}
+	if u.Hostname() == "" || u.Port() == "" {
+		return "", fmt.Errorf("Host or port not provided in YUGABYTED_DB_CONN_STRING: %s", utils.GetRedactedURLs(connStr)[0])
+	}
+
+	u.RawQuery = "" // Removing SSL or any other query params
+	u.Path = ""     // Removing the database name
+
+	// Rebuilding the connection string without Path and RawQuery
+	newConnStr := u.String()
+	return newConnStr, nil
 }

--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -255,7 +255,7 @@ func (pool *ConnectionPool) createNewConnection() (*pgx.Conn, error) {
 
 func (pool *ConnectionPool) connect(uri string) (*pgx.Conn, error) {
 	conn, err := pgx.Connect(context.Background(), uri)
-	redactedUri := utils.GetRedactedURLs([]string{uri})[0]
+	redactedUri := utils.GetRedactedURLs(uri)[0]
 	if err != nil {
 		log.Warnf("Failed to connect to %q: %s", redactedUri, err)
 		return nil, err

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -227,7 +227,7 @@ func (pg *TargetPostgreSQL) InitConnPool() error {
 	for _, tconf := range tconfs {
 		targetUriList = append(targetUriList, tconf.Uri)
 	}
-	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
+	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList...))
 
 	if pg.tconf.Parallelism == 0 {
 		pg.tconf.Parallelism = fetchDefaultParallelJobs(tconfs, PG_DEFAULT_PARALLELISM_FACTOR)

--- a/yb-voyager/src/tgtdb/tconf.go
+++ b/yb-voyager/src/tgtdb/tconf.go
@@ -117,7 +117,7 @@ func generateSSLQueryStringIfNotExists(t *TargetConf) string {
 
 func GetRedactedTargetConf(t *TargetConf) *TargetConf {
 	redacted := *t
-	redacted.Uri = utils.GetRedactedURLs([]string{t.Uri})[0]
+	redacted.Uri = utils.GetRedactedURLs(t.Uri)[0]
 	redacted.Password = "XXX"
 	return &redacted
 }

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -221,7 +221,7 @@ func (yb *TargetYugabyteDB) InitConnPool() error {
 	for _, tconf := range tconfs {
 		targetUriList = append(targetUriList, tconf.Uri)
 	}
-	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList))
+	log.Infof("targetUriList: %s", utils.GetRedactedURLs(targetUriList...))
 
 	if yb.tconf.Parallelism <= 0 {
 		yb.tconf.Parallelism = fetchDefaultParallelJobs(tconfs, YB_DEFAULT_PARALLELISM_FACTOR)
@@ -923,7 +923,7 @@ func fetchCores(tconfs []*TargetConf) (int, error) {
 	targetCores := 0
 	totalCores := 0
 	for _, tconf := range tconfs {
-		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs([]string{tconf.Uri})[0])
+		log.Infof("Determining CPU core count on: %s", utils.GetRedactedURLs(tconf.Uri)[0])
 		conn, err := pgx.Connect(context.Background(), tconf.Uri)
 		if err != nil {
 			log.Warnf("Unable to reach target while querying cores: %v", err)
@@ -941,7 +941,7 @@ func fetchCores(tconfs []*TargetConf) (int, error) {
 		cmd = "COPY yb_voyager_cores(num_cores) FROM PROGRAM 'grep processor /proc/cpuinfo|wc -l';"
 		_, err = conn.Exec(context.Background(), cmd)
 		if err != nil {
-			log.Warnf("Error while running query %s on host %s: %v", cmd, utils.GetRedactedURLs([]string{tconf.Uri}), err)
+			log.Warnf("Error while running query %s on host %s: %v", cmd, utils.GetRedactedURLs(tconf.Uri), err)
 			return 0, err
 		}
 

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -425,7 +425,7 @@ func ToCaseInsensitiveNames(names []string) []string {
 	return names
 }
 
-func GetRedactedURLs(urlList []string) []string {
+func GetRedactedURLs(urlList ...string) []string {
 	result := []string{}
 	for _, u := range urlList {
 		obj, err := url.Parse(u)


### PR DESCRIPTION
- if provided other than yugabyte then ybd-ui won't be able to pickup the payload

Fixes - https://yugabyte.atlassian.net/browse/DB-13912

Q. With the usage of RedactedURL what was the goal:
 - Just avoid password from being sent to services like callhome
 - Or Also avoid password from getting logged in voyager log files also.
 
 I assume it's later, but in that we need to handle case like `url.Parse()` itself fails with some `err`(contains conn string)
 Then we use ErrExit() which ends logging the password