### PR TITLE
[DB-14414] Filtering queries based on tables schema in the query for unsupported query constructs

### DIFF
--- a/.github/workflows/misc-migtests.yml
+++ b/.github/workflows/misc-migtests.yml
@@ -72,6 +72,9 @@ jobs:
 
       - name: "TEST: Assessment Report Test"
         run: migtests/scripts/run-validate-assessment-report.sh pg/assessment-report-test
+      
+      - name: "TEST: Assessment Report Test (Schema list UQC)"
+        run: migtests/scripts/run-validate-assessment-report.sh pg/assessment-report-test-uqc
 
       - name: "TEST: analyze-schema"
         if: ${{ !cancelled() }}

--- a/migtests/tests/pg/assessment-report-test-uqc/cleanup-db
+++ b/migtests/tests/pg/assessment-report-test-uqc/cleanup-db
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+source ${SCRIPTS}/functions.sh
+
+
+echo "Deleting ${SOURCE_DB_NAME} database on source"
+run_psql postgres "DROP DATABASE ${SOURCE_DB_NAME};"

--- a/migtests/tests/pg/assessment-report-test-uqc/env.sh
+++ b/migtests/tests/pg/assessment-report-test-uqc/env.sh
@@ -1,0 +1,3 @@
+export SOURCE_DB_TYPE="postgresql"
+export SOURCE_DB_NAME=${SOURCE_DB_NAME:-"pg_assessment_report_uqc"}
+export SOURCE_DB_SCHEMA="sales,analytics"

--- a/migtests/tests/pg/assessment-report-test-uqc/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test-uqc/expectedAssessmentReport.json
@@ -1,0 +1,237 @@
+{
+	"VoyagerVersion": "IGNORED",
+	"TargetDBVersion": "IGNORED",
+	"MigrationComplexity": "LOW",
+	"SchemaSummary": {
+		"Description": "Objects that will be created on the target YugabyteDB.",
+		"DbName": "pg_assessment_report_uqc",
+		"SchemaNames": [
+			"sales",
+			"analytics"
+		],
+		"DbVersion": "14.13 (Ubuntu 14.13-1.pgdg20.04+1)",
+		"DatabaseObjects": [
+			{
+				"ObjectType": "SCHEMA",
+				"TotalCount": 2,
+				"InvalidCount": 0,
+				"ObjectNames": "analytics, sales"
+			},
+			{
+				"ObjectType": "EXTENSION",
+				"TotalCount": 1,
+				"InvalidCount": 0,
+				"ObjectNames": "pg_stat_statements"
+			},
+			{
+				"ObjectType": "TABLE",
+				"TotalCount": 2,
+				"InvalidCount": 0,
+				"ObjectNames": "analytics.metrics, sales.orders"
+			}
+		]
+	},
+	"Sizing": {
+		"SizingRecommendation": {
+			"ColocatedTables": [
+				"sales.orders",
+				"analytics.metrics"
+			],
+			"ColocatedReasoning": "Recommended instance type with 4 vCPU and 16 GiB memory could fit 2 objects (2 tables/materialized views and 0 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.",
+			"ShardedTables": null,
+			"NumNodes": 3,
+			"VCPUsPerInstance": 4,
+			"MemoryPerInstance": 16,
+			"OptimalSelectConnectionsPerNode": 8,
+			"OptimalInsertConnectionsPerNode": 12,
+			"EstimatedTimeInMinForImport": 1,
+			"ParallelVoyagerJobs": 1
+		},
+		"FailureReasoning": ""
+	},
+	"UnsupportedDataTypes": null,
+	"UnsupportedDataTypesDesc": "Data types of the source database that are not supported on the target YugabyteDB.",
+	"UnsupportedFeatures": [
+		{
+			"FeatureName": "GIST indexes",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "BRIN indexes",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "SPGIST indexes",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Constraint triggers",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Inherited tables",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Tables with stored generated columns",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Conversion objects",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Gin indexes on multi-columns",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Setting attribute=value on column",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Disabling rule on table",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Clustering table on index",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Storage parameters in DDLs",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Extensions",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Exclusion constraints",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Deferrable constraints",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "View with check option",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Index on complex datatypes",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Primary / Unique key constraints on complex datatypes",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Unlogged tables",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "REFERENCING clause for triggers",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "BEFORE ROW triggers on Partitioned tables",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Advisory Locks",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "XML Functions",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "System Columns",
+			"Objects": [],
+			"MinimumVersionsFixedIn": null
+		}
+	],
+	"UnsupportedFeaturesDesc": "Features of the source database that are not supported on the target YugabyteDB.",
+	"TableIndexStats": [
+		{
+			"SchemaName": "sales",
+			"ObjectName": "orders",
+			"RowCount": 2,
+			"ColumnCount": 3,
+			"Reads": 0,
+			"Writes": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "analytics",
+			"ObjectName": "metrics",
+			"RowCount": 2,
+			"ColumnCount": 3,
+			"Reads": 2,
+			"Writes": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		}
+	],
+	"Notes": null,
+	"MigrationCaveats": [
+		{
+			"FeatureName": "Alter partitioned tables to add Primary Key",
+			"Objects": [],
+			"FeatureDescription": "After export schema, the ALTER table should be merged with CREATE table for partitioned tables as alter of partitioned tables to add primary key is not supported.",
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Foreign tables",
+			"Objects": [],
+			"FeatureDescription": "During the export schema phase, SERVER and USER MAPPING objects are not exported. These should be manually created to make the foreign tables work.",
+			"MinimumVersionsFixedIn": null
+		},
+		{
+			"FeatureName": "Policies",
+			"Objects": [],
+			"FeatureDescription": "There are some policies that are created for certain users/roles. During the export schema phase, USERs and GRANTs are not exported. Therefore, they will have to be manually created before running import schema.",
+			"MinimumVersionsFixedIn": null
+		}
+	],
+	"UnsupportedQueryConstructs": [
+		{
+			"ConstructTypeName": "Advisory Locks",
+			"Query": "SELECT metric_name, pg_advisory_lock(metric_id)\nFROM analytics.metrics\nWHERE metric_value \u003e $1",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#advisory-locks-is-not-yet-implemented",
+			"MinimumVersionsFixedIn": null
+		}
+	],
+	"UnsupportedPlPgSqlObjects": null
+}

