### PR TITLE
Introduce Support for Setting Environment Variables from Config File

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -26,6 +26,10 @@ const (
 
 var allowedGlobalConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"export-dir", "log-level", "send-diagnostics", "run-guardrails-checks",
+	// environment variables keys
+	"control-plane-type", "yugabyted-db-conn-string", "java-home",
+	"local-call-home-service-host", "local-call-home-service-port",
+	"yb-tserver-port", "tns-admin",
 )
 
 var allowedSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
@@ -35,6 +39,13 @@ var allowedSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"oracle-cdb-sid", "oracle-cdb-tns-alias",
 )
 
+var allowedSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"name", "db-host", "db-port", "db-user", "db-name", "db-password",
+	"db-schema", "ssl-cert", "ssl-mode", "ssl-key", "ssl-root-cert",
+	"ssl-crl", "db-sid",
+	"oracle-home", "oracle-tns-alias",
+)
+
 var allowedTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"name", "db-host", "db-port", "db-user", "db-password", "db-name",
 	"db-schema", "ssl-cert", "ssl-mode", "ssl-key", "ssl-root-cert", "ssl-crl",
@@ -42,25 +53,35 @@ var allowedTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 
 var allowedAssessMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"iops-capture-interval", "target-db-version", "assessment-metadata-dir",
+	// environment variables keys
+	"report-unsupported-query-constructs", "report-unsupported-plpgsql-objects",
 )
 
 var allowedAnalyzeSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"output-format", "target-db-version",
+	// environment variables keys
+	"report-unsupported-plpgsql-objects",
 )
 
 var allowedExportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"use-orafce", "comments-on-objects", "object-type-list", "exclude-object-type-list",
 	"skip-recommendations", "assessment-report-path",
+	// environment variables keys
+	"ybvoyager-skip-merge-constraints-transformation",
 )
 
 var allowedExportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"disable-pb", "exclude-table-list", "table-list", "exclude-table-list-file-path",
 	"table-list-file-path", "parallel-jobs", "export-type",
+	// environment variables keys
+	"queue-segment-max-bytes", "debezium-dist-dir", "beta-fast-data-export",
 )
 
 var allowedExportDataFromTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"disable-pb", "exclude-table-list", "table-list", "exclude-table-list-file-path",
 	"table-list-file-path",
+	// environment variables keys
+	"yb-master-port", "queue-segment-max-bytes", "debezium-dist-dir", "beta-fast-data-export",
 )
 
 var allowedImportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
@@ -73,14 +94,27 @@ var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"disable-pb", "max-retries", "exclude-table-list", "table-list",
 	"exclude-table-list-file-path", "table-list-file-path", "enable-upsert", "use-public-ip",
 	"target-endpoints", "truncate-tables",
+	// environment variables keys
+	"ybvoyager-max-colocated-batches-in-progress", "num-event-channels", "event-channel-size",
+	"max-events-per-batch", "max-interval-between-batches", "max-cpu-threshold",
+	"adaptive-parallelism-frequency-seconds", "min-available-memory-threshold", "max-batch-size-bytes",
+	"ybvoyager-use-task-picker-for-import",
 )
 
 var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"parallel-jobs", "disable-pb", "max-retries",
+	// environment variables keys
+	"num-event-channels", "event-channel-size", "max-events-per-batch",
+	"max-interval-between-batches", "max-batch-size-bytes",
+	"ybvoyager-use-task-picker-for-import",
 )
 
 var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb", "max-retries",
+	// environment variables keys
+	"ybvoyager-max-colocated-batches-in-progress", "num-event-channels",
+	"event-channel-size", "max-events-per-batch", "max-interval-between-batches",
+	"max-batch-size-bytes", "ybvoyager-use-task-picker-for-import",
 )
 
 var allowedImportDataFileConfigKeys = mapset.NewThreadUnsafeSet[string](
@@ -88,6 +122,8 @@ var allowedImportDataFileConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"batch-size", "parallel-jobs", "enable-adaptive-parallelism", "adaptive-parallelism-max",
 	"format", "delimiter", "data-dir", "file-table-map", "has-header", "escape-char",
 	"quote-char", "file-opts", "null-string", "truncate-tables",
+	// environment variables keys
+	"csv-reader-max-buffer-size-bytes",
 )
 
 var allowedInitCutoverToTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
