### PR TITLE
Move Sizing and TableIndexStats fields out of  in AssessmentYugabyteD payload before deprecating completely

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -500,6 +500,7 @@ func createMigrationAssessmentCompletedEvent() *cp.MigrationAssessmentCompletedE
 		ConversionIssues: schemaAnalysisReport.Issues,
 		Sizing:           assessmentReport.Sizing,
 		TableIndexStats:  assessmentReport.TableIndexStats,
+		Notes:            assessmentReport.Notes,
 		AssessmentJsonReport: AssessmentReportYugabyteD{
 			VoyagerVersion:             assessmentReport.VoyagerVersion,
 			TargetDBVersion:            assessmentReport.TargetDBVersion,

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -498,6 +498,8 @@ func createMigrationAssessmentCompletedEvent() *cp.MigrationAssessmentCompletedE
 			TotalShardedSize:   totalShardedSize,
 		},
 		ConversionIssues: schemaAnalysisReport.Issues,
+		Sizing:           assessmentReport.Sizing,
+		TableIndexStats:  assessmentReport.TableIndexStats,
 		AssessmentJsonReport: AssessmentReportYugabyteD{
 			VoyagerVersion:             assessmentReport.VoyagerVersion,
 			TargetDBVersion:            assessmentReport.TargetDBVersion,

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1137,6 +1137,7 @@ Version History
 1.0: Introduced AssessmentIssue field for storing assessment issues in flattened format
 1.1: Added TargetDBVersion and AssessmentIssueYugabyteD.MinimumVersionFixedIn
 1.2: Syncing it with original AssessmentIssue(adding fields Category, CategoryDescription, Type, Name, Description, Impact, ObjectType) and MigrationComplexityExplanation;
+1.3: Moved Sizing, TableIndexStats, Notes, fields out from depcreated AssessmentJsonReport field to top level struct
 */
 var ASSESS_MIGRATION_YBD_PAYLOAD_VERSION = "1.2"
 
@@ -1155,7 +1156,8 @@ type AssessMigrationPayload struct {
 	ConversionIssues               []utils.AnalyzeSchemaIssue
 	Sizing                         *migassessment.SizingAssessmentReport
 	TableIndexStats                *[]migassessment.TableIndexStats
-	// Depreacted: AssessmentJsonReport is depricated; use the fields directly inside struct
+	Notes                          []string
+	// Depreacted: AssessmentJsonReport is deprecated; use the fields directly inside struct
 	AssessmentJsonReport AssessmentReportYugabyteD
 }
 
@@ -1176,6 +1178,7 @@ type AssessmentIssueYugabyteD struct {
 	Details json.RawMessage `json:"Details,omitempty"`
 }
 
+// To be deprecated in future
 type AssessmentReportYugabyteD struct {
 	VoyagerVersion             string                                `json:"VoyagerVersion"`
 	TargetDBVersion            *ybversion.YBVersion                  `json:"TargetDBVersion"`

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1139,7 +1139,7 @@ Version History
 1.2: Syncing it with original AssessmentIssue(adding fields Category, CategoryDescription, Type, Name, Description, Impact, ObjectType) and MigrationComplexityExplanation;
 1.3: Moved Sizing, TableIndexStats, Notes, fields out from depcreated AssessmentJsonReport field to top level struct
 */
-var ASSESS_MIGRATION_YBD_PAYLOAD_VERSION = "1.2"
+var ASSESS_MIGRATION_YBD_PAYLOAD_VERSION = "1.3"
 
 // TODO: decouple this struct from utils.AnalyzeSchemaIssue struct, right now its tightly coupled;
 // Similarly for migassessment.SizingAssessmentReport and migassessment.TableIndexStats

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1140,6 +1140,8 @@ Version History
 */
 var ASSESS_MIGRATION_YBD_PAYLOAD_VERSION = "1.2"
 
+// TODO: decouple this struct from utils.AnalyzeSchemaIssue struct, right now its tightly coupled;
+// Similarly for migassessment.SizingAssessmentReport and migassessment.TableIndexStats
 type AssessMigrationPayload struct {
 	PayloadVersion                 string
 	VoyagerVersion                 string
@@ -1151,6 +1153,8 @@ type AssessMigrationPayload struct {
 	SourceSizeDetails              SourceDBSizeDetails
 	TargetRecommendations          TargetSizingRecommendations
 	ConversionIssues               []utils.AnalyzeSchemaIssue
+	Sizing                         *migassessment.SizingAssessmentReport
+	TableIndexStats                *[]migassessment.TableIndexStats
 	// Depreacted: AssessmentJsonReport is depricated; use the fields directly inside struct
 	AssessmentJsonReport AssessmentReportYugabyteD
 }


### PR DESCRIPTION
### Describe the changes in this pull request



### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
