### PR TITLE
Removed ora2pg dependency in case of live migration in oracle and mysql

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -408,12 +408,17 @@ func checkDependenciesForExport() (binaryCheckIssues []string, err error) {
 		missingTools = utils.CheckTools("strings")
 
 	case MYSQL:
-		// TODO: For mysql and oracle, we can probably remove the ora2pg check in case it is a live migration
-		// Issue Link: https://github.com/yugabyte/yb-voyager/issues/2102
-		missingTools = utils.CheckTools("ora2pg")
+		// In case if it is not a live migration, then we need to check for ora2pg
+		if !changeStreamingIsEnabled(exportType) && !useDebezium {
+			missingTools = utils.CheckTools("ora2pg")
+		}
 
 	case ORACLE:
-		missingTools = utils.CheckTools("ora2pg", "sqlplus")
+		// In case if it is not a live migration, then we need to check for ora2pg
+		if !changeStreamingIsEnabled(exportType) && !useDebezium {
+			missingTools = utils.CheckTools("ora2pg")
+		}
+		missingTools = utils.CheckTools("sqlplus")
 
 	case YUGABYTEDB:
 		missingTools = utils.CheckTools("strings")


### PR DESCRIPTION
### Describe the changes in this pull request
Removed ora2pg dependency check in case of live migration in oracle and mysql
https://github.com/yugabyte/yb-voyager/issues/2102

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Nope. Only that user wont be prompted that ora2pg is missing in case of live migration.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
