### PR TITLE
Avoid busy-looping in Colocated Picker

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -770,9 +770,9 @@ func importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataS
 				log.Infof("Import of task done: %s", task)
 				continue
 			} else {
-				// // some batches are still in progress, wait for them to complete as decided by the picker.
-				// // don't want to busy-wait, so in case of sequentialTaskPicker, we sleep.
-				// taskPicker.WaitForTasksBatchesTobeImported()
+				// some batches are still in progress, wait for them to complete as decided by the picker.
+				// don't want to busy-wait, so in case of sequentialTaskPicker, we sleep.
+				taskPicker.WaitForTasksBatchesTobeImported()
 				continue
 			}
 

--- a/yb-voyager/cmd/importDataFileTaskImporter.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter.go
@@ -37,7 +37,6 @@ worker pool for processing. It also maintains and updates the progress of the ta
 */
 type FileTaskImporter struct {
 	task                 *ImportFileTask
-	state                *ImportDataState
 	batchProducer        *FileBatchProducer
 	importBatchArgsProto *tgtdb.ImportBatchArgs
 	workerPool           *pool.Pool
@@ -60,7 +59,6 @@ func NewFileTaskImporter(task *ImportFileTask, state *ImportDataState, workerPoo
 
 	fti := &FileTaskImporter{
 		task:                  task,
-		state:                 state,
 		batchProducer:         batchProducer,
 		workerPool:            workerPool,
 		importBatchArgsProto:  getImportBatchArgsProto(task.TableNameTup, task.FilePath),
@@ -68,7 +66,12 @@ func NewFileTaskImporter(task *ImportFileTask, state *ImportDataState, workerPoo
 		totalProgressAmount:   totalProgressAmount,
 		currentProgressAmount: currentProgressAmount,
 	}
+	state.RegisterFileTaskImporter(fti)
 	return fti, nil
+}
+
+func (fti *FileTaskImporter) GetTaskID() int {
+	return fti.task.ID
 }
 
 // as of now, batch production and batch submission
@@ -80,13 +83,13 @@ func (fti *FileTaskImporter) AllBatchesSubmitted() bool {
 	return fti.batchProducer.Done()
 }
 
-func (fti *FileTaskImporter) AllBatchesImported() (bool, error) {
-	taskStatus, err := fti.state.GetFileImportState(fti.task.FilePath, fti.task.TableNameTup)
-	if err != nil {
-		return false, fmt.Errorf("getting file import state: %s", err)
-	}
-	return taskStatus == FILE_IMPORT_COMPLETED, nil
-}
+// func (fti *FileTaskImporter) AllBatchesImported() (bool, error) {
+// 	taskStatus, err := fti.state.GetFileImportState(fti.task.FilePath, fti.task.TableNameTup)
+// 	if err != nil {
+// 		return false, fmt.Errorf("getting file import state: %s", err)
+// 	}
+// 	return taskStatus == FILE_IMPORT_COMPLETED, nil
+// }
 
 func (fti *FileTaskImporter) ProduceAndSubmitNextBatchToWorkerPool() error {
 	if fti.AllBatchesSubmitted() {

--- a/yb-voyager/cmd/importDataFileTaskImporter.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter.go
@@ -83,14 +83,6 @@ func (fti *FileTaskImporter) AllBatchesSubmitted() bool {
 	return fti.batchProducer.Done()
 }
 
-// func (fti *FileTaskImporter) AllBatchesImported() (bool, error) {
-// 	taskStatus, err := fti.state.GetFileImportState(fti.task.FilePath, fti.task.TableNameTup)
-// 	if err != nil {
-// 		return false, fmt.Errorf("getting file import state: %s", err)
-// 	}
-// 	return taskStatus == FILE_IMPORT_COMPLETED, nil
-// }
-
 func (fti *FileTaskImporter) ProduceAndSubmitNextBatchToWorkerPool() error {
 	if fti.AllBatchesSubmitted() {
 		return fmt.Errorf("no more batches to submit")

--- a/yb-voyager/cmd/importDataFileTaskPicker.go
+++ b/yb-voyager/cmd/importDataFileTaskPicker.go
@@ -91,19 +91,6 @@ func (s *SequentialTaskPicker) Pick() (*ImportFileTask, error) {
 	if s.inProgressTask == nil {
 		s.inProgressTask = s.pendingTasks[0]
 		s.pendingTasks = s.pendingTasks[1:]
-		return s.inProgressTask, nil
-	}
-
-	// pick the in-progress task.
-	// if all batches for the in-progress task are already submitted, sleep for a bit
-	// before returning the task, so as to avoid busy-looping and checking if task is done.
-	taskImporter, ok := s.taskImporters[s.inProgressTask.ID]
-	if !ok {
-		return nil, fmt.Errorf("task importer not found for task: %v", s.inProgressTask)
-	}
-	if taskImporter.AllBatchesSubmitted() {
-		log.Infof("All batches submitted for task: %v. Sleeping", s.inProgressTask)
-		time.Sleep(time.Millisecond * 500)
 	}
 
 	return s.inProgressTask, nil

--- a/yb-voyager/cmd/importDataFileTaskPicker.go
+++ b/yb-voyager/cmd/importDataFileTaskPicker.go
@@ -297,10 +297,14 @@ func (c *ColocatedAwareRandomTaskPicker) PickTaskFromInProgressTasks() (*ImportF
 		// batches are submitted for all in-progress tasks.
 		// in case these are the last tasks to be processed (i.e. no more pending tasks),
 		// sleep for a bit before returning the task, so as to avoid busy-looping and checking if task is done.
-		if len(c.tableWisePendingTasks.Keys()) == 0 {
-			log.Infof("All batches submitted for all in-progress tasks. Sleeping")
-			time.Sleep(time.Millisecond * 500)
-		}
+		// if len(c.tableWisePendingTasks.Keys()) == 0 {
+		// 	log.Infof("All batches submitted for all in-progress tasks. Sleeping")
+		// 	time.Sleep(time.Millisecond * 500)
+		// } else {
+		// 	log.Info("All batches submitted for all in-progress tasks. Picking any random task")
+		// }
+		log.Infof("All batches submitted for all in-progress tasks. Sleeping")
+		time.Sleep(time.Millisecond * 100)
 		candidateInProgressTasks = c.inProgressTasks
 	}
 

--- a/yb-voyager/cmd/importDataFileTaskPicker_test.go
+++ b/yb-voyager/cmd/importDataFileTaskPicker_test.go
@@ -74,7 +74,7 @@ func TestSequentialTaskPickerBasic(t *testing.T) {
 		task2,
 	}
 
-	picker, err := NewSequentialTaskPicker(tasks, state, nil)
+	picker, err := NewSequentialTaskPicker(tasks, state)
 	testutils.FatalIfError(t, err)
 
 	assert.True(t, picker.HasMoreTasks())
@@ -108,7 +108,7 @@ func TestSequentialTaskPickerMarkTaskDone(t *testing.T) {
 		task2,
 	}
 
-	picker, err := NewSequentialTaskPicker(tasks, state, nil)
+	picker, err := NewSequentialTaskPicker(tasks, state)
 	testutils.FatalIfError(t, err)
 
 	assert.True(t, picker.HasMoreTasks())
@@ -165,7 +165,7 @@ func TestSequentialTaskPickerResumePicksInProgressTask(t *testing.T) {
 		task2,
 	}
 
-	picker, err := NewSequentialTaskPicker(tasks, state, nil)
+	picker, err := NewSequentialTaskPicker(tasks, state)
 	testutils.FatalIfError(t, err)
 
 	assert.True(t, picker.HasMoreTasks())
@@ -190,7 +190,7 @@ func TestSequentialTaskPickerResumePicksInProgressTask(t *testing.T) {
 
 	// simulate restart by creating a new picker
 	slices.Reverse(tasks) // reorder the tasks so that the in progress task is at the end
-	picker, err = NewSequentialTaskPicker(tasks, state, nil)
+	picker, err = NewSequentialTaskPicker(tasks, state)
 
 	// no matter how many times we call NextTask, it should return the same task (first task)
 	for i := 0; i < 10; i++ {

--- a/yb-voyager/cmd/importDataFileTaskPicker_test.go
+++ b/yb-voyager/cmd/importDataFileTaskPicker_test.go
@@ -252,7 +252,7 @@ func TestColocatedAwareRandomTaskPickerAdheresToMaxTasksInProgress(t *testing.T)
 		},
 	}
 
-	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -354,7 +354,7 @@ func TestColocatedAwareRandomTaskPickerMultipleTasksPerTableAdheresToMaxTasksInP
 		},
 	}
 
-	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -446,7 +446,7 @@ func TestColocatedAwareRandomTaskPickerSingleTask(t *testing.T) {
 		},
 	}
 
-	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -505,7 +505,7 @@ func TestColocatedAwareRandomTaskPickerTasksEqualToMaxTasksInProgress(t *testing
 	}
 
 	// 3 tasks, 3 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -574,7 +574,7 @@ func TestColocatedAwareRandomTaskPickerMultipleTasksPerTableTasksEqualToMaxTasks
 	}
 
 	// 3 tasks, 3 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -643,7 +643,7 @@ func TestColocatedAwareRandomTaskPickerTasksLessThanMaxTasksInProgress(t *testin
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -712,7 +712,7 @@ func TestColocatedAwareRandomTaskPickerMultipleTasksPerTableTasksLessThanMaxTask
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -779,7 +779,7 @@ func TestColocatedAwareRandomTaskPickerAllShardedTasks(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -824,7 +824,7 @@ func TestColocatedAwareRandomTaskPickerAllShardedTasksChooser(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -943,7 +943,7 @@ func TestColocatedAwareRandomTaskPickerAllColocatedTasks(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -988,7 +988,7 @@ func TestColocatedAwareRandomTaskPickerAllColocatedTasksChooser(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1052,7 +1052,7 @@ func TestColocatedAwareRandomTaskPickerMixShardedColocatedTasks(t *testing.T) {
 	}
 
 	// 5 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1107,7 +1107,7 @@ func TestColocatedAwareRandomTaskPickerMixShardedColocatedTasksChooser(t *testin
 	}
 
 	// 5 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1178,7 +1178,7 @@ func TestColocatedAwareRandomTaskPickerResumable(t *testing.T) {
 	}
 
 	// 5 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1205,19 +1205,19 @@ func TestColocatedAwareRandomTaskPickerResumable(t *testing.T) {
 	batch3.MarkInProgress()
 
 	// simulate restart. now, those 3 tasks should be in progress
-	picker, err = NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
+	picker, err = NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 	assert.Equal(t, 3, len(picker.inProgressTasks))
 
 	// simulate restart with  a larger no. of max tasks in progress
-	picker, err = NewColocatedAwareRandomTaskPicker(20, tasks, state, dummyYb, nil)
+	picker, err = NewColocatedAwareRandomTaskPicker(20, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 	assert.Equal(t, 3, len(picker.inProgressTasks))
 
 	// simulate restart with a smaller no. of max tasks in progress
-	picker, err = NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
+	picker, err = NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 	// only two shoudl be inprogress even though previously 3 were in progress.

--- a/yb-voyager/cmd/importDataFileTaskPicker_test.go
+++ b/yb-voyager/cmd/importDataFileTaskPicker_test.go
@@ -74,7 +74,7 @@ func TestSequentialTaskPickerBasic(t *testing.T) {
 		task2,
 	}
 
-	picker, err := NewSequentialTaskPicker(tasks, state)
+	picker, err := NewSequentialTaskPicker(tasks, state, nil)
 	testutils.FatalIfError(t, err)
 
 	assert.True(t, picker.HasMoreTasks())
@@ -108,7 +108,7 @@ func TestSequentialTaskPickerMarkTaskDone(t *testing.T) {
 		task2,
 	}
 
-	picker, err := NewSequentialTaskPicker(tasks, state)
+	picker, err := NewSequentialTaskPicker(tasks, state, nil)
 	testutils.FatalIfError(t, err)
 
 	assert.True(t, picker.HasMoreTasks())
@@ -165,7 +165,7 @@ func TestSequentialTaskPickerResumePicksInProgressTask(t *testing.T) {
 		task2,
 	}
 
-	picker, err := NewSequentialTaskPicker(tasks, state)
+	picker, err := NewSequentialTaskPicker(tasks, state, nil)
 	testutils.FatalIfError(t, err)
 
 	assert.True(t, picker.HasMoreTasks())
@@ -190,7 +190,7 @@ func TestSequentialTaskPickerResumePicksInProgressTask(t *testing.T) {
 
 	// simulate restart by creating a new picker
 	slices.Reverse(tasks) // reorder the tasks so that the in progress task is at the end
-	picker, err = NewSequentialTaskPicker(tasks, state)
+	picker, err = NewSequentialTaskPicker(tasks, state, nil)
 
 	// no matter how many times we call NextTask, it should return the same task (first task)
 	for i := 0; i < 10; i++ {
@@ -252,7 +252,7 @@ func TestColocatedAwareRandomTaskPickerAdheresToMaxTasksInProgress(t *testing.T)
 		},
 	}
 
-	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -354,7 +354,7 @@ func TestColocatedAwareRandomTaskPickerMultipleTasksPerTableAdheresToMaxTasksInP
 		},
 	}
 
-	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -446,7 +446,7 @@ func TestColocatedAwareRandomTaskPickerSingleTask(t *testing.T) {
 		},
 	}
 
-	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -505,7 +505,7 @@ func TestColocatedAwareRandomTaskPickerTasksEqualToMaxTasksInProgress(t *testing
 	}
 
 	// 3 tasks, 3 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -574,7 +574,7 @@ func TestColocatedAwareRandomTaskPickerMultipleTasksPerTableTasksEqualToMaxTasks
 	}
 
 	// 3 tasks, 3 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(3, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -643,7 +643,7 @@ func TestColocatedAwareRandomTaskPickerTasksLessThanMaxTasksInProgress(t *testin
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -712,7 +712,7 @@ func TestColocatedAwareRandomTaskPickerMultipleTasksPerTableTasksLessThanMaxTask
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -779,7 +779,7 @@ func TestColocatedAwareRandomTaskPickerAllShardedTasks(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -824,7 +824,7 @@ func TestColocatedAwareRandomTaskPickerAllShardedTasksChooser(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -943,7 +943,7 @@ func TestColocatedAwareRandomTaskPickerAllColocatedTasks(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -988,7 +988,7 @@ func TestColocatedAwareRandomTaskPickerAllColocatedTasksChooser(t *testing.T) {
 	}
 
 	// 3 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1052,7 +1052,7 @@ func TestColocatedAwareRandomTaskPickerMixShardedColocatedTasks(t *testing.T) {
 	}
 
 	// 5 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1107,7 +1107,7 @@ func TestColocatedAwareRandomTaskPickerMixShardedColocatedTasksChooser(t *testin
 	}
 
 	// 5 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1178,7 +1178,7 @@ func TestColocatedAwareRandomTaskPickerResumable(t *testing.T) {
 	}
 
 	// 5 tasks, 10 max tasks in progress
-	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err := NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 
@@ -1205,19 +1205,19 @@ func TestColocatedAwareRandomTaskPickerResumable(t *testing.T) {
 	batch3.MarkInProgress()
 
 	// simulate restart. now, those 3 tasks should be in progress
-	picker, err = NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb)
+	picker, err = NewColocatedAwareRandomTaskPicker(10, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 	assert.Equal(t, 3, len(picker.inProgressTasks))
 
 	// simulate restart with  a larger no. of max tasks in progress
-	picker, err = NewColocatedAwareRandomTaskPicker(20, tasks, state, dummyYb)
+	picker, err = NewColocatedAwareRandomTaskPicker(20, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 	assert.Equal(t, 3, len(picker.inProgressTasks))
 
 	// simulate restart with a smaller no. of max tasks in progress
-	picker, err = NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb)
+	picker, err = NewColocatedAwareRandomTaskPicker(2, tasks, state, dummyYb, nil)
 	testutils.FatalIfError(t, err)
 	assert.True(t, picker.HasMoreTasks())
 	// only two shoudl be inprogress even though previously 3 were in progress.

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -55,15 +55,22 @@ metainfo/import_data_state/table::<table_name>/file::<base_name>:<path_hash>/
 	batch::<batch_num>.<offset_end>.<record_count>.<byte_count>.<state>
 */
 type ImportDataState struct {
-	exportDir string
-	stateDir  string
+	exportDir               string
+	stateDir                string
+	inProgressTaskImporters map[int]fileTaskImportStatusChecker
 }
 
 func NewImportDataState(exportDir string) *ImportDataState {
 	return &ImportDataState{
-		exportDir: exportDir,
-		stateDir:  filepath.Join(exportDir, "metainfo", "import_data_state", importerRole),
+		exportDir:               exportDir,
+		stateDir:                filepath.Join(exportDir, "metainfo", "import_data_state", importerRole),
+		inProgressTaskImporters: make(map[int]fileTaskImportStatusChecker),
 	}
+}
+
+type fileTaskImportStatusChecker interface {
+	GetTaskID() int
+	AllBatchesSubmitted() bool
 }
 
 func (s *ImportDataState) PrepareForFileImport(filePath string, tableNameTup sqlname.NameTuple) error {
@@ -645,6 +652,30 @@ func (s *ImportDataState) GetImportedEventsStatsForTableList(tableNameTupList []
 	}
 
 	return tablesToEventCounter, nil
+}
+
+func (s *ImportDataState) RegisterFileTaskImporter(importer fileTaskImportStatusChecker) {
+	s.inProgressTaskImporters[importer.GetTaskID()] = importer
+}
+
+func (s *ImportDataState) UnregisterFileTaskImporter(importer fileTaskImportStatusChecker) {
+	delete(s.inProgressTaskImporters, importer.GetTaskID())
+}
+
+func (s *ImportDataState) AllBatchesSubmittedForTask(taskId int) (bool, error) {
+	taskImporter, ok := s.inProgressTaskImporters[taskId]
+	if !ok {
+		return false, fmt.Errorf("task importer with id %d not registered", taskId)
+	}
+	return taskImporter.AllBatchesSubmitted(), nil
+}
+
+func (s *ImportDataState) AllBatchesImported(filepath string, tableNameTup sqlname.NameTuple) (bool, error) {
+	taskStatus, err := s.GetFileImportState(filepath, tableNameTup)
+	if err != nil {
+		return false, fmt.Errorf("getting file import state: %s", err)
+	}
+	return taskStatus == FILE_IMPORT_COMPLETED, nil
 }
 
 //============================================================================

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -57,7 +57,7 @@ metainfo/import_data_state/table::<table_name>/file::<base_name>:<path_hash>/
 type ImportDataState struct {
 	exportDir               string
 	stateDir                string
-	inProgressTaskImporters map[int]fileTaskImportStatusChecker
+	inProgressTaskImporters map[int]fileTaskImportStatusChecker // used to fetch in-memory status from FileTaskImporter
 }
 
 func NewImportDataState(exportDir string) *ImportDataState {


### PR DESCRIPTION
### Describe the changes in this pull request
Avoid busy-looping when using Colocated Picker. A lot of logs were getting printed as a result of the busy loop.

New behavior: If for all in-progress tasks, all batches have been submitted, then sleep for a bit, before checking if the task is done(all batches imported). 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
