### PR TITLE
Implement custom Json Marshaller for AssessmentReport struct

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -493,7 +493,7 @@ func createMigrationAssessmentCompletedEvent() *cp.MigrationAssessmentCompletedE
 	}
 
 	assessmentIssues := flattenAssessmentReportToAssessmentIssues(assessmentReport)
-
+	// assessmentReport.SerializationMode = "full"
 	payload := AssessMigrationPayload{
 		PayloadVersion:      ASSESS_MIGRATION_PAYLOAD_VERSION,
 		VoyagerVersion:      assessmentReport.VoyagerVersion,
@@ -1609,6 +1609,7 @@ func generateAssessmentReportJson(reportDir string) error {
 	}
 	log.Infof("migration complexity explanation: %q", assessmentReport.MigrationComplexityExplanation)
 
+	// assessmentReport.SerializationMode = "minimal"
 	strReport, err := json.MarshalIndent(assessmentReport, "", "\t")
 	if err != nil {
 		return fmt.Errorf("failed to marshal the assessment report: %w", err)

--- a/yb-voyager/cmd/common_test.go
+++ b/yb-voyager/cmd/common_test.go
@@ -138,6 +138,7 @@ func TestAssessmentReportStructs(t *testing.T) {
 				Issues                         []AssessmentIssue                     `json:"-"`
 				TableIndexStats                *[]migassessment.TableIndexStats      `json:"TableIndexStats"`
 				Notes                          []string                              `json:"Notes"`
+				SerializationMode              string                                `json:"-"`
 				UnsupportedDataTypes           []utils.TableColumnsDataTypes         `json:"UnsupportedDataTypes"`
 				UnsupportedDataTypesDesc       string                                `json:"UnsupportedDataTypesDesc"`
 				UnsupportedFeatures            []UnsupportedFeature                  `json:"UnsupportedFeatures"`


### PR DESCRIPTION
### Describe the changes in this pull request
- using this we can achieve different content in json output for assessment report vs ybd payload

Assessment Report struct 
```
type AssessmentReport struct {
	VoyagerVersion                 string                                `json:"VoyagerVersion"`
	TargetDBVersion                *ybversion.YBVersion                  `json:"TargetDBVersion"`
	MigrationComplexity            string                                `json:"MigrationComplexity"`
	MigrationComplexityExplanation string                                `json:"MigrationComplexityExplanation"`
	SchemaSummary                  utils.SchemaSummary                   `json:"SchemaSummary"`
	Sizing                         *migassessment.SizingAssessmentReport `json:"Sizing"`
	Issues                         []AssessmentIssue                     `json:"-"` // disabled in reports till corresponding UI changes are done(json and html reports)
	TableIndexStats                *[]migassessment.TableIndexStats      `json:"TableIndexStats"`
	Notes                          []string                              `json:"Notes"`
	SerializationMode              string                                `json:"-"` // field to control serialization of json

	// fields going to be deprecated
	UnsupportedDataTypes       []utils.TableColumnsDataTypes     `json:"UnsupportedDataTypes"`
	UnsupportedDataTypesDesc   string                            `json:"UnsupportedDataTypesDesc"`
	UnsupportedFeatures        []UnsupportedFeature              `json:"UnsupportedFeatures"`
	UnsupportedFeaturesDesc    string                            `json:"UnsupportedFeaturesDesc"`
	UnsupportedQueryConstructs []utils.UnsupportedQueryConstruct `json:"UnsupportedQueryConstructs"`
	UnsupportedPlPgSqlObjects  []UnsupportedFeature              `json:"UnsupportedPlPgSqlObjects"`
	MigrationCaveats           []UnsupportedFeature              `json:"MigrationCaveats"`
}
```
For ybd we need all the fields.
For Assessment report json we only need the fields before the comment - `// fields going to be deprecated`

Have to add a extra field `SerializationMode` just for the purpose of marshalling, this won't be transmitted further(only in memory).


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
NA

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Existing test enough.

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               |  No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No (not json actually, but struct has changed which shouldn't impact upgradability) |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
