### PR TITLE
[DB-16201] [Prerequisite] Non Txn Path: Fetching Primary Key Columns as part of ImportBatchArgsProto struct

### DIFF
--- a/yb-voyager/cmd/importDataFileTaskImporter.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter.go
@@ -241,11 +241,17 @@ func createImportDataTableMetrics(tableName string, countLiveRows int64, countTo
 }
 
 func getImportBatchArgsProto(tableNameTup sqlname.NameTuple, filePath string) *tgtdb.ImportBatchArgs {
-	columns, _ := TableToColumnNames.Get(tableNameTup)
-	columns, err := tdb.QuoteAttributeNames(tableNameTup, columns)
+	unquotedColumns, _ := TableToColumnNames.Get(tableNameTup)
+	columns, err := tdb.QuoteAttributeNames(tableNameTup, unquotedColumns)
 	if err != nil {
 		utils.ErrExit("if required quote column names: %s", err)
 	}
+
+	pkColumns, err := tdb.FilterPrimaryKeyColumns(tableNameTup, unquotedColumns)
+	if err != nil {
+		utils.ErrExit("getting primary key columns for table %s: %s", tableNameTup.ForMinOutput(), err)
+	}
+
 	// If `columns` is unset at this point, no attribute list is passed in the COPY command.
 	fileFormat := dataFileDescriptor.FileFormat
 
@@ -256,14 +262,15 @@ func getImportBatchArgsProto(tableNameTup sqlname.NameTuple, filePath string) *t
 		fileFormat = datafile.TEXT
 	}
 	importBatchArgsProto := &tgtdb.ImportBatchArgs{
-		TableNameTup: tableNameTup,
-		Columns:      columns,
-		FileFormat:   fileFormat,
-		Delimiter:    dataFileDescriptor.Delimiter,
-		HasHeader:    dataFileDescriptor.HasHeader && fileFormat == datafile.CSV,
-		QuoteChar:    dataFileDescriptor.QuoteChar,
-		EscapeChar:   dataFileDescriptor.EscapeChar,
-		NullString:   dataFileDescriptor.NullString,
+		TableNameTup:      tableNameTup,
+		Columns:           columns,
+		PrimaryKeyColumns: pkColumns,
+		FileFormat:        fileFormat,
+		Delimiter:         dataFileDescriptor.Delimiter,
+		HasHeader:         dataFileDescriptor.HasHeader && fileFormat == datafile.CSV,
+		QuoteChar:         dataFileDescriptor.QuoteChar,
+		EscapeChar:        dataFileDescriptor.EscapeChar,
+		NullString:        dataFileDescriptor.NullString,
 	}
 	log.Infof("ImportBatchArgs: %v", spew.Sdump(importBatchArgsProto))
 	return importBatchArgsProto

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -175,6 +175,10 @@ func (tdb *TargetOracleDB) CreateVoyagerSchema() error {
 	return nil
 }
 
