### PR TITLE
Fixing Runtime Errors for prompts during assess-migration command.

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -185,10 +185,10 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		obfuscatedIssues = append(obfuscatedIssues, obfuscatedIssue)
 	}
 
-	var sizingAssessmentReport callhome.SizingCallhome
+	var callhomeSizingAssessment callhome.SizingCallhome
 	if assessmentReport.Sizing != nil {
 		sizingRecommedation := &assessmentReport.Sizing.SizingRecommendation
-		sizingAssessmentReport = callhome.SizingCallhome{
+		callhomeSizingAssessment = callhome.SizingCallhome{
 			NumColocatedTables:              len(sizingRecommedation.ColocatedTables),
 			ColocatedReasoning:              sizingRecommedation.ColocatedReasoning,
 			NumShardedTables:                len(sizingRecommedation.ShardedTables),
@@ -205,7 +205,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 	assessPayload := callhome.AssessMigrationPhasePayload{
 		PayloadVersion:                 callhome.ASSESS_MIGRATION_CALLHOME_PAYLOAD_VERSION,
 		TargetDBVersion:                assessmentReport.TargetDBVersion,
-		Sizing:                         &sizingAssessmentReport,
+		Sizing:                         &callhomeSizingAssessment,
 		MigrationComplexity:            assessmentReport.MigrationComplexity,
 		MigrationComplexityExplanation: assessmentReport.MigrationComplexityExplanation,
 		SchemaSummary:                  callhome.MarshalledJsonString(schemaSummaryCopy),

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -185,17 +185,21 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		obfuscatedIssues = append(obfuscatedIssues, obfuscatedIssue)
 	}
 
-	sizingAssessmentReport := callhome.SizingCallhome{
-		NumColocatedTables:              len(assessmentReport.Sizing.SizingRecommendation.ColocatedTables),
-		ColocatedReasoning:              assessmentReport.Sizing.SizingRecommendation.ColocatedReasoning,
-		NumShardedTables:                len(assessmentReport.Sizing.SizingRecommendation.ShardedTables),
-		NumNodes:                        assessmentReport.Sizing.SizingRecommendation.NumNodes,
-		VCPUsPerInstance:                assessmentReport.Sizing.SizingRecommendation.VCPUsPerInstance,
-		MemoryPerInstance:               assessmentReport.Sizing.SizingRecommendation.MemoryPerInstance,
-		OptimalSelectConnectionsPerNode: assessmentReport.Sizing.SizingRecommendation.OptimalSelectConnectionsPerNode,
-		OptimalInsertConnectionsPerNode: assessmentReport.Sizing.SizingRecommendation.OptimalInsertConnectionsPerNode,
-		EstimatedTimeInMinForImport:     assessmentReport.Sizing.SizingRecommendation.EstimatedTimeInMinForImport,
-		ParallelVoyagerJobs:             assessmentReport.Sizing.SizingRecommendation.ParallelVoyagerJobs,
+	var sizingAssessmentReport callhome.SizingCallhome
+	if assessmentReport.Sizing != nil {
+		sizingRecommedation := &assessmentReport.Sizing.SizingRecommendation
+		sizingAssessmentReport = callhome.SizingCallhome{
+			NumColocatedTables:              len(sizingRecommedation.ColocatedTables),
+			ColocatedReasoning:              sizingRecommedation.ColocatedReasoning,
+			NumShardedTables:                len(sizingRecommedation.ShardedTables),
+			NumNodes:                        sizingRecommedation.NumNodes,
+			VCPUsPerInstance:                sizingRecommedation.VCPUsPerInstance,
+			MemoryPerInstance:               sizingRecommedation.MemoryPerInstance,
+			OptimalSelectConnectionsPerNode: sizingRecommedation.OptimalSelectConnectionsPerNode,
+			OptimalInsertConnectionsPerNode: sizingRecommedation.OptimalInsertConnectionsPerNode,
+			EstimatedTimeInMinForImport:     sizingRecommedation.EstimatedTimeInMinForImport,
+			ParallelVoyagerJobs:             sizingRecommedation.ParallelVoyagerJobs,
+		}
 	}
 
 	assessPayload := callhome.AssessMigrationPhasePayload{


### PR DESCRIPTION
### Describe the changes in this pull request
1. Fixing Runtime errors encountered when entering N for prompts during assess-migration command.
2. Also added a nit change missed during the last merge :- 
nit: [@atharva-kurhade-yb](https://github.com/atharva-kurhade-yb) you can define a varaible which reference to the field assessmentReport.Sizing.SizingRecommendation of assessmentReport struct and use here to populate callhome.SizingCallhome struct

Jira Ticket :- https://yugabyte.atlassian.net/browse/DB-15232
### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  4. Were there any changes to the configuration?
  5. Has the installation process changed? 
  6. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
