### PR TITLE
Misc changes to target-db-version flag

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1261,7 +1261,6 @@ func init() {
 
 	analyzeSchemaCmd.Flags().StringVar(&targetDbVersionStrFlag, "target-db-version", "",
 		fmt.Sprintf("Target YugabyteDB version to analyze schema for. Defaults to latest stable version (%s)", ybversion.LatestStable.String()))
-	analyzeSchemaCmd.Flags().MarkHidden("target-db-version")
 }
 
 func validateReportOutputFormat(validOutputFormats []string, format string) {

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1261,7 +1261,7 @@ func init() {
 		"format in which report can be generated: ('html', 'txt', 'json', 'xml'). If not provided, reports will be generated in both 'json' and 'html' formats by default.")
 
 	analyzeSchemaCmd.Flags().StringVar(&targetDbVersionStrFlag, "target-db-version", "",
-		fmt.Sprintf("Target YugabyteDB version to analyze schema for. Defaults to latest stable version (%s)", ybversion.LatestStable.String()))
+		fmt.Sprintf("Target YugabyteDB version to analyze schema for (in format A.B.C.D). Defaults to latest stable version (%s)", ybversion.LatestStable.String()))
 }
 
 func validateReportOutputFormat(validOutputFormats []string, format string) {

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1082,6 +1082,7 @@ func analyzeSchema() {
 		utils.ErrExit("failed to get migration UUID: %w", err)
 	}
 
+	utils.PrintAndLog("Analyzing schema for target YugabyteDB version %s\n", targetDbVersion)
 	schemaAnalysisStartedEvent := createSchemaAnalysisStartedEvent()
 	controlPlane.SchemaAnalysisStarted(&schemaAnalysisStartedEvent)
 

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -296,7 +296,6 @@ func init() {
 
 	assessMigrationCmd.Flags().StringVar(&targetDbVersionStrFlag, "target-db-version", "",
 		fmt.Sprintf("Target YugabyteDB version to assess migration for. Defaults to latest stable version (%s)", ybversion.LatestStable.String()))
-	assessMigrationCmd.Flags().MarkHidden("target-db-version")
 }
 
 func assessMigration() (err error) {

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -312,6 +312,8 @@ func assessMigration() (err error) {
 		return fmt.Errorf("failed to get migration UUID: %w", err)
 	}
 
+	utils.PrintAndLog("Assessing for migration to target YugabyteDB version %s\n", targetDbVersion)
+
 	assessmentDir := filepath.Join(exportDir, "assessment")
 	migassessment.AssessmentDir = assessmentDir
 	migassessment.SourceDBType = source.DBType
@@ -1545,7 +1547,6 @@ func validateAssessmentMetadataDirFlag() {
 func validateAndSetTargetDbVersionFlag() error {
 	if targetDbVersionStrFlag == "" {
 		targetDbVersion = ybversion.LatestStable
-		utils.PrintAndLog("Defaulting to latest stable YugabyteDB version: %s", targetDbVersion)
 		return nil
 	}
 	var err error

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -295,7 +295,7 @@ func init() {
 	BoolVar(assessMigrationCmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", true, "run guardrails checks before assess migration. (only valid for PostgreSQL)")
 
 	assessMigrationCmd.Flags().StringVar(&targetDbVersionStrFlag, "target-db-version", "",
-		fmt.Sprintf("Target YugabyteDB version to assess migration for. Defaults to latest stable version (%s)", ybversion.LatestStable.String()))
+		fmt.Sprintf("Target YugabyteDB version to assess migration for (in format A.B.C.D). Defaults to latest stable version (%s)", ybversion.LatestStable.String()))
 }
 
 func assessMigration() (err error) {

--- a/yb-voyager/src/ybversion/yb_version.go
+++ b/yb-voyager/src/ybversion/yb_version.go
@@ -43,7 +43,7 @@ const (
 /*
 YBVersion is a wrapper around hashicorp/go-version.Version that adds some Yugabyte-specific
 functionality.
- 1. It only supports versions with 4 segments (A.B.C.D).
+ 1. It only supports versions with 4 segments (A.B.C.D). No build number is allowed.
  2. It only accepts one of supported Yugabyte version series.
 */
 type YBVersion struct {
@@ -54,6 +54,11 @@ func NewYBVersion(v string) (*YBVersion, error) {
 	v1, err := version.NewVersion(v)
 	if err != nil {
 		return nil, err
+	}
+
+	// Do not allow build number in the version. for example, 2024.1.1.0-b123
+	if v1.Prerelease() != "" {
+		return nil, fmt.Errorf("invalid YB version: %s. Build number is not supported. Version should be of format (A.B.C.D) ", v)
 	}
 
 	ybv := &YBVersion{v1}

--- a/yb-voyager/src/ybversion/yb_version_test.go
+++ b/yb-voyager/src/ybversion/yb_version_test.go
@@ -40,15 +40,16 @@ func TestValidNewYBVersion(t *testing.T) {
 
 func TestInvalidNewYBVersion(t *testing.T) {
 	invalidVersionStrings := []string{
-		"abc.def",        // has to be numbers
-		"2024.0.1-1",     // has to be in supported series
-		"2024",           // has to have 4 segments
-		"2.20.7",         // has to have 4 segments
-		"2024.1.1.1.1.1", // exactly 4 segments
+		"abc.def",         // has to be numbers
+		"2024.0.1-1",      // has to be in supported series
+		"2024",            // has to have 4 segments
+		"2.20.7",          // has to have 4 segments
+		"2024.1.1.1.1.1",  // exactly 4 segments
+		"2024.1.0.0-b123", // build number is not allowed.
 	}
 	for _, v := range invalidVersionStrings {
 		_, err := NewYBVersion(v)
-		assert.Error(t, err)
+		assert.Errorf(t, err, "expected error for %q", v)
 	}
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request
- Unhide the flag
- Print the version being used in analyze-schema/ assess-migration
- Prevent users from passing build number in target-db-version. 
   The problem is that 2024.2.0.0-b145 would be considered to be > 2024.2.0.0. Which means we will have two options:
   a. prevent users from passing build number
   b. Always ask users to pass build number, so that it can be compared against the issues' MinimumVersionsFixedIn(which should also have build number.)
   Going with option a. 

### Describe if there are any user-facing changes
Printing to stdout in case of analyze-schema/assess-migration

### How was this pull request tested?
- added a unit test 
- manual testing

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