@@ -106,6 +142,7 @@ var allowedEndMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
 // Define allowed nested sections
 var allowedConfigSections = map[string]mapset.Set[string]{
 	"source":                        allowedSourceConfigKeys,
+	"source-replica":                allowedSourceReplicaConfigKeys,
 	"target":                        allowedTargetConfigKeys,
 	"assess-migration":              allowedAssessMigrationConfigKeys,
 	"analyze-schema":                allowedAnalyzeSchemaConfigKeys,
@@ -140,6 +177,12 @@ type ConfigFlagOverride struct {
 	Value     string
 }
 
+type ConfigEnvVarSet struct {
+	EnvVar    string
+	ConfigKey string
+	Value     string
+}
+
 /*
 initConfig initializes the configuration for the given Cobra command.
 
@@ -153,7 +196,7 @@ initConfig initializes the configuration for the given Cobra command.
 
 	This setup ensures CLI > Config precedence
 */
-func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, error) {
+func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, []ConfigEnvVarSet, map[string]string, error) {
 	v := viper.New()
 
 	// Precedence of which config file to use:
@@ -168,7 +211,7 @@ func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, error) {
 		// Find home directory.
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
 
 		// Search config in home directory with name "yb-voyager-config" (without extension).
@@ -182,23 +225,183 @@ func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, error) {
 		fmt.Println("Using config file:", color.BlueString(v.ConfigFileUsed()))
 	} else {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return nil, err
+			return nil, nil, nil, err
 		}
 	}
 
 	// Validate the config file for allowed keys and sections
 	err := validateConfigFile(v)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
 	// Bind the config values to the Cobra command flags
 	overrides, err := bindCobraFlagsToViper(cmd, v)
 	if err != nil {
-		return nil, fmt.Errorf("failed to bind cobra flags to viper: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to bind cobra flags to viper: %w", err)
 	}
 
