### PR TITLE
separate callhome UnsupportedFeature for each extension in assess-migration

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -163,24 +163,38 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		return len(constructs)
 	})
 
-	assessPayload := callhome.AssessMigrationPhasePayload{
-		TargetDBVersion:     assessmentReport.TargetDBVersion,
-		MigrationComplexity: assessmentReport.MigrationComplexity,
-		UnsupportedFeatures: callhome.MarshalledJsonString(lo.Map(assessmentReport.UnsupportedFeatures, func(feature UnsupportedFeature, _ int) callhome.UnsupportedFeature {
+	var unsupportedFeatures []callhome.UnsupportedFeature
+	for _, feature := range assessmentReport.UnsupportedFeatures {
+		if feature.FeatureName == EXTENSION_FEATURE {
+			// For extensions, we need to send the extension name in the feature name
+			// for better categorization in callhome
+			for _, object := range feature.Objects {
+				unsupportedFeatures = append(unsupportedFeatures, callhome.UnsupportedFeature{
+					FeatureName:      fmt.Sprintf("%s - %s", feature.FeatureName, object.ObjectName),
+					ObjectCount:      1,
+					TotalOccurrences: 1,
+				})
+			}
+		} else {
 			var objects []string
 			if slices.Contains(featuresToSendObjectsToCallhome, feature.FeatureName) {
 				objects = lo.Map(feature.Objects, func(o ObjectInfo, _ int) string {
 					return o.ObjectName
 				})
 			}
-			res := callhome.UnsupportedFeature{
+			unsupportedFeatures = append(unsupportedFeatures, callhome.UnsupportedFeature{
 				FeatureName:      feature.FeatureName,
 				ObjectCount:      len(feature.Objects),
 				Objects:          objects,
 				TotalOccurrences: len(feature.Objects),
-			}
-			return res
-		})),
+			})
+		}
+	}
+
+	assessPayload := callhome.AssessMigrationPhasePayload{
+		TargetDBVersion:            assessmentReport.TargetDBVersion,
+		MigrationComplexity:        assessmentReport.MigrationComplexity,
+		UnsupportedFeatures:        callhome.MarshalledJsonString(unsupportedFeatures),
 		UnsupportedQueryConstructs: callhome.MarshalledJsonString(countByConstructType),
 		UnsupportedDatatypes:       callhome.MarshalledJsonString(unsupportedDatatypesList),
 		MigrationCaveats: callhome.MarshalledJsonString(lo.Map(assessmentReport.MigrationCaveats, func(feature UnsupportedFeature, _ int) callhome.UnsupportedFeature {

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -115,9 +115,7 @@ var assessMigrationCmd = &cobra.Command{
 }
 
 // Assessment feature names to send the object names for to callhome
-var featuresToSendObjectsToCallhome = []string{
-	EXTENSION_FEATURE,
-}
+var featuresToSendObjectsToCallhome = []string{}
 
 func packAndSendAssessMigrationPayload(status string, errMsg string) {
 	if !shouldSendCallhome() {


### PR DESCRIPTION
### Describe the changes in this pull request

Add extension name to the FeatureName in callhome phase payload of assess-migration to have better categorization.

Sample callhome phase_payload: 
`
 |     "unsupported_features": "[{\"FeatureName\":\"Tables with stored generated columns\",\"ObjectCount\":1,\"TotalOccurrences\":1},{\"FeatureName\":\"Extensions - plperl\",\"ObjectCount\":1,\"TotalOccurrences\":1},{\"FeatureName\":\"Extensions - hstore_plperl\",\"ObjectCount\":1,\"TotalOccurrences\":1}]",
 `

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
Manually with callhome server.

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
