### PR TITLE
Add payload version and standardize field names for issues in analyze schema callhome payload

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1316,6 +1316,7 @@ func packAndSendAnalyzeSchemaPayload(status string, errorMsg string) {
 		Issues:          callhomeIssues,
 		DatabaseObjects: callhome.MarshalledJsonString(lo.Map(schemaAnalysisReport.SchemaSummary.DBObjects, func(dbObject utils.DBObject, _ int) utils.DBObject {
 			dbObject.ObjectNames = ""
+			dbObject.Details = "" // not useful, either static or sometimes sensitive(oracle indexes) information
 			return dbObject
 		})),
 		Error: callhome.SanitizeErrorMsg(errorMsg),

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -158,6 +158,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		Notes: assessmentReport.SchemaSummary.Notes,
 		DBObjects: lo.Map(schemaAnalysisReport.SchemaSummary.DBObjects, func(dbObject utils.DBObject, _ int) utils.DBObject {
 			dbObject.ObjectNames = ""
+			dbObject.Details = "" // not useful, either static or sometimes sensitive(oracle indexes) information
 			return dbObject
 		}),
 	}
@@ -204,7 +205,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		MigrationComplexity:            assessmentReport.MigrationComplexity,
 		MigrationComplexityExplanation: assessmentReport.MigrationComplexityExplanation,
 		SchemaSummary:                  callhome.MarshalledJsonString(schemaSummaryCopy),
-		Issues:                         callhome.MarshalledJsonString(obfuscatedIssues),
+		Issues:                         obfuscatedIssues,
 		Error:                          callhome.SanitizeErrorMsg(errMsg),
 		TableSizingStats:               callhome.MarshalledJsonString(tableSizingStats),
 		IndexSizingStats:               callhome.MarshalledJsonString(indexSizingStats),

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -156,14 +156,27 @@ type ExportSchemaPhasePayload struct {
 	Error                  string `json:"error"`
 }
 
+var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
+
 // SHOULD NOT REMOVE THESE TWO (issues, database_objects) FIELDS of AnalyzePhasePayload as parsing these specifically here
 // https://github.com/yugabyte/yugabyte-growth/blob/ad5df306c50c05136df77cd6548a1091ae577046/diagnostics_v2/main.py#L563
 type AnalyzePhasePayload struct {
-	TargetDBVersion *ybversion.YBVersion `json:"target_db_version"`
-	Issues          string               `json:"issues"`
-	DatabaseObjects string               `json:"database_objects"`
-	Error           string               `json:"error"`
+	PayloadVersion  string                 `json:"payload_version"`
+	TargetDBVersion *ybversion.YBVersion   `json:"target_db_version"`
+	Issues          []AnalyzeIssueCallhome `json:"issues"`
+	DatabaseObjects string                 `json:"database_objects"`
+	Error           string                 `json:"error"`
 }