--- a/migtests/tests/pg/assessment-report-test-uqc/init-db
+++ b/migtests/tests/pg/assessment-report-test-uqc/init-db
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+source ${SCRIPTS}/functions.sh
+
+echo "Creating ${SOURCE_DB_NAME} database on source"
+run_psql postgres "DROP DATABASE IF EXISTS ${SOURCE_DB_NAME};"
+run_psql postgres "CREATE DATABASE ${SOURCE_DB_NAME};"
+
+echo "Initialising source database."
+
+run_psql "${SOURCE_DB_NAME}" "\i pg_assessment_report_uqc.sql"
+
+run_psql "${SOURCE_DB_NAME}" "\i unsupported_query_constructs.sql"
+
+echo "End of init-db script"

--- a/migtests/tests/pg/assessment-report-test-uqc/pg_assessment_report_uqc.sql
+++ b/migtests/tests/pg/assessment-report-test-uqc/pg_assessment_report_uqc.sql
@@ -1,0 +1,44 @@
+-- Create multiple schemas
+CREATE SCHEMA public;
+CREATE SCHEMA sales;
+CREATE SCHEMA hr;
+CREATE SCHEMA analytics;
+
+-- Create tables in each schema
+CREATE TABLE public.employees (
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name TEXT,
+    department_id INT
+);
+
+CREATE TABLE sales.orders (
+    order_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    customer_id INT,
+    amount NUMERIC
+);
+
+CREATE TABLE hr.departments (
+    department_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    department_name TEXT,
+    location TEXT
+);
+
+CREATE TABLE analytics.metrics (
+    metric_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    metric_name TEXT,
+    metric_value NUMERIC
+);
+
+-- Create a view in public schema
+CREATE VIEW public.employee_view AS
+SELECT e.id, e.name, d.department_name
+FROM public.employees e
+JOIN hr.departments d ON e.department_id = d.department_id;
+
+
+-- Insert some sample data
+INSERT INTO hr.departments (department_name, location) VALUES ('Engineering', 'Building A');
+INSERT INTO hr.departments (department_name, location) VALUES ('Sales', 'Building B');
+INSERT INTO public.employees (name, department_id) VALUES ('Alice', 1), ('Bob', 1), ('Charlie', 2);
+INSERT INTO sales.orders (customer_id, amount) VALUES (101, 500.00), (102, 1200.00);
+INSERT INTO analytics.metrics (metric_name, metric_value) VALUES ('ConversionRate', 0.023), ('ChurnRate', 0.05);

--- a/migtests/tests/pg/assessment-report-test-uqc/unsupported_query_constructs.sql
+++ b/migtests/tests/pg/assessment-report-test-uqc/unsupported_query_constructs.sql
@@ -1,0 +1,27 @@
+-- Unsupported Query Constructs 
+DROP EXTENSION IF EXISTS pg_stat_statements;
+CREATE EXTENSION pg_stat_statements;
+SELECT pg_stat_statements_reset();
+SELECT * FROM pg_stat_statements;
+
+
+-- 1) System columns usage (public schema)
+-- Using xmin is considered a system column, which is unsupported.
+SELECT name, xmin FROM public.employees WHERE id = 1;
+
+-- 2) Advisory locks (hr schema)
+-- pg_advisory_lock is an unsupported advisory lock function.
+SELECT hr.departments.department_name, pg_advisory_lock(hr.departments.department_id)
+FROM hr.departments
+WHERE department_name = 'Engineering';
+
+-- 3) XML function usage (public schema)
+-- xmlelement is an XML-related function considered unsupported.
+SELECT xmlelement(name "employee_data", name) AS emp_xml
+FROM public.employees;
+
+-- 4) Advisory locks (analytics schema)
+-- Also uses pg_advisory_lock for another unsupported construct scenario.
+SELECT metric_name, pg_advisory_lock(metric_id)
+FROM analytics.metrics
+WHERE metric_value > 0.02;

--- a/migtests/tests/pg/assessment-report-test-uqc/unsupported_query_constructs.sql
+++ b/migtests/tests/pg/assessment-report-test-uqc/unsupported_query_constructs.sql
@@ -6,22 +6,18 @@ SELECT * FROM pg_stat_statements;
 
 
 -- 1) System columns usage (public schema)
--- Using xmin is considered a system column, which is unsupported.
 SELECT name, xmin FROM public.employees WHERE id = 1;
 
 -- 2) Advisory locks (hr schema)
--- pg_advisory_lock is an unsupported advisory lock function.
 SELECT hr.departments.department_name, pg_advisory_lock(hr.departments.department_id)
 FROM hr.departments
 WHERE department_name = 'Engineering';
 
 -- 3) XML function usage (public schema)
--- xmlelement is an XML-related function considered unsupported.
 SELECT xmlelement(name "employee_data", name) AS emp_xml
 FROM public.employees;
 
 -- 4) Advisory locks (analytics schema)
--- Also uses pg_advisory_lock for another unsupported construct scenario.
 SELECT metric_name, pg_advisory_lock(metric_id)
 FROM analytics.metrics
 WHERE metric_value > 0.02;

--- a/yb-voyager/src/constants/constants.go
+++ b/yb-voyager/src/constants/constants.go
@@ -16,7 +16,13 @@ limitations under the License.
 package constants
 
 const (
-	// OBJECT TYPE
+	// Database Object types
 	TABLE    = "table"
 	FUNCTION = "function"
+
+	// Source DB Types
+	YUGABYTEDB = "yugabytedb"
+	POSTGRESQL = "postgresql"
+	ORACLE     = "oracle"
+	MYSQL      = "mysql"
 )

--- a/yb-voyager/src/constants/constants.go
+++ b/yb-voyager/src/constants/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package constants
+
+const (
+	// OBJECT TYPE
+	TABLE    = "table"
+	FUNCTION = "function"
+)