+func (tdb *TargetOracleDB) FilterPrimaryKeyColumns(table sqlname.NameTuple, columns []string) ([]string, error) {
+	panic("FilterPrimaryKeyColumns not implemented for Oracle")
+}
+
 func (tdb *TargetOracleDB) GetNonEmptyTables(tables []sqlname.NameTuple) []sqlname.NameTuple {
 	result := []sqlname.NameTuple{}
 

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -40,6 +40,7 @@ type TargetDB interface {
 	IsNonRetryableCopyError(err error) bool
 	ImportBatch(batch Batch, args *ImportBatchArgs, exportDir string, tableSchema map[string]map[string]string) (int64, error)
 	QuoteAttributeNames(tableNameTup sqlname.NameTuple, columns []string) ([]string, error)
+	FilterPrimaryKeyColumns(table sqlname.NameTuple, columns []string) ([]string, error)
 	ExecuteBatch(migrationUUID uuid.UUID, batch *EventBatch) error
 	GetListOfTableAttributes(tableNameTup sqlname.NameTuple) ([]string, error)
 	QuoteAttributeName(tableNameTup sqlname.NameTuple, columnName string) (string, error)
@@ -92,9 +93,10 @@ func NewTargetDB(tconf *TargetConf) TargetDB {
 }
 
 type ImportBatchArgs struct {
-	FilePath     string
-	TableNameTup sqlname.NameTuple
-	Columns      []string
+	FilePath          string
+	TableNameTup      sqlname.NameTuple
+	Columns           []string
+	PrimaryKeyColumns []string
 
 	FileFormat string
 	HasHeader  bool

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -399,6 +399,49 @@ outer:
 	return nil
 }
 
+// FilterPrimaryKeyColumns returns the subset of `columns` that belong to the
+// primary‑key definition of the given table.
+func (yb *TargetYugabyteDB) FilterPrimaryKeyColumns(table sqlname.NameTuple, columns []string) ([]string, error) {
+	schemaName, tableName := table.ForCatalogQuery()
+
+	query := fmt.Sprintf(`
+		SELECT a.attname
+		FROM pg_index i
+		JOIN pg_class      c ON c.oid = i.indrelid
+		JOIN pg_namespace  n ON n.oid = c.relnamespace
+		JOIN pg_attribute  a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey)
+		WHERE n.nspname = '%s'
+			AND c.relname  = '%s'
+			AND i.indisprimary;`, schemaName, tableName)
+
+	rows, err := yb.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("query PK columns for %s.%s: %w", schemaName, tableName, err)
+	}
+	defer rows.Close()
+
+	pkSet := make(map[string]struct{})
+	for rows.Next() {
+		var col string
+		if err := rows.Scan(&col); err != nil {
+			return nil, fmt.Errorf("scan PK column: %w", err)
+		}
+		pkSet[col] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	var primaryKeyColumns []string
+	for _, c := range columns {
+		if _, ok := pkSet[c]; ok {
+			primaryKeyColumns = append(primaryKeyColumns, c)
+		}
+	}
+
+	return primaryKeyColumns, nil
+}
+
 func (yb *TargetYugabyteDB) GetNonEmptyTables(tables []sqlname.NameTuple) []sqlname.NameTuple {
 	result := []sqlname.NameTuple{}
 

--- a/yb-voyager/src/tgtdb/yugabytedb_test.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_test.go
@@ -90,6 +90,55 @@ func TestCreateVoyagerSchemaYB(t *testing.T) {
 	}
 }
 
+func TestYugabyteFilterPrimaryKeyColumns(t *testing.T) {
+	testYugabyteDBTarget.ExecuteSqls(
+		`CREATE SCHEMA test_schema;`,
+		`CREATE TABLE test_schema.foo (
+			id INT,
+			category TEXT,
+			name TEXT,
+			PRIMARY KEY (id, category)
+		);`,
+		`CREATE TABLE test_schema.bar (
+			id INT PRIMARY KEY,
+			name TEXT
+		);`,
+		`CREATE TABLE test_schema.baz (
+			id INT,
+			name TEXT
+		);`,
+	)
+	defer testYugabyteDBTarget.ExecuteSqls(`DROP SCHEMA test_schema CASCADE;`)
+
+	tests := []struct {
+		table          sqlname.NameTuple
+		allColumns     []string
+		expectedPKCols []string
+	}{
+		{
+			table:          sqlname.NameTuple{CurrentName: sqlname.NewObjectName(POSTGRESQL, "test_schema", "test_schema", "foo")},
+			allColumns:     []string{"id", "category", "name"},
+			expectedPKCols: []string{"id", "category"},
+		},
+		{
+			table:          sqlname.NameTuple{CurrentName: sqlname.NewObjectName(POSTGRESQL, "test_schema", "test_schema", "bar")},
+			allColumns:     []string{"id", "name"},
+			expectedPKCols: []string{"id"},
+		},
+		{
+			table:          sqlname.NameTuple{CurrentName: sqlname.NewObjectName(POSTGRESQL, "test_schema", "test_schema", "baz")},
+			allColumns:     []string{"id", "name"},
+			expectedPKCols: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		pkCols, err := testYugabyteDBTarget.FilterPrimaryKeyColumns(tt.table, tt.allColumns)
+		assert.NoError(t, err)
+		testutils.AssertEqualStringSlices(t, tt.expectedPKCols, pkCols)
+	}
+}
+
 func TestYugabyteGetNonEmptyTables(t *testing.T) {
 	testYugabyteDBTarget.ExecuteSqls(
 		`CREATE SCHEMA test_schema`,


### PR DESCRIPTION
### Describe the changes in this pull request
https://yugabyte.atlassian.net/browse/DB-16201

- Need the list of Primary Key columns for adding in the `ON CONFLICT(target_list)` clause in the statement for example
```
INSERT ON table (col1, col2, col3...) VALUES (v1, v2, v3...)
    ON CONFLICT (pk1, pk2) DO NOTHING;
```


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Added Unit tests

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
