### PR TITLE
Fix: Clean Table list and Sequences related params in Migration Status Record on startClean

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -324,7 +324,7 @@ func addSummaryDetailsForIndexes() {
 
 func checkStmtsUsingParser(sqlInfoArr []sqlInfo, fpath string, objType string) {
 	for _, sqlStmtInfo := range sqlInfoArr {
-		_, err := queryparser.Parse(sqlStmtInfo.stmt)
+		_, err := queryparser.Parse(sqlStmtInfo.formattedStmt)
 		if err != nil { //if the Stmt is not already report by any of the regexes
 			if !summaryMap[objType].invalidCount[sqlStmtInfo.objName] {
 				reason := fmt.Sprintf("%s - '%s'", UNSUPPORTED_PG_SYNTAX_ISSUE_REASON, err.Error())

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -1356,7 +1356,11 @@ func clearMigrationStateIfRequired() {
 		err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 			record.TableListExportedFromSource = nil
 			record.SourceExportedTableListWithLeafPartitions = nil
+			record.SourceRenameTablesMap = nil
 			record.SourceColumnToSequenceMapping = nil
+			record.TargetExportedTableListWithLeafPartitions = nil
+			record.TargetColumnToSequenceMapping = nil
+			record.TargetRenameTablesMap = nil
 		})
 
 		err = metadb.TruncateTablesInMetaDb(exportDir, []string{metadb.QUEUE_SEGMENT_META_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_PER_TABLE_TABLE_NAME})

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -1353,6 +1353,12 @@ func clearMigrationStateIfRequired() {
 			utils.ErrExit("Failed to remove name registry file: %s", err)
 		}
 
+		err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+			record.TableListExportedFromSource = nil
+			record.SourceExportedTableListWithLeafPartitions = nil
+			record.SourceColumnToSequenceMapping = nil
+		})
+
 		err = metadb.TruncateTablesInMetaDb(exportDir, []string{metadb.QUEUE_SEGMENT_META_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_PER_TABLE_TABLE_NAME})
 		if err != nil {
 			utils.ErrExit("Failed to truncate tables in metadb: %s", err)

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -246,7 +246,7 @@ func fetchOrRetrieveColToSeqMap(msr *metadb.MigrationStatusRecord, tableList []s
 	case TARGET_DB_EXPORTER_FB_ROLE, TARGET_DB_EXPORTER_FF_ROLE:
 		storedColToSeqMap = msr.TargetColumnToSequenceMapping
 	}
-	if storedColToSeqMap != nil {
+	if storedColToSeqMap != nil && !bool(startClean) {
 		return storedColToSeqMap, nil
 	}
 	colToSeqMap := source.DB().GetColumnToSequenceMap(tableList)


### PR DESCRIPTION
### Describe the changes in this pull request
1. Fixes #2397 , cleaning the table list and sequences related flags in the Migration status record.
2. Fixes #2391 , using the `formattedStmt` in `Parse` of analyze-schema and the `Parse` of the `queryissue.ParseRequiredDDLStmts` functions.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  3. Were there any changes to the configuration?
  4. Has the installation process changed? 
  5. Were there any changes to the reports? 
-->
no
### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
