### PR TITLE
Integrated CheckRequiredToolsAreInstalled() function into checkDependenciesForExport() function

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -408,6 +408,8 @@ func checkDependenciesForExport() (binaryCheckIssues []string, err error) {
 		missingTools = utils.CheckTools("strings")
 
 	case MYSQL:
+		// TODO: For mysql and oracle, we can probably remove the ora2pg check in case it is a live migration
+		// Issue Link: https://github.com/yugabyte/yb-voyager/issues/2102
 		missingTools = utils.CheckTools("ora2pg")
 
 	case ORACLE:

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -43,7 +43,7 @@ var useDebezium bool
 var runId string
 var excludeTableListFilePath string
 var tableListFilePath string
-var pgExportDependencies = []string{"pg_dump", "pg_restore", "psql"}
+var pgExportCommands = []string{"pg_dump", "pg_restore", "psql"}
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
@@ -392,9 +392,11 @@ func saveExportTypeInMSR() {
 }
 
 func checkDependenciesForExport() (binaryCheckIssues []string, err error) {
-	if source.DBType == POSTGRESQL {
+	var missingTools []string
+	switch source.DBType {
+	case POSTGRESQL:
 		sourceDBVersion := source.DB().GetVersion()
-		for _, binary := range pgExportDependencies {
+		for _, binary := range pgExportCommands {
 			_, binaryCheckIssue, err := srcdb.GetAbsPathOfPGCommandAboveVersion(binary, sourceDBVersion)
 			if err != nil {
 				return nil, err
@@ -402,7 +404,23 @@ func checkDependenciesForExport() (binaryCheckIssues []string, err error) {
 				binaryCheckIssues = append(binaryCheckIssues, binaryCheckIssue)
 			}
 		}
+
+		missingTools = utils.CheckTools("strings")
+
+	case MYSQL:
+		missingTools = utils.CheckTools("ora2pg")
+
+	case ORACLE:
+		missingTools = utils.CheckTools("ora2pg", "sqlplus")
+
+	case YUGABYTEDB:
+		missingTools = utils.CheckTools("strings")
+
+	default:
+		return nil, fmt.Errorf("unknown source database type %q", source.DBType)
 	}
+
+	binaryCheckIssues = append(binaryCheckIssues, missingTools...)
 
 	if changeStreamingIsEnabled(exportType) || useDebezium {
 		// Check for java
@@ -489,7 +507,7 @@ func checkJavaVersion() (binaryCheckIssue string, err error) {
 	}
 
 	if majorVersion < MIN_REQUIRED_JAVA_VERSION {
-		return fmt.Sprintf("Java version %s is not supported. Please install Java version %d or higher", version, MIN_REQUIRED_JAVA_VERSION), nil
+		return fmt.Sprintf("java: required version >= %d; current version: %s", MIN_REQUIRED_JAVA_VERSION, version), nil
 	}
 
 	return "", nil

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -245,7 +245,6 @@ func exportData() bool {
 
 	clearMigrationStateIfRequired()
 	checkSourceDBCharset()
-	source.DB().CheckRequiredToolsAreInstalled()
 	saveSourceDBConfInMSR()
 	saveExportTypeInMSR()
 	err = InitNameRegistry(exportDir, exporterRole, &source, source.DB(), nil, nil, false)

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -222,8 +222,8 @@ func exportData() bool {
 		if err != nil {
 			utils.ErrExit("check dependencies for export: %v", err)
 		} else if len(binaryCheckIssues) > 0 {
-			color.Red("\nMissing dependencies for export data:")
-			utils.PrintAndLog("\n%s", strings.Join(binaryCheckIssues, "\n"))
+			headerStmt := color.RedString("Missing dependencies for export data:")
+			utils.PrintAndLog("\n%s\n%s", headerStmt, strings.Join(binaryCheckIssues, "\n"))
 			utils.ErrExit("")
 		}
 	}

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -118,7 +118,6 @@ func exportSchema() error {
 	}
 
 	checkSourceDBCharset()
-	source.DB().CheckRequiredToolsAreInstalled()
 	sourceDBVersion := source.DB().GetVersion()
 	source.DBVersion = sourceDBVersion
 	source.DBSize, err = source.DB().GetDatabaseSize()

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -71,10 +71,6 @@ func (ms *MySQL) CheckSchemaExists() bool {
 	return true
 }
 
-func (ms *MySQL) CheckRequiredToolsAreInstalled() {
-	checkTools("ora2pg")
-}
-
 func (ms *MySQL) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.AsQualifiedCatalogName())

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -78,10 +78,6 @@ func (ora *Oracle) CheckSchemaExists() bool {
 	return true
 }
 
-func (ora *Oracle) CheckRequiredToolsAreInstalled() {
-	checkTools("ora2pg", "sqlplus")
-}
-
 func (ora *Oracle) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.ForUserQuery())

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -140,10 +140,6 @@ func (pg *PostgreSQL) getTrimmedSchemaList() []string {
 	return trimmedList
 }
 
-func (pg *PostgreSQL) CheckRequiredToolsAreInstalled() {
-	checkTools("strings")
-}
-
 func (pg *PostgreSQL) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.ForUserQuery())

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -33,7 +33,6 @@ type SourceDB interface {
 	GetConnectionUriWithoutPassword() string
 	GetTableRowCount(tableName sqlname.NameTuple) (int64, error)
 	GetTableApproxRowCount(tableName sqlname.NameTuple) int64
-	CheckRequiredToolsAreInstalled()
 	GetVersion() string
 	GetAllTableNames() []*sqlname.SourceName
 	GetAllTableNamesRaw(schemaName string) ([]string, error)

--- a/yb-voyager/src/srcdb/utils.go
+++ b/yb-voyager/src/srcdb/utils.go
@@ -17,24 +17,9 @@ limitations under the License.
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
-
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
-
-func checkTools(tools ...string) {
-	for _, tool := range tools {
-		execPath, err := exec.LookPath(tool)
-		if err != nil {
-			utils.ErrExit("%q not found. Check if it is installed and included in the path.", tool)
-		}
-		log.Infof("Found %q", execPath)
-	}
-}
 
 func findAllExecutablesInPath(executableName string) ([]string, error) {
 	pathString := os.Getenv("PATH")

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -70,10 +70,6 @@ func (yb *YugabyteDB) Disconnect() {
 	}
 }
 
-func (yb *YugabyteDB) CheckRequiredToolsAreInstalled() {
-	checkTools("strings")
-}
-
 func (yb *YugabyteDB) GetTableRowCount(tableName sqlname.NameTuple) (int64, error) {
 	var rowCount int64
 	query := fmt.Sprintf("select count(*) from %s", tableName.ForUserQuery())

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -717,4 +718,19 @@ func GetFinalReleaseVersionFromRCVersion(msrVoyagerFinalVersion string) (string,
 		return "", fmt.Errorf("unexpected version format %q", msrVoyagerFinalVersion)
 	}
 	return msrVoyagerFinalVersion, nil
+}
+
+// Return list of missing tools from the provided list of tools
+func CheckTools(tools ...string) []string {
+	var missingTools []string
+	for _, tool := range tools {
+		execPath, err := exec.LookPath(tool)
+		if err != nil {
+			missingTools = append(missingTools, fmt.Sprintf("%s", tool))
+		} else {
+			log.Infof("Found %s at %s", tool, execPath)
+		}
+	}
+
+	return missingTools
 }

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -726,7 +726,7 @@ func CheckTools(tools ...string) []string {
 	for _, tool := range tools {
 		execPath, err := exec.LookPath(tool)
 		if err != nil {
-			missingTools = append(missingTools, fmt.Sprintf("%s", tool))
+			missingTools = append(missingTools, tool)
 		} else {
 			log.Infof("Found %s at %s", tool, execPath)
 		}


### PR DESCRIPTION


### Describe the changes in this pull request
We had a function **CheckRequiredToolsAreInstalled()** in the source db interface which we were using to check whether tools like strings, ora2pg, sqlplus were present or not. In this PR I have merged that function into **checkDependenciesForExport()** which is run along with the guardrails.

### Describe if there are any user-facing changes
There is an addition in the command line output for missing dependencies. The overall structure is same. Just that the above mentioned tools will also be shown:
![image](https://github.com/user-attachments/assets/4956320c-10ba-4911-ad19-4248bddaf7cd)

### How was this pull request tested?
This PR was tested manually. I removed the binaries from their locations and tried to get the output for which binaries are missing. No need to add integration tests.
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
