### PR TITLE
Fixed guardrail check for super user permission and the query for checking if schema exist in case of YB Aeon

### DIFF
--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -479,7 +479,7 @@ func createTargetSchemas(conn *pgx.Conn) {
 }
 
 func checkIfTargetSchemaExists(conn *pgx.Conn, targetSchema string) bool {
-	checkSchemaExistQuery := fmt.Sprintf("SELECT schema_name FROM information_schema.schemata WHERE schema_name = '%s'", targetSchema)
+	checkSchemaExistQuery := fmt.Sprintf("select nspname from pg_namespace n where n.nspname = '%s'", targetSchema)
 
 	var fetchedSchema string
 	err := conn.QueryRow(context.Background(), checkSchemaExistQuery).Scan(&fetchedSchema)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1390,24 +1390,49 @@ func IsCurrentUserSuperUser(tconf *TargetConf) (bool, error) {
 	}
 	defer conn.Close(context.Background())
 
-	query := "SELECT rolsuper FROM pg_roles WHERE rolname=current_user"
-	rows, err := conn.Query(context.Background(), query)
-	if err != nil {
-		return false, fmt.Errorf("querying if user is superuser: %w", err)
-	}
-	defer rows.Close()
-
-	var isSuperUser bool
-	if rows.Next() {
-		err = rows.Scan(&isSuperUser)
+	runQueryAndCheckPrivilege := func(query string) (bool, error) {
+		rows, err := conn.Query(context.Background(), query)
 		if err != nil {
-			return false, fmt.Errorf("scanning row for superuser: %w", err)
+			return false, fmt.Errorf("querying if user is superuser: %w", err)
 		}
-	} else {
-		return false, fmt.Errorf("no current user found in pg_roles")
+		defer rows.Close()
+
+		var isProperUser bool
+		if rows.Next() {
+			err = rows.Scan(&isProperUser)
+			if err != nil {
+				return false, fmt.Errorf("scanning row for query: %w", err)
+			}
+		} else {
+			return false, fmt.Errorf("no current user found in pg_roles")
+		}
+		return isProperUser, nil
 	}
 
-	return isSuperUser, nil
+	isSuperUserquery := "SELECT rolsuper FROM pg_roles WHERE rolname=current_user"
+
+	isSuperUser, err := runQueryAndCheckPrivilege(isSuperUserquery)
+
+	if isSuperUser {
+		return true, nil
+	}
+	//In case of YugabyteDB Aeon deployment of target database we need to verify if yb_superuser is granted or not
+	isYbSuperUserQuery := `SELECT 
+    CASE 
+        WHEN EXISTS (
+            SELECT 1
+            FROM pg_auth_members m
+            JOIN pg_roles grantee ON m.member = grantee.oid
+            JOIN pg_roles granted ON m.roleid = granted.oid
+            WHERE grantee.rolname = CURRENT_USER AND granted.rolname = 'yb_superuser'
+        ) 
+        THEN TRUE 
+        ELSE FALSE 
+    END AS is_yb_superuser;`
+
+	isYBSuperUser, err := runQueryAndCheckPrivilege(isYbSuperUserQuery)
+
+	return isYBSuperUser, nil
 }
 
 func (yb *TargetYugabyteDB) GetEnabledTriggersAndFks() (enabledTriggers []string, enabledFks []string, err error) {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1409,10 +1409,13 @@ func IsCurrentUserSuperUser(tconf *TargetConf) (bool, error) {
 		return isProperUser, nil
 	}
 
+	//This rolsuper is set to true in the pg_roles if a user is super user
 	isSuperUserquery := "SELECT rolsuper FROM pg_roles WHERE rolname=current_user"
 
 	isSuperUser, err := runQueryAndCheckPrivilege(isSuperUserquery)
-
+	if err != nil {
+		return false, fmt.Errorf("error checking super user privilege: %w", err)
+	}
 	if isSuperUser {
 		return true, nil
 	}
@@ -1431,6 +1434,9 @@ func IsCurrentUserSuperUser(tconf *TargetConf) (bool, error) {
     END AS is_yb_superuser;`
 
 	isYBSuperUser, err := runQueryAndCheckPrivilege(isYbSuperUserQuery)
+	if err != nil {
+		return false, fmt.Errorf("error checking yb_superuser privilege: %w", err)
+	}
 
 	return isYBSuperUser, nil
 }


### PR DESCRIPTION
### Describe the changes in this pull request
Fixing a few bugs with import schema and YB Aeon type of target db, the difference in behavior is because of yb_superuser with YB Aeon which has a subset of superuser's privileges.
issues are detailed in this ticket 
https://yugabyte.atlassian.net/browse/DB-14398

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually with YB Aeon

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
