### PR TITLE
Fixed the logic for checking source db version compatibility and added it to assess migration too for PG

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -335,6 +335,14 @@ func assessMigration() (err error) {
 		// We will require source db connection for the below checks
 		// Check if required binaries are installed.
 		if source.RunGuardrailsChecks {
+			// Check source database version.
+			log.Info("checking source DB version")
+			err = source.DB().CheckSourceDBVersion(exportType)
+			if err != nil {
+				return fmt.Errorf("source DB version check failed: %w", err)
+			}
+
+			// Check if required binaries are installed.
 			binaryCheckIssues, err := checkDependenciesForExport()
 			if err != nil {
 				return fmt.Errorf("failed to check dependencies for assess migration: %w", err)

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -42,7 +42,7 @@ import (
 
 const MIN_SUPPORTED_PG_VERSION_OFFLINE = "9"
 const MIN_SUPPORTED_PG_VERSION_LIVE = "10"
-const MAX_SUPPORTED_PG_VERSION = "16"
+const MAX_SUPPORTED_PG_VERSION = "17"
 const MISSING = "MISSING"
 const GRANTED = "GRANTED"
 const NO_USAGE_PERMISSION = "NO USAGE PERMISSION"
@@ -979,14 +979,23 @@ func (pg *PostgreSQL) CheckSourceDBVersion(exportType string) error {
 	if pgVersion == "" {
 		return fmt.Errorf("failed to get source database version")
 	}
+
+	// Extract the major version from the full version string
+	re := regexp.MustCompile(`^(\d+)`)
+	match := re.FindStringSubmatch(pgVersion)
+	if len(match) < 2 {
+		return fmt.Errorf("failed to extract major version from source database version: %s", pgVersion)
+	}
+	majorVersion := match[1]
+
 	supportedVersionRange := fmt.Sprintf("%s to %s", MIN_SUPPORTED_PG_VERSION_OFFLINE, MAX_SUPPORTED_PG_VERSION)
 
-	if version.CompareSimple(pgVersion, MAX_SUPPORTED_PG_VERSION) > 0 || version.CompareSimple(pgVersion, MIN_SUPPORTED_PG_VERSION_OFFLINE) < 0 {
+	if version.CompareSimple(majorVersion, MAX_SUPPORTED_PG_VERSION) > 0 || version.CompareSimple(majorVersion, MIN_SUPPORTED_PG_VERSION_OFFLINE) < 0 {
 		return fmt.Errorf("current source db version: %s. Supported versions: %s", pgVersion, supportedVersionRange)
 	}
 	// for live migration
 	if exportType == utils.CHANGES_ONLY || exportType == utils.SNAPSHOT_AND_CHANGES {
-		if version.CompareSimple(pgVersion, MIN_SUPPORTED_PG_VERSION_LIVE) < 0 {
+		if version.CompareSimple(majorVersion, MIN_SUPPORTED_PG_VERSION_LIVE) < 0 {
 			supportedVersionRange = fmt.Sprintf("%s to %s", MIN_SUPPORTED_PG_VERSION_LIVE, MAX_SUPPORTED_PG_VERSION)
 			utils.PrintAndLog(color.RedString("Warning: Live Migration: Current source db version: %s. Supported versions: %s", pgVersion, supportedVersionRange))
 		}

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -981,18 +981,13 @@ func (pg *PostgreSQL) CheckSourceDBVersion(exportType string) error {
 	}
 
 	// Extract the major version from the full version string
-	// Version can be like: 17.2 (Ubuntu 17.2-1.pgdg20.04+1), 17.2, 17alpha1 etc
+	// Version can be like: 17.2 (Ubuntu 17.2-1.pgdg20.04+1), 17.2, 17alpha1 etc.
 	re := regexp.MustCompile(`^(\d+)`)
 	match := re.FindStringSubmatch(pgVersion)
 	if len(match) < 2 {
 		return fmt.Errorf("failed to extract major version from source database version: %s", pgVersion)
 	}
 	majorVersion := match[1]
-
-	fmt.Println("Source DB Major version: ", majorVersion)
-	fmt.Println("match[1]: ", match[1])
-	fmt.Println("match[0]: ", match[0])
-	fmt.Println("match len: ", len(match))
 
 	supportedVersionRange := fmt.Sprintf("%s to %s", MIN_SUPPORTED_PG_VERSION_OFFLINE, MAX_SUPPORTED_PG_VERSION)
 

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -981,12 +981,18 @@ func (pg *PostgreSQL) CheckSourceDBVersion(exportType string) error {
 	}
 
 	// Extract the major version from the full version string
+	// Version can be like: 17.2 (Ubuntu 17.2-1.pgdg20.04+1), 17.2, 17alpha1 etc
 	re := regexp.MustCompile(`^(\d+)`)
 	match := re.FindStringSubmatch(pgVersion)
 	if len(match) < 2 {
 		return fmt.Errorf("failed to extract major version from source database version: %s", pgVersion)
 	}
 	majorVersion := match[1]
+
+	fmt.Println("Source DB Major version: ", majorVersion)
+	fmt.Println("match[1]: ", match[1])
+	fmt.Println("match[0]: ", match[0])
+	fmt.Println("match len: ", len(match))
 
 	supportedVersionRange := fmt.Sprintf("%s to %s", MIN_SUPPORTED_PG_VERSION_OFFLINE, MAX_SUPPORTED_PG_VERSION)
 


### PR DESCRIPTION
### Describe the changes in this pull request
There was a bug in the logic for checking if source db version is compatibily in PG. Even with 16.2 source db version and max allowed version 16, it was failing. Fixed the logic to check only the major version.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
None

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually tested

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
