### PR TITLE
Added check to ensure archive changes command is not run before the streaming phase of export data has started

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -466,6 +466,19 @@ func CreateMigrationProjectIfNotExists(dbType string, exportDir string) {
 	metaDB = initMetaDB(exportDir)
 }
 
+func IsMetaDBPresent(exportDir string) (bool, error) {
+	// Check the directory for the presence of the migration status record
+	metaDBPath := metadb.GetMetaDBPath(exportDir)
+	_, err := os.Stat(metaDBPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func initMetaDB(migrationExportDir string) *metadb.MetaDB {
 	err := metadb.CreateAndInitMetaDBIfRequired(migrationExportDir)
 	if err != nil {


### PR DESCRIPTION
Before running archives changes command that following checks are done:
- Code firstly checks if meta.db is present or not
- If the the first check passes then it checks whether `msr.ExportDataSourceDebeziumStarted` is true or not

If either of the two checks fail, we exit with an appropriate message.
