### PR TITLE
Send information about control plane usage in the migration to callhome

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1264,8 +1264,8 @@ func packAndSendAnalyzeSchemaPayload(status string, errorMsg string) {
 			dbObject.Details = "" // not useful, either static or sometimes sensitive(oracle indexes) information
 			return dbObject
 		})),
-		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ControlPlaneType: getControlPlaneType(),
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(analyzePayload)

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1264,8 +1264,8 @@ func packAndSendAnalyzeSchemaPayload(status string, errorMsg string) {
 			dbObject.Details = "" // not useful, either static or sometimes sensitive(oracle indexes) information
 			return dbObject
 		})),
-		Error: callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
+		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(analyzePayload)

--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1265,6 +1265,7 @@ func packAndSendAnalyzeSchemaPayload(status string, errorMsg string) {
 			return dbObject
 		})),
 		Error: callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(analyzePayload)

--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -79,8 +79,9 @@ func packAndSendAssessMigrationBulkPayload(status string, errorMsg string) {
 		bulkAssessmentDBConfigs[i].Password = ""
 	}
 	assessMigBulkPayload := callhome.AssessMigrationBulkPhasePayload{
-		FleetConfigCount: len(bulkAssessmentDBConfigs),
-		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		FleetConfigCount:  len(bulkAssessmentDBConfigs),
+		Error:             callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(assessMigBulkPayload)

--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -79,9 +79,9 @@ func packAndSendAssessMigrationBulkPayload(status string, errorMsg string) {
 		bulkAssessmentDBConfigs[i].Password = ""
 	}
 	assessMigBulkPayload := callhome.AssessMigrationBulkPhasePayload{
-		FleetConfigCount:   len(bulkAssessmentDBConfigs),
-		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		FleetConfigCount: len(bulkAssessmentDBConfigs),
+		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ControlPlaneType: getControlPlaneType(),
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(assessMigBulkPayload)

--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -79,9 +79,9 @@ func packAndSendAssessMigrationBulkPayload(status string, errorMsg string) {
 		bulkAssessmentDBConfigs[i].Password = ""
 	}
 	assessMigBulkPayload := callhome.AssessMigrationBulkPhasePayload{
-		FleetConfigCount:  len(bulkAssessmentDBConfigs),
-		Error:             callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
+		FleetConfigCount:   len(bulkAssessmentDBConfigs),
+		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(assessMigBulkPayload)

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -212,7 +212,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		IndexSizingStats:               callhome.MarshalledJsonString(indexSizingStats),
 		SourceConnectivity:             assessmentMetadataDirFlag == "",
 		IopsInterval:                   intervalForCapturingIOPS,
-		YugabyteDUIEnable:              getControlPlaneType() == YUGABYTED,
+		YugabyteDUIEnabled:             getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(assessPayload)

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -212,7 +212,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		IndexSizingStats:               callhome.MarshalledJsonString(indexSizingStats),
 		SourceConnectivity:             assessmentMetadataDirFlag == "",
 		IopsInterval:                   intervalForCapturingIOPS,
-		YugabyteDUIEnabled:             getControlPlaneType() == YUGABYTED,
+		ControlPlaneType:               getControlPlaneType(),
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(assessPayload)

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -212,6 +212,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg string) {
 		IndexSizingStats:               callhome.MarshalledJsonString(indexSizingStats),
 		SourceConnectivity:             assessmentMetadataDirFlag == "",
 		IopsInterval:                   intervalForCapturingIOPS,
+		YugabyteDUIEnable:              getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(assessPayload)

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -120,6 +120,7 @@ func packAndSendEndMigrationPayload(status string, errorMsg string) {
 		BackupSchemaFiles:    bool(backupSchemaFiles),
 		SaveMigrationReports: bool(saveMigrationReports),
 		Error:                callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable:    getControlPlaneType() == YUGABYTED,
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(endMigrationPayload)
 	payload.Status = status

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -120,7 +120,7 @@ func packAndSendEndMigrationPayload(status string, errorMsg string) {
 		BackupSchemaFiles:    bool(backupSchemaFiles),
 		SaveMigrationReports: bool(saveMigrationReports),
 		Error:                callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable:    getControlPlaneType() == YUGABYTED,
+		YugabyteDUIEnabled:   getControlPlaneType() == YUGABYTED,
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(endMigrationPayload)
 	payload.Status = status

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -120,7 +120,7 @@ func packAndSendEndMigrationPayload(status string, errorMsg string) {
 		BackupSchemaFiles:    bool(backupSchemaFiles),
 		SaveMigrationReports: bool(saveMigrationReports),
 		Error:                callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled:   getControlPlaneType() == YUGABYTED,
+		ControlPlaneType:     getControlPlaneType(),
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(endMigrationPayload)
 	payload.Status = status

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -180,10 +180,10 @@ func packAndSendExportDataPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = EXPORT_DATA_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs:      int64(source.NumConnections),
-		StartClean:        bool(startClean),
-		Error:             callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:       int64(source.NumConnections),
+		StartClean:         bool(startClean),
+		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 
 	updateExportSnapshotDataStatsInPayload(&exportDataPayload)

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -180,10 +180,10 @@ func packAndSendExportDataPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = EXPORT_DATA_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs:       int64(source.NumConnections),
-		StartClean:         bool(startClean),
-		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:     int64(source.NumConnections),
+		StartClean:       bool(startClean),
+		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ControlPlaneType: getControlPlaneType(),
 	}
 
 	updateExportSnapshotDataStatsInPayload(&exportDataPayload)

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -180,9 +180,10 @@ func packAndSendExportDataPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = EXPORT_DATA_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs: int64(source.NumConnections),
-		StartClean:   bool(startClean),
-		Error:        callhome.SanitizeErrorMsg(errorMsg),
+		ParallelJobs:      int64(source.NumConnections),
+		StartClean:        bool(startClean),
+		Error:             callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
 	}
 
 	updateExportSnapshotDataStatsInPayload(&exportDataPayload)

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -135,10 +135,10 @@ func packAndSendExportDataFromTargetPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = EXPORT_DATA_FROM_TARGET_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs:       int64(source.NumConnections),
-		StartClean:         bool(startClean),
-		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:     int64(source.NumConnections),
+		StartClean:       bool(startClean),
+		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ControlPlaneType: getControlPlaneType(),
 	}
 
 	exportDataPayload.Phase = exportPhase

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -135,9 +135,10 @@ func packAndSendExportDataFromTargetPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = EXPORT_DATA_FROM_TARGET_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs: int64(source.NumConnections),
-		StartClean:   bool(startClean),
-		Error:        callhome.SanitizeErrorMsg(errorMsg),
+		ParallelJobs:      int64(source.NumConnections),
+		StartClean:        bool(startClean),
+		Error:             callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
 	}
 
 	exportDataPayload.Phase = exportPhase

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -135,10 +135,10 @@ func packAndSendExportDataFromTargetPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = EXPORT_DATA_FROM_TARGET_PHASE
 	exportDataPayload := callhome.ExportDataPhasePayload{
-		ParallelJobs:      int64(source.NumConnections),
-		StartClean:        bool(startClean),
-		Error:             callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:       int64(source.NumConnections),
+		StartClean:         bool(startClean),
+		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 
 	exportDataPayload.Phase = exportPhase

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -212,7 +212,7 @@ func packAndSendExportSchemaPayload(status string, errorMsg string) {
 		UseOrafce:              bool(source.UseOrafce),
 		CommentsOnObjects:      bool(source.CommentsOnObjects),
 		Error:                  callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled:     getControlPlaneType() == YUGABYTED,
+		ControlPlaneType:       getControlPlaneType(),
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(exportSchemaPayload)

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -212,7 +212,7 @@ func packAndSendExportSchemaPayload(status string, errorMsg string) {
 		UseOrafce:              bool(source.UseOrafce),
 		CommentsOnObjects:      bool(source.CommentsOnObjects),
 		Error:                  callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable:      getControlPlaneType() == YUGABYTED,
+		YugabyteDUIEnabled:     getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(exportSchemaPayload)

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -212,6 +212,7 @@ func packAndSendExportSchemaPayload(status string, errorMsg string) {
 		UseOrafce:              bool(source.UseOrafce),
 		CommentsOnObjects:      bool(source.CommentsOnObjects),
 		Error:                  callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable:      getControlPlaneType() == YUGABYTED,
 	}
 
 	payload.PhasePayload = callhome.MarshalledJsonString(exportSchemaPayload)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -965,11 +965,11 @@ func packAndSendImportDataPayload(status string, errorMsg string) {
 	payload.TargetDBDetails = callhome.MarshalledJsonString(targetDBDetails)
 	payload.MigrationPhase = IMPORT_DATA_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:      int64(tconf.Parallelism),
-		StartClean:        bool(startClean),
-		EnableUpsert:      bool(tconf.EnableUpsert),
-		Error:             callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:       int64(tconf.Parallelism),
+		StartClean:         bool(startClean),
+		EnableUpsert:       bool(tconf.EnableUpsert),
+		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 
 	//Getting the imported snapshot details

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -965,11 +965,11 @@ func packAndSendImportDataPayload(status string, errorMsg string) {
 	payload.TargetDBDetails = callhome.MarshalledJsonString(targetDBDetails)
 	payload.MigrationPhase = IMPORT_DATA_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:       int64(tconf.Parallelism),
-		StartClean:         bool(startClean),
-		EnableUpsert:       bool(tconf.EnableUpsert),
-		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:     int64(tconf.Parallelism),
+		StartClean:       bool(startClean),
+		EnableUpsert:     bool(tconf.EnableUpsert),
+		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ControlPlaneType: getControlPlaneType(),
 	}
 
 	//Getting the imported snapshot details

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -965,10 +965,11 @@ func packAndSendImportDataPayload(status string, errorMsg string) {
 	payload.TargetDBDetails = callhome.MarshalledJsonString(targetDBDetails)
 	payload.MigrationPhase = IMPORT_DATA_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs: int64(tconf.Parallelism),
-		StartClean:   bool(startClean),
-		EnableUpsert: bool(tconf.EnableUpsert),
-		Error:        callhome.SanitizeErrorMsg(errorMsg),
+		ParallelJobs:      int64(tconf.Parallelism),
+		StartClean:        bool(startClean),
+		EnableUpsert:      bool(tconf.EnableUpsert),
+		Error:             callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
 	}
 
 	//Getting the imported snapshot details

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -363,7 +363,7 @@ func packAndSendImportDataFilePayload(status string, errorMsg string) {
 		StartClean:         bool(startClean),
 		DataFileParameters: callhome.MarshalledJsonString(dataFileParameters),
 		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		ControlPlaneType: getControlPlaneType(),
 	}
 	switch true {
 	case strings.Contains(dataDir, "s3://"):

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -363,7 +363,7 @@ func packAndSendImportDataFilePayload(status string, errorMsg string) {
 		StartClean:         bool(startClean),
 		DataFileParameters: callhome.MarshalledJsonString(dataFileParameters),
 		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable:  getControlPlaneType() == YUGABYTED,
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 	switch true {
 	case strings.Contains(dataDir, "s3://"):

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -363,6 +363,7 @@ func packAndSendImportDataFilePayload(status string, errorMsg string) {
 		StartClean:         bool(startClean),
 		DataFileParameters: callhome.MarshalledJsonString(dataFileParameters),
 		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable:  getControlPlaneType() == YUGABYTED,
 	}
 	switch true {
 	case strings.Contains(dataDir, "s3://"):

--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -97,7 +97,7 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg string) {
 	payload.MigrationType = LIVE_MIGRATION
 
 	sourceDBDetails := callhome.SourceDBDetails{
-		DBType:    tconf.TargetDBType,
+		DBType: tconf.TargetDBType,
 	}
 	if targetDBDetails != nil {
 		sourceDBDetails.DBVersion = targetDBDetails.DBVersion
@@ -106,10 +106,11 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = IMPORT_DATA_SOURCE_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:     int64(tconf.Parallelism),
-		StartClean:       bool(startClean),
-		LiveWorkflowType: FALL_BACK,
-		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ParallelJobs:      int64(tconf.Parallelism),
+		StartClean:        bool(startClean),
+		LiveWorkflowType:  FALL_BACK,
+		Error:             callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
 	}
 
 	importDataPayload.Phase = importPhase

--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -106,11 +106,11 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = IMPORT_DATA_SOURCE_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:       int64(tconf.Parallelism),
-		StartClean:         bool(startClean),
-		LiveWorkflowType:   FALL_BACK,
-		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:     int64(tconf.Parallelism),
+		StartClean:       bool(startClean),
+		LiveWorkflowType: FALL_BACK,
+		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ControlPlaneType: getControlPlaneType(),
 	}
 
 	importDataPayload.Phase = importPhase

--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -106,11 +106,11 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = IMPORT_DATA_SOURCE_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:      int64(tconf.Parallelism),
-		StartClean:        bool(startClean),
-		LiveWorkflowType:  FALL_BACK,
-		Error:             callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:       int64(tconf.Parallelism),
+		StartClean:         bool(startClean),
+		LiveWorkflowType:   FALL_BACK,
+		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 
 	importDataPayload.Phase = importPhase

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -110,11 +110,11 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = IMPORT_DATA_SOURCE_REPLICA_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:       int64(tconf.Parallelism),
-		StartClean:         bool(startClean),
-		LiveWorkflowType:   FALL_FORWARD,
-		Error:              callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:     int64(tconf.Parallelism),
+		StartClean:       bool(startClean),
+		LiveWorkflowType: FALL_FORWARD,
+		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ControlPlaneType: getControlPlaneType(),
 	}
 	importRowsMap, err := getImportedSnapshotRowsMap("source-replica")
 	if err != nil {

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -110,10 +110,11 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = IMPORT_DATA_SOURCE_REPLICA_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:     int64(tconf.Parallelism),
-		StartClean:       bool(startClean),
-		LiveWorkflowType: FALL_FORWARD,
-		Error:            callhome.SanitizeErrorMsg(errorMsg),
+		ParallelJobs:      int64(tconf.Parallelism),
+		StartClean:        bool(startClean),
+		LiveWorkflowType:  FALL_FORWARD,
+		Error:             callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
 	}
 	importRowsMap, err := getImportedSnapshotRowsMap("source-replica")
 	if err != nil {

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -110,11 +110,11 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg string) {
 
 	payload.MigrationPhase = IMPORT_DATA_SOURCE_REPLICA_PHASE
 	importDataPayload := callhome.ImportDataPhasePayload{
-		ParallelJobs:      int64(tconf.Parallelism),
-		StartClean:        bool(startClean),
-		LiveWorkflowType:  FALL_FORWARD,
-		Error:             callhome.SanitizeErrorMsg(errorMsg),
-		YugabyteDUIEnable: getControlPlaneType() == YUGABYTED,
+		ParallelJobs:       int64(tconf.Parallelism),
+		StartClean:         bool(startClean),
+		LiveWorkflowType:   FALL_FORWARD,
+		Error:              callhome.SanitizeErrorMsg(errorMsg),
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 	importRowsMap, err := getImportedSnapshotRowsMap("source-replica")
 	if err != nil {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -293,7 +293,7 @@ func packAndSendImportSchemaPayload(status string, errMsg string) {
 		PostSnapshotImport: bool(flagPostSnapshotImport),
 		StartClean:         bool(startClean),
 		Error:              callhome.SanitizeErrorMsg(errMsg),
-		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
+		ControlPlaneType:   getControlPlaneType(),
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(importSchemaPayload)
 	err := callhome.SendPayload(&payload)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -293,7 +293,7 @@ func packAndSendImportSchemaPayload(status string, errMsg string) {
 		PostSnapshotImport: bool(flagPostSnapshotImport),
 		StartClean:         bool(startClean),
 		Error:              callhome.SanitizeErrorMsg(errMsg),
-		YugabyteDUIEnable:  getControlPlaneType() == YUGABYTED,
+		YugabyteDUIEnabled: getControlPlaneType() == YUGABYTED,
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(importSchemaPayload)
 	err := callhome.SendPayload(&payload)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -293,6 +293,7 @@ func packAndSendImportSchemaPayload(status string, errMsg string) {
 		PostSnapshotImport: bool(flagPostSnapshotImport),
 		StartClean:         bool(startClean),
 		Error:              callhome.SanitizeErrorMsg(errMsg),
+		YugabyteDUIEnable:  getControlPlaneType() == YUGABYTED,
 	}
 	payload.PhasePayload = callhome.MarshalledJsonString(importSchemaPayload)
 	err := callhome.SendPayload(&payload)

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -112,6 +112,7 @@ type AssessMigrationPhasePayload struct {
 	IndexSizingStats               string                    `json:"index_sizing_stats"`
 	SourceConnectivity             bool                      `json:"source_connectivity"`
 	IopsInterval                   int64                     `json:"iops_interval"`
+	YugabyteDUIEnable              bool                      `json:"yugabyted_ui_enable"`
 }
 
 type AssessmentIssueCallhome struct {
@@ -145,8 +146,9 @@ type ObjectSizingStats struct {
 }
 
 type AssessMigrationBulkPhasePayload struct {
-	FleetConfigCount int    `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
-	Error            string `json:"error"`
+	FleetConfigCount  int    `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
+	Error             string `json:"error"`
+	YugabyteDUIEnable bool   `json:"yugabyted_ui_enable"`
 }
 
 type ExportSchemaPhasePayload struct {
@@ -155,6 +157,7 @@ type ExportSchemaPhasePayload struct {
 	UseOrafce              bool   `json:"use_orafce"`
 	CommentsOnObjects      bool   `json:"comments_on_objects"`
 	Error                  string `json:"error"`
+	YugabyteDUIEnable      bool   `json:"yugabyted_ui_enable"`
 }
 
 var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
@@ -162,11 +165,12 @@ var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
 // SHOULD NOT REMOVE THESE TWO (issues, database_objects) FIELDS of AnalyzePhasePayload as parsing these specifically here
 // https://github.com/yugabyte/yugabyte-growth/blob/ad5df306c50c05136df77cd6548a1091ae577046/diagnostics_v2/main.py#L563
 type AnalyzePhasePayload struct {
-	PayloadVersion  string                 `json:"payload_version"`
-	TargetDBVersion *ybversion.YBVersion   `json:"target_db_version"`
-	Issues          []AnalyzeIssueCallhome `json:"issues"`
-	DatabaseObjects string                 `json:"database_objects"`
-	Error           string                 `json:"error"`
+	PayloadVersion    string                 `json:"payload_version"`
+	TargetDBVersion   *ybversion.YBVersion   `json:"target_db_version"`
+	Issues            []AnalyzeIssueCallhome `json:"issues"`
+	DatabaseObjects   string                 `json:"database_objects"`
+	Error             string                 `json:"error"`
+	YugabyteDUIEnable bool                   `json:"yugabyted_ui_enable"`
 }
 
 type AnalyzeIssueCallhome struct {
@@ -190,6 +194,7 @@ type ExportDataPhasePayload struct {
 	EventsExportRate    int64  `json:"events_export_rate_3m,omitempty"`
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	Error               string `json:"error"`
+	YugabyteDUIEnable   bool   `json:"yugabyted_ui_enable"`
 }
 
 type ImportSchemaPhasePayload struct {
@@ -201,6 +206,7 @@ type ImportSchemaPhasePayload struct {
 	PostSnapshotImport bool   `json:"post_snapshot_import"`
 	StartClean         bool   `json:"start_clean"`
 	Error              string `json:"error"`
+	YugabyteDUIEnable  bool   `json:"yugabyted_ui_enable"`
 }
 
 type ImportDataPhasePayload struct {
@@ -215,6 +221,7 @@ type ImportDataPhasePayload struct {
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	EnableUpsert        bool   `json:"enable_upsert"`
 	Error               string `json:"error"`
+	YugabyteDUIEnable   bool   `json:"yugabyted_ui_enable"`
 }
 
 type ImportDataFilePhasePayload struct {
@@ -225,6 +232,7 @@ type ImportDataFilePhasePayload struct {
 	StartClean         bool   `json:"start_clean"`
 	DataFileParameters string `json:"data_file_parameters"`
 	Error              string `json:"error"`
+	YugabyteDUIEnable  bool   `json:"yugabyted_ui_enable"`
 }
 
 type DataFileParameters struct {
@@ -242,6 +250,7 @@ type EndMigrationPhasePayload struct {
 	BackupSchemaFiles    bool   `json:"backup_schema_files"`
 	SaveMigrationReports bool   `json:"save_migration_reports"`
 	Error                string `json:"error"`
+	YugabyteDUIEnable    bool   `json:"yugabyted_ui_enable"`
 }
 
 func MarshalledJsonString[T any](value T) string {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -112,7 +112,7 @@ type AssessMigrationPhasePayload struct {
 	IndexSizingStats               string                    `json:"index_sizing_stats"`
 	SourceConnectivity             bool                      `json:"source_connectivity"`
 	IopsInterval                   int64                     `json:"iops_interval"`
-	YugabyteDUIEnable              bool                      `json:"yugabyted_ui_enable"`
+	YugabyteDUIEnabled             bool                      `json:"yugabyted_ui_enabled"`
 }
 
 type AssessmentIssueCallhome struct {
@@ -146,9 +146,9 @@ type ObjectSizingStats struct {
 }
 
 type AssessMigrationBulkPhasePayload struct {
-	FleetConfigCount  int    `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
-	Error             string `json:"error"`
-	YugabyteDUIEnable bool   `json:"yugabyted_ui_enable"`
+	FleetConfigCount   int    `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
+	Error              string `json:"error"`
+	YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
 }
 
 type ExportSchemaPhasePayload struct {
@@ -157,7 +157,7 @@ type ExportSchemaPhasePayload struct {
 	UseOrafce              bool   `json:"use_orafce"`
 	CommentsOnObjects      bool   `json:"comments_on_objects"`
 	Error                  string `json:"error"`
-	YugabyteDUIEnable      bool   `json:"yugabyted_ui_enable"`
+	YugabyteDUIEnabled     bool   `json:"yugabyted_ui_enabled"`
 }
 
 var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
@@ -165,12 +165,12 @@ var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
 // SHOULD NOT REMOVE THESE TWO (issues, database_objects) FIELDS of AnalyzePhasePayload as parsing these specifically here
 // https://github.com/yugabyte/yugabyte-growth/blob/ad5df306c50c05136df77cd6548a1091ae577046/diagnostics_v2/main.py#L563
 type AnalyzePhasePayload struct {
-	PayloadVersion    string                 `json:"payload_version"`
-	TargetDBVersion   *ybversion.YBVersion   `json:"target_db_version"`
-	Issues            []AnalyzeIssueCallhome `json:"issues"`
-	DatabaseObjects   string                 `json:"database_objects"`
-	Error             string                 `json:"error"`
-	YugabyteDUIEnable bool                   `json:"yugabyted_ui_enable"`
+	PayloadVersion     string                 `json:"payload_version"`
+	TargetDBVersion    *ybversion.YBVersion   `json:"target_db_version"`
+	Issues             []AnalyzeIssueCallhome `json:"issues"`
+	DatabaseObjects    string                 `json:"database_objects"`
+	Error              string                 `json:"error"`
+	YugabyteDUIEnabled bool                   `json:"yugabyted_ui_enabled"`
 }
 
 type AnalyzeIssueCallhome struct {
@@ -194,7 +194,7 @@ type ExportDataPhasePayload struct {
 	EventsExportRate    int64  `json:"events_export_rate_3m,omitempty"`
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	Error               string `json:"error"`
-	YugabyteDUIEnable   bool   `json:"yugabyted_ui_enable"`
+	YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
 }
 
 type ImportSchemaPhasePayload struct {
@@ -206,7 +206,7 @@ type ImportSchemaPhasePayload struct {
 	PostSnapshotImport bool   `json:"post_snapshot_import"`
 	StartClean         bool   `json:"start_clean"`
 	Error              string `json:"error"`
-	YugabyteDUIEnable  bool   `json:"yugabyted_ui_enable"`
+	YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
 }
 
 type ImportDataPhasePayload struct {
@@ -221,7 +221,7 @@ type ImportDataPhasePayload struct {
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	EnableUpsert        bool   `json:"enable_upsert"`
 	Error               string `json:"error"`
-	YugabyteDUIEnable   bool   `json:"yugabyted_ui_enable"`
+	YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
 }
 
 type ImportDataFilePhasePayload struct {
@@ -232,7 +232,7 @@ type ImportDataFilePhasePayload struct {
 	StartClean         bool   `json:"start_clean"`
 	DataFileParameters string `json:"data_file_parameters"`
 	Error              string `json:"error"`
-	YugabyteDUIEnable  bool   `json:"yugabyted_ui_enable"`
+	YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
 }
 
 type DataFileParameters struct {
@@ -250,7 +250,7 @@ type EndMigrationPhasePayload struct {
 	BackupSchemaFiles    bool   `json:"backup_schema_files"`
 	SaveMigrationReports bool   `json:"save_migration_reports"`
 	Error                string `json:"error"`
-	YugabyteDUIEnable    bool   `json:"yugabyted_ui_enable"`
+	YugabyteDUIEnabled   bool   `json:"yugabyted_ui_enabled"`
 }
 
 func MarshalledJsonString[T any](value T) string {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -97,7 +97,7 @@ type TargetDBDetails struct {
 	Cores     int    `json:"total_cores"`
 }
 
-var ASSESS_MIGRATION_CALLHOME_PAYLOAD_VERSION = "1.0"
+var ASSESS_MIGRATION_CALLHOME_PAYLOAD_VERSION = "1.1"
 
 type AssessMigrationPhasePayload struct {
 	PayloadVersion                 string                    `json:"payload_version"`
@@ -112,7 +112,7 @@ type AssessMigrationPhasePayload struct {
 	IndexSizingStats               string                    `json:"index_sizing_stats"`
 	SourceConnectivity             bool                      `json:"source_connectivity"`
 	IopsInterval                   int64                     `json:"iops_interval"`
-	ControlPlaneType               string                      `json:"control_plane_type"`
+	ControlPlaneType               string                    `json:"control_plane_type"`
 }
 
 type AssessmentIssueCallhome struct {
@@ -148,7 +148,7 @@ type ObjectSizingStats struct {
 type AssessMigrationBulkPhasePayload struct {
 	FleetConfigCount int    `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
 	Error            string `json:"error"`
-	ControlPlaneType string   `json:"control_plane_type"`
+	ControlPlaneType string `json:"control_plane_type"`
 }
 
 type ExportSchemaPhasePayload struct {
@@ -157,10 +157,10 @@ type ExportSchemaPhasePayload struct {
 	UseOrafce              bool   `json:"use_orafce"`
 	CommentsOnObjects      bool   `json:"comments_on_objects"`
 	Error                  string `json:"error"`
-	ControlPlaneType       string   `json:"control_plane_type"`
+	ControlPlaneType       string `json:"control_plane_type"`
 }
 
-var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
+var ANALYZE_PHASE_PAYLOAD_VERSION = "1.1"
 
 // SHOULD NOT REMOVE THESE TWO (issues, database_objects) FIELDS of AnalyzePhasePayload as parsing these specifically here
 // https://github.com/yugabyte/yugabyte-growth/blob/ad5df306c50c05136df77cd6548a1091ae577046/diagnostics_v2/main.py#L563
@@ -170,7 +170,7 @@ type AnalyzePhasePayload struct {
 	Issues           []AnalyzeIssueCallhome `json:"issues"`
 	DatabaseObjects  string                 `json:"database_objects"`
 	Error            string                 `json:"error"`
-	ControlPlaneType string                   `json:"control_plane_type"`
+	ControlPlaneType string                 `json:"control_plane_type"`
 }
 
 type AnalyzeIssueCallhome struct {
@@ -194,7 +194,7 @@ type ExportDataPhasePayload struct {
 	EventsExportRate    int64  `json:"events_export_rate_3m,omitempty"`
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	Error               string `json:"error"`
-	ControlPlaneType    string   `json:"control_plane_type"`
+	ControlPlaneType    string `json:"control_plane_type"`
 }
 
 type ImportSchemaPhasePayload struct {
@@ -206,7 +206,7 @@ type ImportSchemaPhasePayload struct {
 	PostSnapshotImport bool   `json:"post_snapshot_import"`
 	StartClean         bool   `json:"start_clean"`
 	Error              string `json:"error"`
-	ControlPlaneType   string   `json:"control_plane_type"`
+	ControlPlaneType   string `json:"control_plane_type"`
 }
 
 type ImportDataPhasePayload struct {
@@ -221,7 +221,7 @@ type ImportDataPhasePayload struct {
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	EnableUpsert        bool   `json:"enable_upsert"`
 	Error               string `json:"error"`
-	ControlPlaneType    string   `json:"control_plane_type"`
+	ControlPlaneType    string `json:"control_plane_type"`
 }
 
 type ImportDataFilePhasePayload struct {
@@ -232,7 +232,7 @@ type ImportDataFilePhasePayload struct {
 	StartClean         bool   `json:"start_clean"`
 	DataFileParameters string `json:"data_file_parameters"`
 	Error              string `json:"error"`
-	ControlPlaneType   string   `json:"control_plane_type"`
+	ControlPlaneType   string `json:"control_plane_type"`
 }
 
 type DataFileParameters struct {
@@ -250,7 +250,7 @@ type EndMigrationPhasePayload struct {
 	BackupSchemaFiles    bool   `json:"backup_schema_files"`
 	SaveMigrationReports bool   `json:"save_migration_reports"`
 	Error                string `json:"error"`
-	ControlPlaneType     string   `json:"control_plane_type"`
+	ControlPlaneType     string `json:"control_plane_type"`
 }
 
 func MarshalledJsonString[T any](value T) string {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -112,7 +112,7 @@ type AssessMigrationPhasePayload struct {
 	IndexSizingStats               string                    `json:"index_sizing_stats"`
 	SourceConnectivity             bool                      `json:"source_connectivity"`
 	IopsInterval                   int64                     `json:"iops_interval"`
-	YugabyteDUIEnabled             bool                      `json:"yugabyted_ui_enabled"`
+	ControlPlaneType               string                      `json:"control_plane_type"`
 }
 
 type AssessmentIssueCallhome struct {
@@ -146,9 +146,9 @@ type ObjectSizingStats struct {
 }
 
 type AssessMigrationBulkPhasePayload struct {
-	FleetConfigCount   int    `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
-	Error              string `json:"error"`
-	YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
+	FleetConfigCount int    `json:"fleet_config_count"` // Not storing any source info just the count of db configs passed to bulk cmd
+	Error            string `json:"error"`
+	ControlPlaneType string   `json:"control_plane_type"`
 }
 
 type ExportSchemaPhasePayload struct {
@@ -157,7 +157,7 @@ type ExportSchemaPhasePayload struct {
 	UseOrafce              bool   `json:"use_orafce"`
 	CommentsOnObjects      bool   `json:"comments_on_objects"`
 	Error                  string `json:"error"`
-	YugabyteDUIEnabled     bool   `json:"yugabyted_ui_enabled"`
+	ControlPlaneType       string   `json:"control_plane_type"`
 }
 
 var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
@@ -165,12 +165,12 @@ var ANALYZE_PHASE_PAYLOAD_VERSION = "1.0"
 // SHOULD NOT REMOVE THESE TWO (issues, database_objects) FIELDS of AnalyzePhasePayload as parsing these specifically here
 // https://github.com/yugabyte/yugabyte-growth/blob/ad5df306c50c05136df77cd6548a1091ae577046/diagnostics_v2/main.py#L563
 type AnalyzePhasePayload struct {
-	PayloadVersion     string                 `json:"payload_version"`
-	TargetDBVersion    *ybversion.YBVersion   `json:"target_db_version"`
-	Issues             []AnalyzeIssueCallhome `json:"issues"`
-	DatabaseObjects    string                 `json:"database_objects"`
-	Error              string                 `json:"error"`
-	YugabyteDUIEnabled bool                   `json:"yugabyted_ui_enabled"`
+	PayloadVersion   string                 `json:"payload_version"`
+	TargetDBVersion  *ybversion.YBVersion   `json:"target_db_version"`
+	Issues           []AnalyzeIssueCallhome `json:"issues"`
+	DatabaseObjects  string                 `json:"database_objects"`
+	Error            string                 `json:"error"`
+	ControlPlaneType string                   `json:"control_plane_type"`
 }
 
 type AnalyzeIssueCallhome struct {
@@ -194,7 +194,7 @@ type ExportDataPhasePayload struct {
 	EventsExportRate    int64  `json:"events_export_rate_3m,omitempty"`
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	Error               string `json:"error"`
-	YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
+	ControlPlaneType    string   `json:"control_plane_type"`
 }
 
 type ImportSchemaPhasePayload struct {
@@ -206,7 +206,7 @@ type ImportSchemaPhasePayload struct {
 	PostSnapshotImport bool   `json:"post_snapshot_import"`
 	StartClean         bool   `json:"start_clean"`
 	Error              string `json:"error"`
-	YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
+	ControlPlaneType   string   `json:"control_plane_type"`
 }
 
 type ImportDataPhasePayload struct {
@@ -221,7 +221,7 @@ type ImportDataPhasePayload struct {
 	LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 	EnableUpsert        bool   `json:"enable_upsert"`
 	Error               string `json:"error"`
-	YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
+	ControlPlaneType    string   `json:"control_plane_type"`
 }
 
 type ImportDataFilePhasePayload struct {
@@ -232,7 +232,7 @@ type ImportDataFilePhasePayload struct {
 	StartClean         bool   `json:"start_clean"`
 	DataFileParameters string `json:"data_file_parameters"`
 	Error              string `json:"error"`
-	YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
+	ControlPlaneType   string   `json:"control_plane_type"`
 }
 
 type DataFileParameters struct {
@@ -250,7 +250,7 @@ type EndMigrationPhasePayload struct {
 	BackupSchemaFiles    bool   `json:"backup_schema_files"`
 	SaveMigrationReports bool   `json:"save_migration_reports"`
 	Error                string `json:"error"`
-	YugabyteDUIEnabled   bool   `json:"yugabyted_ui_enabled"`
+	ControlPlaneType     string   `json:"control_plane_type"`
 }
 
 func MarshalledJsonString[T any](value T) string {

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -88,7 +88,7 @@ func TestCallhomeStructs(t *testing.T) {
 				IndexSizingStats               string                    `json:"index_sizing_stats"`
 				SourceConnectivity             bool                      `json:"source_connectivity"`
 				IopsInterval                   int64                     `json:"iops_interval"`
-				YugabyteDUIEnabled             bool                      `json:"yugabyted_ui_enabled"`
+				ControlPlaneType               string                    `json:"control_plane_type"`
 			}{},
 		},
 		{
@@ -123,9 +123,9 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate AssessMigrationBulkPhasePayload Struct Definition",
 			actualType: reflect.TypeOf(AssessMigrationBulkPhasePayload{}),
 			expectedType: struct {
-				FleetConfigCount   int    `json:"fleet_config_count"`
-				Error              string `json:"error"`
-				YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
+				FleetConfigCount int    `json:"fleet_config_count"`
+				Error            string `json:"error"`
+				ControlPlaneType string `json:"control_plane_type"`
 			}{},
 		},
 		{
@@ -148,19 +148,19 @@ func TestCallhomeStructs(t *testing.T) {
 				UseOrafce              bool   `json:"use_orafce"`
 				CommentsOnObjects      bool   `json:"comments_on_objects"`
 				Error                  string `json:"error"`
-				YugabyteDUIEnabled     bool   `json:"yugabyted_ui_enabled"`
+				ControlPlaneType       string `json:"control_plane_type"`
 			}{},
 		},
 		{
 			name:       "Validate AnalyzePhasePayload Struct Definition",
 			actualType: reflect.TypeOf(AnalyzePhasePayload{}),
 			expectedType: struct {
-				PayloadVersion     string                 `json:"payload_version"`
-				TargetDBVersion    *ybversion.YBVersion   `json:"target_db_version"`
-				Issues             []AnalyzeIssueCallhome `json:"issues"`
-				DatabaseObjects    string                 `json:"database_objects"`
-				Error              string                 `json:"error"`
-				YugabyteDUIEnabled bool                   `json:"yugabyted_ui_enabled"`
+				PayloadVersion   string                 `json:"payload_version"`
+				TargetDBVersion  *ybversion.YBVersion   `json:"target_db_version"`
+				Issues           []AnalyzeIssueCallhome `json:"issues"`
+				DatabaseObjects  string                 `json:"database_objects"`
+				Error            string                 `json:"error"`
+				ControlPlaneType string                 `json:"control_plane_type"`
 			}{},
 		},
 		{
@@ -189,7 +189,7 @@ func TestCallhomeStructs(t *testing.T) {
 				EventsExportRate        int64  `json:"events_export_rate_3m,omitempty"`
 				LiveWorkflowType        string `json:"live_workflow_type,omitempty"`
 				Error                   string `json:"error"`
-				YugabyteDUIEnabled      bool   `json:"yugabyted_ui_enabled"`
+				ControlPlaneType        string `json:"control_plane_type"`
 			}{},
 		},
 		{
@@ -204,7 +204,7 @@ func TestCallhomeStructs(t *testing.T) {
 				PostSnapshotImport bool   `json:"post_snapshot_import"`
 				StartClean         bool   `json:"start_clean"`
 				Error              string `json:"error"`
-				YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
+				ControlPlaneType   string `json:"control_plane_type"`
 			}{},
 		},
 		{
@@ -221,7 +221,7 @@ func TestCallhomeStructs(t *testing.T) {
 				LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 				EnableUpsert        bool   `json:"enable_upsert"`
 				Error               string `json:"error"`
-				YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
+				ControlPlaneType    string `json:"control_plane_type"`
 			}{},
 		},
 		{
@@ -235,7 +235,7 @@ func TestCallhomeStructs(t *testing.T) {
 				StartClean         bool   `json:"start_clean"`
 				DataFileParameters string `json:"data_file_parameters"`
 				Error              string `json:"error"`
-				YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
+				ControlPlaneType   string `json:"control_plane_type"`
 			}{},
 		},
 		{
@@ -259,8 +259,7 @@ func TestCallhomeStructs(t *testing.T) {
 				BackupSchemaFiles    bool   `json:"backup_schema_files"`
 				SaveMigrationReports bool   `json:"save_migration_reports"`
 				Error                string `json:"error"`
-				YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
-
+				ControlPlaneType     string `json:"control_plane_type"`
 			}{},
 		},
 	}

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/ybversion"
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
@@ -87,6 +88,7 @@ func TestCallhomeStructs(t *testing.T) {
 				IndexSizingStats               string                    `json:"index_sizing_stats"`
 				SourceConnectivity             bool                      `json:"source_connectivity"`
 				IopsInterval                   int64                     `json:"iops_interval"`
+				YugabyteDUIEnabled             bool                      `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
@@ -121,8 +123,9 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate AssessMigrationBulkPhasePayload Struct Definition",
 			actualType: reflect.TypeOf(AssessMigrationBulkPhasePayload{}),
 			expectedType: struct {
-				FleetConfigCount int    `json:"fleet_config_count"`
-				Error            string `json:"error"`
+				FleetConfigCount   int    `json:"fleet_config_count"`
+				Error              string `json:"error"`
+				YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
@@ -145,17 +148,19 @@ func TestCallhomeStructs(t *testing.T) {
 				UseOrafce              bool   `json:"use_orafce"`
 				CommentsOnObjects      bool   `json:"comments_on_objects"`
 				Error                  string `json:"error"`
+				YugabyteDUIEnabled     bool   `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
 			name:       "Validate AnalyzePhasePayload Struct Definition",
 			actualType: reflect.TypeOf(AnalyzePhasePayload{}),
 			expectedType: struct {
-				PayloadVersion  string                 `json:"payload_version"`
-				TargetDBVersion *ybversion.YBVersion   `json:"target_db_version"`
-				Issues          []AnalyzeIssueCallhome `json:"issues"`
-				DatabaseObjects string                 `json:"database_objects"`
-				Error           string                 `json:"error"`
+				PayloadVersion     string                 `json:"payload_version"`
+				TargetDBVersion    *ybversion.YBVersion   `json:"target_db_version"`
+				Issues             []AnalyzeIssueCallhome `json:"issues"`
+				DatabaseObjects    string                 `json:"database_objects"`
+				Error              string                 `json:"error"`
+				YugabyteDUIEnabled bool                   `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
@@ -184,6 +189,7 @@ func TestCallhomeStructs(t *testing.T) {
 				EventsExportRate        int64  `json:"events_export_rate_3m,omitempty"`
 				LiveWorkflowType        string `json:"live_workflow_type,omitempty"`
 				Error                   string `json:"error"`
+				YugabyteDUIEnabled      bool   `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
@@ -198,6 +204,7 @@ func TestCallhomeStructs(t *testing.T) {
 				PostSnapshotImport bool   `json:"post_snapshot_import"`
 				StartClean         bool   `json:"start_clean"`
 				Error              string `json:"error"`
+				YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
@@ -214,6 +221,7 @@ func TestCallhomeStructs(t *testing.T) {
 				LiveWorkflowType    string `json:"live_workflow_type,omitempty"`
 				EnableUpsert        bool   `json:"enable_upsert"`
 				Error               string `json:"error"`
+				YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
@@ -227,6 +235,7 @@ func TestCallhomeStructs(t *testing.T) {
 				StartClean         bool   `json:"start_clean"`
 				DataFileParameters string `json:"data_file_parameters"`
 				Error              string `json:"error"`
+				YugabyteDUIEnabled bool   `json:"yugabyted_ui_enabled"`
 			}{},
 		},
 		{
@@ -250,6 +259,8 @@ func TestCallhomeStructs(t *testing.T) {
 				BackupSchemaFiles    bool   `json:"backup_schema_files"`
 				SaveMigrationReports bool   `json:"save_migration_reports"`
 				Error                string `json:"error"`
+				YugabyteDUIEnabled  bool   `json:"yugabyted_ui_enabled"`
+
 			}{},
 		},
 	}


### PR DESCRIPTION
### Describe the changes in this pull request
Added information to phase_payload of every migration_phase about YugabyteD UI enable or not.
fixes - #2388 
### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
no

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
manually
### Does your PR have changes that can cause upgrade issues? 
Added new field to all phase_payloads but its not a breaking change as its a json column
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         |  No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
