### PR TITLE
Updated the pg grant permission script to prompt the user for permission before transferring ownership of tables to replication group

### DIFF
--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -156,7 +156,8 @@ GRANT pg_read_all_stats to :voyager_user;
     -- Prompt the user to let them know that ownership of the tables will be transferred to the replication group and proceed only if they confirm
     \echo ''
     \echo 'This script will transfer ownership of all tables in the specified schemas to the specified replication group as required by debezium. User ybvoyager and the original owner of the tables will be added to the replication group.'
-    \prompt 'Proceed? (yes/no): ' proceed
+    -- Only 'yes' or 'no' are valid inputs. 'y' and 'n' are not valid inputs.
+    \prompt 'Proceed with the transfer of ownership? (yes/no): ' proceed
 
     \if :proceed
         \echo 'Proceeding with the transfer of ownership...'

--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -153,6 +153,18 @@ GRANT pg_read_all_stats to :voyager_user;
     \echo '--- Creating Replication Group ---'
     CREATE ROLE :replication_group;
 
+    -- Prompt the user to let them know that ownership of the tables will be transferred to the replication group and proceed only if they confirm
+    \echo ''
+    \echo 'This script will transfer ownership of all tables in the specified schemas to the specified replication group as required by debezium. User ybvoyager and the original owner of the tables will be added to the replication group.'
+    \prompt 'Proceed? (yes/no): ' proceed
+
+    \if :proceed
+        \echo 'Proceeding with the transfer of ownership...'
+    \else
+        \echo 'Aborting the script.'
+        \q
+    \endif
+
     -- Add the original owner of the tables to the group
     \echo ''
     \echo '--- Adding Original Owner to Replication Group ---'

--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -155,7 +155,7 @@ GRANT pg_read_all_stats to :voyager_user;
 
     -- Prompt the user to let them know that ownership of the tables will be transferred to the replication group and proceed only if they confirm
     \echo ''
-    \echo 'This script will transfer ownership of all tables in the specified schemas to the specified replication group. The migration user and the original owner of the tables will be added to the replication group.'
+    \echo 'Transferring ownership of all tables in the specified schemas to the specified replication group. The migration user and the original owner of the tables will be added to the replication group.'
     -- Only 'yes' or 'no' are valid inputs. 'y' and 'n' are not valid inputs.
     \prompt 'Proceed with the transfer of ownership? (yes/no): ' proceed
 

--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -155,7 +155,7 @@ GRANT pg_read_all_stats to :voyager_user;
 
     -- Prompt the user to let them know that ownership of the tables will be transferred to the replication group and proceed only if they confirm
     \echo ''
-    \echo 'This script will transfer ownership of all tables in the specified schemas to the specified replication group as required by debezium. User ybvoyager and the original owner of the tables will be added to the replication group.'
+    \echo 'This script will transfer ownership of all tables in the specified schemas to the specified replication group. The migration user and the original owner of the tables will be added to the replication group.'
     -- Only 'yes' or 'no' are valid inputs. 'y' and 'n' are not valid inputs.
     \prompt 'Proceed with the transfer of ownership? (yes/no): ' proceed
 

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -45,8 +45,10 @@ grant_user_permission_postgresql() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" -v schema_list="${db_schema}" -v is_live_migration=0 -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
-
+	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+                                    -v schema_list="${db_schema}" \
+                                    -v is_live_migration=0 \
+                                    -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
 }
 
 run_pg_restore() {
@@ -156,7 +158,12 @@ grant_permissions_for_live_migration_pg() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" -v schema_list="${db_schema}" -v replication_group='replication_group' -v is_live_migration=1 -v is_live_migration_fall_back=0 -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+                                    -v schema_list="${db_schema}" \
+                                    -v replication_group='replication_group' \
+                                    -v is_live_migration=1 \
+                                    -v is_live_migration_fall_back=0 \
+                                    -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
 }
 
 grant_permissions() {
@@ -677,7 +684,12 @@ setup_fallback_environment() {
 		rm -f $TEMP_SCRIPT
 	    elif [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" -v schema_list="${SOURCE_DB_SCHEMA}" -v replication_group='replication_group' -v is_live_migration=1 -v is_live_migration_fall_back=1 -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+                                    -v schema_list="${SOURCE_DB_SCHEMA}" \
+                                    -v replication_group='replication_group' \
+                                    -v is_live_migration=1 \
+                                    -v is_live_migration_fall_back=1 \
+                                    -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
 
 		disable_triggers_sql=$(mktemp)
         drop_constraints_sql=$(mktemp)

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -68,7 +68,12 @@ main() {
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		#give fallback permissions for pg before starting as it is required for running snapshot validations where we insert data with ybvoyager user which will not have any usage permissions on sequences.
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" -v schema_list="${SOURCE_DB_SCHEMA}" -v replication_group='replication_group' -v is_live_migration=1 -v is_live_migration_fall_back=1 -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+                                    -v schema_list="${SOURCE_DB_SCHEMA}" \
+                                    -v replication_group='replication_group' \
+                                    -v is_live_migration=1 \
+                                    -v is_live_migration_fall_back=1 \
+                                    -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
 	fi
 
 	step "Check the Voyager version installed"


### PR DESCRIPTION
### Describe the changes in this pull request
- Added a prompt to ask the user whether they want to proceed with the transfer of ownership of tables to the replication group
- This is done just before the transfer happens in the script
- The user can only provide 'yes' or 'no' as input. They cannot provide 'y' or 'n' since the psql \if does not support string comparision. 'yes' however is considered as 1 and 'no' as 0.

Issue: https://github.com/yugabyte/yb-voyager/issues/2485

Example:
```
This script will transfer ownership of all tables in the specified schemas to the specified replication group as required by debezium. User ybvoyager and the original owner of the tables will be added to the replication group.
Proceed with the transfer of ownership? (yes/no): no
Aborting the script.
```

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
In the pg permission grant script the user will now be asked whether they are okay with transfer of ownership of tables to replication group

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
