### PR TITLE
Fix: nil pointer exception while sending the callhome payload for import data to source/source-replica

### DIFF
--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -98,7 +98,9 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg string) {
 
 	sourceDBDetails := callhome.SourceDBDetails{
 		DBType:    tconf.TargetDBType,
-		DBVersion: targetDBDetails.DBVersion,
+	}
+	if targetDBDetails != nil {
+		sourceDBDetails.DBVersion = targetDBDetails.DBVersion
 	}
 	payload.SourceDBDetails = callhome.MarshalledJsonString(sourceDBDetails)
 
@@ -112,7 +114,7 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg string) {
 
 	importDataPayload.Phase = importPhase
 
-	if importPhase != dbzm.MODE_SNAPSHOT {
+	if importPhase != dbzm.MODE_SNAPSHOT && statsReporter != nil {
 		importDataPayload.EventsImportRate = statsReporter.EventsImportRateLast3Min
 		importDataPayload.TotalImportedEvents = statsReporter.TotalEventsImported
 	}

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -100,9 +100,11 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg string) {
 	payload.MigrationType = LIVE_MIGRATION
 
 	sourceDBDetails := callhome.SourceDBDetails{
-		DBType:    tconf.TargetDBType,
-		DBVersion: targetDBDetails.DBVersion,
-		Role:      "replica",
+		DBType: tconf.TargetDBType,
+		Role:   "replica",
+	}
+	if targetDBDetails != nil {
+		sourceDBDetails.DBVersion = targetDBDetails.DBVersion
 	}
 	payload.SourceDBDetails = callhome.MarshalledJsonString(sourceDBDetails)
 
@@ -128,7 +130,7 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg string) {
 
 	importDataPayload.Phase = importPhase
 
-	if importPhase != dbzm.MODE_SNAPSHOT {
+	if importPhase != dbzm.MODE_SNAPSHOT && statsReporter != nil {
 		importDataPayload.EventsImportRate = statsReporter.EventsImportRateLast3Min
 		importDataPayload.TotalImportedEvents = statsReporter.TotalEventsImported
 	}


### PR DESCRIPTION
### Describe the changes in this pull request
Fixing the nil pointer exception while sending the call home payload for exit/error case during initial phase of import data to source/source-replica. 
fixes #2364 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually
### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
