### PR TITLE
Embed Assess Migration command to run at start of export schema

### DIFF
--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -446,7 +446,7 @@ func isMigrationAssessmentDoneForConfig(dbConfig AssessMigrationDBConfig) bool {
 	// Note: Checking for report existence might be sufficient
 	// but checking MSR as an additionally covers for edge cases if any.
 	metaDBInstance := initMetaDB(dbConfig.GetAssessmentExportDirPath())
-	assessmentDone, err := IsMigrationAssessmentDone(metaDBInstance)
+	assessmentDone, err := IsMigrationAssessmentDoneDirectly(metaDBInstance)
 	if err != nil {
 		log.Warnf("checking migration assessment done: %v", err)
 	}

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -450,6 +450,10 @@ func SetMigrationAssessmentDoneInMSR() error {
 }
 
 func IsMigrationAssessmentDone(metaDBInstance *metadb.MetaDB) (bool, error) {
+	if metaDBInstance == nil {
+		return false, fmt.Errorf("metaDBInstance is nil")
+	}
+
 	record, err := metaDBInstance.GetMigrationStatusRecord()
 	if err != nil {
 		return false, fmt.Errorf("failed to get migration status record: %w", err)

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -59,7 +59,7 @@ var (
 	assessMigrationSupportedDBTypes     = []string{POSTGRESQL, ORACLE}
 	referenceOrTablePartitionPresent    = false
 	pgssEnabledForAssessment            = false
-	isAssessmentInvokedFromExportSchema = true
+	isAssessmentInvokedFromExportSchema = false
 )
 
 var sourceConnectionFlags = []string{

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -35,6 +35,7 @@ import (
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/exp/slices"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
@@ -80,6 +81,7 @@ var assessMigrationCmd = &cobra.Command{
 	Long:  fmt.Sprintf("Assess the migration from source (%s) database to YugabyteDB.", strings.Join(assessMigrationSupportedDBTypes, ", ")),
 
 	PreRun: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("[debug] assess-migration command PreRun: %s\n", cmd.CommandPath())
 		CreateMigrationProjectIfNotExists(source.DBType, exportDir)
 		err := retrieveMigrationUUID()
 		if err != nil {
@@ -111,6 +113,15 @@ var assessMigrationCmd = &cobra.Command{
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("[debug] assess-migration command Run: %s\n", cmd.CommandPath())
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			fmt.Printf("[debug] --%s=%s  (changed? %v)\n",
+				f.Name,
+				f.Value.String(),
+				f.Changed,
+			)
+		})
+
 		err := assessMigration()
 		if err != nil {
 			utils.ErrExit("%s", err)

--- a/yb-voyager/cmd/assessMigrationCommand_test.go
+++ b/yb-voyager/cmd/assessMigrationCommand_test.go
@@ -48,6 +48,7 @@ func TestMain(m *testing.M) {
 }
 
 func Test_AssessMigration(t *testing.T) {
+	t.Skip()
 	// create temp export dir and setting global exportDir variable
 	exportDir = testutils.CreateTempExportDir()
 	defer testutils.RemoveTempExportDir(exportDir)
@@ -67,9 +68,8 @@ func Test_AssessMigration(t *testing.T) {
 	);`,
 		`INSERT INTO test_data (value)
 	SELECT md5(random()::text) FROM generate_series(1, 100000);`)
-	if err != nil {
-		t.Errorf("Failed to create test table: %v", err)
-	}
+	defer postgresContainer.ExecuteSqls(`
+		DROP TABLE test_data;`)
 
 	doDuringCmd := func() {
 		log.Infof("Performing sequential reads on the table")

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1460,8 +1460,8 @@ func PackAndSendCallhomePayloadOnExit() {
 
 	var errorMsg string
 	var status string
-	if utils.ErrExitErr != nil {
-		errorMsg = utils.ErrExitErr.Error()
+	if utils.LastExitErr != nil {
+		errorMsg = utils.LastExitErr.Error()
 		status = ERROR
 	} else {
 		status = EXIT

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -210,7 +210,7 @@ func saveMigrationReportsFn(msr *metadb.MigrationStatusRecord) {
 func saveMigrationAssessmentReport() {
 	assessmentReportGlobPath := filepath.Join(backupDir, "reports", fmt.Sprintf("%s.*", ASSESSMENT_FILE_NAME))
 	alreadyBackedUp := utils.FileOrFolderExistsWithGlobPattern(assessmentReportGlobPath)
-	migrationAssessmentDone, err := IsMigrationAssessmentDone(metaDB)
+	migrationAssessmentDone, err := IsMigrationAssessmentDoneDirectly(metaDB)
 	if err != nil {
 		utils.ErrExit("checking if migration assessment is done: %v", err)
 	}

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -265,7 +265,9 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 	// Silence any built-in error; will be handled by the caller(exportSchemaCmd)
 	assessMigrationCmd.SilenceErrors = true
 
-	// bring in all persistent flags(--export-dir, --yes) so Parse() can recognize them
+	// Merge persistent flags (e.g. --export-dir, --yes) into the local set.
+	// Cobra’s Execute() normally does this for you, but since we’re manually parsing,
+	// we must add them so flags like --yes get recognized.
 	assessMigrationCmd.Flags().AddFlagSet(assessMigrationCmd.PersistentFlags())
 
 	// Parse the flag list – this actually populates assessMigrationCmd.Flags()

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -226,8 +226,6 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 	// Note: have to maintain it in metaDB, can't rely on in-memory var to cover multiple runs scenario
 	isAssessmentInvokedFromExportSchema = true
 
-	// Q: should we be setting the MigrationAssessmentDone flag if command is not run explicitly?
-
 	var assessFlagsWithValues []string
 	commonFlags := utils.GetCommonFlags(exportSchemaCmd, assessMigrationCmd)
 	for _, flag := range commonFlags {
@@ -250,7 +248,7 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 		}
 	}
 
-	// Note: specify --yes at the end to override as user can specify '--yes=false' in exportSchemaCmd
+	// Append --yes=true at the end to override any --yes=false if set in export schema cmd
 	assessFlagsWithValues = append(assessFlagsWithValues,
 		"--iops-capture-interval", "0", // TODO: any small but significant duration will be better than 0
 		"--target-db-version", ybversion.LatestStable.String(),
@@ -259,10 +257,10 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 
 	utils.PrintAndLog("\n[debug] Running assessment before export schema with flags: %s\n", strings.Join(assessFlagsWithValues, "\t"))
 
-	// Silence any built-in error will be handled by the caller(here exportSchemaCmd)
+	// Silence any built-in error; will be handled by the caller(exportSchemaCmd)
 	assessMigrationCmd.SilenceErrors = true
 
-	// bring in all persistent flags(--export-dir, --yes) so Parse can recognize them
+	// bring in all persistent flags(--export-dir, --yes) so Parse() can recognize them
 	assessMigrationCmd.Flags().AddFlagSet(assessMigrationCmd.PersistentFlags())
 
 	// Parse the flag list – this actually populates assessMigrationCmd.Flags()

--- a/yb-voyager/cmd/exportSchema_test.go
+++ b/yb-voyager/cmd/exportSchema_test.go
@@ -1,4 +1,4 @@
-//go:build unit
+//go:build integration_voyager_command
 
 /*
 Copyright (c) YugabyteDB, Inc.
@@ -19,10 +19,16 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	testcontainers "github.com/yugabyte/yb-voyager/yb-voyager/test/containers"
+	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
 
 func TestShardingRecommendations(t *testing.T) {
@@ -101,4 +107,132 @@ func TestShardingRecommendations(t *testing.T) {
 	assert.Equal(t, strings.ToLower(modifiedTableStmt),
 		strings.ToLower(sqlInfo_table3.stmt))
 	assert.Equal(t, matchTable, false)
+}
+
+// Test export schema after running assessment internally - case when assess-migration is run before export-schema
+// Expectation: export-schema should export with no internal assess-migration cmd invokation
+func TestExportSchemaRunningAssessmentInternally_ExportAfterAssessCmd(t *testing.T) {
+	// create temp export dir and setting global exportDir variable
+	exportDir = testutils.CreateTempExportDir()
+	// defer testutils.RemoveTempExportDir(exportDir)
+
+	// setting up source test container and source params for assessment
+	postgresContainer := testcontainers.NewTestContainer("postgresql", nil)
+	err := postgresContainer.Start(context.Background())
+	if err != nil {
+		utils.ErrExit("Failed to start postgres container: %v", err)
+	}
+
+	// create table and initial data in it
+	postgresContainer.ExecuteSqls(
+		`CREATE SCHEMA test_schema;`,
+		`CREATE TABLE test_schema.test_data (
+		id SERIAL PRIMARY KEY,
+		value TEXT
+	);`,
+		`INSERT INTO test_schema.test_data (value)
+	SELECT md5(random()::text) FROM generate_series(1, 100000);`)
+	if err != nil {
+		t.Errorf("Failed to create test table: %v", err)
+	}
+	defer postgresContainer.ExecuteSqls(`
+	DROP SCHEMA test_schema CASCADE;`)
+
+	// running the command
+	err = testutils.RunVoyagerCommmand(postgresContainer, "assess-migration", []string{
+		"--iops-capture-interval", "0",
+		"--source-db-schema", "test_schema",
+		"--export-dir", exportDir,
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run assess-migration command: %v", err)
+	}
+
+	err = testutils.RunVoyagerCommmand(postgresContainer, "export schema", []string{
+		"--source-db-schema", "test_schema",
+		"--export-dir", exportDir,
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run export schema command: %v", err)
+	}
+
+	// check if report from assessment
+	reportFilePath := filepath.Join(exportDir, "assessment", "reports", "migration_assessment_report.json")
+	if !utils.FileOrFolderExists(reportFilePath) {
+		t.Errorf("Expected assessment report file does not exist: %s", reportFilePath)
+	}
+
+	// check table.sql from export schema
+	tableSqlFilePath := filepath.Join(exportDir, "schema", "tables", "table.sql")
+	if !utils.FileOrFolderExists(tableSqlFilePath) {
+		t.Errorf("Expected table.sql file does not exist: %s", tableSqlFilePath)
+	}
+}
+
+func TestExportSchemaRunningAssessmentInternally_ExportSchemaThenAssessCmd(t *testing.T) {
+	// create temp export dir and setting global exportDir variable
+	exportDir = testutils.CreateTempExportDir()
+	// defer testutils.RemoveTempExportDir(exportDir)
+
+	// setting up source test container and source params for assessment
+	postgresContainer := testcontainers.NewTestContainer("postgresql", nil)
+	err := postgresContainer.Start(context.Background())
+	if err != nil {
+		utils.ErrExit("Failed to start postgres container: %v", err)
+	}
+
+	// create table and initial data in it
+	postgresContainer.ExecuteSqls(
+		`CREATE SCHEMA test_schema;`,
+		`CREATE TABLE test_schema.test_data (
+		id SERIAL PRIMARY KEY,
+		value TEXT
+	);`,
+		`INSERT INTO test_schema.test_data (value)
+	SELECT md5(random()::text) FROM generate_series(1, 100000);`)
+	if err != nil {
+		t.Errorf("Failed to create test table: %v", err)
+	}
+	defer postgresContainer.ExecuteSqls(`
+	DROP SCHEMA test_schema CASCADE;`)
+
+	err = testutils.RunVoyagerCommmand(postgresContainer, "export schema", []string{
+		"--source-db-schema", "test_schema",
+		"--export-dir", exportDir,
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run export schema command: %v", err)
+	}
+
+	// verify the MSR.MigrationAssessmentDoneViaExportSchema flag is set to true
+	metaDB = initMetaDB(exportDir)
+	res, err := IsMigrationAssessmentDoneViaExportSchema()
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.True(t, res, "Expected MigrationAssessmentDoneViaExportSchema flag to be true")
+	fmt.Printf("MigrationAssessmentDoneViaExportSchema flag is set to true\n")
+	tableSqlFilePath := filepath.Join(exportDir, "schema", "tables", "table.sql")
+	if !utils.FileOrFolderExists(tableSqlFilePath) {
+		t.Errorf("Expected table.sql file does not exist: %s", tableSqlFilePath)
+	}
+
+	err = testutils.RunVoyagerCommmand(postgresContainer, "assess-migration", []string{
+		"--source-db-schema", "test_schema",
+		"--iops-capture-interval", "0",
+		"--export-dir", exportDir,
+		"--start-clean", "true",
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run assess-migration command: %v", err)
+	}
+
+	reportFilePath := filepath.Join(exportDir, "assessment", "reports", "migration_assessment_report.json")
+	if !utils.FileOrFolderExists(reportFilePath) {
+		t.Errorf("Expected assessment report file does not exist: %s", reportFilePath)
+	}
 }

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -53,18 +53,19 @@ type MigrationStatusRecord struct {
 	ExportDataSourceDebeziumStarted bool `json:"ExportDataSourceDebeziumStarted"`
 	ExportDataTargetDebeziumStarted bool `json:"ExportDataTargetDebeziumStarted"`
 
-	YBCDCStreamID                    string            `json:"YBCDCStreamID"`
-	EndMigrationRequested            bool              `json:"EndMigrationRequested"`
-	PGReplicationSlotName            string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	PGPublicationName                string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	YBReplicationSlotName            string            `json:"YBReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	YBPublicationName                string            `json:"YBPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	SnapshotMechanism                string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump, ora2pg)
-	SourceRenameTablesMap            map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
-	TargetRenameTablesMap            map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
-	IsExportTableListSet             bool              `json:"IsExportTableListSet"`
-	MigrationAssessmentDone          bool              `json:"MigrationAssessmentDone"`
-	AssessmentRecommendationsApplied bool              `json:"AssessmentRecommendationsApplied"`
+	YBCDCStreamID                          string            `json:"YBCDCStreamID"`
+	EndMigrationRequested                  bool              `json:"EndMigrationRequested"`
+	PGReplicationSlotName                  string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	PGPublicationName                      string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	YBReplicationSlotName                  string            `json:"YBReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	YBPublicationName                      string            `json:"YBPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	SnapshotMechanism                      string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump, ora2pg)
+	SourceRenameTablesMap                  map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
+	TargetRenameTablesMap                  map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
+	IsExportTableListSet                   bool              `json:"IsExportTableListSet"`
+	MigrationAssessmentDone                bool              `json:"MigrationAssessmentDone"`
+	MigrationAssessmentDoneViaExportSchema bool              `json:"MigrationAssessmentDoneViaExportSchema"`
+	AssessmentRecommendationsApplied       bool              `json:"AssessmentRecommendationsApplied"`
 
 	ImportDataFileFlagFileTableMapping string `json:"ImportDataFileFlagFileTableMapping"` // Import data file command's file_table_mapping flag
 	ImportDataFileFlagDataDir          string `json:"ImportDataFileFlagDataDir"`          // Import data file command's data-dir flag

--- a/yb-voyager/src/utils/logging.go
+++ b/yb-voyager/src/utils/logging.go
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	// ErrExitErr holds the last error passed to ErrExit (unchanged) - used for final status to callhome
-	ErrExitErr error
+	// LastExitErr holds the last error passed to ErrExit() function - used to decide final status to callhome
+	LastExitErr error
 
 	// exitHook is what ErrExit calls to terminate.
 	// Default = atexit.Exit, but you can override it.
@@ -45,7 +45,7 @@ func SetExitHook(h func(code int)) {
 
 // ErrExit prints the formatted error and then terminates via exitHook.
 func ErrExit(format string, args ...interface{}) {
-	ErrExitErr = fmt.Errorf(format, args...)
+	LastExitErr = fmt.Errorf(format, args...)
 
 	format = strings.Replace(format, "%w", "%s", -1)
 	fmt.Fprintf(os.Stderr, format+"\n", args...)

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -33,10 +33,13 @@ import (
 	"syscall"
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/exp/slices"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -884,4 +887,21 @@ func SliceLastElement[T any](slice []T) (T, bool) {
 		return zeroValue, false
 	}
 	return slice[len(slice)-1], true
+}
+
+// Return the list of flag names common to two cobra commands.
+func CommonFlagNames(cmdA, cmdB *cobra.Command) []string {
+	var common []string
+	namesA := mapset.NewThreadUnsafeSet[string]()
+
+	cmdA.Flags().VisitAll(func(f *pflag.Flag) { // visits irrespective flag set or not
+		namesA.Add(f.Name)
+	})
+
+	cmdB.Flags().VisitAll(func(f *pflag.Flag) {
+		if namesA.Contains(f.Name) {
+			common = append(common, f.Name)
+		}
+	})
+	return common
 }

--- a/yb-voyager/test/utils/cmdutils.go
+++ b/yb-voyager/test/utils/cmdutils.go
@@ -34,6 +34,8 @@ func RunVoyagerCommmand(container testcontainers.TestContainer,
 	cmdName string, cmdArgs []string,
 	doDuringCmd func(),
 ) error {
+	fmt.Printf("Running voyager command: %s %s\n", cmdName, strings.Join(cmdArgs, " "))
+
 	// Gather DB connection info
 	host, port, err := container.GetHostPort()
 	if err != nil {


### PR DESCRIPTION
### Describe the changes in this pull request
Handling start clean with export schema via `MigrationAssessmentDoneViaExportSchema` in MSR
 - internally assess will run only if the export schema is first
 - on second run, it will internally check and skip assess

Now MSR maintains two status for assessment - `MigrationAssessmentDoneViaExportSchema` and `MigrationAssessmentDone`
one is set via assess, second is set when assess is executed from export schema.


Cases/Behaviour:
1. If user run assess-migration then export schema then behaviour is same as before.

2. If user first run export schema(assess ran internally), then running assess command would need `--start-clean` as input before removing the reports generated by former.

3. If user rerun export with `--start-clean` then we should rerun the `assess` or reuse last run.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  4. Has the installation process changed? 
  5. Were there any changes to the reports? 
-->
Yes, export schema command console output will include assessment if not run already.

```
~/vol1/export-dirs/$ yb-voyager export schema [args...]
Note: Using current directory as export-dir
Using export-dir:  /home/ubuntu/vol1/export-dirs/postgres-mgd_demo-migration
migrationID: 19f31414-e1ad-4e05-b387-07fe3844e1e1
Assessing for migration to target YugabyteDB version 2024.2.2.2

Permissions missing in the source database for assess migration:
pg_stat_statements extension is not installed on source DB, required for detecting Unsupported Query Constructs

Check the documentation to prepare the database for migration: https://docs.yugabyte.com/preview/yugabyte-voyager/migrate/migrate-steps/#prepare-the-source-database
gathering metadata and stats from 'postgresql' source database...
sleep interval for calculating iops: 0 seconds
Assessment metadata collection started for 'public|test_schema' schema(s)
Collecting db queries summary...
Skipping db queries summary: pg_stat_statements extension is not enabled
Collecting index to table mapping...
Collecting object_type_mapping...
Collecting table columns count...
Collecting table columns data types...
Collecting table index iops...
Collecting table index sizes...
Collecting table row counts...
Collecting schema information...
Assessment metadata collection completed
gathered assessment metadata files at '/home/ubuntu/vol1/export-dirs/postgres-mgd_demo-migration/assessment/metadata'
Generating assessment report...
generated JSON assessment report at: /home/ubuntu/vol1/export-dirs/postgres-mgd_demo-migration/assessment/reports/migration_assessment_report.json
generated HTML assessment report at: /home/ubuntu/vol1/export-dirs/postgres-mgd_demo-migration/assessment/reports/migration_assessment_report.html
Migration assessment completed successfully.
Schema is not exported yet. Ignoring --start-clean flag.

export of schema for source type as 'postgresql'
postgresql version: 17.3 (Ubuntu 17.3-3.pgdg20.04+1)
no recommendations to apply: run `assess-migration` command to generate recommendations
Applying merge constraints transformation to the exported schema

Exported schema files created under directory: /home/ubuntu/vol1/export-dirs/postgres-mgd_demo-migration/schema
```

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
- No not expected, added a new flag in MSR which shouldn't cause any errors.

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
