### PR TITLE
Checking mysql-community-devel package instead of mysql-devel package in the airgapped installation script when the OS is RHEL9

### DIFF
--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -614,6 +614,18 @@ check_yum_package_version() {
 check_yum_dependencies() {
     for requirement in "${centos_yum_package_requirements[@]}"; do
         IFS='|' read -r package version_type required_version <<< "$requirement"
+       
+        # In case of rhel9 the mysql-devel package is not available. However, mysql-community-devel is available. So check for that instead.
+        # Check if OS is rhel9
+        version=$(source /etc/os-release; echo "$VERSION_ID")
+	    # Extract only the major version
+	    majorVersion=$(echo $version | cut -d '.' -f 1)
+        if [ "$majorVersion" -eq 9 ]; then
+            if [[ "$package" == "mysql-devel" ]]; then
+                package="mysql-community-devel"
+            fi
+        fi
+
         check_yum_package_version "$package" "$version_type" "$required_version"
     done
 

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -620,10 +620,8 @@ check_yum_dependencies() {
         version=$(source /etc/os-release; echo "$VERSION_ID")
 	    # Extract only the major version
 	    majorVersion=$(echo $version | cut -d '.' -f 1)
-        if [ "$majorVersion" -eq 9 ]; then
-            if [[ "$package" == "mysql-devel" ]]; then
-                package="mysql-community-devel"
-            fi
+        if [[ "$majorVersion" -eq 9 && "$package" == "mysql-devel" ]]; then
+            package="mysql-community-devel"
         fi
 
         check_yum_package_version "$package" "$version_type" "$required_version"


### PR DESCRIPTION
Why is it needed?
The mysql-devel package is not available in RHEL9. Therefore, we need to install mysql-community-devel instead. Because of this reason, in case of RHEL9 airgapped installation we need to check whether the mysql-community-devel package is installed or not instead of the mysql-devel package.

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
