### PR TITLE
Add --skip-debezium flag in installer script to avoid installing debezium when only offline setup is required

### DIFF
--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -543,9 +543,9 @@ rebuild_voyager_local() {
 get_passed_options() {
 	if [ "$1" == "linux" ]
 	then
-		OPTS=$(getopt -o "lpnvV", --long install-from-local-source,only-pg-support,skip-debezium,rebuild-voyager-local,version: --name 'install-yb-voyager' -- $ARGS_LINUX)
+		OPTS=$(getopt -o "lpdvV", --long install-from-local-source,only-pg-support,skip-debezium,rebuild-voyager-local,version: --name 'install-yb-voyager' -- $ARGS_LINUX)
 	else
-		OPTS=$(getopt  lpvV  $ARGS_MACOS)
+		OPTS=$(getopt  lpdvV  $ARGS_MACOS)
 	fi
 
 	eval set -- "$OPTS"
@@ -560,11 +560,11 @@ get_passed_options() {
 				ONLY_PG="true"; 
 				shift 
 				;;
-			--skip-debezium )
+			-d | --skip-debezium )
 				SKIP_DEBEZIUM="true"
 				shift
 				;;
-			--rebuild-voyager-local )
+			-v | --rebuild-voyager-local )
 				REBUILD_VOYAGER_LOCAL="true";
 				shift
 				;;

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -12,7 +12,7 @@ LOG_FILE=/tmp/install-yb-voyager.log
 VERSION="latest"
 
 ONLY_PG="false"
-NO_DEBEZIUM_SETUP="false"
+SKIP_DEBEZIUM="false"
 
 trap on_exit EXIT
 
@@ -324,7 +324,7 @@ check_java() {
 }
 
 install_debezium_server(){
-	if [ $NO_DEBEZIUM_SETUP == "true" ] ; then
+	if [ $SKIP_DEBEZIUM == "true" ] ; then
 		return
 	fi
 
@@ -543,7 +543,7 @@ rebuild_voyager_local() {
 get_passed_options() {
 	if [ "$1" == "linux" ]
 	then
-		OPTS=$(getopt -o "lpnvV", --long install-from-local-source,only-pg-support,no-debezium,rebuild-voyager-local,version: --name 'install-yb-voyager' -- $ARGS_LINUX)
+		OPTS=$(getopt -o "lpnvV", --long install-from-local-source,only-pg-support,skip-debezium,rebuild-voyager-local,version: --name 'install-yb-voyager' -- $ARGS_LINUX)
 	else
 		OPTS=$(getopt  lpvV  $ARGS_MACOS)
 	fi
@@ -560,11 +560,11 @@ get_passed_options() {
 				ONLY_PG="true"; 
 				shift 
 				;;
-			-n | --no-debezium )
-				NO_DEBEZIUM_SETUP="true"
+			--skip-debezium )
+				SKIP_DEBEZIUM="true"
 				shift
 				;;
-			-v | --rebuild-voyager-local )
+			--rebuild-voyager-local )
 				REBUILD_VOYAGER_LOCAL="true";
 				shift
 				;;

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -12,7 +12,7 @@ LOG_FILE=/tmp/install-yb-voyager.log
 VERSION="latest"
 
 ONLY_PG="false"
-NO_LIVE_SETUP="false"
+NO_DEBEZIUM_SETUP="false"
 
 trap on_exit EXIT
 
@@ -324,7 +324,7 @@ check_java() {
 }
 
 install_debezium_server(){
-	if [ $NO_LIVE_SETUP == "true" ] ; then
+	if [ $NO_DEBEZIUM_SETUP == "true" ] ; then
 		return
 	fi
 
@@ -543,7 +543,7 @@ rebuild_voyager_local() {
 get_passed_options() {
 	if [ "$1" == "linux" ]
 	then
-		OPTS=$(getopt -o "lpvV", --long install-from-local-source,only-pg-support,rebuild-voyager-local,version: --name 'install-yb-voyager' -- $ARGS_LINUX)
+		OPTS=$(getopt -o "lpnvV", --long install-from-local-source,only-pg-support,no-debezium,rebuild-voyager-local,version: --name 'install-yb-voyager' -- $ARGS_LINUX)
 	else
 		OPTS=$(getopt  lpvV  $ARGS_MACOS)
 	fi
@@ -560,8 +560,8 @@ get_passed_options() {
 				ONLY_PG="true"; 
 				shift 
 				;;
-			--no-live )
-				NO_LIVE_SETUP="true"
+			-n | --no-debezium )
+				NO_DEBEZIUM_SETUP="true"
 				shift
 				;;
 			-v | --rebuild-voyager-local )

--- a/installer_scripts/install-yb-voyager
+++ b/installer_scripts/install-yb-voyager
@@ -12,6 +12,7 @@ LOG_FILE=/tmp/install-yb-voyager.log
 VERSION="latest"
 
 ONLY_PG="false"
+NO_LIVE_SETUP="false"
 
 trap on_exit EXIT
 
@@ -323,14 +324,18 @@ check_java() {
 }
 
 install_debezium_server(){
+	if [ $NO_LIVE_SETUP == "true" ] ; then
+		return
+	fi
+
 	if [ "${VERSION}" != "local" ]
 	then
 		output "Installing debezium:${DEBEZIUM_VERSION}"
 		install_debezium_server_from_release
 		return
 	fi
-	output "Installing debezium:${VERSION}."
 
+	output "Installing debezium:${VERSION}."
 	check_install_maven
 	clean_debezium
 	install_debezium_local ${DEBEZIUM_LOCAL_REF}
@@ -554,6 +559,10 @@ get_passed_options() {
 			-p | --only-pg-support ) 
 				ONLY_PG="true"; 
 				shift 
+				;;
+			--no-live )
+				NO_LIVE_SETUP="true"
+				shift
 				;;
 			-v | --rebuild-voyager-local )
 				REBUILD_VOYAGER_LOCAL="true";


### PR DESCRIPTION
### Describe the changes in this pull request
Added a new flag to installer script `--skip-debezium` to avoid installing debezium for cases like when only offline setup is required

```
./installer_scripts/install-yb-voyager  --install-from-local-source --skip-debezium
```

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
If user doesn't provide this new flag(old way of invoking installler script) there won't be any change in behaviour for them.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Existing tests ensure that nothing is getting affected with this new flag, unless its specified

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              |  No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
