### PR TITLE
Enable Assessment Issue in assessment report json

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -892,6 +892,7 @@ normalize_json() {
             .OptimalInsertConnectionsPerNode? = "IGNORED" |
             .RowCount? = "IGNORED" |
 			.FeatureDescription? = "IGNORED" | # Ignore FeatureDescription instead of fixing it in all tests since it will be removed soon
+			.AssessmentIssues? = "IGNORED" | # Ignore AssessmentIssues until all tests are updated
             # Replace newline characters in SqlStatement with spaces
 			.SqlStatement? |= (
 				if type == "string" then

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -511,8 +511,23 @@ func createMigrationAssessmentCompletedEvent() *cp.MigrationAssessmentCompletedE
 			TotalColocatedSize: totalColocatedSize,
 			TotalShardedSize:   totalShardedSize,
 		},
-		ConversionIssues:     schemaAnalysisReport.Issues,
-		AssessmentJsonReport: assessmentReport,
+		ConversionIssues: schemaAnalysisReport.Issues,
+		AssessmentJsonReport: AssessmentReportYugabyteD{
+			VoyagerVersion:             assessmentReport.VoyagerVersion,
+			TargetDBVersion:            assessmentReport.TargetDBVersion,
+			MigrationComplexity:        assessmentReport.MigrationComplexity,
+			SchemaSummary:              assessmentReport.SchemaSummary,
+			Sizing:                     assessmentReport.Sizing,
+			TableIndexStats:            assessmentReport.TableIndexStats,
+			Notes:                      assessmentReport.Notes,
+			UnsupportedDataTypes:       assessmentReport.UnsupportedDataTypes,
+			UnsupportedDataTypesDesc:   assessmentReport.UnsupportedDataTypesDesc,
+			UnsupportedFeatures:        assessmentReport.UnsupportedFeatures,
+			UnsupportedFeaturesDesc:    assessmentReport.UnsupportedFeaturesDesc,
+			UnsupportedQueryConstructs: assessmentReport.UnsupportedQueryConstructs,
+			UnsupportedPlPgSqlObjects:  assessmentReport.UnsupportedPlPgSqlObjects,
+			MigrationCaveats:           assessmentReport.MigrationCaveats,
+		},
 	}
 
 	payloadBytes, err := json.Marshal(payload)
@@ -1075,7 +1090,7 @@ func fetchUnsupportedPGFeaturesFromSchemaReport(schemaAnalysisReport utils.Schem
 	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.JSONB_SUBSCRIPTING_NAME, "", queryissue.JSONB_SUBSCRIPTING, schemaAnalysisReport, false))
 	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.FOREIGN_KEY_REFERENCES_PARTITIONED_TABLE_NAME, "", queryissue.FOREIGN_KEY_REFERENCES_PARTITIONED_TABLE, schemaAnalysisReport, false))
 	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.JSON_TYPE_PREDICATE_NAME, "", queryissue.JSON_TYPE_PREDICATE, schemaAnalysisReport, false))
