### PR TITLE
Support target ssl modes in export-data-from-target for  logical replication

### DIFF
--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -118,14 +118,22 @@ func initSourceConfFromTargetConf() error {
 	} else {
 		source.Schema = targetConf.Schema
 	}
-	if (targetConf.SSLCertPath != "" || targetConf.SSLKey != "") && source.SSLMode != "disable" {
-		if !utils.AskPrompt("Warning: SSL cert and key are not supported for 'export data from target' yet. Do you want to ignore these settings and continue") {
-			{
-				fmt.Println("Exiting...")
-				return fmt.Errorf("SSL cert and key are not supported for 'export data from target' yet")
+
+	if msr.UseYBgRPCConnector {
+		if (targetConf.SSLCertPath != "" || targetConf.SSLKey != "") && source.SSLMode != "disable" {
+			if !utils.AskPrompt("Warning: SSL cert and key are not supported for 'export data from target' yet. Do you want to ignore these settings and continue") {
+				{
+					fmt.Println("Exiting...")
+					return fmt.Errorf("SSL cert and key are not supported for 'export data from target' yet")
+				}
 			}
 		}
+	} else {
+		source.SSLCertPath = targetConf.SSLCertPath
+		source.SSLKey = targetConf.SSLKey
+		source.SSLRootCert = targetConf.SSLRootCert
 	}
+
 	source.SSLCRL = targetConf.SSLCRL
 	source.SSLQueryString = targetConf.SSLQueryString
 	source.Uri = targetConf.Uri

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -108,7 +108,6 @@ func verifySSLFlags(cmd *cobra.Command, msr *metadb.MigrationStatusRecord) error
 			return fmt.Errorf("invalid SSL mode '%s' for 'export data from target'. Please restart 'export data from target' with the --target-ssl-mode flag with one of these modes: %v", source.SSLMode, allowedSSLModes)
 		}
 		if cmd.Flags().Changed("target-ssl-mode") || cmd.Flags().Changed("target-ssl-root-cert") {
-			fmt.Printf("target-ssl-root-cert: %s, target-ssl-mode: %s\n", source.SSLRootCert, source.SSLMode)
 			// in logical replication connnector, passing ssl root cert / ssl mode in export-data-from-target is not supported.
 			// It will automatically be picked up from the target db conf stored in MSR.
 			return fmt.Errorf("target-ssl-mode and target-ssl-root-cert are not supported for 'export data from target' When using logical replication conector." +

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -129,6 +129,8 @@ func initSourceConfFromTargetConf() error {
 			}
 		}
 	} else {
+		// TODO: in this case disallow passing target-ssl-mode and target-root-cert via CLI.
+		source.SSLMode = targetConf.SSLMode
 		source.SSLCertPath = targetConf.SSLCertPath
 		source.SSLKey = targetConf.SSLKey
 		source.SSLRootCert = targetConf.SSLRootCert

--- a/yb-voyager/cmd/exportDataFromTarget.go
+++ b/yb-voyager/cmd/exportDataFromTarget.go
@@ -48,7 +48,7 @@ var exportDataFromTargetCmd = &cobra.Command{
 		} else {
 			exporterRole = TARGET_DB_EXPORTER_FF_ROLE
 		}
-		err = verifySSLFlags(msr)
+		err = verifySSLFlags(cmd, msr)
 		if err != nil {
 			utils.ErrExit("failed to verify SSL flags: %v", err)
 		}
@@ -91,7 +91,7 @@ Therefore, we allow users to override the ssl root cert in export-data-from-targ
 
 For logical-replication connecter, all SSL modes are supported.
 */
-func verifySSLFlags(msr *metadb.MigrationStatusRecord) error {
+func verifySSLFlags(cmd *cobra.Command, msr *metadb.MigrationStatusRecord) error {
 	allowedSSLModes := []string{constants.DISABLE, constants.PREFER, constants.ALLOW, constants.REQUIRE, constants.VERIFY_CA, constants.VERIFY_FULL}
 	// the debezium GRPC connector has some limitations because of which prefer and allow are not supported.
 	allowedSSLModesGRPCConnector := []string{constants.DISABLE, constants.REQUIRE, constants.VERIFY_CA, constants.VERIFY_FULL}
@@ -107,7 +107,8 @@ func verifySSLFlags(msr *metadb.MigrationStatusRecord) error {
 		if !lo.Contains(allowedSSLModes, source.SSLMode) {
 			return fmt.Errorf("invalid SSL mode '%s' for 'export data from target'. Please restart 'export data from target' with the --target-ssl-mode flag with one of these modes: %v", source.SSLMode, allowedSSLModes)
 		}
-		if source.SSLRootCert != "" || source.SSLMode != "" {
+		if cmd.Flags().Changed("target-ssl-mode") || cmd.Flags().Changed("target-ssl-root-cert") {
+			fmt.Printf("target-ssl-root-cert: %s, target-ssl-mode: %s\n", source.SSLRootCert, source.SSLMode)
 			// in logical replication connnector, passing ssl root cert / ssl mode in export-data-from-target is not supported.
 			// It will automatically be picked up from the target db conf stored in MSR.
 			return fmt.Errorf("target-ssl-mode and target-ssl-root-cert are not supported for 'export data from target' When using logical replication conector." +

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -289,11 +289,14 @@ func startExportDataFromTargetIfRequired() {
 		"--table-list", strings.Join(importTableNames, ","),
 		fmt.Sprintf("--transaction-ordering=%t", transactionOrdering),
 		fmt.Sprintf("--send-diagnostics=%t", callhome.SendDiagnostics),
-		"--target-ssl-mode", tconf.SSLMode,
+
 		"--log-level", config.LogLevel,
 	}
-	if msr.UseYBgRPCConnector && tconf.SSLRootCert != "" {
-		cmd = append(cmd, "--target-ssl-root-cert", tconf.SSLRootCert)
+	if msr.UseYBgRPCConnector {
+		cmd = append(cmd, "--target-ssl-mode", tconf.SSLMode)
+		if tconf.SSLRootCert != "" {
+			cmd = append(cmd, "--target-ssl-root-cert", tconf.SSLRootCert)
+		}
 	}
 	if utils.DoNotPrompt {
 		cmd = append(cmd, "--yes")

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -280,10 +280,6 @@ func startExportDataFromTargetIfRequired() {
 
 	lockFile.Unlock() // unlock export dir from import data cmd before switching current process to ff/fb sync cmd
 
-	if msr.UseYBgRPCConnector && (tconf.SSLMode == "prefer" || tconf.SSLMode == "allow") {
-		utils.PrintAndLog(color.RedString("Warning: SSL mode '%s' is not supported for 'export data from target' yet. Downgrading it to 'disable'.\nIf you don't want these settings you can restart the 'export data from target' with a different value for --target-ssl-mode and --target-ssl-root-cert flag.", source.SSLMode))
-		tconf.SSLMode = "disable"
-	}
 	cmd := []string{"yb-voyager", "export", "data", "from", "target",
 		"--export-dir", exportDir,
 		"--table-list", strings.Join(importTableNames, ","),
@@ -293,6 +289,10 @@ func startExportDataFromTargetIfRequired() {
 		"--log-level", config.LogLevel,
 	}
 	if msr.UseYBgRPCConnector {
+		if tconf.SSLMode == "prefer" || tconf.SSLMode == "allow" {
+			utils.PrintAndLog(color.RedString("Warning: SSL mode '%s' is not supported for 'export data from target' yet. Downgrading it to 'disable'.\nIf you don't want these settings you can restart the 'export data from target' with a different value for --target-ssl-mode and --target-ssl-root-cert flag.", source.SSLMode))
+			tconf.SSLMode = "disable"
+		}
 		cmd = append(cmd, "--target-ssl-mode", tconf.SSLMode)
 		if tconf.SSLRootCert != "" {
 			cmd = append(cmd, "--target-ssl-root-cert", tconf.SSLRootCert)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -292,7 +292,7 @@ func startExportDataFromTargetIfRequired() {
 		"--target-ssl-mode", tconf.SSLMode,
 		"--log-level", config.LogLevel,
 	}
-	if tconf.SSLRootCert != "" {
+	if msr.UseYBgRPCConnector && tconf.SSLRootCert != "" {
 		cmd = append(cmd, "--target-ssl-root-cert", tconf.SSLRootCert)
 	}
 	if utils.DoNotPrompt {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -280,7 +280,7 @@ func startExportDataFromTargetIfRequired() {
 
 	lockFile.Unlock() // unlock export dir from import data cmd before switching current process to ff/fb sync cmd
 
-	if tconf.SSLMode == "prefer" || tconf.SSLMode == "allow" {
+	if msr.UseYBgRPCConnector && (tconf.SSLMode == "prefer" || tconf.SSLMode == "allow") {
 		utils.PrintAndLog(color.RedString("Warning: SSL mode '%s' is not supported for 'export data from target' yet. Downgrading it to 'disable'.\nIf you don't want these settings you can restart the 'export data from target' with a different value for --target-ssl-mode and --target-ssl-root-cert flag.", source.SSLMode))
 		tconf.SSLMode = "disable"
 	}

--- a/yb-voyager/src/constants/ssl.go
+++ b/yb-voyager/src/constants/ssl.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package constants
+
+// ssl modes
+const (
+	DISABLE     = "disable"
+	PREFER      = "prefer"
+	ALLOW       = "allow"
+	REQUIRE     = "require"
+	VERIFY_CA   = "verify-ca"
+	VERIFY_FULL = "verify-full"
+)

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -282,6 +282,13 @@ var yugabyteSSLRootCertTemplate = `
 debezium.source.database.sslrootcert=%s
 `
 
+var yugabyteLogicalReplicationSSLTemplate = `
+debezium.source.database.sslmode=%s
+debezium.source.database.sslrootcert=%s
+debezium.source.database.sslcert=%s
+debezium.source.database.sslkey=%s
+`
+
 func (c *Config) String() string {
 	dataDir := filepath.Join(c.ExportDir, "data")
 	offsetFileName := fmt.Sprintf("offsets.%s.dat", c.ExporterRole)
@@ -369,6 +376,12 @@ func (c *Config) String() string {
 			if c.PublicationName != "" {
 				conf = conf + fmt.Sprintf(yugabyteLogicalReplicationPublicationNameTemplate, c.PublicationName)
 			}
+			sslConf := fmt.Sprintf(yugabyteLogicalReplicationSSLTemplate,
+				c.SSLMode,
+				c.SSLRootCert,
+				c.SSLCertPath,
+				c.SSLKey)
+			conf = conf + sslConf
 		} else {
 			conf = fmt.Sprintf(yugabyteConfigTemplate,
 				quarkusLogPort,
@@ -392,12 +405,13 @@ func (c *Config) String() string {
 				c.MetadataDBPath,
 				c.RunId,
 				c.ExporterRole)
+			sslConf := fmt.Sprintf(yugabyteSSLModeTemplate, c.SSLMode)
+			if c.SSLRootCert != "" {
+				sslConf += fmt.Sprintf(yugabyteSSLRootCertTemplate, c.SSLRootCert)
+			}
+			conf = conf + sslConf
 		}
-		sslConf := fmt.Sprintf(yugabyteSSLModeTemplate, c.SSLMode)
-		if c.SSLRootCert != "" {
-			sslConf += fmt.Sprintf(yugabyteSSLRootCertTemplate, c.SSLRootCert)
-		}
-		conf = conf + sslConf
+
 		//TODO test SSL for other methods for yugabytedb
 		if c.TransactionOrdering {
 			conf = conf + yugabyteSrcTransactionOrderingConfigTemplate


### PR DESCRIPTION
### Describe the changes in this pull request
- Allow all SSL modes in case of logical replication connector in export-data-from-target
- Pass along ssl config to debezium
- Disallow users from passing ssl mode and ssl-root-cert to export-data-from-target in case of logical replication connector. It will automatically be picked up from the import data configuration. 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually tested.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
