### PR TITLE
Fix: Not logging the source-replica-db-password in the import-data-to-source-replica command log file

### DIFF
--- a/yb-voyager/cmd/logging.go
+++ b/yb-voyager/cmd/logging.go
@@ -81,7 +81,7 @@ func InitLogging(logDir string, logLevel string, disableLogging bool, cmdName st
 func redactPasswordFromArgs() {
 	for i := 0; i < len(os.Args); i++ {
 		opt := os.Args[i]
-		if opt == "--source-db-password" || opt == "--target-db-password" || opt == "--ff-db-password" {
+		if opt == "--source-db-password" || opt == "--target-db-password" || opt == "--source-replica-db-password" {
 			os.Args[i+1] = "XXX"
 		}
 	}


### PR DESCRIPTION
### Describe the changes in this pull request
Fixing logging of source-replica db password in log file
https://yugabyte.atlassian.net/browse/DB-14595

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
N/A

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually, 
```
2024-12-19 16:29:23.042375 INFO logging.go:76 Args: [yb-voyager import data to source-replica --export-dir /Users/priyanshigupta/Documents/voyager/yb-voyager/migtests/tests/pg/basic-public-live-test/export-dir --source-replica-db-user postgres --source-replica-db-name ff_db --source-replica-db-password XXX --disable-pb true --send-diagnostics=false --parallel-jobs 3 --max-retries 1 --source-replica-db-host 127.0.0.1]

```
### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No|
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