-	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.SQL_BODY_IN_FUNCTION_NAME, "", queryissue.SQL_BODY_IN_FUNCTION, schemaAnalysisReport, false,))
+	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.SQL_BODY_IN_FUNCTION_NAME, "", queryissue.SQL_BODY_IN_FUNCTION, schemaAnalysisReport, false))
 	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.CTE_WITH_MATERIALIZED_CLAUSE_NAME, "", queryissue.CTE_WITH_MATERIALIZED_CLAUSE, schemaAnalysisReport, false))
 
 	return lo.Filter(unsupportedFeatures, func(f UnsupportedFeature, _ int) bool {

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1073,17 +1073,17 @@ type AssessmentReport struct {
 
 // Fields apart from Category, CategoryDescription, TypeName and Impact will be populated only if/when available
 type AssessmentIssue struct {
-	Category              string // expected values: unsupported_features, unsupported_query_constructs, migration_caveats, unsupported_plpgsql_objects, unsupported_datatype
-	CategoryDescription   string
-	Type                  string // Ex: GIN_INDEXES, SECURITY_INVOKER_VIEWS, STORED_GENERATED_COLUMNS
-	Name                  string // Ex: "Stored generated columns are not supported."
-	Description           string
-	Impact                string // Level-1, Level-2, Level-3 (no default: need to be assigned for each issue)
-	ObjectType            string // For datatype category, ObjectType will be datatype (for eg "geometry")
-	ObjectName            string
-	SqlStatement          string
-	DocsLink              string
-	MinimumVersionFixedIn map[string]*ybversion.YBVersion
+	Category              string                          `json:"Category"` // expected values: unsupported_features, unsupported_query_constructs, migration_caveats, unsupported_plpgsql_objects, unsupported_datatype
+	CategoryDescription   string                          `json:"CategoryDescription"`
+	Type                  string                          `json:"Type"` // Ex: GIN_INDEXES, SECURITY_INVOKER_VIEWS, STORED_GENERATED_COLUMNS
+	Name                  string                          `json:"Name"` // Ex: GIN Indexes, Security Invoker Views, Stored Generated Columns
+	Description           string                          `json:"Description"`
+	Impact                string                          `json:"Impact"`     // // Level-1, Level-2, Level-3 (no default: need to be assigned for each issue)
+	ObjectType            string                          `json:"ObjectType"` // For datatype category, ObjectType will be datatype (for eg "geometry")
+	ObjectName            string                          `json:"ObjectName"`
+	SqlStatement          string                          `json:"SqlStatement"`
+	DocsLink              string                          `json:"DocsLink"`
+	MinimumVersionFixedIn map[string]*ybversion.YBVersion `json:"MinimumVersionFixedIn"`
 }
 
 type UnsupportedFeature struct {

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1057,7 +1057,7 @@ type AssessmentReport struct {
 	MigrationComplexityExplanation string                                `json:"MigrationComplexityExplanation"`
 	SchemaSummary                  utils.SchemaSummary                   `json:"SchemaSummary"`
 	Sizing                         *migassessment.SizingAssessmentReport `json:"Sizing"`
-	Issues                         []AssessmentIssue                     `json:"-"` // disabled in reports till corresponding UI changes are done(json and html reports)
+	Issues                         []AssessmentIssue                     `json:"AssessmentIssues"`
 	TableIndexStats                *[]migassessment.TableIndexStats      `json:"TableIndexStats"`
 	Notes                          []string                              `json:"Notes"`
 
@@ -1139,7 +1139,7 @@ type AssessMigrationPayload struct {
 	TargetRecommendations TargetSizingRecommendations
 	ConversionIssues      []utils.AnalyzeSchemaIssue
 	// Depreacted: AssessmentJsonReport is depricated; use the fields directly inside struct
-	AssessmentJsonReport AssessmentReport
+	AssessmentJsonReport AssessmentReportYugabyteD
 }
 
 type AssessmentIssueYugabyteD struct {
@@ -1154,6 +1154,23 @@ type AssessmentIssueYugabyteD struct {
 
 	// Store Type-specific details - extensible, can refer any struct
 	Details json.RawMessage `json:"Details,omitempty"`
+}
+
+type AssessmentReportYugabyteD struct {
+	VoyagerVersion             string                                `json:"VoyagerVersion"`
+	TargetDBVersion            *ybversion.YBVersion                  `json:"TargetDBVersion"`
+	MigrationComplexity        string                                `json:"MigrationComplexity"`
+	SchemaSummary              utils.SchemaSummary                   `json:"SchemaSummary"`
+	Sizing                     *migassessment.SizingAssessmentReport `json:"Sizing"`
+	TableIndexStats            *[]migassessment.TableIndexStats      `json:"TableIndexStats"`
+	Notes                      []string                              `json:"Notes"`
+	UnsupportedDataTypes       []utils.TableColumnsDataTypes         `json:"UnsupportedDataTypes"` // using utils.TableColumnsDataTypes struct for ybd since it's unlikely to change rather removed
+	UnsupportedDataTypesDesc   string                                `json:"UnsupportedDataTypesDesc"`
+	UnsupportedFeatures        []UnsupportedFeature                  `json:"UnsupportedFeatures"` // using UnsupportedFeature struct for ybd since it's unlikely to change rather removed
+	UnsupportedFeaturesDesc    string                                `json:"UnsupportedFeaturesDesc"`
+	UnsupportedQueryConstructs []utils.UnsupportedQueryConstruct     `json:"UnsupportedQueryConstructs"`
+	UnsupportedPlPgSqlObjects  []UnsupportedFeature                  `json:"UnsupportedPlPgSqlObjects"`
+	MigrationCaveats           []UnsupportedFeature                  `json:"MigrationCaveats"`
 }
 
 /*

--- a/yb-voyager/cmd/common_test.go
+++ b/yb-voyager/cmd/common_test.go
@@ -126,6 +126,23 @@ func TestAssessmentReportStructs(t *testing.T) {
 			}{},
 		},
 		{
+			name:       "Validate Assessment Issue Struct Definition",
+			actualType: reflect.TypeOf(AssessmentIssue{}),
+			expectedType: struct {
+				Category              string                          `json:"Category"`
+				CategoryDescription   string                          `json:"CategoryDescription"`
+				Type                  string                          `json:"Type"`
+				Name                  string                          `json:"Name"`
+				Description           string                          `json:"Description"`
+				Impact                string                          `json:"Impact"`
+				ObjectType            string                          `json:"ObjectType"`
+				ObjectName            string                          `json:"ObjectName"`
+				SqlStatement          string                          `json:"SqlStatement"`
+				DocsLink              string                          `json:"DocsLink"`
+				MinimumVersionFixedIn map[string]*ybversion.YBVersion `json:"MinimumVersionFixedIn"`
+			}{},
+		},
+		{
 			name:       "Validate AssessmentReport Struct Definition",
 			actualType: reflect.TypeOf(AssessmentReport{}),
 			expectedType: struct {
@@ -135,7 +152,7 @@ func TestAssessmentReportStructs(t *testing.T) {
 				MigrationComplexityExplanation string                                `json:"MigrationComplexityExplanation"`
 				SchemaSummary                  utils.SchemaSummary                   `json:"SchemaSummary"`
 				Sizing                         *migassessment.SizingAssessmentReport `json:"Sizing"`
-				Issues                         []AssessmentIssue                     `json:"-"`
+				Issues                         []AssessmentIssue                     `json:"AssessmentIssues"`
 				TableIndexStats                *[]migassessment.TableIndexStats      `json:"TableIndexStats"`
 				Notes                          []string                              `json:"Notes"`
 				UnsupportedDataTypes           []utils.TableColumnsDataTypes         `json:"UnsupportedDataTypes"`
@@ -199,6 +216,7 @@ func TestAssessmentReportJson(t *testing.T) {
 			},
 			FailureReasoning: "Test failure reasoning",
 		},
+		// TODO add expected values for Issues field
 		Issues: nil,
 		TableIndexStats: &[]migassessment.TableIndexStats{
 			{
@@ -346,6 +364,7 @@ func TestAssessmentReportJson(t *testing.T) {
 		},
 		"FailureReasoning": "Test failure reasoning"
 	},
+	"AssessmentIssues": null,
 	"TableIndexStats": [
 		{
 			"SchemaName": "public",


### PR DESCRIPTION
### Describe the changes in this pull request
- also separated out the report struct for ybd payload
Replacement of this change - https://github.com/yugabyte/yb-voyager/pull/2205/
https://yugabyte.atlassian.net/browse/DB-14926

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Yes, assessment json report will have new field `AssessmentIssues`, for now this is redudant since we have old fields also.
Once we verify and upate the existing tests then we can remove this field

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Existing tests passing is enough

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes <-- |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
