### PR TITLE
Fix: retrieving migration uuid early in the export schema phase

### DIFF
--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -66,6 +66,11 @@ var exportSchemaCmd = &cobra.Command{
 }
 
 func exportSchema() error {
+	err := retrieveMigrationUUID()
+	if err != nil {
+		log.Errorf("failed to get migration UUID: %v", err)
+		return fmt.Errorf("failed to get migration UUID: %w", err)
+	}
 	if metaDBIsCreated(exportDir) && schemaIsExported() {
 		if startClean {
 			proceed := utils.AskPrompt(
@@ -93,7 +98,7 @@ func exportSchema() error {
 
 	utils.PrintAndLog("export of schema for source type as '%s'\n", source.DBType)
 	// Check connection with source database.
-	err := source.DB().Connect()
+	err = source.DB().Connect()
 	if err != nil {
 		log.Errorf("failed to connect to the source db: %s", err)
 		return fmt.Errorf("failed to connect to the source db: %w", err)
@@ -151,12 +156,6 @@ func exportSchema() error {
 				return fmt.Errorf("grant the required permissions and try again")
 			}
 		}
-	}
-
-	err = retrieveMigrationUUID()
-	if err != nil {
-		log.Errorf("failed to get migration UUID: %v", err)
-		return fmt.Errorf("failed to get migration UUID: %w", err)
 	}
 
 	exportSchemaStartEvent := createExportSchemaStartedEvent()

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -66,11 +66,6 @@ var exportSchemaCmd = &cobra.Command{
 }
 
 func exportSchema() error {
-	err := retrieveMigrationUUID()
-	if err != nil {
-		log.Errorf("failed to get migration UUID: %v", err)
-		return fmt.Errorf("failed to get migration UUID: %w", err)
-	}
 	if metaDBIsCreated(exportDir) && schemaIsExported() {
 		if startClean {
 			proceed := utils.AskPrompt(
@@ -95,7 +90,12 @@ func exportSchema() error {
 		utils.PrintAndLog("Schema is not exported yet. Ignoring --start-clean flag.\n\n")
 	}
 	CreateMigrationProjectIfNotExists(source.DBType, exportDir)
-
+	err := retrieveMigrationUUID()
+	if err != nil {
+		log.Errorf("failed to get migration UUID: %v", err)
+		return fmt.Errorf("failed to get migration UUID: %w", err)
+	}
+	
 	utils.PrintAndLog("export of schema for source type as '%s'\n", source.DBType)
 	// Check connection with source database.
 	err = source.DB().Connect()

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -132,6 +132,11 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 		utils.ErrExit("Failed to get migration status record: %s", err)
 	}
 
+	err = retrieveMigrationUUID()
+	if err != nil {
+		utils.ErrExit("failed to get migration UUID: %w", err)
+	}
+
 	// Check if target DB has the required permissions
 	if tconf.RunGuardrailsChecks {
 		checkImportDataPermissions()
@@ -470,10 +475,6 @@ func updateTargetConfInMigrationStatus() {
 }
 
 func importData(importFileTasks []*ImportFileTask) {
-	err := retrieveMigrationUUID()
-	if err != nil {
-		utils.ErrExit("failed to get migration UUID: %w", err)
-	}
 
 	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && (tconf.EnableUpsert) {
 		if !utils.AskPrompt(color.RedString("WARNING: Ensure that tables on target YugabyteDB do not have secondary indexes. " +

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -91,6 +91,10 @@ var importDataFileCmd = &cobra.Command{
 		dataStore = datastore.NewDataStore(dataDir)
 		importFileTasks := prepareImportFileTasks()
 		prepareForImportDataCmd(importFileTasks)
+		err := retrieveMigrationUUID()
+		if err != nil {
+			utils.ErrExit("failed to get migration UUID: %w", err)
+		}
 		importData(importFileTasks)
 		packAndSendImportDataFilePayload(COMPLETE)
 


### PR DESCRIPTION
### Describe the changes in this pull request

fixes https://github.com/yugabyte/yb-voyager/issues/2127

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
N/A

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
