### PR TITLE
Added support for finalize-schema-post-data-import in the config file

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -86,7 +86,11 @@ var allowedExportDataFromTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 
 var allowedImportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"continue-on-error", "object-type-list", "exclude-object-type-list", "straight-order",
-	"post-snapshot-import", "ignore-exists", "enable-orafce",
+	"ignore-exists", "enable-orafce",
+)
+
+var allowedFinalizeSchemaPostDataImportConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"continue-on-error", "ignore-exists", "refresh-mviews",
 )
 
 var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
@@ -142,24 +146,25 @@ var allowedEndMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
 
 // Define allowed nested sections
 var allowedConfigSections = map[string]mapset.Set[string]{
-	"source":                        allowedSourceConfigKeys,
-	"source-replica":                allowedSourceReplicaConfigKeys,
-	"target":                        allowedTargetConfigKeys,
-	"assess-migration":              allowedAssessMigrationConfigKeys,
-	"analyze-schema":                allowedAnalyzeSchemaConfigKeys,
-	"export-schema":                 allowedExportSchemaConfigKeys,
-	"export-data":                   allowedExportDataConfigKeys,
-	"export-data-from-source":       allowedExportDataConfigKeys,
-	"export-data-from-target":       allowedExportDataFromTargetConfigKeys,
-	"import-schema":                 allowedImportSchemaConfigKeys,
-	"import-data":                   allowedImportDataConfigKeys,
-	"import-data-to-target":         allowedImportDataConfigKeys,
-	"import-data-to-source":         allowedImportDataToSourceConfigKeys,
-	"import-data-to-source-replica": allowedImportDataToSourceReplicaConfigKeys,
-	"import-data-file":              allowedImportDataFileConfigKeys,
-	"initiate-cutover-to-target":    allowedInitCutoverToTargetConfigKeys,
-	"archive-changes":               allowedArchiveChangesConfigKeys,
-	"end-migration":                 allowedEndMigrationConfigKeys,
+	"source":                           allowedSourceConfigKeys,
+	"source-replica":                   allowedSourceReplicaConfigKeys,
+	"target":                           allowedTargetConfigKeys,
+	"assess-migration":                 allowedAssessMigrationConfigKeys,
+	"analyze-schema":                   allowedAnalyzeSchemaConfigKeys,
+	"export-schema":                    allowedExportSchemaConfigKeys,
+	"export-data":                      allowedExportDataConfigKeys,
+	"export-data-from-source":          allowedExportDataConfigKeys,
+	"export-data-from-target":          allowedExportDataFromTargetConfigKeys,
+	"import-schema":                    allowedImportSchemaConfigKeys,
+	"finalize-schema-post-data-import": allowedFinalizeSchemaPostDataImportConfigKeys,
+	"import-data":                      allowedImportDataConfigKeys,
+	"import-data-to-target":            allowedImportDataConfigKeys,
+	"import-data-to-source":            allowedImportDataToSourceConfigKeys,
+	"import-data-to-source-replica":    allowedImportDataToSourceReplicaConfigKeys,
+	"import-data-file":                 allowedImportDataFileConfigKeys,
+	"initiate-cutover-to-target":       allowedInitCutoverToTargetConfigKeys,
+	"archive-changes":                  allowedArchiveChangesConfigKeys,
+	"end-migration":                    allowedEndMigrationConfigKeys,
 }
 
 // Define mutually exclusive section groups


### PR DESCRIPTION
### Describe the changes in this pull request
Added support to add a section for finalize-schema-post-data-import and its relevant parameters in the config file. Example:
```
finalize-schema-post-data-import:
  ignore-exists: true
  continue-on-error: true
  refresh-mviews: false
```

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Users will be able to add finalize-schema-post-data-import flags in the config file now

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
