### PR TITLE
Regression: Unit test failing due to recent PR merging using code changed in build tags PR

### DIFF
--- a/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
@@ -681,7 +681,7 @@ func TestCopyUnsupportedConstructIssuesDetected(t *testing.T) {
 
 	for stmt, expectedIssues := range expectedIssues {
 		issues, err := parserIssueDetector.getDMLIssues(stmt)
-		fatalIfError(t, err)
+		testutils.FatalIfError(t, err)
 		assert.Equal(t, len(expectedIssues), len(issues))
 		for _, expectedIssue := range expectedIssues {
 			found := slices.ContainsFunc(issues, func(queryIssue QueryIssue) bool {


### PR DESCRIPTION
…

### Describe the changes in this pull request
Fixes the regression introduced in bbfc84cd40ecbe3a570077181b1281014b77eed1
`fatalIfError` was renamed to `testutils.FatalIfError()`in this commit, but recent commit was still using old name and git merge was unable to detect this conflict.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
NA

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
