### PR TITLE
export schema prompt to nudge user to run assess-migraiton

### DIFF
--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -103,6 +103,7 @@ func AskPrompt(args ...string) bool {
 
 	}
 	fmt.Printf("? [Y/N]: ")
+	log.Infof("Prompt: %s", strings.Join(args, " "))
 
 	_, err := fmt.Scan(&input)
 


### PR DESCRIPTION
### Describe the changes in this pull request
Motivation: A lot of users don't seem to be running assess-migration. We want to nudge users to do so. 
In export-schema, for postgres source type, if user has not run assess-migration, prompt the user to do so. 

### Describe if there are any user-facing changes
<img width="845" alt="image" src="https://github.com/user-attachments/assets/2d7d837f-4a4a-4161-ab09-fc7dfd38d4e7" />


<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