--- a/yb-voyager/src/namereg/namereg_test.go
+++ b/yb-voyager/src/namereg/namereg_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/testutils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
 var oracleToYBNameRegistry = &NameRegistry{
-	SourceDBType: ORACLE,
+	SourceDBType: constants.ORACLE,
 	params: NameRegistryParams{
 		Role: TARGET_DB_IMPORTER_ROLE,
 	},
@@ -41,15 +42,15 @@ func buildNameTuple(reg *NameRegistry, sourceSchema, sourceTable, targetSchema, 
 		sourceName = sqlname.NewObjectName(reg.SourceDBType, sourceSchema, sourceSchema, sourceTable)
 	}
 	if targetSchema != "" && targetTable != "" {
-		targetName = sqlname.NewObjectName(YUGABYTEDB, targetSchema, targetSchema, targetTable)
+		targetName = sqlname.NewObjectName(constants.YUGABYTEDB, targetSchema, targetSchema, targetTable)
 	}
 	return NewNameTuple(reg.params.Role, sourceName, targetName)
 }
 
 func TestNameTuple(t *testing.T) {
 	assert := assert.New(t)
-	sourceName := sqlname.NewObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1")
-	targetName := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "table1")
+	sourceName := sqlname.NewObjectName(constants.ORACLE, "SAKILA", "SAKILA", "TABLE1")
+	targetName := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", "table1")
 
 	ntup := NewNameTuple(TARGET_DB_IMPORTER_ROLE, sourceName, targetName)
 
