### PR TITLE
Added more integration tests for PG with different schema and basic test YB source for table-list of export-data

### DIFF
--- a/migtests/tests/pg/sequences/pg_sequences_automation.sql
+++ b/migtests/tests/pg/sequences/pg_sequences_automation.sql
@@ -236,7 +236,7 @@ CREATE TABLE users (
     name TEXT
 );
 
-ALTER TABLE ONLY users ALTER COLUMN user_code SET DEFAULT generate_user_code()
+ALTER TABLE ONLY users ALTER COLUMN user_code SET DEFAULT generate_user_code();
 
 ALTER SEQUENCE public.user_code_seq OWNED BY public.users.user_code;
 

--- a/yb-voyager/cmd/importDataTestUtils.go
+++ b/yb-voyager/cmd/importDataTestUtils.go
@@ -41,6 +41,7 @@ func (d *dummyTDB) MaxBatchSizeInBytes() int64 {
 }
 
 type TestTargetDB struct {
+	Tconf tgtdb.TargetConf
 	testcontainers.TestContainer
 	tgtdb.TargetDB
 }


### PR DESCRIPTION

### Describe the changes in this pull request
Added more integration tests for table-list area in export data
1. PG with different schema of multi-level partiitons and Glob pattern cases in table-list
2. YB with a test case of basic table-list and guardrail validation.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  3. Were there any changes to the configuration?
  4. Has the installation process changed? 
  5. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Automation 
### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              |No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
