### PR TITLE
Redacting password while logging connection params in import data to target

### DIFF
--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -242,7 +242,9 @@ func (yb *TargetYugabyteDB) InitConnPool() error {
 		SessionInitScript: getYBSessionInitScript(yb.tconf),
 	}
 	yb.connPool = NewConnectionPool(params)
-	log.Info("Initialized connection pool with settings: ", spew.Sdump(params))
+	redactedParams := params
+	redactedParams.ConnUriList = utils.GetRedactedURLs(redactedParams.ConnUriList)
+	log.Info("Initialized connection pool with settings: ", spew.Sdump(redactedParams))
 	return nil
 }
 

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -431,7 +431,7 @@ func GetRedactedURLs(urlList []string) []string {
 	for _, u := range urlList {
 		obj, err := url.Parse(u)
 		if err != nil {
-			ErrExit("invalid URL: %q", u)
+			ErrExit("error redacting connection url: invalid connection URL")
 		}
 		result = append(result, obj.Redacted())
 	}

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -431,7 +431,8 @@ func GetRedactedURLs(urlList []string) []string {
 	for _, u := range urlList {
 		obj, err := url.Parse(u)
 		if err != nil {
-			ErrExit("error redacting connection url: invalid connection URL")
+			log.Error("error redacting connection url: invalid connection URL")
+			fmt.Printf("error redacting connection url: invalid connection URL: %v", u)
 		}
 		result = append(result, obj.Redacted())
 	}


### PR DESCRIPTION
### Describe the changes in this pull request
Fixes https://github.com/yugabyte/yb-voyager/issues/2095

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
N/A

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually, password is no more coming up in log
```
2024-12-17 12:26:25.722074 INFO yugabytedb.go:247 Initialized connection pool with settings: (*tgtdb.ConnectionParams)(0x14000983700)({
 NumConnections: (int) 2,
 NumMaxConnections: (int) 4,
 ConnUriList: ([]string) (len=1 cap=1) {
  (string) (len=74) "postgresql://yugabyte:xxxxx@10.9.x.x:5433/pg_constraints?sslmode=prefer"
 },
 SessionInitScript: ([]string) (len=3 cap=4) {
  (string) (len=29) "SET client_encoding TO 'UTF8'",
  (string) (len=39) "SET session_replication_role TO replica",
  (string) (len=53) "SET default_transaction_isolation = 'repeatable read'"
 }
})
```

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
