### PR TITLE
[DB-14911] In assess-migration, warn/prompt the user if read/write IOPS is mostly 0, asking user to run it against a typical workload

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -1748,7 +1748,6 @@ func validateAndSetTargetDbVersionFlag() error {
 
 func validateSourceDBIOPSForAssessMigration() error {
 	var totalIOPS int64
-	totalIOPS = 0
 
 	tableIndexStats, err := assessmentDB.FetchAllStats()
 	if err != nil {
@@ -1756,8 +1755,8 @@ func validateSourceDBIOPSForAssessMigration() error {
 	}
 
 	// Checking if source schema has zero objects.
-	if len(*tableIndexStats) == 0 {
-		if utils.AskPrompt("No objects found in mentioned schemas. Do you want to continue with the assessment:") {
+	if tableIndexStats == nil || len(*tableIndexStats) == 0 {
+		if utils.AskPrompt("No objects found in the specified schema(s). Do you want to continue anyway") {
 			return nil
 		} else {
 			utils.ErrExit("Aborting..")
@@ -1772,7 +1771,7 @@ func validateSourceDBIOPSForAssessMigration() error {
 
 	// Checking if source schema IOPS is not zero.
 	if totalIOPS == 0 {
-		if utils.AskPrompt("Detected mentioned schema IOPS as zero. Do you want to continue the assessment:") {
+		if utils.AskPrompt("Detected 0 read/write IOPS on the tables in specified schema(s). In order to get an accurate assessment, it is recommended that the source database is actively handling its typical workloads. Do you want to continue anyway") {
 			return nil
 		} else {
 			utils.ErrExit("Aborting..")

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -395,7 +395,7 @@ func assessMigration() (err error) {
 
 	err = validateSourceDBIOPSForAssessMigration()
 	if err != nil {
-		return fmt.Errorf("failed to validate source database IOPS: %v", err)
+		return fmt.Errorf("failed to validate source database IOPS: %w", err)
 	}
 
 	err = runAssessment()
@@ -1766,7 +1766,6 @@ func validateSourceDBIOPSForAssessMigration() error {
 	}
 
 	for _, stat := range *tableIndexStats {
-		fmt.Printf("%s\n", stat.ObjectName)
 		totalIOPS += utils.SafeDereferenceInt64(stat.ReadsPerSecond)
 		totalIOPS += utils.SafeDereferenceInt64(stat.WritesPerSecond)
 	}
@@ -1780,6 +1779,6 @@ func validateSourceDBIOPSForAssessMigration() error {
 			return nil
 		}
 	}
-	// fmt.Printf("%d\n", totalIOPS)
+
 	return nil
 }


### PR DESCRIPTION
### Describe the changes in this pull request
Added a function in assessMigrationCommand ti validate the SourceDB IOPS before assessment report generation.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