@@ -76,8 +77,8 @@ func TestNameTuple(t *testing.T) {
 
 func TestNameTupleMatchesPattern(t *testing.T) {
 	assert := assert.New(t)
-	sourceName := sqlname.NewObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1")
-	targetName := sqlname.NewObjectName(YUGABYTEDB, "public", "sakila", "table1")
+	sourceName := sqlname.NewObjectName(constants.ORACLE, "SAKILA", "SAKILA", "TABLE1")
+	targetName := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "sakila", "table1")
 	ntup := NewNameTuple(TARGET_DB_IMPORTER_ROLE, sourceName, targetName)
 
 	testCases := []struct {
@@ -112,8 +113,8 @@ func TestNameTupleMatchesPattern(t *testing.T) {
 
 func TestNameTupleMatchesPatternMySQL(t *testing.T) {
 	assert := assert.New(t)
-	sourceName := sqlname.NewObjectName(MYSQL, "test", "test", "Table1")
-	targetName := sqlname.NewObjectName(YUGABYTEDB, "public", "test", "table1")
+	sourceName := sqlname.NewObjectName(constants.MYSQL, "test", "test", "Table1")
+	targetName := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "test", "table1")
 	ntup := NewNameTuple(TARGET_DB_IMPORTER_ROLE, sourceName, targetName)
 	testCases := []struct {
 		pattern string
@@ -150,7 +151,7 @@ func TestNameMatchesPattern(t *testing.T) {
 	require := require.New(t)
 
 	reg := &NameRegistry{
-		SourceDBType: ORACLE,
+		SourceDBType: constants.ORACLE,
 		params: NameRegistryParams{
 			Role: SOURCE_DB_EXPORTER_ROLE,
 		},
@@ -472,7 +473,7 @@ func TestNameRegistryWithDummyDBs(t *testing.T) {
 		params := NameRegistryParams{
 			FilePath:       "",
 			Role:           currentMode,
-			SourceDBType:   ORACLE,
+			SourceDBType:   constants.ORACLE,
 			SourceDBSchema: "SAKILA",
 			SourceDBName:   "ORCLPDB1",
 			TargetDBSchema: tSchema,
@@ -490,7 +491,7 @@ func TestNameRegistryWithDummyDBs(t *testing.T) {
 
 	err := reg.Init()
 	require.Nil(err)
-	assert.Equal(ORACLE, reg.SourceDBType)
+	assert.Equal(constants.ORACLE, reg.SourceDBType)
 	assert.Equal("SAKILA", reg.DefaultSourceDBSchemaName)
 	assert.Equal(sourceNamesMap, reg.SourceDBTableNames)
 	table1 := buildNameTuple(reg, "SAKILA", "TABLE1", "", "")
@@ -506,7 +507,7 @@ func TestNameRegistryWithDummyDBs(t *testing.T) {
 	reg = newNameRegistry("")
 	err = reg.Init()
 	require.Nil(err)
-	assert.Equal(ORACLE, reg.SourceDBType)
+	assert.Equal(constants.ORACLE, reg.SourceDBType)
 	assert.Equal("SAKILA", reg.DefaultSourceDBSchemaName)
 	assert.Equal(sourceNamesMap, reg.SourceDBTableNames)
 	ntup, err = reg.LookupTableName("TABLE1")
@@ -606,11 +607,11 @@ func TestNameRegistryJson(t *testing.T) {
 
 	// Create a sample NameRegistry instance
 	reg := &NameRegistry{
-		SourceDBType: ORACLE,
+		SourceDBType: constants.ORACLE,
 		params: NameRegistryParams{
 			FilePath:       outputFilePath,
 			Role:           TARGET_DB_IMPORTER_ROLE,
-			SourceDBType:   ORACLE,
+			SourceDBType:   constants.ORACLE,
 			SourceDBSchema: "SAKILA",
 			SourceDBName:   "ORCLPDB1",
 			TargetDBSchema: "ybsakila",

--- a/yb-voyager/src/query/queryissue/detectors_test.go
+++ b/yb-voyager/src/query/queryissue/detectors_test.go
@@ -627,7 +627,7 @@ func TestCombinationOfDetectors1WithObjectCollector(t *testing.T) {
 		visited := make(map[protoreflect.Message]bool)
 		unsupportedConstructs := []string{}
 
-		objectCollector := queryparser.NewObjectCollector()
+		objectCollector := queryparser.NewObjectCollector(nil)
 		processor := func(msg protoreflect.Message) error {
 			for _, detector := range detectors {
 				log.Debugf("running detector %T", detector)

--- a/yb-voyager/src/query/queryparser/object_collector.go
+++ b/yb-voyager/src/query/queryparser/object_collector.go
@@ -23,14 +23,35 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// ObjectCollector collects unique schema-qualified object names.
+// ObjectPredicate defines a function signature that decides whether to include an object.
+type ObjectPredicate func(schemaName string, objectName string, objectType string) bool
+
+// Using a predicate makes it easy to adapt or swap filtering logic in the future without changing the collector.
+
+// ObjectCollector collects unique schema-qualified object names based on the provided predicate.
 type ObjectCollector struct {
 	objectSet map[string]bool
+	predicate ObjectPredicate
 }
 
-func NewObjectCollector() *ObjectCollector {
+// AllObjectsPredicate always returns true, meaning it will collect all objects found.
+func AllObjectsPredicate(schemaName, objectName, objectType string) bool {
+	return true
+}
+
+// TablesOnlyPredicate returns true only if the object type is "table".
+func TablesOnlyPredicate(schemaName, objectName, objectType string) bool {
+	return objectType == "table"
+}
+
+func NewObjectCollector(predicate ObjectPredicate) *ObjectCollector {
+	if predicate == nil {
+		predicate = AllObjectsPredicate
+	}
+
 	return &ObjectCollector{
 		objectSet: make(map[string]bool),
+		predicate: predicate,
 	}
 }
 
@@ -56,7 +77,10 @@ func (c *ObjectCollector) Collect(msg protoreflect.Message) {
 		relName := GetStringField(msg, "relname")
 		objectName := lo.Ternary(schemaName != "", schemaName+"."+relName, relName)
 		log.Debugf("[RangeVar] fetched schemaname=%s relname=%s objectname=%s field\n", schemaName, relName, objectName)
-		c.addObject(objectName)
+		// it will be either table or view, considering objectType=table for both
+		if c.predicate(schemaName, relName, "table") {
+			c.addObject(objectName)
+		}
 
 	// Extract target table names from DML statements
 	case PG_QUERY_INSERTSTMT_NODE, PG_QUERY_UPDATESTMT_NODE, PG_QUERY_DELETESTMT_NODE:
@@ -66,7 +90,9 @@ func (c *ObjectCollector) Collect(msg protoreflect.Message) {
 			relName := GetStringField(relationMsg, "relname")
 			objectName := lo.Ternary(schemaName != "", schemaName+"."+relName, relName)
 			log.Debugf("[IUD] fetched schemaname=%s relname=%s objectname=%s field\n", schemaName, relName, objectName)
-			c.addObject(objectName)
+			if c.predicate(schemaName, relName, "table") {
+				c.addObject(objectName)
+			}
 		}
 
 	// Extract function names
@@ -78,7 +104,9 @@ func (c *ObjectCollector) Collect(msg protoreflect.Message) {
 
 		objectName := lo.Ternary(schemaName != "", schemaName+"."+functionName, functionName)
 		log.Debugf("[Funccall] fetched schemaname=%s objectname=%s field\n", schemaName, objectName)
-		c.addObject(objectName)
+		if c.predicate(schemaName, functionName, "function") {
+			c.addObject(objectName)
+		}
 
 		// Add more cases as needed for other message types
 	}

--- a/yb-voyager/src/query/queryparser/object_collector.go
+++ b/yb-voyager/src/query/queryparser/object_collector.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -41,7 +42,7 @@ func AllObjectsPredicate(schemaName, objectName, objectType string) bool {
 
 // TablesOnlyPredicate returns true only if the object type is "table".
 func TablesOnlyPredicate(schemaName, objectName, objectType string) bool {
-	return objectType == "table"
+	return objectType == constants.TABLE
 }
 
 func NewObjectCollector(predicate ObjectPredicate) *ObjectCollector {
@@ -78,7 +79,7 @@ func (c *ObjectCollector) Collect(msg protoreflect.Message) {
 		objectName := lo.Ternary(schemaName != "", schemaName+"."+relName, relName)
 		log.Debugf("[RangeVar] fetched schemaname=%s relname=%s objectname=%s field\n", schemaName, relName, objectName)
 		// it will be either table or view, considering objectType=table for both
-		if c.predicate(schemaName, relName, "table") {
+		if c.predicate(schemaName, relName, constants.TABLE) {
 			c.addObject(objectName)
 		}
 
@@ -104,7 +105,7 @@ func (c *ObjectCollector) Collect(msg protoreflect.Message) {
 
 		objectName := lo.Ternary(schemaName != "", schemaName+"."+functionName, functionName)
 		log.Debugf("[Funccall] fetched schemaname=%s objectname=%s field\n", schemaName, objectName)
-		if c.predicate(schemaName, functionName, "function") {
+		if c.predicate(schemaName, functionName, constants.FUNCTION) {
 			c.addObject(objectName)
 		}
 

--- a/yb-voyager/src/query/queryparser/traversal_proto.go
+++ b/yb-voyager/src/query/queryparser/traversal_proto.go
@@ -219,7 +219,7 @@ func GetSchemaUsed(query string) ([]string, error) {
 
 	msg := GetProtoMessageFromParseTree(parseTree)
 	visited := make(map[protoreflect.Message]bool)
-	objectCollector := NewObjectCollector()
+	objectCollector := NewObjectCollector(TablesOnlyPredicate)
 	err = TraverseParseTree(msg, visited, func(msg protoreflect.Message) error {
 		objectCollector.Collect(msg)
 		return nil

--- a/yb-voyager/src/query/queryparser/traversal_test.go
+++ b/yb-voyager/src/query/queryparser/traversal_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+// Test ObjectCollector with default predicate(AllObjectsPredicate)
 func TestObjectCollector(t *testing.T) {
 	tests := []struct {
 		Sql             string
@@ -67,7 +68,7 @@ func TestObjectCollector(t *testing.T) {
 			Sql: `CREATE VIEW analytics.top_customers AS
 					SELECT user_id, COUNT(*) as order_count	FROM public.orders GROUP BY user_id HAVING COUNT(*) > 10;`,
 			ExpectedObjects: []string{"analytics.top_customers", "public.orders", "count"},
-			ExpectedSchemas: []string{"analytics", "public", ""},
+			ExpectedSchemas: []string{"analytics", "public", ""}, // "" -> unknown schemaName
 		},
 		{
 			Sql: `WITH user_orders AS (
@@ -115,7 +116,7 @@ func TestObjectCollector(t *testing.T) {
 		parseResult, err := Parse(tc.Sql)
 		assert.NoError(t, err)
 
-		objectsCollector := NewObjectCollector()
+		objectsCollector := NewObjectCollector(nil)
 		processor := func(msg protoreflect.Message) error {
 			objectsCollector.Collect(msg)
 			return nil
@@ -136,6 +137,7 @@ func TestObjectCollector(t *testing.T) {
 	}
 }
 
+// Test ObjectCollector with default predicate(AllObjectsPredicate)
 // test focussed on collecting function names from DMLs
 func TestObjectCollector2(t *testing.T) {
 	tests := []struct {
@@ -216,7 +218,7 @@ func TestObjectCollector2(t *testing.T) {
 		parseResult, err := Parse(tc.Sql)
 		assert.NoError(t, err)
 
-		objectsCollector := NewObjectCollector()
+		objectsCollector := NewObjectCollector(nil)
 		processor := func(msg protoreflect.Message) error {
 			objectsCollector.Collect(msg)
 			return nil
@@ -237,9 +239,117 @@ func TestObjectCollector2(t *testing.T) {
 	}
 }
 
-/*
+// Test ObjectCollector with TablesOnlyPredicate
+func TestTableObjectCollector(t *testing.T) {
+	tests := []struct {
+		Sql             string
+		ExpectedObjects []string
+		ExpectedSchemas []string
+	}{
+		{
+			Sql:             `SELECT * from public.employees`,
+			ExpectedObjects: []string{"public.employees"},
+			ExpectedSchemas: []string{"public"},
+		},
+		{
+			Sql:             `SELECT * from employees`,
+			ExpectedObjects: []string{"employees"},
+			ExpectedSchemas: []string{""}, // empty schemaname indicates unqualified objectname
+		},
+		{
+			Sql:             `SELECT * from s1.employees`,
+			ExpectedObjects: []string{"s1.employees"},
+			ExpectedSchemas: []string{"s1"},
+		},
+		{
+			Sql:             `SELECT * from s2.employees where salary > (Select salary from s3.employees)`,
+			ExpectedObjects: []string{"s3.employees", "s2.employees"},
+			ExpectedSchemas: []string{"s3", "s2"},
+		},
+		{
+			Sql:             `SELECT c.name, SUM(o.amount) AS total_spent FROM sales.customers c JOIN finance.orders o ON c.id = o.customer_id GROUP BY c.name HAVING SUM(o.amount) > 1000`,
+			ExpectedObjects: []string{"sales.customers", "finance.orders"},
+			ExpectedSchemas: []string{"sales", "finance"},
+		},
+		{
+			Sql:             `SELECT name FROM hr.employees WHERE department_id IN (SELECT id FROM public.departments WHERE location_id IN (SELECT id FROM eng.locations WHERE country = 'USA'))`,
+			ExpectedObjects: []string{"hr.employees", "public.departments", "eng.locations"},
+			ExpectedSchemas: []string{"hr", "public", "eng"},
+		},
+		{
+			Sql:             `SELECT name FROM sales.customers UNION SELECT name FROM marketing.customers;`,
+			ExpectedObjects: []string{"sales.customers", "marketing.customers"},
+			ExpectedSchemas: []string{"sales", "marketing"},
+		},
+		{
+			Sql: `CREATE VIEW analytics.top_customers AS
+					SELECT user_id, COUNT(*) as order_count	FROM public.orders GROUP BY user_id HAVING COUNT(*) > 10;`,
+			ExpectedObjects: []string{"analytics.top_customers", "public.orders"},
+			ExpectedSchemas: []string{"analytics", "public"},
+		},
+		{
+			Sql: `WITH user_orders AS (
+					SELECT u.id, o.id as order_id
+					FROM users u
+					JOIN orders o ON u.id = o.user_id
+					WHERE o.amount > 100
+				), order_items AS (
+					SELECT o.order_id, i.product_id
+					FROM order_items i
+					JOIN user_orders o ON i.order_id = o.order_id
+				)
+				SELECT p.name, COUNT(oi.product_id) FROM products p
+				JOIN order_items oi ON p.id = oi.product_id GROUP BY p.name;`,
+			ExpectedObjects: []string{"users", "orders", "order_items", "user_orders", "products"},
+			ExpectedSchemas: []string{""},
+		},
+		{
+			Sql: `UPDATE finance.accounts
+						SET balance = balance + 1000
+						WHERE account_id IN (
+							SELECT account_id FROM public.users WHERE active = true
+					);`,
+			ExpectedObjects: []string{"finance.accounts", "public.users"},
+			ExpectedSchemas: []string{"finance", "public"},
+		},
+		{
+			Sql:             `SELECT classid, objid, refobjid FROM pg_depend WHERE refclassid = $1::regclass AND deptype = $2 ORDER BY 3`,
+			ExpectedObjects: []string{"pg_depend"},
+			ExpectedSchemas: []string{""},
+		},
+		{
+			Sql:             `SELECT pg_advisory_unlock_shared(100);`,
+			ExpectedObjects: []string{}, // empty slice represents no object collected
+			ExpectedSchemas: []string{},
+		},
+		{
+			Sql:             `SELECT xpath_exists('/employee/name', '<employee><name>John</name></employee>'::xml)`,
+			ExpectedObjects: []string{},
+			ExpectedSchemas: []string{},
+		},
+	}
 
+	for _, tc := range tests {
+		parseResult, err := Parse(tc.Sql)
+		assert.NoError(t, err)
 
-	COPY (SELECT ctid, xmin, id, data FROM schema_name.my_table)
-	TO '/path/to/file_with_system_columns.csv' WITH CSV;
-*/
+		objectsCollector := NewObjectCollector(TablesOnlyPredicate)
+		processor := func(msg protoreflect.Message) error {
+			objectsCollector.Collect(msg)
+			return nil
+		}
+
+		visited := make(map[protoreflect.Message]bool)
+		parseTreeMsg := GetProtoMessageFromParseTree(parseResult)
+		err = TraverseParseTree(parseTreeMsg, visited, processor)
+		assert.NoError(t, err)
+
+		collectedObjects := objectsCollector.GetObjects()
+		collectedSchemas := objectsCollector.GetSchemaList()
+
+		assert.ElementsMatch(t, tc.ExpectedObjects, collectedObjects,
+			"Objects list mismatch for sql [%s]. Expected: %v(len=%d), Actual: %v(len=%d)", tc.Sql, tc.ExpectedObjects, len(tc.ExpectedObjects), collectedObjects, len(collectedObjects))
+		assert.ElementsMatch(t, tc.ExpectedSchemas, collectedSchemas,
+			"Schema list mismatch for sql [%s]. Expected: %v(len=%d), Actual: %v(len=%d)", tc.Sql, tc.ExpectedSchemas, len(tc.ExpectedSchemas), collectedSchemas, len(collectedSchemas))
+	}
+}

--- a/yb-voyager/src/query/queryparser/traversal_test.go
+++ b/yb-voyager/src/query/queryparser/traversal_test.go
@@ -327,6 +327,16 @@ func TestTableObjectCollector(t *testing.T) {
 			ExpectedObjects: []string{},
 			ExpectedSchemas: []string{},
 		},
+		{
+			Sql: `SELECT t.id,
+					xpath('/root/node', xmlparse(document t.xml_column)) AS extracted_nodes,
+					s2.some_function()
+				FROM s1.some_table t
+				WHERE t.id IN (SELECT id FROM s2.some_function())
+				AND pg_advisory_lock(t.id);`,
+			ExpectedObjects: []string{"s1.some_table"},
+			ExpectedSchemas: []string{"s1"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/yb-voyager/src/tgtdb/attr_name_registry_test.go
+++ b/yb-voyager/src/tgtdb/attr_name_registry_test.go
@@ -3,12 +3,13 @@ package tgtdb
 import (
 	"testing"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
 func TestAttributeNameRegistry_QuoteAttributeName_POSTGRES(t *testing.T) {
 	reg := NewAttributeNameRegistry(nil, &TargetConf{TargetDBType: POSTGRESQL})
-	o := sqlname.NewObjectName(sqlname.POSTGRESQL, "public", "public", "test_table")
+	o := sqlname.NewObjectName(constants.POSTGRESQL, "public", "public", "test_table")
 	tableNameTup := sqlname.NameTuple{SourceName: o, TargetName: o, CurrentName: o}
 
 	// Mocking GetListOfTableAttributes to return a list of attributes
@@ -81,7 +82,7 @@ func TestAttributeNameRegistry_QuoteAttributeName_POSTGRES(t *testing.T) {
 }
 func TestAttributeNameRegistry_QuoteAttributeName_ORACLE(t *testing.T) {
 	reg := NewAttributeNameRegistry(nil, &TargetConf{TargetDBType: ORACLE})
-	o := sqlname.NewObjectName(sqlname.ORACLE, "TEST", "TEST", "test_table")
+	o := sqlname.NewObjectName(constants.ORACLE, "TEST", "TEST", "test_table")
 	tableNameTup := sqlname.NameTuple{SourceName: o, TargetName: o, CurrentName: o}
 
 	// Mocking GetListOfTableAttributes to return a list of attributes

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -32,6 +32,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/sqlldr"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -691,7 +692,7 @@ func (tdb *TargetOracleDB) ClearMigrationState(migrationUUID uuid.UUID, exportDi
 	tables := []sqlname.NameTuple{}
 	for _, tableName := range tableNames {
 		parts := strings.Split(tableName, ".")
-		objName := sqlname.NewObjectName(sqlname.ORACLE, "", parts[0], strings.ToUpper(parts[1]))
+		objName := sqlname.NewObjectName(constants.ORACLE, "", parts[0], strings.ToUpper(parts[1]))
 		nt := sqlname.NameTuple{
 			CurrentName: objName,
 			SourceName:  objName,

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -34,6 +34,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -785,7 +786,7 @@ func (pg *TargetPostgreSQL) ClearMigrationState(migrationUUID uuid.UUID, exportD
 	tables := []sqlname.NameTuple{}
 	for _, tableName := range tableNames {
 		parts := strings.Split(tableName, ".")
-		objName := sqlname.NewObjectName(sqlname.POSTGRESQL, "", parts[0], parts[1])
+		objName := sqlname.NewObjectName(constants.POSTGRESQL, "", parts[0], parts[1])
 		nt := sqlname.NameTuple{
 			CurrentName: objName,
 			SourceName:  objName,

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -40,6 +40,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -1320,7 +1321,7 @@ func (yb *TargetYugabyteDB) ClearMigrationState(migrationUUID uuid.UUID, exportD
 	tables := []sqlname.NameTuple{}
 	for _, tableName := range tableNames {
 		parts := strings.Split(tableName, ".")
-		objName := sqlname.NewObjectName(sqlname.YUGABYTEDB, "", parts[0], parts[1])
+		objName := sqlname.NewObjectName(constants.YUGABYTEDB, "", parts[0], parts[1])
 		nt := sqlname.NameTuple{
 			CurrentName: objName,
 			SourceName:  objName,

--- a/yb-voyager/src/utils/sqlname/nametuple.go
+++ b/yb-voyager/src/utils/sqlname/nametuple.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 )
 
 //================================================
@@ -185,7 +186,8 @@ func (t NameTuple) Key() string {
 // ================================================
 func quote2(dbType, name string) string {
 	switch dbType {
-	case POSTGRESQL, YUGABYTEDB, ORACLE, MYSQL:
+	case constants.POSTGRESQL, constants.YUGABYTEDB,
+		constants.ORACLE, constants.MYSQL:
 		return `"` + name + `"`
 	default:
 		panic("unknown source db type " + dbType)
@@ -194,15 +196,15 @@ func quote2(dbType, name string) string {
 
 func minQuote2(objectName, sourceDBType string) string {
 	switch sourceDBType {
-	case YUGABYTEDB, POSTGRESQL:
+	case constants.YUGABYTEDB, constants.POSTGRESQL:
 		if IsAllLowercase(objectName) && !IsReservedKeywordPG(objectName) {
 			return objectName
 		} else {
 			return `"` + objectName + `"`
 		}
-	case MYSQL:
+	case constants.MYSQL:
 		return `"` + objectName + `"`
-	case ORACLE:
+	case constants.ORACLE:
 		if IsAllUppercase(objectName) && !IsReservedKeywordOracle(objectName) {
 			return objectName
 		} else {

--- a/yb-voyager/src/utils/sqlname/nametuple_test.go
+++ b/yb-voyager/src/utils/sqlname/nametuple_test.go
@@ -19,17 +19,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 )
 
 func TestNameTupleEquals(t *testing.T) {
 	assert := assert.New(t)
-	o1 := NewObjectName(POSTGRESQL, "public", "public", "table1")
-	o2 := NewObjectName(POSTGRESQL, "public", "public", "table1")
+	o1 := NewObjectName(constants.POSTGRESQL, "public", "public", "table1")
+	o2 := NewObjectName(constants.POSTGRESQL, "public", "public", "table1")
 	nameTuple1 := NameTuple{CurrentName: o1, SourceName: o1, TargetName: o1}
 	nameTuple2 := NameTuple{CurrentName: o2, SourceName: o2, TargetName: o2}
 	assert.True(nameTuple1.Equals(nameTuple2))
 
-	o3 := NewObjectName(POSTGRESQL, "public", "public", "table2")
+	o3 := NewObjectName(constants.POSTGRESQL, "public", "public", "table2")
 	nameTuple3 := NameTuple{CurrentName: o3, SourceName: o3, TargetName: o3}
 	assert.False(nameTuple1.Equals(nameTuple3))
 }
@@ -39,7 +40,7 @@ func TestPGDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
 
 	// Test NewTableName() with PostgreSQL and default schema "public" and
 	// a table name belonging to default schema.
-	tableName := NewObjectName(POSTGRESQL, "public", "public", "table1")
+	tableName := NewObjectName(constants.POSTGRESQL, "public", "public", "table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "public",
@@ -68,7 +69,7 @@ func TestPGNonDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with PostgreSQL and default schema "public" and
 	// a table name belonging to a non-default schema.
-	tableName := NewObjectName(POSTGRESQL, "public", "schema1", "table1")
+	tableName := NewObjectName(constants.POSTGRESQL, "public", "schema1", "table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "schema1",
@@ -97,7 +98,7 @@ func TestPGDefaultSchemaCaseSensitiveTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with PostgreSQL and default schema "public" and
 	// a case-sensitive name with mixed cases.
-	tableName := NewObjectName(POSTGRESQL, "public", "public", "Table1")
+	tableName := NewObjectName(constants.POSTGRESQL, "public", "public", "Table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "public",
@@ -126,7 +127,7 @@ func TestPGNonDefaultSchemaCaseSensitiveTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with PostgreSQL and default schema "public" and
 	// a case-sensitive name with mixed cases.
-	tableName := NewObjectName(POSTGRESQL, "public", "schema1", "Table1")
+	tableName := NewObjectName(constants.POSTGRESQL, "public", "schema1", "Table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "schema1",
@@ -155,7 +156,7 @@ func TestPGNonDefaultSchemaTableNameWithSpecialChars(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with PostgreSQL and default schema "public" and
 	// a case-sensitive name with mixed cases.
-	tableName := NewObjectName(POSTGRESQL, "public", "schema1", "table$1")
+	tableName := NewObjectName(constants.POSTGRESQL, "public", "schema1", "table$1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "schema1",
@@ -186,7 +187,7 @@ func TestOracleDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with Oracle and default schema "SAKILA" and
 	// a table name belonging to default schema.
-	tableName := NewObjectName(ORACLE, "SAKILA", "SAKILA", "TABLE1")
+	tableName := NewObjectName(constants.ORACLE, "SAKILA", "SAKILA", "TABLE1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "SAKILA",
@@ -215,7 +216,7 @@ func TestOracleNonDefaultSchemaCaseInsensitiveTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with Oracle and default schema "SAKILA" and
 	// a table name belonging to a non-default schema.
-	tableName := NewObjectName(ORACLE, "SAKILA", "SCHEMA1", "TABLE1")
+	tableName := NewObjectName(constants.ORACLE, "SAKILA", "SCHEMA1", "TABLE1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "SCHEMA1",
@@ -244,7 +245,7 @@ func TestOracleDefaultSchemaCaseSensitiveTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with Oracle and default schema "SAKILA" and
 	// a case-sensitive name with mixed cases.
-	tableName := NewObjectName(ORACLE, "SAKILA", "SAKILA", "Table1")
+	tableName := NewObjectName(constants.ORACLE, "SAKILA", "SAKILA", "Table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "SAKILA",
@@ -273,7 +274,7 @@ func TestOracleNonDefaultSchemaCaseSensitiveTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with Oracle and default schema "SAKILA" and
 	// a case-sensitive name with mixed cases.
-	tableName := NewObjectName(ORACLE, "SAKILA", "SCHEMA1", "Table1")
+	tableName := NewObjectName(constants.ORACLE, "SAKILA", "SCHEMA1", "Table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "SCHEMA1",
@@ -304,7 +305,7 @@ func TestMySQLDefaultSchemaCaseSensitiveLowerCaseTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with MySQL and default schema "sakila" and
 	// a table name belonging to default schema.
-	tableName := NewObjectName(MYSQL, "sakila", "sakila", "table1")
+	tableName := NewObjectName(constants.MYSQL, "sakila", "sakila", "table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "sakila",
@@ -333,7 +334,7 @@ func TestMySQLNonDefaultSchemaCaseSensitiveLowerCaseTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with MySQL and default schema "sakila" and
 	// a table name belonging to a non-default schema.
-	tableName := NewObjectName(MYSQL, "sakila", "schema1", "table1")
+	tableName := NewObjectName(constants.MYSQL, "sakila", "schema1", "table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "schema1",
@@ -362,7 +363,7 @@ func TestMySQLDefaultSchemaCaseSensitiveMixedCaseTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with MySQL and default schema "sakila" and
 	// a case-sensitive name with mixed cases.
-	tableName := NewObjectName(MYSQL, "sakila", "sakila", "Table1")
+	tableName := NewObjectName(constants.MYSQL, "sakila", "sakila", "Table1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "sakila",
@@ -391,7 +392,7 @@ func TestMySQLNonDefaultSchemaCaseSensitiveUpperCaseTableName(t *testing.T) {
 	assert := assert.New(t)
 	// Test NewTableName() with MySQL and default schema "sakila" and
 	// a case-sensitive name with all upper case letters.
-	tableName := NewObjectName(MYSQL, "sakila", "schema1", "TABLE1")
+	tableName := NewObjectName(constants.MYSQL, "sakila", "schema1", "TABLE1")
 	assert.NotNil(tableName)
 	expectedTableName := &ObjectName{
 		SchemaName:        "schema1",

--- a/yb-voyager/src/utils/sqlname/sqlname.go
+++ b/yb-voyager/src/utils/sqlname/sqlname.go
@@ -20,14 +20,8 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"golang.org/x/exp/slices"
-)
-
-const (
-	YUGABYTEDB = "yugabytedb"
-	POSTGRESQL = "postgresql"
-	ORACLE     = "oracle"
-	MYSQL      = "mysql"
 )
 
 var (
@@ -113,9 +107,9 @@ func NewTargetName(schemaName, objectName string) *TargetName {
 	}
 	return &TargetName{
 		ObjectName: Identifier{
-			Quoted:    quote(objectName, YUGABYTEDB),
-			Unquoted:  unquote(objectName, YUGABYTEDB),
-			MinQuoted: minQuote(objectName, YUGABYTEDB),
+			Quoted:    quote(objectName, constants.YUGABYTEDB),
+			Unquoted:  unquote(objectName, constants.YUGABYTEDB),
+			MinQuoted: minQuote(objectName, constants.YUGABYTEDB),
 		},
 		SchemaName: Identifier{
 			Quoted:    `"` + schemaName + `"`,
@@ -123,9 +117,9 @@ func NewTargetName(schemaName, objectName string) *TargetName {
 			MinQuoted: schemaName,
 		},
 		Qualified: Identifier{
-			Quoted:    schemaName + "." + quote(objectName, YUGABYTEDB),
-			Unquoted:  schemaName + "." + unquote(objectName, YUGABYTEDB),
-			MinQuoted: schemaName + "." + minQuote(objectName, YUGABYTEDB),
+			Quoted:    schemaName + "." + quote(objectName, constants.YUGABYTEDB),
+			Unquoted:  schemaName + "." + unquote(objectName, constants.YUGABYTEDB),
+			MinQuoted: schemaName + "." + minQuote(objectName, constants.YUGABYTEDB),
 		},
 	}
 }
@@ -160,17 +154,17 @@ func IsQuoted(s string) bool {
 
 func quote(s string, dbType string) string {
 	if IsQuoted(s) {
-		if s[0] == '`' && dbType == YUGABYTEDB {
+		if s[0] == '`' && dbType == constants.YUGABYTEDB {
 			return `"` + unquote(s, dbType) + `"` // `Foo` -> "Foo"
 		}
 		return s
 	}
 	switch dbType {
-	case POSTGRESQL, YUGABYTEDB:
+	case constants.POSTGRESQL, constants.YUGABYTEDB:
 		return `"` + strings.ToLower(s) + `"`
-	case MYSQL:
+	case constants.MYSQL:
 		return s // TODO - learn the semantics of quoting in MySQL.
-	case ORACLE:
+	case constants.ORACLE:
 		return `"` + strings.ToUpper(s) + `"`
 	default:
 		panic("unknown source db type " + dbType)
@@ -182,11 +176,11 @@ func unquote(s string, dbType string) string {
 		return s[1 : len(s)-1]
 	}
 	switch dbType {
-	case POSTGRESQL, YUGABYTEDB:
+	case constants.POSTGRESQL, constants.YUGABYTEDB:
 		return strings.ToLower(s)
-	case MYSQL:
+	case constants.MYSQL:
 		return s
-	case ORACLE:
+	case constants.ORACLE:
 		return strings.ToUpper(s)
 	default:
 		panic("unknown source db type")
@@ -210,15 +204,15 @@ func SetDifference(a, b []*SourceName) []*SourceName {
 func minQuote(objectName, sourceDBType string) string {
 	objectName = unquote(objectName, sourceDBType)
 	switch sourceDBType {
-	case YUGABYTEDB, POSTGRESQL:
+	case constants.YUGABYTEDB, constants.POSTGRESQL:
 		if IsAllLowercase(objectName) && !IsReservedKeywordPG(objectName) {
 			return objectName
 		} else {
 			return `"` + objectName + `"`
 		}
-	case MYSQL:
+	case constants.MYSQL:
 		return objectName
-	case ORACLE:
+	case constants.ORACLE:
 		if IsAllUppercase(objectName) && !IsReservedKeywordOracle(objectName) {
 			return objectName
 		} else {
@@ -246,7 +240,7 @@ func IsAllLowercase(s string) bool {
 		if !(unicode.IsLetter(rune(c)) || unicode.IsDigit(rune(c))) { // check for special chars
 			return false
 		}
-		if unicode.IsUpper(rune(c)) { 
+		if unicode.IsUpper(rune(c)) {
 			return false
 		}
 	}
@@ -255,11 +249,11 @@ func IsAllLowercase(s string) bool {
 
 func IsCaseSensitive(s string, sourceDbType string) bool {
 	switch sourceDbType {
-	case ORACLE:
+	case constants.ORACLE:
 		return !IsAllUppercase(s)
-	case POSTGRESQL:
+	case constants.POSTGRESQL:
 		return !IsAllLowercase(s)
-	case MYSQL:
+	case constants.MYSQL:
 		return false
 	}
 	panic("invalid source db type")


### PR DESCRIPTION
### Describe the changes in this pull request
- Removed collection of functions names in the queries being detected for unsupported query constructs.
- Only considering the table objects(schema names of them) to compare with the user provided schema list.


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
N/A, only the queries to be displayed in UQC assessment report would change based on the schema list provided by the user.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
- Added unit test to verify that ObjectCollector is collecting all objects and table objects, depending on the predicate provided to it.

- Added a new end to end test `pg/assessment-report-test-uqc`
- Also manually tested end to end scenario, where HTML report doesn't show the queries from different schema tables.


### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
