### PR TITLE
Printing a note if the export dir version is higher than the previous breaking change version but does not match the current version

### DIFF
--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -128,6 +128,14 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			// Initialize the metaDB variable only if the metaDB is already created. For example, resumption of a command.
 			if metaDBIsCreated(exportDir) {
 				metaDB = initMetaDB(exportDir)
+				msr, err := metaDB.GetMigrationStatusRecord()
+				if err != nil {
+					utils.ErrExit("get migration status record: %v", err)
+				}
+
+				msrVoyagerVersionString := msr.VoyagerVersion
+
+				detectVersionCompatibility(msrVoyagerVersionString, exportDir)
 			}
 
 			if perfProfile {


### PR DESCRIPTION


### Describe the changes in this pull request

- Printing a note in the scenario when the export dir version(msr version) is greater than the previous  breaking change version of the new voyager binary working on the export dir but the export dir version is not the same as the current version of the new voyager binary.
- Moreover, moved the logic to check the version compatibility from initMetaDB to root.go where we are checking whether metaDB is already present or nor. With the previous implementation, the not was printing twice - every time initMetaDB was called.

### Describe if there are any user-facing changes
Just a note will get printed in the scenario mentioned above which will look like:
![image](https://github.com/user-attachments/assets/27770c10-1e48-42ac-8d71-829bb70f4998)

<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
The PR was tested manually, I sent various values of msrVersion to the function and also modified the current and previous breaking change version
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