-	return overrides, nil
+	envVarsSet, envVarsAlreadySet, err := bindEnvVarsToViper(cmd, v)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to bind environment variables to viper: %w", err)
+	}
+
+	return overrides, envVarsSet, envVarsAlreadySet, nil
+}
+
+// map of string environment variable names to their config keys
+var confParamEnvVarPairs = map[string]string{
+	"control-plane-type":           "CONTROL_PLANE_TYPE",
+	"yugabyted-db-conn-string":     "YUGABYTED_DB_CONN_STRING",
+	"java-home":                    "JAVA_HOME",
+	"local-call-home-service-host": "LOCAL_CALL_HOME_SERVICE_HOST",
+	"local-call-home-service-port": "LOCAL_CALL_HOME_SERVICE_PORT",
+	"yb-tserver-port":              "YB_TSERVER_PORT",
+	"tns-admin":                    "TNS_ADMIN",
+	"send-diagnostics":             "YB_VOYAGER_SEND_DIAGNOSTICS",
+
+	"source.db-password": "SOURCE_DB_PASSWORD",
+
+	"target.db-password": "TARGET_DB_PASSWORD",
+
+	"source-replica.db-password": "SOURCE_REPLICA_DB_PASSWORD",
+
+	"assess-migration.report-unsupported-query-constructs": "REPORT_UNSUPPORTED_QUERY_CONSTRUCTS",
+	"assess-migration.report-unsupported-plpgsql-objects":  "REPORT_UNSUPPORTED_PLPGSQL_OBJECTS",
+
+	"analyze-schema.report-unsupported-plpgsql-objects": "REPORT_UNSUPPORTED_PLPGSQL_OBJECTS",
+
+	"export-schema.ybvoyager-skip-merge-constraints-transformation": "YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS",
+
+	"export-data.queue-segment-max-bytes": "QUEUE_SEGMENT_MAX_BYTES",
+	"export-data.debezium-dist-dir":       "DEBEZIUM_DIST_DIR",
+	"export-data.beta-fast-data-export":   "BETA_FAST_DATA_EXPORT",
+
+	"export-data-from-source.queue-segment-max-bytes": "QUEUE_SEGMENT_MAX_BYTES",
+	"export-data-from-source.debezium-dist-dir":       "DEBEZIUM_DIST_DIR",
+	"export-data-from-source.beta-fast-data-export":   "BETA_FAST_DATA_EXPORT",
+
+	"export-data-from-target.yb-master-port":          "YB_MASTER_PORT",
+	"export-data-from-target.queue-segment-max-bytes": "QUEUE_SEGMENT_MAX_BYTES",
+	"export-data-from-target.debezium-dist-dir":       "DEBEZIUM_DIST_DIR",
+	"export-data-from-target.beta-fast-data-export":   "BETA_FAST_DATA_EXPORT",
+
+	"import-data-file.csv-reader-max-buffer-size-bytes": "CSV_READER_MAX_BUFFER_SIZE_BYTES",
+
+	"import-data.ybvoyager-max-colocated-batches-in-progress": "YBVOYAGER_MAX_COLOCATED_BATCHES_IN_PROGRESS",
+	"import-data.num-event-channels":                          "NUM_EVENT_CHANNELS",
+	"import-data.event-channel-size":                          "EVENT_CHANNEL_SIZE",
+	"import-data.max-events-per-batch":                        "MAX_EVENTS_PER_BATCH",
+	"import-data.max-interval-between-batches":                "MAX_INTERVAL_BETWEEN_BATCHES",
+	"import-data.max-cpu-threshold":                           "MAX_CPU_THRESHOLD",
+	"import-data.adaptive-parallelism-frequency-seconds":      "ADAPTIVE_PARALLELISM_FREQUENCY_SECONDS",
+	"import-data.min-available-memory-threshold":              "MIN_AVAILABLE_MEMORY_THRESHOLD",
+	"import-data.max-batch-size-bytes":                        "MAX_BATCH_SIZE_BYTES",
+	"import-data.ybvoyager-use-task-picker-for-import":        "YBVOYAGER_USE_TASK_PICKER_FOR_IMPORT",
+
+	"import-data-to-target.ybvoyager-max-colocated-batches-in-progress": "YBVOYAGER_MAX_COLOCATED_BATCHES_IN_PROGRESS",
+	"import-data-to-target.num-event-channels":                          "NUM_EVENT_CHANNELS",
+	"import-data-to-target.event-channel-size":                          "EVENT_CHANNEL_SIZE",
+	"import-data-to-target.max-events-per-batch":                        "MAX_EVENTS_PER_BATCH",
+	"import-data-to-target.max-interval-between-batches":                "MAX_INTERVAL_BETWEEN_BATCHES",
+	"import-data-to-target.max-cpu-threshold":                           "MAX_CPU_THRESHOLD",
+	"import-data-to-target.adaptive-parallelism-frequency-seconds":      "ADAPTIVE_PARALLELISM_FREQUENCY_SECONDS",
+	"import-data-to-target.min-available-memory-threshold":              "MIN_AVAILABLE_MEMORY_THRESHOLD",
+	"import-data-to-target.max-batch-size-bytes":                        "MAX_BATCH_SIZE_BYTES",
+
+	"import-data-to-source-replica.ybvoyager-max-colocated-batches-in-progress": "YBVOYAGER_MAX_COLOCATED_BATCHES_IN_PROGRESS",
+	"import-data-to-source-replica.num-event-channels":                          "NUM_EVENT_CHANNELS",
+	"import-data-to-source-replica.event-channel-size":                          "EVENT_CHANNEL_SIZE",
+	"import-data-to-source-replica.max-events-per-batch":                        "MAX_EVENTS_PER_BATCH",
+	"import-data-to-source-replica.max-interval-between-batches":                "MAX_INTERVAL_BETWEEN_BATCHES",
+	"import-data-to-source-replica.max-batch-size-bytes":                        "MAX_BATCH_SIZE_BYTES",
+	"import-data-to-source.ybvoyager-use-task-picker-for-import":                "YBVOYAGER_USE_TASK_PICKER_FOR_IMPORT",
+	"import-data-to-source-replica.ybvoyager-use-task-picker-for-import":        "YBVOYAGER_USE_TASK_PICKER_FOR_IMPORT",
+
+	"import-data-to-source.num-event-channels":           "NUM_EVENT_CHANNELS",
+	"import-data-to-source.event-channel-size":           "EVENT_CHANNEL_SIZE",
+	"import-data-to-source.max-events-per-batch":         "MAX_EVENTS_PER_BATCH",
+	"import-data-to-source.max-interval-between-batches": "MAX_INTERVAL_BETWEEN_BATCHES",
+	"import-data-to-source.max-batch-size-bytes":         "MAX_BATCH_SIZE_BYTES",
+}
+
+/*
+bindEnvVarsToViper sets up environment variables based on the resolved Viper config for a given Cobra command.
+
+It identifies config keys relevant to the command being executed, checks whether they are already exported as
+environment variables, and sets them only if not already present. This enables legacy parts of the codebase
+that use os.Getenv to still benefit from values defined in the config file.
+
+Resolution precedence:
+  - If the environment variable is already set in the shell, it is respected and not overridden.
+  - If the environment variable is unset but the config file defines the key, it is set using os.Setenv.
+  - If neither is set, the environment variable is not set at all.
+
+Config key matching logic:
+  - For command-scoped keys: the config key must be prefixed with <command-path> (e.g., "export-data.table-list").
+  - For global keys (like "export-dir"), config keys without a dot are always allowed.
+  - Keys scoped under sections like "source.", "source-replica.", or "target." are also accepted globally.
+
+Alias support:
+  - If a command like "export data from source" is executed, it will internally map to a config prefix
+    like "export-data" or "export-data-from-source", depending on what exists in the config file.
+	The config params will be used according to the resolved prefix by this logic.
+
+Returns:
+  - A map of environment variables that were set via os.Setenv, useful for diagnostics or logging.
+
+Note:
+  - These environment variables are scoped to the Go process only and are not visible to the parent shell.
+  - They can be used freely within os.Getenv calls, but cannot be accessed via `echo $VAR` after CLI exits.
+*/
+
+func bindEnvVarsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigEnvVarSet, map[string]string, error) {
+	subCmdPath := strings.TrimPrefix(cmd.CommandPath(), cmd.Root().Name())
+	subCmdPath = strings.TrimSpace(subCmdPath) // remove leading space if any
+	// Replace spaces with hyphens
+	configKeyPrefix := strings.ReplaceAll(subCmdPath, " ", "-")
+	configKeyPrefix = setToAliasPrefixIfSet(configKeyPrefix, v)
+
+	var envVarsSet []ConfigEnvVarSet
+	envVarsAlreadySet := make(map[string]string)
+
+	// Iterate over known config-to-env-var mappings and set env vars
+	// only if:
+	// - the config key is relevant to this command (matches configKeyPrefix or known sections like source./target.)
+	// - the env var is not already exported in the shell
+	// - the config key is explicitly set in the config file (non-empty value)
+	// This ensures the correct config values are surfaced to os.Getenv consumers,
+	// without overriding environment variables that the user has already exported.
+	for confKey, envVar := range confParamEnvVarPairs {
+		// Proceed if key is relevant to this command (has correct prefix) or is global
+		if strings.HasPrefix(confKey, configKeyPrefix+".") ||
+			strings.HasPrefix(confKey, "source.") ||
+			strings.HasPrefix(confKey, "source-replica.") ||
+			strings.HasPrefix(confKey, "target.") ||
+			len(strings.Split(confKey, ".")) == 1 {
+
+			// Skip if env var already exported
+			if existingVal, exists := os.LookupEnv(envVar); exists {
+				envVarsAlreadySet[envVar] = existingVal
+				continue
+			}
+
+			val := v.GetString(confKey)
+			// Set the env var only if Viper has a non-empty value
+			if val != "" {
+				if err := os.Setenv(envVar, val); err != nil {
+					return nil, nil, fmt.Errorf("failed to set environment variable %s: %w", envVar, err)
+				}
+				envVarsSet = append(envVarsSet, ConfigEnvVarSet{
+					EnvVar:    envVar,
+					ConfigKey: confKey,
+					Value:     val,
+				})
+			}
+		}
+	}
+
+	return envVarsSet, envVarsAlreadySet, nil
 }
 
 /*

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -64,7 +64,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Initialize the config file
-		overrides, err := initConfig(cmd)
+		overrides, envVarsSet, envVarsAlreadySet, err := initConfig(cmd)
 		if err != nil {
 			// not using utils.ErrExit as logging is not initialized yet
 			fmt.Printf("ERROR: Failed to initialize config: %v\n", err)
@@ -151,9 +151,17 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			setControlPlane(getControlPlaneType())
 		}
 
-		// Log the config file overrides
+		// Log the flag values set from the config file
 		for _, f := range overrides {
 			log.Infof("Flag '%s' set from config key '%s' with value '%s'\n", f.FlagName, f.ConfigKey, f.Value)
+		}
+		// Log the env variables already set in the environment by the user
+		for envVar, val := range envVarsAlreadySet {
+			log.Infof("Environment variable '%s' already set with value '%s'\n", envVar, val)
+		}
+		// Log the env variables set from the config file
+		for _, val := range envVarsSet {
+			log.Infof("Environment variable '%s' set from config key '%s' with value '%s'\n", val.EnvVar, val.ConfigKey, val.Value)
 		}
 
 	},

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -64,7 +64,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Initialize the config file
-		overrides, envVarsSet, envVarsAlreadySet, err := initConfig(cmd)
+		overrides, envVarsSetViaConfig, envVarsAlreadyExported, err := initConfig(cmd)
 		if err != nil {
 			// not using utils.ErrExit as logging is not initialized yet
 			fmt.Printf("ERROR: Failed to initialize config: %v\n", err)
@@ -156,11 +156,11 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			log.Infof("Flag '%s' set from config key '%s' with value '%s'\n", f.FlagName, f.ConfigKey, f.Value)
 		}
 		// Log the env variables already set in the environment by the user
-		for envVar, val := range envVarsAlreadySet {
+		for envVar, val := range envVarsAlreadyExported {
 			log.Infof("Environment variable '%s' already set with value '%s'\n", envVar, val)
 		}
 		// Log the env variables set from the config file
-		for _, val := range envVarsSet {
+		for _, val := range envVarsSetViaConfig {
 			log.Infof("Environment variable '%s' set from config key '%s' with value '%s'\n", val.EnvVar, val.ConfigKey, val.Value)
 		}
 


### PR DESCRIPTION
### Describe the changes in this pull request
### Overview

This PR introduces the `bindEnvVarsToViper` function, which sets up environment variables based on the values provided in the config file for a given Cobra command. This bridges the gap between Viper-based config parsing and legacy parts of the codebase that rely on `os.Getenv`.

### Behavior

- If an environment variable is **already set in the shell**, it is **respected and not overridden**.
- If it is **unset** and a corresponding value exists in the config file, the value is **exported to the process environment** using `os.Setenv`.
- If neither is set, the variable is left unset.

### Config Key Matching Logic

- Command-specific keys must be prefixed with the command path (e.g., `export-data.table-list`).
- Global config keys (e.g., `export-dir`) are allowed if they don't contain a `.`.
- Keys under nested sections like `source.`, `target.`, or `source-replica.` are also supported.

### Alias Command Support

Alias commands like `export data from source` are internally resolved to a known prefix (e.g., `export-data` or `export-data-from-source`). The config keys are then matched against this resolved prefix.

### Return Value

The function returns a list of all environment variables that were set via `os.Setenv` — useful for debugging or logging purposes.

### Notes

- These environment variables are **only available within the current Go process** and are **not visible to the parent shell** (i.e., cannot be accessed via `echo $VAR` after CLI exits).
- They are accessible within the application using `os.Getenv`.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Users can now specify the environment variables in the config file itself.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
