### PR TITLE
Adding flags --pg-only, --oracle-only and --mysql-only for installing and checking database specific dependencies in the airgapped script

### DIFF
--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -370,7 +370,11 @@ check_pg_dump_and_pg_restore_version() {
         output "Found sufficient pg_dump version = ${PG_DUMP_VERSION}"
     else
         echo ""
-        echo -e "\e[31mERROR: pg_dump not found or insufficient version ${PG_DUMP_VERSION}. Please install pg_dump>=${MIN_REQUIRED_MAJOR_VERSION}\e[0m"
+        if [[ -z "$PG_DUMP_VERSION" ]]; then
+            echo -e "\e[31mERROR: pg_dump not found. Please install pg_dump version >= ${MIN_REQUIRED_MAJOR_VERSION}.\e[0m"
+        else
+            echo -e "\e[31mERROR: pg_dump version ${PG_DUMP_VERSION} is insufficient. Please install pg_dump>=${MIN_REQUIRED_MAJOR_VERSION}\e[0m"
+        fi
         pg_dump_wrong_version=1
     fi
 
@@ -380,7 +384,11 @@ check_pg_dump_and_pg_restore_version() {
         output "Found sufficient pg_restore version = ${PG_RESTORE_VERSION}"
     else
         echo ""
-        echo -e "\e[31mERROR: pg_restore not found or insufficient version ${PG_RESTORE_VERSION}. Please install pg_restore>=${MIN_REQUIRED_MAJOR_VERSION}\e[0m"
+        if [[ -z "$PG_RESTORE_VERSION" ]]; then
+            echo -e "\e[31mERROR: pg_restore not found. Please install pg_restore version >= ${MIN_REQUIRED_MAJOR_VERSION}.\e[0m"
+        else
+            echo -e "\e[31mERROR: pg_restore version ${PG_RESTORE_VERSION} is insufficient. Please install pg_restore>=${MIN_REQUIRED_MAJOR_VERSION}\e[0m"
+        fi
         pg_restore_wrong_version=1
     fi
 
@@ -390,7 +398,12 @@ check_pg_dump_and_pg_restore_version() {
         output "Found sufficient psql version = ${PSQL_VERSION}"
     else
         echo ""
-        echo -e "\e[31mERROR: psql not found or insufficient version ${PSQL_VERSION}. Please install psql>=${MIN_REQUIRED_MAJOR_VERSION}\e[0m"
+        if [[ -z "$PSQL_VERSION" ]]; then
+            echo -e "\e[31mERROR: psql not found. Please install psql version >= ${MIN_REQUIRED_MAJOR_VERSION}.\e[0m"
+        else
+            # If psql is found but version is less than min required version
+            echo -e "\e[31mERROR: psql version ${PSQL_VERSION} is insufficient. Please install psql>=${MIN_REQUIRED_MAJOR_VERSION}\e[0m"
+        fi
         psql_wrong_version=1
     fi
 }

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -461,6 +461,9 @@ centos_main() {
         if { [ ${#centos_missing_yum_packages[@]} -ne 0 ] || [ ${#missing_cpan_modules[@]} -ne 0 ] || [ "$binutils_wrong_version" -eq 1 ] || [ "$java_wrong_version" -eq 1 ] || [ "$pg_dump_wrong_version" -eq 1 ] || [ "$pg_restore_wrong_version" -eq 1 ] || [ "$psql_wrong_version" -eq 1 ]; } && [ "$FORCE_INSTALL" = "false" ]; then 
             echo ""
             echo -e "\e[33mThe script searches for specific package names only. If similar packages are not detected but are present and deemed reliable, use --force-install to install Voyager.\e[0m"
+            if [ "$CHECK_ONLY_DEPENDENCIES" = "true" ]; then
+                exit 0
+            fi
             exit 1
         fi
 

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -527,12 +527,12 @@ centos_main() {
         echo -e "\e[31mERROR: perl-DBD-MySQL did not get installed.\e[0m"
         exit 1
     fi
-    # sudo yum install -y -q perl-DBD-Oracle*.rpm 1>&2
-    # if [ $? -ne 0 ]; then
-    #     echo ""
-    #     echo -e "\e[31mERROR: perl-DBD-Oracle did not get installed.\e[0m"
-    #     exit 1
-    # fi
+    sudo yum install -y -q perl-DBD-Oracle*.rpm 1>&2
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo -e "\e[31mERROR: perl-DBD-Oracle did not get installed.\e[0m"
+        exit 1
+    fi
 
     echo "Installing ora2pg..."
     sudo yum install -y -q ora2pg*.noarch.rpm 1>&2 

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -344,13 +344,13 @@ check_java() {
 }
 
 get_passed_options() {
-	OPTS=$(getopt -o "dfhpmo", --long check-only-dependencies,force-install,pg-only,oracle-only,mysql-only,help --name 'install-voyager-airgapped' -- $ARGS_LINUX)
+	OPTS=$(getopt -o "dfhpmo", --long check-dependencies-only,force-install,pg-only,oracle-only,mysql-only,help --name 'install-voyager-airgapped' -- $ARGS_LINUX)
 
 	eval set -- "$OPTS"
 
 	while true; do
 		case "$1" in
-			-d | --check-only-dependencies ) 
+			-d | --check-dependencies-only ) 
 				CHECK_ONLY_DEPENDENCIES="true";
 				shift
 				;;
@@ -373,7 +373,7 @@ get_passed_options() {
             -h | --help )
                 echo "Usage: $0 [options]"
                 echo "Options:"
-                echo "  -d, --check-only-dependencies  Check only dependencies and exit."
+                echo "  -d, --check-dependencies-only  Check only dependencies and exit."
                 echo "  -f, --force-install            Force install packages without checking dependencies."
                 echo "  -h, --help                     Display this help message."
                 echo "  -p, --pg-only                  Install and check only PostgreSQL related packages."

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -565,7 +565,7 @@ centos_main() {
             packages_to_install="cpan modules, ora2pg, debezium, yb-voyager"
         fi
 
-	    echo -n "Do you want to proceed with the installation of packages ($packages_to_install)? [Y/n]: "
+	    echo -n "Do you want to proceed with the installation of packages ($packages_to_install)? [y/n]: "
 	    read yn
 	    case $yn in
 		[Yy]* )
@@ -593,6 +593,7 @@ centos_main() {
 
     if [ "$MYSQL_ONLY" -eq 1 ]; then
         echo "Installing mariadb-connector-c and perl-DBD-MySQL..."
+        echo ""
 
         # sudo yum install -y -q mariadb-connector-c*.rpm 1>&2
         # if [ $? -ne 0 ]; then
@@ -610,6 +611,7 @@ centos_main() {
 
     if [ "$ORACLE_ONLY" -eq 1 ]; then
         echo "Installing perl-DBD-Oracle..."
+        echo ""
 
         # sudo yum install -y -q perl-DBD-Oracle*.rpm 1>&2
         # if [ $? -ne 0 ]; then

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -721,14 +721,12 @@ check_yum_dependencies() {
     for requirement in "${centos_yum_all_db_common_package_requirements[@]}"; do
         IFS='|' read -r package version_type required_version <<< "$requirement"
         check_yum_package_version "$package" "$version_type" "$required_version"
-        echo "Package: $package, version_type: $version_type, required_version: $required_version"
     done
 
     if [ "$MYSQL_ONLY" -eq 1 ]; then
         for requirement in "${centos_yum_mysql_oracle_common_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_yum_package_version "$package" "$version_type" "$required_version"
-            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
 
         for requirement in "${centos_yum_mysql_package_requirements[@]}"; do
@@ -744,7 +742,6 @@ check_yum_dependencies() {
             fi
 
             check_yum_package_version "$package" "$version_type" "$required_version"
-            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
     fi
 
@@ -752,13 +749,11 @@ check_yum_dependencies() {
         for requirement in "${centos_yum_mysql_oracle_common_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_yum_package_version "$package" "$version_type" "$required_version"
-            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
 
         for requirement in "${centos_yum_oracle_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_yum_package_version "$package" "$version_type" "$required_version"
-            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
     fi
 
@@ -958,14 +953,12 @@ check_apt_dependencies() {
     for requirement in "${ubuntu_apt_all_db_common_package_requirements[@]}"; do
         IFS='|' read -r package version_type required_version <<< "$requirement"
         check_apt_package_version "$package" "$version_type" "$required_version"
-        echo "Package: $package, version_type: $version_type, required_version: $required_version"
     done
 
     if [ "$MYSQL_ONLY" -eq 1 ]; then
         for requirement in "${ubuntu_apt_mysql_oracle_common_package_requirements[@]}" "${ubuntu_apt_mysql_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_apt_package_version "$package" "$version_type" "$required_version"
-            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
     fi
 
@@ -973,7 +966,6 @@ check_apt_dependencies() {
         for requirement in "${ubuntu_apt_mysql_oracle_common_package_requirements[@]}" "${ubuntu_apt_oracle_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_apt_package_version "$package" "$version_type" "$required_version"
-            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
     fi
 

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -684,6 +684,9 @@ ubuntu_main() {
         if { [ ${#ubuntu_missing_apt_packages[@]} -ne 0 ] || [ ${#missing_cpan_modules[@]} -ne 0 ] || [ "$binutils_wrong_version" -eq 1 ] || [ "$java_wrong_version" -eq 1 ] || [ "$pg_dump_wrong_version" -eq 1 ] || [ "$pg_restore_wrong_version" -eq 1 ] || [ "$psql_wrong_version" -eq 1 ]; } && [ "$FORCE_INSTALL" = "false" ]; then
             echo ""
             echo -e "\e[33mThe script searches for specific package names only. If similar packages are not detected but are present and deemed reliable, use --force-install to install Voyager.\e[0m"
+            if [ "$CHECK_ONLY_DEPENDENCIES" = "true" ]; then
+                exit 0
+            fi
             exit 1
         fi
     

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -527,12 +527,12 @@ centos_main() {
         echo -e "\e[31mERROR: perl-DBD-MySQL did not get installed.\e[0m"
         exit 1
     fi
-    sudo yum install -y -q perl-DBD-Oracle*.rpm 1>&2
-    if [ $? -ne 0 ]; then
-        echo ""
-        echo -e "\e[31mERROR: perl-DBD-Oracle did not get installed.\e[0m"
-        exit 1
-    fi
+    # sudo yum install -y -q perl-DBD-Oracle*.rpm 1>&2
+    # if [ $? -ne 0 ]; then
+    #     echo ""
+    #     echo -e "\e[31mERROR: perl-DBD-Oracle did not get installed.\e[0m"
+    #     exit 1
+    # fi
 
     echo "Installing ora2pg..."
     sudo yum install -y -q ora2pg*.noarch.rpm 1>&2 

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -581,7 +581,7 @@ centos_main() {
     if [ "$MYSQL_ONLY" -eq 1 ] || [ "$ORACLE_ONLY" -eq 1 ]; then
         echo ""
         echo "Installing cpan modules..."
-        # echo ""
+        echo ""
         # for module_info in "${cpan_modules_requirements[@]}"; do
         #     # Split each entry by '|' to get module details
         #     IFS="|" read -r module_name requirement_type required_version package <<< "$module_info"

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -136,15 +136,15 @@ main() {
 			;;
 	esac
     # Check if yb-voyager is installed using yb-voyager version. Else exit with error and log it too.
-    # echo ""
-    # yb_voyager_version=$(yb-voyager version)
-    # if [ $? -ne 0 ]; then
-    #     echo -e "\e[31mERROR: yb-voyager did not get installed.\e[0m"
-    #     exit 1
-    # else
-    #     echo "yb-voyager version"
-    #     echo "$yb_voyager_version"
-    # fi
+    echo ""
+    yb_voyager_version=$(yb-voyager version)
+    if [ $? -ne 0 ]; then
+        echo -e "\e[31mERROR: yb-voyager did not get installed.\e[0m"
+        exit 1
+    else
+        echo "yb-voyager version"
+        echo "$yb_voyager_version"
+    fi
 }
 
 #=============================================================================
@@ -582,73 +582,73 @@ centos_main() {
         echo ""
         echo "Installing cpan modules..."
         echo ""
-        # for module_info in "${cpan_modules_requirements[@]}"; do
-        #     # Split each entry by '|' to get module details
-        #     IFS="|" read -r module_name requirement_type required_version package <<< "$module_info"
+        for module_info in "${cpan_modules_requirements[@]}"; do
+            # Split each entry by '|' to get module details
+            IFS="|" read -r module_name requirement_type required_version package <<< "$module_info"
         
-        #     # Call the install function with module details
-        #     install_perl_module "$module_name" "$requirement_type" "$required_version" "$package"
-        # done
+            # Call the install function with module details
+            install_perl_module "$module_name" "$requirement_type" "$required_version" "$package"
+        done
     fi
 
     if [ "$MYSQL_ONLY" -eq 1 ]; then
         echo "Installing mariadb-connector-c and perl-DBD-MySQL..."
         echo ""
 
-        # sudo yum install -y -q mariadb-connector-c*.rpm 1>&2
-        # if [ $? -ne 0 ]; then
-        #     echo ""
-        #     echo -e "\e[31mERROR: mariadb-connector-c did not get installed.\e[0m"
-        #     exit 1
-        # fi
-        # sudo yum install -y -q perl-DBD-MySQL*.rpm 1>&2
-        # if [ $? -ne 0 ]; then
-        #     echo ""
-        #     echo -e "\e[31mERROR: perl-DBD-MySQL did not get installed.\e[0m"
-        #     exit 1
-        # fi
+        sudo yum install -y -q mariadb-connector-c*.rpm 1>&2
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo -e "\e[31mERROR: mariadb-connector-c did not get installed.\e[0m"
+            exit 1
+        fi
+        sudo yum install -y -q perl-DBD-MySQL*.rpm 1>&2
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo -e "\e[31mERROR: perl-DBD-MySQL did not get installed.\e[0m"
+            exit 1
+        fi
     fi
 
     if [ "$ORACLE_ONLY" -eq 1 ]; then
         echo "Installing perl-DBD-Oracle..."
         echo ""
 
-        # sudo yum install -y -q perl-DBD-Oracle*.rpm 1>&2
-        # if [ $? -ne 0 ]; then
-        #     echo ""
-        #     echo -e "\e[31mERROR: perl-DBD-Oracle did not get installed.\e[0m"
-        #     exit 1
-        # fi
+        sudo yum install -y -q perl-DBD-Oracle*.rpm 1>&2
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo -e "\e[31mERROR: perl-DBD-Oracle did not get installed.\e[0m"
+            exit 1
+        fi
     fi
 
     # Install ora2pg only if MYSQL_ONLY or ORACLE_ONLY is 1
     if [ "$MYSQL_ONLY" -eq 1 ] || [ "$ORACLE_ONLY" -eq 1 ]; then
         echo "Installing ora2pg..."
-        # sudo yum install -y -q ora2pg*.noarch.rpm 1>&2 
-        # if [ $? -ne 0 ]; then
-        #     echo ""
-        #     echo -e "\e[31mERROR: ora2pg did not get installed.\e[0m"
-        #     exit 1
-        # fi
+        sudo yum install -y -q ora2pg*.noarch.rpm 1>&2 
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo -e "\e[31mERROR: ora2pg did not get installed.\e[0m"
+            exit 1
+        fi
     fi
     echo ""
     # The package name is like debezium-2.3.3-1.8.0b0111.noarch.rpm. The DEBEZIUM_YUM_VERSION is 2.3.3-1.8.0. Add * to match the version.
     echo "Installing debezium..."
-    # sudo yum install -y -q debezium*.noarch.rpm 1>&2
-    # if [ $? -ne 0 ]; then
-    #     echo ""
-    #     echo -e "\e[31mERROR: debezium did not get installed.\e[0m"
-    #     exit 1
-    # fi
+    sudo yum install -y -q debezium*.noarch.rpm 1>&2
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo -e "\e[31mERROR: debezium did not get installed.\e[0m"
+        exit 1
+    fi
     echo ""
     echo "Installing yb-voyager..."
     # The package name is like yb-voyager-1.8.0-b0111.x86_64.rpm. The YB_VOYAGER_YUM_VERSION is 1.8.0. Add * to match the version.
-    # sudo yum install -y -q yb-voyager*.x86_64.rpm 1>&2
-    # if [ $? -ne 0 ]; then
-    #     echo ""
-    #     echo -e "\e[31mERROR: yb-voyager did not get installed.\e[0m"
-    #     exit 1
-    # fi
+    sudo yum install -y -q yb-voyager*.x86_64.rpm 1>&2
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo -e "\e[31mERROR: yb-voyager did not get installed.\e[0m"
+        exit 1
+    fi
     echo ""
     echo "Installation completed." 
 
@@ -861,13 +861,13 @@ ubuntu_main() {
         echo ""
         echo "Installing cpan modules..."
         echo ""
-        # for module_info in "${cpan_modules_requirements[@]}"; do
-        #     # Split each entry by '|' to get module details
-        #     IFS="|" read -r module_name requirement_type required_version package <<< "$module_info"
+        for module_info in "${cpan_modules_requirements[@]}"; do
+            # Split each entry by '|' to get module details
+            IFS="|" read -r module_name requirement_type required_version package <<< "$module_info"
         
-        #     # Call the install function with module details
-        #     install_perl_module "$module_name" "$requirement_type" "$required_version" "$package"
-        # done
+            # Call the install function with module details
+            install_perl_module "$module_name" "$requirement_type" "$required_version" "$package"
+        done
     fi
 
     if [ "$MYSQL_ONLY" -eq 1 ]; then
@@ -875,12 +875,12 @@ ubuntu_main() {
         echo "Installing libdbd-mysql-perl..."
         echo ""
 
-        # sudo dpkg -i ./libdbd-mysql-perl*.deb 1>&2
-        # if [ $? -ne 0 ]; then
-        #     echo ""
-        #     echo -e "\e[31mERROR: libdbd-mysql-perl did not get installed.\e[0m"
-        #     exit 1
-        # fi
+        sudo dpkg -i ./libdbd-mysql-perl*.deb 1>&2
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo -e "\e[31mERROR: libdbd-mysql-perl did not get installed.\e[0m"
+            exit 1
+        fi
     fi
 
     if [ "$ORACLE_ONLY" -eq 1 ]; then
@@ -888,41 +888,41 @@ ubuntu_main() {
         echo "Installing libdbd-oracle-perl..."
         echo ""
 
-        # sudo dpkg -i ./libdbd-oracle-perl*.deb 1>&2
-        # if [ $? -ne 0 ]; then
-        #     echo ""
-        #     echo -e "\e[31mERROR: libdbd-oracle-perl did not get installed.\e[0m"
-        #     exit 1
-        # fi
+        sudo dpkg -i ./libdbd-oracle-perl*.deb 1>&2
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo -e "\e[31mERROR: libdbd-oracle-perl did not get installed.\e[0m"
+            exit 1
+        fi
     fi
 
     # Install ora2pg if either of ORACLE_ONLY or MYSQL_ONLY is 1
     if [ "$ORACLE_ONLY" -eq 1 ] || [ "$MYSQL_ONLY" -eq 1 ]; then
         echo "Installing ora2pg..."
-        # sudo apt install -y -q ./ora2pg*all.deb 1>&2
-        # if [ $? -ne 0 ]; then
-        #     echo ""
-        #     echo -e "\e[31mERROR: ora2pg did not get installed.\e[0m"
-        #     exit 1
-        # fi
+        sudo apt install -y -q ./ora2pg*all.deb 1>&2
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo -e "\e[31mERROR: ora2pg did not get installed.\e[0m"
+            exit 1
+        fi
     fi
 
     echo ""
     echo "Installing debezium..."
-    # sudo apt install -y -q ./debezium*all.deb 1>&2
-    # if [ $? -ne 0 ]; then
-    #     echo ""
-    #     echo -e "\e[31mERROR: debezium did not get installed.\e[0m"
-    #     exit 1
-    # fi
+    sudo apt install -y -q ./debezium*all.deb 1>&2
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo -e "\e[31mERROR: debezium did not get installed.\e[0m"
+        exit 1
+    fi
     echo ""
     echo "Installing yb-voyager..."
-    # sudo apt install -y -q ./yb-voyager*amd64.deb 1>&2
-    # if [ $? -ne 0 ]; then
-    #     echo ""
-    #     echo -e "\e[31mERROR: yb-voyager did not get installed.\e[0m"
-    #     exit 1
-    # fi
+    sudo apt install -y -q ./yb-voyager*amd64.deb 1>&2
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo -e "\e[31mERROR: yb-voyager did not get installed.\e[0m"
+        exit 1
+    fi
     echo ""
     echo "Installation completed."
 

--- a/installer_scripts/install-voyager-airgapped.sh
+++ b/installer_scripts/install-voyager-airgapped.sh
@@ -719,12 +719,14 @@ check_yum_dependencies() {
     for requirement in "${centos_yum_all_db_common_package_requirements[@]}"; do
         IFS='|' read -r package version_type required_version <<< "$requirement"
         check_yum_package_version "$package" "$version_type" "$required_version"
+        echo "Package: $package, version_type: $version_type, required_version: $required_version"
     done
 
     if [ "$MYSQL_ONLY" -eq 1 ]; then
         for requirement in "${centos_yum_mysql_oracle_common_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_yum_package_version "$package" "$version_type" "$required_version"
+            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
 
         for requirement in "${centos_yum_mysql_package_requirements[@]}"; do
@@ -740,6 +742,7 @@ check_yum_dependencies() {
             fi
 
             check_yum_package_version "$package" "$version_type" "$required_version"
+            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
     fi
 
@@ -747,11 +750,13 @@ check_yum_dependencies() {
         for requirement in "${centos_yum_mysql_oracle_common_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_yum_package_version "$package" "$version_type" "$required_version"
+            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
 
         for requirement in "${centos_yum_oracle_package_requirements[@]}"; do
             IFS='|' read -r package version_type required_version <<< "$requirement"
             check_yum_package_version "$package" "$version_type" "$required_version"
+            echo "Package: $package, version_type: $version_type, required_version: $required_version"
         done
     fi
 


### PR DESCRIPTION
### Describe the changes in this pull request
There was a requirement to install and check only database specifc dependencies in the airgapped installation.
In response to that added three new flags:
```
--pg-only: Installs and checks only PG related dependencies
--oracle-only: Installs and checks only Oracle related dependencies
--mysql-only: Installs and checks only Mysql related dependencies
```
These flags work in combination with other previous flags as well like --check-only and --help
At a time only one of the three flags can be provided. Morover, if no flag is provided then dependencies related to all the databases are checked and installed.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
- Changes in the dependencies being checked and installed when database specific flags are provided.
- The previous flag --check-only-dependencies  has been changed to --check-dependencies-only

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