+
+type AnalyzeIssueCallhome struct {
+	Category   string `json:"category"`
+	Type       string `json:"type"`
+	Name       string `json:"name"`
+	Impact     string `json:"impact"`
+	ObjectType string `json:"object_type"`
+	ObjectName string `json:"object_name"`
+}
+
 type ExportDataPhasePayload struct {
 	ParallelJobs            int64  `json:"parallel_jobs"`
 	TotalRows               int64  `json:"total_rows_exported"`
@@ -228,13 +241,6 @@ type EndMigrationPhasePayload struct {
 	BackupSchemaFiles    bool   `json:"backup_schema_files"`
 	SaveMigrationReports bool   `json:"save_migration_reports"`
 	Error                string `json:"error"`
-}
-
-var DoNotStoreFlags = []string{
-	"source-db-password",
-	"target-db-password",
-	"source-replica-db-password",
-	"export-dir",
 }
 
 func MarshalledJsonString[T any](value T) string {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -99,18 +99,18 @@ type TargetDBDetails struct {
 var ASSESS_MIGRATION_CALLHOME_PAYLOAD_VERSION = "1.0"
 
 type AssessMigrationPhasePayload struct {
-	PayloadVersion                 string               `json:"payload_version"`
-	TargetDBVersion                *ybversion.YBVersion `json:"target_db_version"`
-	Sizing                         *SizingCallhome      `json:"sizing"`
-	MigrationComplexity            string               `json:"migration_complexity"`
-	MigrationComplexityExplanation string               `json:"migration_complexity_explanation"`
-	SchemaSummary                  string               `json:"schema_summary"`
-	Issues                         string               `json:"assessment_issues"`
-	Error                          string               `json:"error"`
-	TableSizingStats               string               `json:"table_sizing_stats"`
-	IndexSizingStats               string               `json:"index_sizing_stats"`
-	SourceConnectivity             bool                 `json:"source_connectivity"`
-	IopsInterval                   int64                `json:"iops_interval"`
+	PayloadVersion                 string                    `json:"payload_version"`
+	TargetDBVersion                *ybversion.YBVersion      `json:"target_db_version"`
+	Sizing                         *SizingCallhome           `json:"sizing"`
+	MigrationComplexity            string                    `json:"migration_complexity"`
+	MigrationComplexityExplanation string                    `json:"migration_complexity_explanation"`
+	SchemaSummary                  string                    `json:"schema_summary"`
+	Issues                         []AssessmentIssueCallhome `json:"assessment_issues"`
+	Error                          string                    `json:"error"`
+	TableSizingStats               string                    `json:"table_sizing_stats"`
+	IndexSizingStats               string                    `json:"index_sizing_stats"`
+	SourceConnectivity             bool                      `json:"source_connectivity"`
+	IopsInterval                   int64                     `json:"iops_interval"`
 }
 
 type AssessmentIssueCallhome struct {

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -75,18 +75,18 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate AssessMigrationPhasePayload Struct Definition",
 			actualType: reflect.TypeOf(AssessMigrationPhasePayload{}),
 			expectedType: struct {
-				PayloadVersion                 string               `json:"payload_version"`
-				TargetDBVersion                *ybversion.YBVersion `json:"target_db_version"`
-				Sizing                         *SizingCallhome      `json:"sizing"`
-				MigrationComplexity            string               `json:"migration_complexity"`
-				MigrationComplexityExplanation string               `json:"migration_complexity_explanation"`
-				SchemaSummary                  string               `json:"schema_summary"`
-				Issues                         string               `json:"assessment_issues"`
-				Error                          string               `json:"error"`
-				TableSizingStats               string               `json:"table_sizing_stats"`
-				IndexSizingStats               string               `json:"index_sizing_stats"`
-				SourceConnectivity             bool                 `json:"source_connectivity"`
-				IopsInterval                   int64                `json:"iops_interval"`
+				PayloadVersion                 string                    `json:"payload_version"`
+				TargetDBVersion                *ybversion.YBVersion      `json:"target_db_version"`
+				Sizing                         *SizingCallhome           `json:"sizing"`
+				MigrationComplexity            string                    `json:"migration_complexity"`
+				MigrationComplexityExplanation string                    `json:"migration_complexity_explanation"`
+				SchemaSummary                  string                    `json:"schema_summary"`
+				Issues                         []AssessmentIssueCallhome `json:"assessment_issues"`
+				Error                          string                    `json:"error"`
+				TableSizingStats               string                    `json:"table_sizing_stats"`
+				IndexSizingStats               string                    `json:"index_sizing_stats"`
+				SourceConnectivity             bool                      `json:"source_connectivity"`
+				IopsInterval                   int64                     `json:"iops_interval"`
 			}{},
 		},
 		{
@@ -151,8 +151,9 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate AnalyzePhasePayload Struct Definition",
 			actualType: reflect.TypeOf(AnalyzePhasePayload{}),
 			expectedType: struct {
+				PayloadVersion string `json:"payload_version"`
 				TargetDBVersion *ybversion.YBVersion `json:"target_db_version"`
-				Issues          string               `json:"issues"`
+				Issues          []AnalyzeIssueCallhome `json:"issues"`
 				DatabaseObjects string               `json:"database_objects"`
 				Error           string               `json:"error"`
 			}{},

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -151,11 +151,23 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate AnalyzePhasePayload Struct Definition",
 			actualType: reflect.TypeOf(AnalyzePhasePayload{}),
 			expectedType: struct {
-				PayloadVersion string `json:"payload_version"`
-				TargetDBVersion *ybversion.YBVersion `json:"target_db_version"`
+				PayloadVersion  string                 `json:"payload_version"`
+				TargetDBVersion *ybversion.YBVersion   `json:"target_db_version"`
 				Issues          []AnalyzeIssueCallhome `json:"issues"`
-				DatabaseObjects string               `json:"database_objects"`
-				Error           string               `json:"error"`
+				DatabaseObjects string                 `json:"database_objects"`
+				Error           string                 `json:"error"`
+			}{},
+		},
+		{
+			name:       "Validate AnalyzeIssueCallhome Struct Definition",
+			actualType: reflect.TypeOf(AnalyzeIssueCallhome{}),
+			expectedType: struct {
+				Category   string `json:"category"`
+				Type       string `json:"type"`
+				Name       string `json:"name"`
+				Impact     string `json:"impact"`
+				ObjectType string `json:"object_type"`
+				ObjectName string `json:"object_name"`
 			}{},
 		},
 		{


### PR DESCRIPTION
### Describe the changes in this pull request
Added version to analyze payload
Only sending this info for each analyze issue in callhome payload. Not sending(issue reason at all)
```
type AnalyzePhasePayload struct {
	PayloadVersion  string                 `json:"payload_version"`
	TargetDBVersion *ybversion.YBVersion   `json:"target_db_version"`
	Issues          []AnalyzeIssueCallhome `json:"issues"`
	DatabaseObjects string                 `json:"database_objects"`
	Error           string                 `json:"error"`
}

type AnalyzeIssueCallhome struct {
	Category   string `json:"category"`
	Type       string `json:"type"`
	Name       string `json:"name"`
	Impact     string `json:"impact"`
	ObjectType string `json:"object_type"`
	ObjectName string `json:"object_name"`
}

```

Fixes:
- https://yugabyte.atlassian.net/browse/DB-14480
- https://yugabyte.atlassian.net/browse/DB-15083
  


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Callhome payloads for analyze phase will be changed, need to update the queries there.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually tested - payload version is present, index info for oracle not coming after changes.


### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
