### PR TITLE
Fix regex parser for parsing functions having SQL body with language sql (PG 15 feature)

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -921,6 +921,9 @@ sqlParsingLoop:
 			} else if matches := dollarQuoteRegex.FindStringSubmatch(currLine); matches != nil {
 				dollarQuoteFlag = 1 //denotes start of the code/body part
 				codeBlockDelimiter = matches[0]
+			} else if strings.Contains(currLine, "BEGIN ATOMIC") {
+				dollarQuoteFlag = 1 //denotes start of the sql body part https://www.postgresql.org/docs/15/sql-createfunction.html#:~:text=a%20new%20session.-,sql_body,-The%20body%20of
+				codeBlockDelimiter = "END"
 			}
 		case CODE_BLOCK_STARTED:
 			if strings.Contains(currLine, codeBlockDelimiter) {

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -926,14 +926,25 @@ sqlParsingLoop:
 				codeBlockDelimiter = "END" //SQL body to determine the end of BEGIN ATOMIC ... END; sql body
 			}
 		case CODE_BLOCK_STARTED:
-			if strings.Contains(currLine, codeBlockDelimiter) ||
-				strings.Contains(currLine, strings.ToLower(codeBlockDelimiter)) {
-				//TODO: anyways we should be using pg-parser: but for now for the END sql body delimiter checking the UPPER and LOWER both
-				dollarQuoteFlag = 2 //denotes end of code/body part
-				if isEndOfSqlStmt(currLine) {
-					break sqlParsingLoop
+			switch codeBlockDelimiter {
+			case "END":
+				if strings.Contains(currLine, codeBlockDelimiter) ||
+					strings.Contains(currLine, strings.ToLower(codeBlockDelimiter)) {
+					//TODO: anyways we should be using pg-parser: but for now for the END sql body delimiter checking the UPPER and LOWER both
+					dollarQuoteFlag = 2 //denotes end of code/body part
+					if isEndOfSqlStmt(currLine) {
+						break sqlParsingLoop
+					}
+				}
+			default:
+				if strings.Contains(currLine, codeBlockDelimiter) {
+					dollarQuoteFlag = 2 //denotes end of code/body part
+					if isEndOfSqlStmt(currLine) {
+						break sqlParsingLoop
+					}
 				}
 			}
+
 		case CODE_BLOCK_COMPLETED:
 			if isEndOfSqlStmt(currLine) {
 				break sqlParsingLoop

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -134,6 +134,7 @@ var (
 	parserIssueDetector = queryissue.NewParserIssueDetector()
 	multiRegex          = regexp.MustCompile(`([a-zA-Z0-9_\.]+[,|;])`)
 	dollarQuoteRegex    = regexp.MustCompile(`(\$.*\$)`)
+	sqlBodyBeginRegex   = re("BEGIN", "ATOMIC")
 	//TODO: optional but replace every possible space or new line char with [\s\n]+ in all regexs
 	viewWithCheckRegex        = re("VIEW", capture(ident), anything, "WITH", opt(commonClause), "CHECK", "OPTION")
 	rangeRegex                = re("PRECEDING", "and", anything, ":float")
@@ -921,12 +922,15 @@ sqlParsingLoop:
 			} else if matches := dollarQuoteRegex.FindStringSubmatch(currLine); matches != nil {
 				dollarQuoteFlag = 1 //denotes start of the code/body part
 				codeBlockDelimiter = matches[0]
-			} else if strings.Contains(currLine, "BEGIN ATOMIC") {
-				dollarQuoteFlag = 1 //denotes start of the sql body part https://www.postgresql.org/docs/15/sql-createfunction.html#:~:text=a%20new%20session.-,sql_body,-The%20body%20of
-				codeBlockDelimiter = "END"
+			} else if matches := sqlBodyBeginRegex.FindStringSubmatch(currLine); matches != nil {
+				dollarQuoteFlag = 1        //denotes start of the sql body part https://www.postgresql.org/docs/15/sql-createfunction.html#:~:text=a%20new%20session.-,sql_body,-The%20body%20of
+				codeBlockDelimiter = "END" //SQL body to determine the end of BEGIN ATOMIC ... END; sql body
 			}
 		case CODE_BLOCK_STARTED:
-			if strings.Contains(currLine, codeBlockDelimiter) {
+			if strings.Contains(currLine, codeBlockDelimiter) ||
+				strings.Contains(currLine, strings.ToLower(codeBlockDelimiter)) {
+				//TODO: anyways we should be using pg-parser: for the END sql body delimiter checking the UPPER and LOWER both
+				//not using regex as there are some issues while doing that (not debugged that)
 				dollarQuoteFlag = 2 //denotes end of code/body part
 				if isEndOfSqlStmt(currLine) {
 					break sqlParsingLoop

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -913,7 +913,6 @@ sqlParsingLoop:
 
 		stmt += currLine + " "
 		formattedStmt += currLine + "\n"
-
 		// Assuming that both the dollar quote strings will not be in same line
 		switch dollarQuoteFlag {
 		case CODE_BLOCK_NOT_STARTED:
@@ -929,8 +928,7 @@ sqlParsingLoop:
 		case CODE_BLOCK_STARTED:
 			if strings.Contains(currLine, codeBlockDelimiter) ||
 				strings.Contains(currLine, strings.ToLower(codeBlockDelimiter)) {
-				//TODO: anyways we should be using pg-parser: for the END sql body delimiter checking the UPPER and LOWER both
-				//not using regex as there are some issues while doing that (not debugged that)
+				//TODO: anyways we should be using pg-parser: but for now for the END sql body delimiter checking the UPPER and LOWER both
 				dollarQuoteFlag = 2 //denotes end of code/body part
 				if isEndOfSqlStmt(currLine) {
 					break sqlParsingLoop
@@ -978,6 +976,9 @@ func isEndOfSqlStmt(line string) bool {
 	if cmtStartIdx != -1 {
 		line = line[0:cmtStartIdx] // ignore comment
 		line = strings.TrimRight(line, " ")
+	}
+	if len(line) == 0 {
+		return false
 	}
 	return line[len(line)-1] == ';'
 }

--- a/yb-voyager/cmd/analyzeSchema_test.go
+++ b/yb-voyager/cmd/analyzeSchema_test.go
@@ -255,7 +255,6 @@ end;`,
 		t.Errorf("Expected %d SQL statements for %s, got %d", len(expectedSqlInfoArr), objType, len(sqlInfoArr))
 	} 
 
-	fmt.Printf("sqlinfoarr - %v", sqlInfoArr)
 	for i, expectedSqlInfo := range expectedSqlInfoArr {
 		assert.Equal(t, expectedSqlInfo.objName, sqlInfoArr[i].objName)
 		assert.Equal(t, expectedSqlInfo.stmt, sqlInfoArr[i].stmt)

--- a/yb-voyager/cmd/analyzeSchema_test.go
+++ b/yb-voyager/cmd/analyzeSchema_test.go
@@ -76,13 +76,12 @@ CREATE TABLE another_table (
 		t.Errorf("Error creating file for the objType %s: %v", objType, err)
 	}
 
-
 	defer os.Remove(sqlFile.Name())
 
 	sqlInfoArr := parseSqlFileForObjectType(sqlFile.Name(), objType)
 	// Validate the number of SQL statements found
 	if len(sqlInfoArr) != len(expectedSqlInfoArr) {
-		t.Errorf("Expected %d SQL statements for %s, got %d",len(expectedSqlInfoArr),  objType, len(sqlInfoArr))
+		t.Errorf("Expected %d SQL statements for %s, got %d", len(expectedSqlInfoArr), objType, len(sqlInfoArr))
 	}
 
 	for i, expectedSqlInfo := range expectedSqlInfoArr {
@@ -140,8 +139,96 @@ $$ LANGUAGE plpgsql;`,
 
 	// Validate the number of SQL statements found
 	if len(sqlInfoArr) != len(expectedSqlInfoArr) {
-		t.Errorf("Expected %d SQL statements for %s, got %d",len(expectedSqlInfoArr), objType, len(sqlInfoArr))
+		t.Errorf("Expected %d SQL statements for %s, got %d", len(expectedSqlInfoArr), objType, len(sqlInfoArr))
 	}
+
+	for i, expectedSqlInfo := range expectedSqlInfoArr {
+		assert.Equal(t, expectedSqlInfo.objName, sqlInfoArr[i].objName)
+		assert.Equal(t, expectedSqlInfo.stmt, sqlInfoArr[i].stmt)
+		assert.Equal(t, expectedSqlInfo.formattedStmt, sqlInfoArr[i].formattedStmt)
+	}
+
+}
+
+func TestFunctionSQLFile(t *testing.T) {
+	functionFileContent := `CREATE FUNCTION public.asterisks(n integer) RETURNS SETOF text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    BEGIN ATOMIC
+ SELECT repeat('*'::text, g.g) AS repeat
+    FROM generate_series(1, asterisks.n) g(g);
+END; 
+
+CREATE OR REPLACE FUNCTION copy_high_earners(threshold NUMERIC) RETURNS VOID AS $$
+DECLARE
+    temp_salary employees.salary%TYPE;
+BEGIN
+    CREATE TEMP TABLE temp_high_earners AS
+    SELECT * FROM employees WHERE salary > threshold;
+    FOR temp_salary IN SELECT salary FROM temp_high_earners LOOP
+        RAISE NOTICE 'High earner salary: %', temp_salary;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE BEGIN ATOMIC; SELECT $1 + $2; END;
+
+CREATE FUNCTION public.asterisks1(n integer) RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    RETURN repeat('*'::text, n);`
+
+	expectedSqlInfoArr := []sqlInfo{
+		sqlInfo{
+			objName:       "public.asterisks",
+			stmt:          "CREATE FUNCTION public.asterisks(n integer) RETURNS SETOF text     LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE     BEGIN ATOMIC  SELECT repeat('*'::text, g.g) AS repeat     FROM generate_series(1, asterisks.n) g(g); END; ",
+			formattedStmt: `CREATE FUNCTION public.asterisks(n integer) RETURNS SETOF text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    BEGIN ATOMIC
+ SELECT repeat('*'::text, g.g) AS repeat
+    FROM generate_series(1, asterisks.n) g(g);
+END;`,
+		},
+		sqlInfo{
+			objName:       "copy_high_earners",
+			stmt:          "CREATE OR REPLACE FUNCTION copy_high_earners(threshold NUMERIC) RETURNS VOID AS $$ DECLARE     temp_salary employees.salary%TYPE; BEGIN     CREATE TEMP TABLE temp_high_earners AS     SELECT * FROM employees WHERE salary > threshold;     FOR temp_salary IN SELECT salary FROM temp_high_earners LOOP         RAISE NOTICE 'High earner salary: %', temp_salary;     END LOOP; END; $$ LANGUAGE plpgsql; ",
+			formattedStmt: `CREATE OR REPLACE FUNCTION copy_high_earners(threshold NUMERIC) RETURNS VOID AS $$
+DECLARE
+    temp_salary employees.salary%TYPE;
+BEGIN
+    CREATE TEMP TABLE temp_high_earners AS
+    SELECT * FROM employees WHERE salary > threshold;
+    FOR temp_salary IN SELECT salary FROM temp_high_earners LOOP
+        RAISE NOTICE 'High earner salary: %', temp_salary;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;`,
+		},
+		sqlInfo{
+			objName:       "add",
+			stmt:          "CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE BEGIN ATOMIC; SELECT $1 + $2; END; ",
+			formattedStmt: `CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE BEGIN ATOMIC; SELECT $1 + $2; END;`,
+		},
+		sqlInfo{
+			objName:       "public.asterisks1",
+			stmt:          "CREATE FUNCTION public.asterisks1(n integer) RETURNS text     LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE     RETURN repeat('*'::text, n); ",
+			formattedStmt: `CREATE FUNCTION public.asterisks1(n integer) RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    RETURN repeat('*'::text, n);`,
+		},
+	}
+	objType := "FUNCTION"
+	sqlFile, err := setupFile(objType, functionFileContent)
+	if err != nil {
+		t.Errorf("Error creating file for the objType %s: %v", objType, err)
+	}
+
+	defer os.Remove(sqlFile.Name())
+
+	sqlInfoArr := parseSqlFileForObjectType(sqlFile.Name(), objType)
+
+	// Validate the number of SQL statements found
+	if len(sqlInfoArr) != len(expectedSqlInfoArr) {
+		t.Errorf("Expected %d SQL statements for %s, got %d", len(expectedSqlInfoArr), objType, len(sqlInfoArr))
+	} 
 
 	for i, expectedSqlInfo := range expectedSqlInfoArr {
 		assert.Equal(t, expectedSqlInfo.objName, sqlInfoArr[i].objName)

--- a/yb-voyager/cmd/analyzeSchema_test.go
+++ b/yb-voyager/cmd/analyzeSchema_test.go
@@ -172,6 +172,16 @@ $$ LANGUAGE plpgsql;
 
 CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE BEGIN ATOMIC; SELECT $1 + $2; END;
 
+CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE 
+BEGIN ATOMIC; SELECT $1 + $2; END;
+
+CREATE FUNCTION public.case_sensitive_test(n integer) RETURNS SETOF text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    begin atomic
+ SELECT repeat('*'::text, g.g) AS repeat
+    FROM generate_series(1, asterisks.n) g(g);
+end; 
+
 CREATE FUNCTION public.asterisks1(n integer) RETURNS text
     LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
     RETURN repeat('*'::text, n);`
@@ -208,6 +218,21 @@ $$ LANGUAGE plpgsql;`,
 			formattedStmt: `CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE BEGIN ATOMIC; SELECT $1 + $2; END;`,
 		},
 		sqlInfo{
+			objName:       "add",
+			stmt:          "CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE BEGIN ATOMIC; SELECT $1 + $2; END; ",
+			formattedStmt: "CREATE FUNCTION add(int, int) RETURNS int IMMUTABLE PARALLEL SAFE\nBEGIN ATOMIC; SELECT $1 + $2; END;",
+		},
+		sqlInfo{
+			objName:       "public.case_sensitive_test",
+			stmt:          "CREATE FUNCTION public.case_sensitive_test(n integer) RETURNS SETOF text     LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE     begin atomic  SELECT repeat('*'::text, g.g) AS repeat     FROM generate_series(1, asterisks.n) g(g); end; ",
+			formattedStmt: `CREATE FUNCTION public.case_sensitive_test(n integer) RETURNS SETOF text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    begin atomic
+ SELECT repeat('*'::text, g.g) AS repeat
+    FROM generate_series(1, asterisks.n) g(g);
+end;`,
+		},
+		sqlInfo{
 			objName:       "public.asterisks1",
 			stmt:          "CREATE FUNCTION public.asterisks1(n integer) RETURNS text     LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE     RETURN repeat('*'::text, n); ",
 			formattedStmt: `CREATE FUNCTION public.asterisks1(n integer) RETURNS text
@@ -230,6 +255,7 @@ $$ LANGUAGE plpgsql;`,
 		t.Errorf("Expected %d SQL statements for %s, got %d", len(expectedSqlInfoArr), objType, len(sqlInfoArr))
 	} 
 
+	fmt.Printf("sqlinfoarr - %v", sqlInfoArr)
 	for i, expectedSqlInfo := range expectedSqlInfoArr {
 		assert.Equal(t, expectedSqlInfo.objName, sqlInfoArr[i].objName)
 		assert.Equal(t, expectedSqlInfo.stmt, sqlInfoArr[i].stmt)


### PR DESCRIPTION
### Describe the changes in this pull request
SQL body syntax - https://www.postgresql.org/docs/15/sql-createfunction.html#:~:text=a%20new%20session.-,sql_body,-The%20body%20of, where with language SQL
```
BEGIN ATOMIC;
....
END;
```
or 
```
language sql
RETURN ...;
```

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
N/A
### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
unit tests added and end-to end tests added in other PR - #2165 
### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
