### PR TITLE
Minor refactor to proto detectors

### DIFF
--- a/yb-voyager/go.mod
+++ b/yb-voyager/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/deckarep/golang-set/v2 v2.7.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/yb-voyager/go.sum
+++ b/yb-voyager/go.sum
@@ -836,6 +836,8 @@ github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjI
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.7.0 h1:gIloKvD7yH2oip4VLhsv3JyLLFnC0Y2mlusgcvJYW5k=
+github.com/deckarep/golang-set/v2 v2.7.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=

--- a/yb-voyager/src/query/queryissue/detectors.go
+++ b/yb-voyager/src/query/queryissue/detectors.go
@@ -16,10 +16,10 @@ limitations under the License.
 package queryissue
 
 import (
+	mapset "github.com/deckarep/golang-set/v2"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/reflect/protoreflect"
-
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/query/queryparser"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -31,86 +31,141 @@ const (
 // To Add a new unsupported query construct implement this interface for all possible nodes for that construct
 // each detector will work on specific type of node
 type UnsupportedConstructDetector interface {
-	Detect(msg protoreflect.Message) ([]string, error)
+	Detect(msg protoreflect.Message) error
+	GetIssues() []QueryIssue
 }
 
 type FuncCallDetector struct {
+	query string
 	// right now it covers Advisory Locks and XML functions
-	unsupportedFuncs map[string]string
+	// unsupportedFuncs map[string]string
+	advisoryLocksFuncsDetected mapset.Set[string]
+	xmlFuncsDetected           mapset.Set[string]
 }
 
-func NewFuncCallDetector() *FuncCallDetector {
-	unsupportedFuncs := make(map[string]string)
-	for _, fname := range unsupportedAdvLockFuncs {
-		unsupportedFuncs[fname] = ADVISORY_LOCKS_NAME
-	}
-	for _, fname := range unsupportedXmlFunctions {
-		unsupportedFuncs[fname] = XML_FUNCTIONS_NAME
-	}
+func NewFuncCallDetector(query string) *FuncCallDetector {
+	// unsupportedFuncs := make(map[string]string)
+	// for _, fname := range unsupportedAdvLockFuncs {
+	// 	unsupportedFuncs[fname] = ADVISORY_LOCKS_NAME
+	// }
+	// for _, fname := range unsupportedXmlFunctions {
+	// 	unsupportedFuncs[fname] = XML_FUNCTIONS_NAME
+	// }
 
 	return &FuncCallDetector{
-		unsupportedFuncs: unsupportedFuncs,
+		query:                      query,
+		advisoryLocksFuncsDetected: mapset.NewThreadUnsafeSet[string](),
+		xmlFuncsDetected:           mapset.NewThreadUnsafeSet[string](),
 	}
 }
 
 // Detect checks if a FuncCall node uses an unsupported function.
-func (d *FuncCallDetector) Detect(msg protoreflect.Message) ([]string, error) {
+func (d *FuncCallDetector) Detect(msg protoreflect.Message) error {
 	if queryparser.GetMsgFullName(msg) != queryparser.PG_QUERY_FUNCCALL_NODE {
-		return nil, nil
+		return nil
 	}
 
 	_, funcName := queryparser.GetFuncNameFromFuncCall(msg)
 	log.Debugf("fetched function name from %s node: %q", queryparser.PG_QUERY_FUNCCALL_NODE, funcName)
-	if constructType, isUnsupported := d.unsupportedFuncs[funcName]; isUnsupported {
-		log.Debugf("detected unsupported function %q in msg - %+v", funcName, msg)
-		return []string{constructType}, nil
+
+	if unsupportedAdvLockFuncs.ContainsOne(funcName) {
+		d.advisoryLocksFuncsDetected.Add(funcName)
 	}
-	return nil, nil
+	if unsupportedXmlFunctions.ContainsOne(funcName) {
+		d.xmlFuncsDetected.Add(funcName)
+	}
+
+	// if constructType, isUnsupported := d.unsupportedFuncs[funcName]; isUnsupported {
+	// 	log.Debugf("detected unsupported function %q in msg - %+v", funcName, msg)
+	// 	return []string{constructType}, nil
+	// }
+	return nil
+}
+
+func (d *FuncCallDetector) GetIssues() []QueryIssue {
+	var issues []QueryIssue
+	if d.advisoryLocksFuncsDetected.Cardinality() > 0 {
+		issues = append(issues, NewAdvisoryLocksIssue(DML_QUERY_OBJECT_TYPE, "", d.query))
+	}
+	if d.xmlFuncsDetected.Cardinality() > 0 {
+		issues = append(issues, NewXmlFunctionsIssue(DML_QUERY_OBJECT_TYPE, "", d.query))
+	}
+	return issues
 }
 
 type ColumnRefDetector struct {
-	unsupportedColumns map[string]string
+	query                            string
+	unsupportedSystemColumnsDetected mapset.Set[string]
+	// unsupportedColumns map[string]string
 }
 
-func NewColumnRefDetector() *ColumnRefDetector {
-	unsupportedColumns := make(map[string]string)
-	for _, colName := range unsupportedSysCols {
-		unsupportedColumns[colName] = SYSTEM_COLUMNS_NAME
-	}
+func NewColumnRefDetector(query string) *ColumnRefDetector {
+	// unsupportedColumns := make(map[string]string)
+	// for _, colName := range unsupportedSysCols {
+	// 	unsupportedColumns[colName] = SYSTEM_COLUMNS_NAME
+	// }
 
 	return &ColumnRefDetector{
-		unsupportedColumns: unsupportedColumns,
+		query:                            query,
+		unsupportedSystemColumnsDetected: mapset.NewThreadUnsafeSet[string](),
 	}
 }
 
 // Detect checks if a ColumnRef node uses an unsupported system column
-func (d *ColumnRefDetector) Detect(msg protoreflect.Message) ([]string, error) {
+func (d *ColumnRefDetector) Detect(msg protoreflect.Message) error {
 	if queryparser.GetMsgFullName(msg) != queryparser.PG_QUERY_COLUMNREF_NODE {
-		return nil, nil
+		return nil
 	}
 
 	_, colName := queryparser.GetColNameFromColumnRef(msg)
 	log.Debugf("fetched column name from %s node: %q", queryparser.PG_QUERY_COLUMNREF_NODE, colName)
-	if constructType, isUnsupported := d.unsupportedColumns[colName]; isUnsupported {
-		log.Debugf("detected unsupported system column %q in msg - %+v", colName, msg)
-		return []string{constructType}, nil
+
+	if unsupportedSysCols.ContainsOne(colName) {
+		d.unsupportedSystemColumnsDetected.Add(colName)
 	}
-	return nil, nil
+
+	// if constructType, isUnsupported := d.unsupportedColumns[colName]; isUnsupported {
+	// 	log.Debugf("detected unsupported system column %q in msg - %+v", colName, msg)
+	// 	return []string{constructType}, nil
+	// }
+	return nil
 }
 
-type XmlExprDetector struct{}
+func (d *ColumnRefDetector) GetIssues() []QueryIssue {
+	var issues []QueryIssue
+	if d.unsupportedSystemColumnsDetected.Cardinality() > 0 {
+		issues = append(issues, NewSystemColumnsIssue(DML_QUERY_OBJECT_TYPE, "", d.query))
+	}
+	return issues
+}
 
-func NewXmlExprDetector() *XmlExprDetector {
-	return &XmlExprDetector{}
+type XmlExprDetector struct {
+	query    string
+	detected bool
+}
+
+func NewXmlExprDetector(query string) *XmlExprDetector {
+	return &XmlExprDetector{
+		query: query,
+	}
 }
 
 // Detect checks if a XmlExpr node is present, means Xml type/functions are used
-func (d *XmlExprDetector) Detect(msg protoreflect.Message) ([]string, error) {
+func (d *XmlExprDetector) Detect(msg protoreflect.Message) error {
 	if queryparser.GetMsgFullName(msg) == queryparser.PG_QUERY_XMLEXPR_NODE {
-		log.Debug("detected xml expression")
-		return []string{XML_FUNCTIONS_NAME}, nil
+		d.detected = true
+		// log.Debug("detected xml expression")
+		// return []string{XML_FUNCTIONS_NAME}, nil
 	}
-	return nil, nil
+	return nil
+}
+
+func (d *XmlExprDetector) GetIssues() []QueryIssue {
+	var issues []QueryIssue
+	if d.detected {
+		issues = append(issues, NewXmlFunctionsIssue(DML_QUERY_OBJECT_TYPE, "", d.query))
+	}
+	return issues
 }
 
 /*
@@ -126,18 +181,32 @@ ASSUMPTION:
 
 - link: https://github.com/postgres/postgres/blob/ea792bfd93ab8ad4ef4e3d1a741b8595db143677/src/include/nodes/parsenodes.h#L651
 */
-type RangeTableFuncDetector struct{}
+type RangeTableFuncDetector struct {
+	query    string
+	detected bool
+}
 
-func NewRangeTableFuncDetector() *RangeTableFuncDetector {
-	return &RangeTableFuncDetector{}
+func NewRangeTableFuncDetector(query string) *RangeTableFuncDetector {
+	return &RangeTableFuncDetector{
+		query: query,
+	}
 }
 
 // Detect checks if a RangeTableFunc node is present for a XMLTABLE() function
-func (d *RangeTableFuncDetector) Detect(msg protoreflect.Message) ([]string, error) {
+func (d *RangeTableFuncDetector) Detect(msg protoreflect.Message) error {
 	if queryparser.GetMsgFullName(msg) == queryparser.PG_QUERY_RANGETABLEFUNC_NODE {
 		if queryparser.IsXMLTable(msg) {
-			return []string{XML_FUNCTIONS_NAME}, nil
+			d.detected = true
+			// return []string{XML_FUNCTIONS_NAME}, nil
 		}
 	}
-	return nil, nil
+	return nil
+}
+
+func (d *RangeTableFuncDetector) GetIssues() []QueryIssue {
+	var issues []QueryIssue
+	if d.detected {
+		issues = append(issues, NewXmlFunctionsIssue(DML_QUERY_OBJECT_TYPE, "", d.query))
+	}
+	return issues
 }

--- a/yb-voyager/src/query/queryissue/detectors.go
+++ b/yb-voyager/src/query/queryissue/detectors.go
@@ -30,6 +30,8 @@ const (
 
 // To Add a new unsupported query construct implement this interface for all possible nodes for that construct
 // each detector will work on specific type of node
+// detector <> isssueType many:many
+// detector <> issueType 1:many
 type UnsupportedConstructDetector interface {
 	Detect(msg protoreflect.Message) error
 	GetIssues() []QueryIssue

--- a/yb-voyager/src/query/queryissue/detectors.go
+++ b/yb-voyager/src/query/queryissue/detectors.go
@@ -30,8 +30,6 @@ const (
 
 // To Add a new unsupported query construct implement this interface for all possible nodes for that construct
 // each detector will work on specific type of node
-// detector <> isssueType many:many
-// detector <> issueType 1:many
 type UnsupportedConstructDetector interface {
 	Detect(msg protoreflect.Message) error
 	GetIssues() []QueryIssue
@@ -40,20 +38,11 @@ type UnsupportedConstructDetector interface {
 type FuncCallDetector struct {
 	query string
 	// right now it covers Advisory Locks and XML functions
-	// unsupportedFuncs map[string]string
 	advisoryLocksFuncsDetected mapset.Set[string]
 	xmlFuncsDetected           mapset.Set[string]
 }
 
 func NewFuncCallDetector(query string) *FuncCallDetector {
-	// unsupportedFuncs := make(map[string]string)
-	// for _, fname := range unsupportedAdvLockFuncs {
-	// 	unsupportedFuncs[fname] = ADVISORY_LOCKS_NAME
-	// }
-	// for _, fname := range unsupportedXmlFunctions {
-	// 	unsupportedFuncs[fname] = XML_FUNCTIONS_NAME
-	// }
-
 	return &FuncCallDetector{
 		query:                      query,
 		advisoryLocksFuncsDetected: mapset.NewThreadUnsafeSet[string](),
@@ -77,10 +66,6 @@ func (d *FuncCallDetector) Detect(msg protoreflect.Message) error {
 		d.xmlFuncsDetected.Add(funcName)
 	}
 
-	// if constructType, isUnsupported := d.unsupportedFuncs[funcName]; isUnsupported {
-	// 	log.Debugf("detected unsupported function %q in msg - %+v", funcName, msg)
-	// 	return []string{constructType}, nil
-	// }
 	return nil
 }
 
@@ -98,15 +83,9 @@ func (d *FuncCallDetector) GetIssues() []QueryIssue {
 type ColumnRefDetector struct {
 	query                            string
 	unsupportedSystemColumnsDetected mapset.Set[string]
-	// unsupportedColumns map[string]string
 }
 
 func NewColumnRefDetector(query string) *ColumnRefDetector {
-	// unsupportedColumns := make(map[string]string)
-	// for _, colName := range unsupportedSysCols {
-	// 	unsupportedColumns[colName] = SYSTEM_COLUMNS_NAME
-	// }
-
 	return &ColumnRefDetector{
 		query:                            query,
 		unsupportedSystemColumnsDetected: mapset.NewThreadUnsafeSet[string](),
@@ -125,11 +104,6 @@ func (d *ColumnRefDetector) Detect(msg protoreflect.Message) error {
 	if unsupportedSysCols.ContainsOne(colName) {
 		d.unsupportedSystemColumnsDetected.Add(colName)
 	}
-
-	// if constructType, isUnsupported := d.unsupportedColumns[colName]; isUnsupported {
-	// 	log.Debugf("detected unsupported system column %q in msg - %+v", colName, msg)
-	// 	return []string{constructType}, nil
-	// }
 	return nil
 }
 
@@ -156,8 +130,6 @@ func NewXmlExprDetector(query string) *XmlExprDetector {
 func (d *XmlExprDetector) Detect(msg protoreflect.Message) error {
 	if queryparser.GetMsgFullName(msg) == queryparser.PG_QUERY_XMLEXPR_NODE {
 		d.detected = true
-		// log.Debug("detected xml expression")
-		// return []string{XML_FUNCTIONS_NAME}, nil
 	}
 	return nil
 }
@@ -199,7 +171,6 @@ func (d *RangeTableFuncDetector) Detect(msg protoreflect.Message) error {
 	if queryparser.GetMsgFullName(msg) == queryparser.PG_QUERY_RANGETABLEFUNC_NODE {
 		if queryparser.IsXMLTable(msg) {
 			d.detected = true
-			// return []string{XML_FUNCTIONS_NAME}, nil
 		}
 	}
 	return nil

--- a/yb-voyager/src/query/queryissue/detectors_test.go
+++ b/yb-voyager/src/query/queryissue/detectors_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -76,27 +75,30 @@ func TestFuncCallDetector(t *testing.T) {
 		`SELECT pg_advisory_unlock_all();`,
 	}
 
-	detector := NewFuncCallDetector()
 	for _, sql := range advisoryLockSqls {
+		detector := NewFuncCallDetector(sql)
+
 		parseResult, err := queryparser.Parse(sql)
 		assert.NoError(t, err, "Failed to parse SQL: %s", sql)
 
 		visited := make(map[protoreflect.Message]bool)
-		unsupportedConstructs := []string{}
+		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
-			constructs, err := detector.Detect(msg)
+			err := detector.Detect(msg)
 			if err != nil {
 				return err
 			}
-			unsupportedConstructs = append(unsupportedConstructs, constructs...)
+			// unsupportedConstructs = append(unsupportedConstructs, constructs...)
 			return nil
 		}
 
 		parseTreeMsg := queryparser.GetProtoMessageFromParseTree(parseResult)
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
-		assert.Contains(t, unsupportedConstructs, ADVISORY_LOCKS_NAME, "Advisory Locks not detected in SQL: %s", sql)
+
+		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
+		// assert.Contains(t, unsupportedConstructs, ADVISORY_LOCKS_NAME, "Advisory Locks not detected in SQL: %s", sql)
 	}
 }
 
@@ -141,27 +143,28 @@ func TestColumnRefDetector(t *testing.T) {
         HAVING COUNT(*) > 1;`,
 	}
 
-	detector := NewColumnRefDetector()
 	for _, sql := range systemColumnSqls {
+		detector := NewColumnRefDetector(sql)
 		parseResult, err := queryparser.Parse(sql)
 		assert.NoError(t, err, "Failed to parse SQL: %s", sql)
 
 		visited := make(map[protoreflect.Message]bool)
-		unsupportedConstructs := []string{}
+		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
-			constructs, err := detector.Detect(msg)
+			err := detector.Detect(msg)
 			if err != nil {
 				return err
 			}
-			unsupportedConstructs = append(unsupportedConstructs, constructs...)
+			// unsupportedConstructs = append(unsupportedConstructs, constructs...)
 			return nil
 		}
 
 		parseTreeMsg := queryparser.GetProtoMessageFromParseTree(parseResult)
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
-		assert.Contains(t, unsupportedConstructs, SYSTEM_COLUMNS_NAME, "System Columns not detected in SQL: %s", sql)
+		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
+		// assert.Contains(t, unsupportedConstructs, SYSTEM_COLUMNS_NAME, "System Columns not detected in SQL: %s", sql)
 	}
 }
 
@@ -325,27 +328,29 @@ func TestRangeTableFuncDetector(t *testing.T) {
 		s.report_id;`,
 	}
 
-	detector := NewRangeTableFuncDetector()
 	for _, sql := range xmlTableSqls {
+		detector := NewRangeTableFuncDetector(sql)
 		parseResult, err := queryparser.Parse(sql)
 		assert.NoError(t, err, "Failed to parse SQL: %s", sql)
 
 		visited := make(map[protoreflect.Message]bool)
-		unsupportedConstructs := []string{}
+		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
-			constructs, err := detector.Detect(msg)
+			err := detector.Detect(msg)
 			if err != nil {
 				return err
 			}
-			unsupportedConstructs = append(unsupportedConstructs, constructs...)
+			// unsupportedConstructs = append(unsupportedConstructs, constructs...)
 			return nil
 		}
 
 		parseTreeMsg := queryparser.GetProtoMessageFromParseTree(parseResult)
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
-		assert.Contains(t, unsupportedConstructs, XML_FUNCTIONS_NAME, "XML Functions not detected in SQL: %s", sql)
+
+		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
+		// assert.Contains(t, unsupportedConstructs, XML_FUNCTIONS_NAME, "XML Functions not detected in SQL: %s", sql)
 	}
 }
 
@@ -356,85 +361,85 @@ func TestXMLFunctionsDetectors(t *testing.T) {
 		`SELECT id, xpath('/person/name/text()', data) AS name FROM xml_example;`,
 		`SELECT id FROM employees WHERE xmlexists('/id' PASSING BY VALUE xmlcolumn);`,
 		`SELECT e.id, x.employee_xml
-        FROM employees e
-        JOIN (
-            SELECT xmlelement(name "employee", xmlattributes(e.id AS "id"), e.name) AS employee_xml
-            FROM employees e
-        ) x ON x.employee_xml IS NOT NULL
-        WHERE xmlexists('//employee[name="John Doe"]' PASSING BY REF x.employee_xml);`,
+		        FROM employees e
+		        JOIN (
+		            SELECT xmlelement(name "employee", xmlattributes(e.id AS "id"), e.name) AS employee_xml
+		            FROM employees e
+		        ) x ON x.employee_xml IS NOT NULL
+		        WHERE xmlexists('//employee[name="John Doe"]' PASSING BY REF x.employee_xml);`,
 		`WITH xml_data AS (
-            SELECT 
-                id, 
-                xml_column,
-                xpath('/root/element/@attribute', xml_column) as xpath_result
-            FROM xml_documents
-        )
-        SELECT 
-            x.id,
-            (xt.value).text as value
-        FROM 
-            xml_data x
-            CROSS JOIN LATERAL unnest(x.xpath_result) as xt(value);`,
+		            SELECT
+		                id,
+		                xml_column,
+		                xpath('/root/element/@attribute', xml_column) as xpath_result
+		            FROM xml_documents
+		        )
+		        SELECT
+		            x.id,
+		            (xt.value).text as value
+		        FROM
+		            xml_data x
+		            CROSS JOIN LATERAL unnest(x.xpath_result) as xt(value);`,
 		`SELECT e.id, e.name
-        FROM employees e
-        WHERE CASE
-            WHEN e.department = 'IT' THEN xmlexists('//access[@level="high"]' PASSING e.permissions)
-            ELSE FALSE
-        END;`,
+		        FROM employees e
+		        WHERE CASE
+		            WHEN e.department = 'IT' THEN xmlexists('//access[@level="high"]' PASSING e.permissions)
+		            ELSE FALSE
+		        END;`,
 		`SELECT xmlserialize(
-            content xmlelement(name "employees",
-                xmlagg(
-                    xmlelement(name "employee",
-                        xmlattributes(e.id AS "id"),
-                        e.name
-                    )
-                )
-            ) AS CLOB
-        ) AS employees_xml
-        FROM employees e
-        WHERE e.status = 'active';`,
+		            content xmlelement(name "employees",
+		                xmlagg(
+		                    xmlelement(name "employee",
+		                        xmlattributes(e.id AS "id"),
+		                        e.name
+		                    )
+		                )
+		            ) AS CLOB
+		        ) AS employees_xml
+		        FROM employees e
+		        WHERE e.status = 'active';`,
 		`CREATE VIEW employee_xml_view AS
-        SELECT e.id,
-            xmlelement(name "employee",
-                xmlattributes(e.id AS "id"),
-                e.name,
-                e.department
-            ) AS employee_xml
-        FROM employees e;`,
+		        SELECT e.id,
+		            xmlelement(name "employee",
+		                xmlattributes(e.id AS "id"),
+		                e.name,
+		                e.department
+		            ) AS employee_xml
+		        FROM employees e;`,
 		`SELECT  xmltext('<inventory><item>Widget</item></inventory>') AS inventory_text
-FROM inventory
-WHERE id = 5;`,
+		FROM inventory
+		WHERE id = 5;`,
 		`SELECT xmlforest(name, department) AS employee_info
-FROM employees
-WHERE id = 4;`,
+		FROM employees
+		WHERE id = 4;`,
 		`SELECT xmltable.*
-		FROM xmldata,
-		    XMLTABLE('//ROWS/ROW'
-		            PASSING data
-		            COLUMNS id int PATH '@id',
-		                ordinality FOR ORDINALITY,
-		                "COUNTRY_NAME" text,
-		                country_id text PATH 'COUNTRY_ID',
-		                size_sq_km float PATH 'SIZE[@unit = "sq_km"]',
-		                size_other text PATH
-		                'concat(SIZE[@unit!="sq_km"], " ", SIZE[@unit!="sq_km"]/@unit)',
-		                 premier_name text PATH 'PREMIER_NAME' DEFAULT 'not specified');`,
+				FROM xmldata,
+				    XMLTABLE('//ROWS/ROW'
+				            PASSING data
+				            COLUMNS id int PATH '@id',
+				                ordinality FOR ORDINALITY,
+				                "COUNTRY_NAME" text,
+				                country_id text PATH 'COUNTRY_ID',
+				                size_sq_km float PATH 'SIZE[@unit = "sq_km"]',
+				                size_other text PATH
+				                'concat(SIZE[@unit!="sq_km"], " ", SIZE[@unit!="sq_km"]/@unit)',
+				                 premier_name text PATH 'PREMIER_NAME' DEFAULT 'not specified');`,
 		`SELECT xmltable.*
-		FROM XMLTABLE(XMLNAMESPACES('http://example.com/myns' AS x,
-		                            'http://example.com/b' AS "B"),
-		             '/x:example/x:item'
-		                PASSING (SELECT data FROM xmldata)
-		                COLUMNS foo int PATH '@foo',
-		                  bar int PATH '@B:bar');`,
+				FROM XMLTABLE(XMLNAMESPACES('http://example.com/myns' AS x,
+				                            'http://example.com/b' AS "B"),
+				             '/x:example/x:item'
+				                PASSING (SELECT data FROM xmldata)
+				                COLUMNS foo int PATH '@foo',
+				                  bar int PATH '@B:bar');`,
 		`SELECT xml_is_well_formed_content('<project>Alpha</project>') AS is_well_formed_content
-FROM projects
-WHERE project_id = 10;`,
+		FROM projects
+		WHERE project_id = 10;`,
 		`SELECT xml_is_well_formed_document(xmlforest(name, department)) AS is_well_formed_document
-FROM employees
-WHERE id = 2;`,
+		FROM employees
+		WHERE id = 2;`,
 		`SELECT xml_is_well_formed(xmltext('<employee><name>Jane Doe</name></employee>')) AS is_well_formed
-FROM employees
-WHERE id = 1;`,
+		FROM employees
+		WHERE id = 1;`,
 		`SELECT xmlparse(DOCUMENT '<employee><name>John</name></employee>');`,
 		`SELECT xpath_exists('/employee/name', '<employee><name>John</name></employee>'::xml)`,
 		`SELECT table_to_xml('employees', TRUE, FALSE, '');`,
@@ -465,28 +470,28 @@ WHERE id = 1;`,
 		`SELECT xml_send('<root><data>send</data></root>');`,
 	}
 
-	detectors := []UnsupportedConstructDetector{
-		NewXmlExprDetector(),
-		NewRangeTableFuncDetector(),
-		NewFuncCallDetector(),
-	}
-
 	for _, sql := range xmlFunctionSqls {
+		detectors := []UnsupportedConstructDetector{
+			NewXmlExprDetector(sql),
+			NewRangeTableFuncDetector(sql),
+			NewFuncCallDetector(sql),
+		}
+
 		parseResult, err := queryparser.Parse(sql)
 		assert.NoError(t, err)
 
 		visited := make(map[protoreflect.Message]bool)
-		unsupportedConstructs := []string{}
+		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
 			for _, detector := range detectors {
 				log.Debugf("running detector %T", detector)
-				constructs, err := detector.Detect(msg)
+				err := detector.Detect(msg)
 				if err != nil {
 					log.Debugf("error in detector %T: %v", detector, err)
 					return fmt.Errorf("error in detectors %T: %w", detector, err)
 				}
-				unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
+				// unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
 			}
 			return nil
 		}
@@ -494,8 +499,15 @@ WHERE id = 1;`,
 		parseTreeMsg := queryparser.GetProtoMessageFromParseTree(parseResult)
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
+
+		var allIssues []QueryIssue
+		for _, detector := range detectors {
+			allIssues = append(allIssues, detector.GetIssues()...)
+		}
+
+		assert.Equal(t, 1, len(allIssues), "Expected 1 issue for SQL: %s", sql)
 		// The detector should detect XML Functions in these queries
-		assert.Contains(t, unsupportedConstructs, XML_FUNCTIONS_NAME, "XML Functions not detected in SQL: %s", sql)
+		// assert.Contains(t, unsupportedConstructs, XML_FUNCTIONS_NAME, "XML Functions not detected in SQL: %s", sql)
 	}
 }
 
@@ -530,29 +542,29 @@ RETURNING id,
                      xmlattributes(id AS "ID"),
                      xmlforest(name AS "Name", salary AS "NewSalary", xmin AS "TransactionStartID", xmax AS "TransactionEndID"));`,
 	}
-	expectedConstructs := []string{ADVISORY_LOCKS_NAME, SYSTEM_COLUMNS_NAME, XML_FUNCTIONS_NAME}
+	// expectedConstructs := []string{ADVISORY_LOCKS_NAME, SYSTEM_COLUMNS_NAME, XML_FUNCTIONS_NAME}
 
-	detectors := []UnsupportedConstructDetector{
-		NewFuncCallDetector(),
-		NewColumnRefDetector(),
-		NewXmlExprDetector(),
-	}
 	for _, sql := range combinationSqls {
+		detectors := []UnsupportedConstructDetector{
+			NewFuncCallDetector(sql),
+			NewColumnRefDetector(sql),
+			NewXmlExprDetector(sql),
+		}
 		parseResult, err := queryparser.Parse(sql)
 		assert.NoError(t, err)
 
 		visited := make(map[protoreflect.Message]bool)
-		unsupportedConstructs := []string{}
+		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
 			for _, detector := range detectors {
 				log.Debugf("running detector %T", detector)
-				constructs, err := detector.Detect(msg)
+				err := detector.Detect(msg)
 				if err != nil {
 					log.Debugf("error in detector %T: %v", detector, err)
 					return fmt.Errorf("error in detectors %T: %w", detector, err)
 				}
-				unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
+				// unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
 			}
 			return nil
 		}
@@ -560,7 +572,15 @@ RETURNING id,
 		parseTreeMsg := queryparser.GetProtoMessageFromParseTree(parseResult)
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, expectedConstructs, unsupportedConstructs, "Detected constructs do not exactly match the expected constructs. Expected: %v, Actual: %v", expectedConstructs, unsupportedConstructs)
+
+		var allIssues []QueryIssue
+		for _, detector := range detectors {
+			allIssues = append(allIssues, detector.GetIssues()...)
+		}
+
+		assert.Equal(t, 3, len(allIssues), "Expected 1 issue for SQL: %s", sql)
+
+		// assert.ElementsMatch(t, expectedConstructs, unsupportedConstructs, "Detected constructs do not exactly match the expected constructs. Expected: %v, Actual: %v", expectedConstructs, unsupportedConstructs)
 	}
 }
 
@@ -613,30 +633,30 @@ func TestCombinationOfDetectors1WithObjectCollector(t *testing.T) {
 		},
 	}
 
-	expectedConstructs := []string{ADVISORY_LOCKS_NAME, SYSTEM_COLUMNS_NAME, XML_FUNCTIONS_NAME}
+	// expectedConstructs := []string{ADVISORY_LOCKS_NAME, SYSTEM_COLUMNS_NAME, XML_FUNCTIONS_NAME}
 
-	detectors := []UnsupportedConstructDetector{
-		NewFuncCallDetector(),
-		NewColumnRefDetector(),
-		NewXmlExprDetector(),
-	}
 	for _, tc := range tests {
+		detectors := []UnsupportedConstructDetector{
+			NewFuncCallDetector(tc.Sql),
+			NewColumnRefDetector(tc.Sql),
+			NewXmlExprDetector(tc.Sql),
+		}
 		parseResult, err := queryparser.Parse(tc.Sql)
 		assert.NoError(t, err)
 
 		visited := make(map[protoreflect.Message]bool)
-		unsupportedConstructs := []string{}
+		// unsupportedConstructs := []string{}
 
 		objectCollector := queryparser.NewObjectCollector()
 		processor := func(msg protoreflect.Message) error {
 			for _, detector := range detectors {
 				log.Debugf("running detector %T", detector)
-				constructs, err := detector.Detect(msg)
+				err := detector.Detect(msg)
 				if err != nil {
 					log.Debugf("error in detector %T: %v", detector, err)
 					return fmt.Errorf("error in detectors %T: %w", detector, err)
 				}
-				unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
+				// unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
 			}
 			objectCollector.Collect(msg)
 			return nil
@@ -645,7 +665,13 @@ func TestCombinationOfDetectors1WithObjectCollector(t *testing.T) {
 		parseTreeMsg := queryparser.GetProtoMessageFromParseTree(parseResult)
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, expectedConstructs, unsupportedConstructs, "Detected constructs do not exactly match the expected constructs. Expected: %v, Actual: %v", expectedConstructs, unsupportedConstructs)
+
+		var allIssues []QueryIssue
+		for _, detector := range detectors {
+			allIssues = append(allIssues, detector.GetIssues()...)
+		}
+
+		// assert.ElementsMatch(t, expectedConstructs, unsupportedConstructs, "Detected constructs do not exactly match the expected constructs. Expected: %v, Actual: %v", expectedConstructs, unsupportedConstructs)
 
 		collectedObjects := objectCollector.GetObjects()
 		collectedSchemas := objectCollector.GetSchemaList()

--- a/yb-voyager/src/query/queryissue/detectors_test.go
+++ b/yb-voyager/src/query/queryissue/detectors_test.go
@@ -97,8 +97,10 @@ func TestFuncCallDetector(t *testing.T) {
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
-		assert.Equal(t, ADVISORY_LOCKS, detector.GetIssues()[0].Type, "Expected Advisory Locks issue for SQL: %s", sql)
+		issues := detector.GetIssues()
+
+		assert.Equal(t, 1, len(issues), "Expected 1 issue for SQL: %s", sql)
+		assert.Equal(t, ADVISORY_LOCKS, issues[0].Type, "Expected Advisory Locks issue for SQL: %s", sql)
 	}
 }
 
@@ -161,8 +163,11 @@ func TestColumnRefDetector(t *testing.T) {
 		parseTreeMsg := queryparser.GetProtoMessageFromParseTree(parseResult)
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
-		assert.Equal(t, SYSTEM_COLUMNS, detector.GetIssues()[0].Type, "Expected System Columns issue for SQL: %s", sql)
+
+		issues := detector.GetIssues()
+
+		assert.Equal(t, 1, len(issues), "Expected 1 issue for SQL: %s", sql)
+		assert.Equal(t, SYSTEM_COLUMNS, issues[0].Type, "Expected System Columns issue for SQL: %s", sql)
 	}
 }
 
@@ -345,8 +350,10 @@ func TestRangeTableFuncDetector(t *testing.T) {
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
-		assert.Equal(t, XML_FUNCTIONS, detector.GetIssues()[0].Type, "Expected XML Functions issue for SQL: %s", sql)
+		issues := detector.GetIssues()
+
+		assert.Equal(t, 1, len(issues), "Expected 1 issue for SQL: %s", sql)
+		assert.Equal(t, XML_FUNCTIONS, issues[0].Type, "Expected XML Functions issue for SQL: %s", sql)
 	}
 }
 
@@ -633,7 +640,6 @@ func TestCombinationOfDetectors1WithObjectCollector(t *testing.T) {
 		},
 	}
 
-	// expectedConstructs := []string{ADVISORY_LOCKS_NAME, SYSTEM_COLUMNS_NAME, XML_FUNCTIONS_NAME}
 	expectedIssueTypes := mapset.NewThreadUnsafeSet[string]([]string{ADVISORY_LOCKS, SYSTEM_COLUMNS, XML_FUNCTIONS}...)
 
 	for _, tc := range tests {

--- a/yb-voyager/src/query/queryissue/detectors_test.go
+++ b/yb-voyager/src/query/queryissue/detectors_test.go
@@ -83,7 +83,6 @@ func TestFuncCallDetector(t *testing.T) {
 		assert.NoError(t, err, "Failed to parse SQL: %s", sql)
 
 		visited := make(map[protoreflect.Message]bool)
-		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
 			err := detector.Detect(msg)

--- a/yb-voyager/src/query/queryissue/detectors_test.go
+++ b/yb-voyager/src/query/queryissue/detectors_test.go
@@ -90,7 +90,6 @@ func TestFuncCallDetector(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			// unsupportedConstructs = append(unsupportedConstructs, constructs...)
 			return nil
 		}
 
@@ -99,7 +98,7 @@ func TestFuncCallDetector(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
-		// assert.Contains(t, unsupportedConstructs, ADVISORY_LOCKS_NAME, "Advisory Locks not detected in SQL: %s", sql)
+		assert.Equal(t, ADVISORY_LOCKS, detector.GetIssues()[0].Type, "Expected Advisory Locks issue for SQL: %s", sql)
 	}
 }
 
@@ -150,14 +149,12 @@ func TestColumnRefDetector(t *testing.T) {
 		assert.NoError(t, err, "Failed to parse SQL: %s", sql)
 
 		visited := make(map[protoreflect.Message]bool)
-		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
 			err := detector.Detect(msg)
 			if err != nil {
 				return err
 			}
-			// unsupportedConstructs = append(unsupportedConstructs, constructs...)
 			return nil
 		}
 
@@ -165,7 +162,7 @@ func TestColumnRefDetector(t *testing.T) {
 		err = queryparser.TraverseParseTree(parseTreeMsg, visited, processor)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
-		// assert.Contains(t, unsupportedConstructs, SYSTEM_COLUMNS_NAME, "System Columns not detected in SQL: %s", sql)
+		assert.Equal(t, SYSTEM_COLUMNS, detector.GetIssues()[0].Type, "Expected System Columns issue for SQL: %s", sql)
 	}
 }
 
@@ -335,14 +332,12 @@ func TestRangeTableFuncDetector(t *testing.T) {
 		assert.NoError(t, err, "Failed to parse SQL: %s", sql)
 
 		visited := make(map[protoreflect.Message]bool)
-		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
 			err := detector.Detect(msg)
 			if err != nil {
 				return err
 			}
-			// unsupportedConstructs = append(unsupportedConstructs, constructs...)
 			return nil
 		}
 
@@ -351,7 +346,7 @@ func TestRangeTableFuncDetector(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, 1, len(detector.GetIssues()), "Expected 1 issue for SQL: %s", sql)
-		// assert.Contains(t, unsupportedConstructs, XML_FUNCTIONS_NAME, "XML Functions not detected in SQL: %s", sql)
+		assert.Equal(t, XML_FUNCTIONS, detector.GetIssues()[0].Type, "Expected XML Functions issue for SQL: %s", sql)
 	}
 }
 
@@ -482,7 +477,6 @@ func TestXMLFunctionsDetectors(t *testing.T) {
 		assert.NoError(t, err)
 
 		visited := make(map[protoreflect.Message]bool)
-		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
 			for _, detector := range detectors {
@@ -492,7 +486,6 @@ func TestXMLFunctionsDetectors(t *testing.T) {
 					log.Debugf("error in detector %T: %v", detector, err)
 					return fmt.Errorf("error in detectors %T: %w", detector, err)
 				}
-				// unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
 			}
 			return nil
 		}
@@ -515,9 +508,6 @@ func TestXMLFunctionsDetectors(t *testing.T) {
 		}
 
 		assert.True(t, xmlIssueDetected, "Expected XML Functions issue for SQL: %s", sql)
-		// assert.Equal(t, 1, len(allIssues), "Expected 1 issue for SQL: %s", sql)
-		// The detector should detect XML Functions in these queries
-		// assert.Contains(t, unsupportedConstructs, XML_FUNCTIONS_NAME, "XML Functions not detected in SQL: %s", sql)
 	}
 }
 
@@ -564,7 +554,6 @@ RETURNING id,
 		assert.NoError(t, err)
 
 		visited := make(map[protoreflect.Message]bool)
-		// unsupportedConstructs := []string{}
 
 		processor := func(msg protoreflect.Message) error {
 			for _, detector := range detectors {
@@ -574,7 +563,6 @@ RETURNING id,
 					log.Debugf("error in detector %T: %v", detector, err)
 					return fmt.Errorf("error in detectors %T: %w", detector, err)
 				}
-				// unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
 			}
 			return nil
 		}
@@ -593,9 +581,6 @@ RETURNING id,
 		}
 
 		assert.True(t, expectedIssueTypes.Equal(issueTypesDetected), "Expected issue types do not match the detected issue types. Expected: %v, Actual: %v", expectedIssueTypes, issueTypesDetected)
-		// assert.Equal(t, 3, len(allIssues), "Expected 1 issue for SQL: %s", sql)
-
-		// assert.ElementsMatch(t, expectedConstructs, unsupportedConstructs, "Detected constructs do not exactly match the expected constructs. Expected: %v, Actual: %v", expectedConstructs, unsupportedConstructs)
 	}
 }
 
@@ -661,7 +646,6 @@ func TestCombinationOfDetectors1WithObjectCollector(t *testing.T) {
 		assert.NoError(t, err)
 
 		visited := make(map[protoreflect.Message]bool)
-		// unsupportedConstructs := []string{}
 
 		objectCollector := queryparser.NewObjectCollector()
 		processor := func(msg protoreflect.Message) error {
@@ -672,7 +656,6 @@ func TestCombinationOfDetectors1WithObjectCollector(t *testing.T) {
 					log.Debugf("error in detector %T: %v", detector, err)
 					return fmt.Errorf("error in detectors %T: %w", detector, err)
 				}
-				// unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
 			}
 			objectCollector.Collect(msg)
 			return nil
@@ -692,8 +675,6 @@ func TestCombinationOfDetectors1WithObjectCollector(t *testing.T) {
 		}
 
 		assert.True(t, expectedIssueTypes.Equal(issueTypesDetected), "Expected issue types do not match the detected issue types. Expected: %v, Actual: %v", expectedIssueTypes, issueTypesDetected)
-
-		// assert.ElementsMatch(t, expectedConstructs, unsupportedConstructs, "Detected constructs do not exactly match the expected constructs. Expected: %v, Actual: %v", expectedConstructs, unsupportedConstructs)
 
 		collectedObjects := objectCollector.GetObjects()
 		collectedSchemas := objectCollector.GetSchemaList()

--- a/yb-voyager/src/query/queryissue/helpers.go
+++ b/yb-voyager/src/query/queryissue/helpers.go
@@ -16,21 +16,25 @@ limitations under the License.
 
 package queryissue
 
+import (
+	mapset "github.com/deckarep/golang-set/v2"
+)
+
 // Refer: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
-var unsupportedAdvLockFuncs = []string{
+var unsupportedAdvLockFuncs = mapset.NewThreadUnsafeSet([]string{
 	"pg_advisory_lock", "pg_advisory_lock_shared",
 	"pg_advisory_unlock", "pg_advisory_unlock_all", "pg_advisory_unlock_shared",
 	"pg_advisory_xact_lock", "pg_advisory_xact_lock_shared",
 	"pg_try_advisory_lock", "pg_try_advisory_lock_shared",
 	"pg_try_advisory_xact_lock", "pg_try_advisory_xact_lock_shared",
-}
+}...)
 
-var unsupportedSysCols = []string{
+var unsupportedSysCols = mapset.NewThreadUnsafeSet([]string{
 	"xmin", "xmax", "cmin", "cmax", "ctid",
-}
+}...)
 
 // Refer: https://www.postgresql.org/docs/17/functions-xml.html#FUNCTIONS-XML-PROCESSING
-var unsupportedXmlFunctions = []string{
+var unsupportedXmlFunctions = mapset.NewThreadUnsafeSet([]string{
 	// 1. Producing XML content
 	"xmltext", "xmlcomment", "xmlconcat", "xmlelement", "xmlforest",
 	"xmlpi", "xmlroot", "xmlagg",
@@ -52,7 +56,7 @@ var unsupportedXmlFunctions = []string{
 		WHERE prorettype = 'xml'::regtype;
 	*/
 	"xmlconcat2", "xmlvalidate", "xml_in", "xml_out", "xml_recv", "xml_send", // System XML I/O
-}
+}...)
 
 var UnsupportedIndexMethods = []string{
 	"gist",

--- a/yb-voyager/src/query/queryissue/issues_ddl.go
+++ b/yb-voyager/src/query/queryissue/issues_ddl.go
@@ -449,3 +449,21 @@ var percentTypeSyntax = issue.Issue{
 func NewPercentTypeSyntaxIssue(objectType string, objectName string, sqlStatement string) QueryIssue {
 	return newQueryIssue(percentTypeSyntax, objectType, objectName, sqlStatement, map[string]interface{}{})
 }
+
+// unsupportedIndexIssue
+//   ObjectType = INDEX
+//   ObjectName = idx_name ON table_name
+//   invalidCount.Type = INDEX
+//   invalidCount.Name = ObjectName (because this is fully qualified)
+//   DisplayName = ObjectName
+
+// deferrableConstraintIssue
+//  ObjectType = TABLE
+//  ObjectName = table_name
+// 	invalidCount.Type = TABLE
+//  invalidCount.Name = ObjectName
+//  DisplayName = table_name (constraint_name) (!= ObjectName)
+
+// Solutions
+// 1. Define a issue.ObjectDisplayName
+// 2. Keep it in issue.Details and write logic in UI layer to construct display name.

--- a/yb-voyager/src/query/queryissue/issues_ddl.go
+++ b/yb-voyager/src/query/queryissue/issues_ddl.go
@@ -449,21 +449,3 @@ var percentTypeSyntax = issue.Issue{
 func NewPercentTypeSyntaxIssue(objectType string, objectName string, sqlStatement string) QueryIssue {
 	return newQueryIssue(percentTypeSyntax, objectType, objectName, sqlStatement, map[string]interface{}{})
 }
-
-// unsupportedIndexIssue
-//   ObjectType = INDEX
-//   ObjectName = idx_name ON table_name
-//   invalidCount.Type = INDEX
-//   invalidCount.Name = ObjectName (because this is fully qualified)
-//   DisplayName = ObjectName
-
-// deferrableConstraintIssue
-//  ObjectType = TABLE
-//  ObjectName = table_name
-// 	invalidCount.Type = TABLE
-//  invalidCount.Name = ObjectName
-//  DisplayName = table_name (constraint_name) (!= ObjectName)
-
-// Solutions
-// 1. Define a issue.ObjectDisplayName
-// 2. Keep it in issue.Details and write logic in UI layer to construct display name.

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -402,6 +402,14 @@ func (p *ParserIssueDetector) genericIssues(query string) ([]QueryIssue, error) 
 		result = append(result, issues...)
 	}
 
+	// xmlissue1 - XMLFunctionsIssue
+	//	functions: xmleelement
+	// xmlissue2 - XMLExpressionsIssue
+	//	functions: xmlconcat
+
+	// query - 2 xml functions
+	//
+
 	// for _, unsupportedConstruct := range unsupportedConstructs {
 	// 	switch unsupportedConstruct {
 	// 	case ADVISORY_LOCKS_NAME:

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -385,7 +385,6 @@ func (p *ParserIssueDetector) genericIssues(query string) ([]QueryIssue, error) 
 				log.Debugf("error in detector %T: %v", detector, err)
 				return fmt.Errorf("error in detectors %T: %w", detector, err)
 			}
-			// unsupportedConstructs = lo.Union(unsupportedConstructs, constructs)
 		}
 		return nil
 	}

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -397,9 +397,25 @@ func (p *ParserIssueDetector) genericIssues(query string) ([]QueryIssue, error) 
 		return result, fmt.Errorf("error traversing parse tree message: %w", err)
 	}
 
+	xmlIssueAdded := false
 	for _, detector := range detectors {
 		issues := detector.GetIssues()
-		result = append(result, issues...)
+		for _, issue := range issues {
+			if issue.Type == XML_FUNCTIONS {
+				if xmlIssueAdded {
+					// currently, both FuncCallDetector and XmlExprDetector can detect XMLFunctionsIssue
+					// but we want to only return one XMLFunctionsIssue.
+					// TODO: refactor to avoid this
+					// Possible Solutions:
+					// 1. Have a dedicated detector for XMLFunctions and Expressions so that a single issue is returned
+					// 2. Separate issue types for XML Functions and XML expressions.
+					continue
+				} else {
+					xmlIssueAdded = true
+				}
+			}
+			result = append(result, issues...)
+		}
 	}
 
 	// xmlissue1 - XMLFunctionsIssue

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -369,7 +369,6 @@ func (p *ParserIssueDetector) genericIssues(query string) ([]QueryIssue, error) 
 		return nil, fmt.Errorf("error parsing query: %w", err)
 	}
 	var result []QueryIssue
-	// var unsupportedConstructs []string
 	visited := make(map[protoreflect.Message]bool)
 	detectors := []UnsupportedConstructDetector{
 		NewFuncCallDetector(query),
@@ -418,23 +417,5 @@ func (p *ParserIssueDetector) genericIssues(query string) ([]QueryIssue, error) 
 		}
 	}
 
-	// xmlissue1 - XMLFunctionsIssue
-	//	functions: xmleelement
-	// xmlissue2 - XMLExpressionsIssue
-	//	functions: xmlconcat
-
-	// query - 2 xml functions
-	//
-
-	// for _, unsupportedConstruct := range unsupportedConstructs {
-	// 	switch unsupportedConstruct {
-	// 	case ADVISORY_LOCKS_NAME:
-	// 		result = append(result, NewAdvisoryLocksIssue(DML_QUERY_OBJECT_TYPE, "", query))
-	// 	case SYSTEM_COLUMNS_NAME:
-	// 		result = append(result, NewSystemColumnsIssue(DML_QUERY_OBJECT_TYPE, "", query))
-	// 	case XML_FUNCTIONS_NAME:
-	// 		result = append(result, NewXmlFunctionsIssue(DML_QUERY_OBJECT_TYPE, "", query))
-	// 	}
-	// }
 	return result, nil
 }

--- a/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
@@ -305,6 +305,10 @@ func TestUnloggedTableIssueReportedInOlderVersion(t *testing.T) {
 	assert.True(t, cmp.Equal(issues[0], NewUnloggedTableIssue("TABLE", "tbl_unlog", stmt)))
 }
 
+// currently, both FuncCallDetector and XmlExprDetector can detect XMLFunctionsIssue
+// statement below has both XML functions and XML expressions.
+// but we want to only return one XMLFunctionsIssue from parserIssueDetector.getDMLIssues
+// and there is some workaround in place to avoid returning multiple issues in .genericIssues method
 func TestSingleXMLIssueIsDetected(t *testing.T) {
 	stmt := `
 	SELECT e.id, x.employee_xml

--- a/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
@@ -304,3 +304,19 @@ func TestUnloggedTableIssueReportedInOlderVersion(t *testing.T) {
 	assert.Equal(t, 1, len(issues))
 	assert.True(t, cmp.Equal(issues[0], NewUnloggedTableIssue("TABLE", "tbl_unlog", stmt)))
 }
+
+func TestSingleXMLIssueIsDetected(t *testing.T) {
+	stmt := `
+	SELECT e.id, x.employee_xml
+		FROM employees e
+		JOIN (
+			SELECT xmlelement(name "employee", xmlattributes(e.id AS "id"), e.name) AS employee_xml
+			FROM employees e
+		) x ON x.employee_xml IS NOT NULL
+		WHERE xmlexists('//employee[name="John Doe"]' PASSING BY REF x.employee_xml);`
+
+	parserIssueDetector := NewParserIssueDetector()
+	issues, err := parserIssueDetector.getDMLIssues(stmt)
+	fatalIfError(t, err)
+	assert.Equal(t, 1, len(issues))
+}


### PR DESCRIPTION
### Describe the changes in this pull request
1. Change interface of `UnsupportedConstructDetector` to make each detector responsible for constructing and returning issues. Currently, this was being done in ParserIssueDetector.getGenericIssues, which seems like the wrong place for it. With pg17 features, all the issue construction will be added to this function itself, which I want to avoid.  Detectors do the detection, and they should also construct the issues since they have all the information necessary to do so. 
2. Store functions being detected in `FuncCallDetector` . Will be useful for later reporting.
3. This refactor led to one side-effect related to XML issues. Worked around that for now. 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  4. Has the installation process changed? 
  5. Were there any changes to the reports? 
-->

### How was this pull request tested?
Existing unit tests suffice. 

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
