### PR TITLE
Fix expected file for mgi pg schema for MinimumVersionsFixedIn field in Unsupported PL/pgSQL objects 

### DIFF
--- a/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
@@ -13762,6 +13762,7 @@
 					"SqlStatement": "acc_accession.accID%TYPE"
 				}
 			],
+			"MinimumVersionsFixedIn": null,
 			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#type-syntax-is-not-supported"
 		}
 	]


### PR DESCRIPTION
### Describe the changes in this pull request
Fixing automation test expected json file for `mgi` pg schema

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
N/A

### How was this pull request tested?
tested locally for this test
Jenkins - 
https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/4160
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
