### PR TITLE
Embed Assess Migration command to run at start of export schema

### DIFF
--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -446,7 +446,7 @@ func isMigrationAssessmentDoneForConfig(dbConfig AssessMigrationDBConfig) bool {
 	// Note: Checking for report existence might be sufficient
 	// but checking MSR as an additionally covers for edge cases if any.
 	metaDBInstance := initMetaDB(dbConfig.GetAssessmentExportDirPath())
-	assessmentDone, err := IsMigrationAssessmentDone(metaDBInstance)
+	assessmentDone, err := IsMigrationAssessmentDoneDirectly(metaDBInstance)
 	if err != nil {
 		log.Warnf("checking migration assessment done: %v", err)
 	}

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -50,15 +50,15 @@ import (
 )
 
 var (
-	assessmentMetadataDir             string
-	assessmentMetadataDirFlag         string
-	assessmentReport                  AssessmentReport
-	assessmentDB                      *migassessment.AssessmentDB
-	intervalForCapturingIOPS          int64
-	assessMigrationSupportedDBTypes   = []string{POSTGRESQL, ORACLE}
-	referenceOrTablePartitionPresent  = false
-	pgssEnabledForAssessment          = false
-	assessmentInvokedFromExportSchema utils.BoolStr
+	assessmentMetadataDir            string
+	assessmentMetadataDirFlag        string
+	assessmentReport                 AssessmentReport
+	assessmentDB                     *migassessment.AssessmentDB
+	intervalForCapturingIOPS         int64
+	assessMigrationSupportedDBTypes  = []string{POSTGRESQL, ORACLE}
+	referenceOrTablePartitionPresent = false
+	pgssEnabledForAssessment         = false
+	invokedByExportSchema            utils.BoolStr
 )
 
 var sourceConnectionFlags = []string{
@@ -295,9 +295,9 @@ func init() {
 	assessMigrationCmd.Flags().StringVar(&targetDbVersionStrFlag, "target-db-version", "",
 		fmt.Sprintf("Target YugabyteDB version to assess migration for (in format A.B.C.D). Defaults to latest stable version (%s)", ybversion.LatestStable.String()))
 
-	BoolVar(assessMigrationCmd.Flags(), &assessmentInvokedFromExportSchema, "assessment-invoked-from-export-schema", false,
-		"Flag to indicate if the assessment is invoked from export schema command. ")
-	assessMigrationCmd.Flags().MarkHidden("assessment-invoked-from-export-schema") // mark hidden
+	BoolVar(assessMigrationCmd.Flags(), &invokedByExportSchema, "invoked-by-export-schema", false,
+		"Flag to indicate if the assessment is invoked by export schema command. ")
+	assessMigrationCmd.Flags().MarkHidden("invoked-by-export-schema") // mark hidden
 }
 
 func assessMigration() (err error) {
@@ -434,7 +434,7 @@ func fetchSourceInfo() {
 
 func SetMigrationAssessmentDoneInMSR() error {
 	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-		if assessmentInvokedFromExportSchema {
+		if invokedByExportSchema {
 			record.MigrationAssessmentDoneViaExportSchema = true
 			record.MigrationAssessmentDone = false
 		} else {

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -210,7 +210,7 @@ func saveMigrationReportsFn(msr *metadb.MigrationStatusRecord) {
 func saveMigrationAssessmentReport() {
 	assessmentReportGlobPath := filepath.Join(backupDir, "reports", fmt.Sprintf("%s.*", ASSESSMENT_FILE_NAME))
 	alreadyBackedUp := utils.FileOrFolderExistsWithGlobPattern(assessmentReportGlobPath)
-	migrationAssessmentDone, err := IsMigrationAssessmentDone(metaDB)
+	migrationAssessmentDone, err := IsMigrationAssessmentDoneDirectly(metaDB)
 	if err != nil {
 		utils.ErrExit("checking if migration assessment is done: %v", err)
 	}

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -261,7 +261,7 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 
 	// run and ignore exit status
 	if err := cmd.Run(); err != nil {
-		utils.PrintAndLog("failed to assess the schema: %v, continuing with export schema", err)
+		utils.PrintAndLog("failed to assess the schema: %v, continuing with export schema...", err)
 		log.Warnf("assess migration cmd stderr: %s", stderrBuf.String())
 	}
 

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -101,21 +101,15 @@ func exportSchema(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to get migration UUID during export schema: %w", err)
 	}
 
-	err = runAssessMigrationCmdBeforExportSchemaIfRequired(cmd)
-	if err != nil {
-		log.Warnf("failed to run assess-migration command before export schema: %v", err)
-	}
-
-	utils.PrintAndLog("\nexport of schema for source type as '%s'\n", source.DBType)
-	// Check connection with source database.
-	err = source.DB().Connect()
-	if err != nil {
-		log.Errorf("failed to connect to the source db: %s", err)
-		return fmt.Errorf("failed to connect to the source db during export schema: %w", err)
-	}
-	defer source.DB().Disconnect()
 
 	if source.RunGuardrailsChecks {
+		// Check connection with source database.
+		err = source.DB().Connect()
+		if err != nil {
+			log.Errorf("failed to connect to the source db: %s", err)
+			return fmt.Errorf("failed to connect to the source db during export schema: %w", err)
+		}
+
 		// Check source database version.
 		log.Info("checking source DB version")
 		err = source.DB().CheckSourceDBVersion(exportType)
@@ -130,8 +124,24 @@ func exportSchema(cmd *cobra.Command) error {
 		} else if len(binaryCheckIssues) > 0 {
 			return fmt.Errorf("\n%s\n%s", color.RedString("\nMissing dependencies for export schema:"), strings.Join(binaryCheckIssues, "\n"))
 		}
+
+		source.DB().Disconnect() // connect again after assessment
 	}
 
+	err = runAssessMigrationCmdBeforExportSchemaIfRequired(cmd)
+	if err != nil {
+		log.Warnf("failed to run assess-migration command before export schema: %v", err)
+	}
+
+	err = source.DB().Connect()
+	if err != nil {
+		log.Errorf("failed to connect to the source db: %s", err)
+		return fmt.Errorf("failed to connect to the source db during export schema: %w", err)
+	}
+	defer source.DB().Disconnect() // final disconnect
+
+
+	utils.PrintAndLog("\nexport of schema for source type as '%s'\n", source.DBType)
 	checkSourceDBCharset()
 	sourceDBVersion := source.DB().GetVersion()
 	source.DBVersion = sourceDBVersion

--- a/yb-voyager/cmd/exportSchema_test.go
+++ b/yb-voyager/cmd/exportSchema_test.go
@@ -148,6 +148,22 @@ func TestExportSchemaRunningAssessmentInternally_ExportAfterAssessCmd(t *testing
 		t.Errorf("Failed to run assess-migration command: %v", err)
 	}
 
+	// verify the MSR.MigrationAssessmentDone flag is set to true
+	metaDB = initMetaDB(exportDir)
+	res, err := IsMigrationAssessmentDoneDirectly(metaDB)
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.True(t, res, "Expected MigrationAssessmentDone flag to be true")
+
+	// verify the MSR.MigrationAssessmentDoneViaExportSchema flag is set to false
+	metaDB = initMetaDB(exportDir)
+	res, err = IsMigrationAssessmentDoneViaExportSchema()
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.False(t, res, "Expected MigrationAssessmentDoneViaExportSchema flag to be false")
+
 	err = testutils.RunVoyagerCommmand(postgresContainer, "export schema", []string{
 		"--source-db-schema", "test_schema",
 		"--export-dir", exportDir,
@@ -156,6 +172,21 @@ func TestExportSchemaRunningAssessmentInternally_ExportAfterAssessCmd(t *testing
 	if err != nil {
 		t.Errorf("Failed to run export schema command: %v", err)
 	}
+
+	// doing the same check in MSR to ensure nothing has changed after export schema
+	metaDB = initMetaDB(exportDir)
+	res, err = IsMigrationAssessmentDoneDirectly(metaDB)
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.True(t, res, "Expected MigrationAssessmentDone flag to be true")
+
+	metaDB = initMetaDB(exportDir)
+	res, err = IsMigrationAssessmentDoneViaExportSchema()
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.False(t, res, "Expected MigrationAssessmentDoneViaExportSchema flag to be false")
 
 	// check if report from assessment
 	reportFilePath := filepath.Join(exportDir, "assessment", "reports", "migration_assessment_report.json")

--- a/yb-voyager/cmd/exportSchema_test.go
+++ b/yb-voyager/cmd/exportSchema_test.go
@@ -1,4 +1,4 @@
-//go:build unit
+//go:build integration_voyager_command
 
 /*
 Copyright (c) YugabyteDB, Inc.
@@ -19,10 +19,15 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	testcontainers "github.com/yugabyte/yb-voyager/yb-voyager/test/containers"
+	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
 
 func TestShardingRecommendations(t *testing.T) {
@@ -101,4 +106,149 @@ func TestShardingRecommendations(t *testing.T) {
 	assert.Equal(t, strings.ToLower(modifiedTableStmt),
 		strings.ToLower(sqlInfo_table3.stmt))
 	assert.Equal(t, matchTable, false)
+}
+
+// Test export schema after running assessment internally - case when assess-migration is run before export-schema
+// Expectation: export-schema should export with no internal assess-migration cmd invokation
+func TestExportSchemaRunningAssessmentInternally_ExportAfterAssessCmd(t *testing.T) {
+	// create temp export dir and setting global exportDir variable
+	exportDir = testutils.CreateTempExportDir()
+	// defer testutils.RemoveTempExportDir(exportDir)
+
+	// setting up source test container and source params for assessment
+	postgresContainer := testcontainers.NewTestContainer("postgresql", nil)
+	err := postgresContainer.Start(context.Background())
+	if err != nil {
+		utils.ErrExit("Failed to start postgres container: %v", err)
+	}
+
+	// create table and initial data in it
+	postgresContainer.ExecuteSqls(
+		`CREATE SCHEMA test_schema;`,
+		`CREATE TABLE test_schema.test_data (
+		id SERIAL PRIMARY KEY,
+		value TEXT
+	);`,
+		`INSERT INTO test_schema.test_data (value)
+	SELECT md5(random()::text) FROM generate_series(1, 100000);`)
+	if err != nil {
+		t.Errorf("Failed to create test table: %v", err)
+	}
+	defer postgresContainer.ExecuteSqls(`
+	DROP SCHEMA test_schema CASCADE;`)
+
+	// running the command
+	err = testutils.RunVoyagerCommmand(postgresContainer, "assess-migration", []string{
+		"--iops-capture-interval", "0",
+		"--source-db-schema", "test_schema",
+		"--export-dir", exportDir,
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run assess-migration command: %v", err)
+	}
+
+	err = testutils.RunVoyagerCommmand(postgresContainer, "export schema", []string{
+		"--source-db-schema", "test_schema",
+		"--export-dir", exportDir,
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run export schema command: %v", err)
+	}
+
+	// check if report from assessment
+	reportFilePath := filepath.Join(exportDir, "assessment", "reports", "migration_assessment_report.json")
+	if !utils.FileOrFolderExists(reportFilePath) {
+		t.Errorf("Expected assessment report file does not exist: %s", reportFilePath)
+	}
+
+	// check table.sql from export schema
+	tableSqlFilePath := filepath.Join(exportDir, "schema", "tables", "table.sql")
+	if !utils.FileOrFolderExists(tableSqlFilePath) {
+		t.Errorf("Expected table.sql file does not exist: %s", tableSqlFilePath)
+	}
+}
+
+func TestExportSchemaRunningAssessmentInternally_ExportSchemaThenAssessCmd(t *testing.T) {
+	// create temp export dir and setting global exportDir variable
+	exportDir = testutils.CreateTempExportDir()
+	// defer testutils.RemoveTempExportDir(exportDir)
+
+	// setting up source test container and source params for assessment
+	postgresContainer := testcontainers.NewTestContainer("postgresql", nil)
+	err := postgresContainer.Start(context.Background())
+	if err != nil {
+		utils.ErrExit("Failed to start postgres container: %v", err)
+	}
+
+	// create table and initial data in it
+	postgresContainer.ExecuteSqls(
+		`CREATE SCHEMA test_schema;`,
+		`CREATE TABLE test_schema.test_data (
+		id SERIAL PRIMARY KEY,
+		value TEXT
+	);`,
+		`INSERT INTO test_schema.test_data (value)
+	SELECT md5(random()::text) FROM generate_series(1, 100000);`)
+	if err != nil {
+		t.Errorf("Failed to create test table: %v", err)
+	}
+	defer postgresContainer.ExecuteSqls(`
+	DROP SCHEMA test_schema CASCADE;`)
+
+	err = testutils.RunVoyagerCommmand(postgresContainer, "export schema", []string{
+		"--source-db-schema", "test_schema",
+		"--export-dir", exportDir,
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run export schema command: %v", err)
+	}
+
+	// verify the MSR.MigrationAssessmentDoneViaExportSchema flag is set to true
+	metaDB = initMetaDB(exportDir)
+	res, err := IsMigrationAssessmentDoneViaExportSchema()
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.True(t, res, "Expected MigrationAssessmentDoneViaExportSchema flag to be true")
+
+	// verify if table.sql exists or not
+	tableSqlFilePath := filepath.Join(exportDir, "schema", "tables", "table.sql")
+	if !utils.FileOrFolderExists(tableSqlFilePath) {
+		t.Errorf("Expected table.sql file does not exist: %s", tableSqlFilePath)
+	}
+
+	err = testutils.RunVoyagerCommmand(postgresContainer, "assess-migration", []string{
+		"--source-db-schema", "test_schema",
+		"--iops-capture-interval", "0",
+		"--export-dir", exportDir,
+		"--start-clean", "true",
+		"--yes",
+	}, nil)
+	if err != nil {
+		t.Errorf("Failed to run assess-migration command: %v", err)
+	}
+
+	reportFilePath := filepath.Join(exportDir, "assessment", "reports", "migration_assessment_report.json")
+	if !utils.FileOrFolderExists(reportFilePath) {
+		t.Errorf("Expected assessment report file does not exist: %s", reportFilePath)
+	}
+
+	// verify the MSR.MigrationAssessmentDone flag is set to true
+	metaDB = initMetaDB(exportDir)
+	res, err = IsMigrationAssessmentDoneDirectly(metaDB)
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.True(t, res, "Expected MigrationAssessmentDone flag to be true")
+
+	// verify the MSR.MigrationAssessmentDoneViaExportSchema flag is set to true
+	metaDB = initMetaDB(exportDir)
+	res, err = IsMigrationAssessmentDoneViaExportSchema()
+	if err != nil {
+		t.Errorf("Failed to check MigrationAssessmentDoneViaExportSchema flag: %v", err)
+	}
+	assert.False(t, res, "Expected MigrationAssessmentDoneViaExportSchema flag to be false")
 }

--- a/yb-voyager/cmd/exportSchema_test.go
+++ b/yb-voyager/cmd/exportSchema_test.go
@@ -244,7 +244,7 @@ func TestExportSchemaRunningAssessmentInternally_ExportSchemaThenAssessCmd(t *te
 	}
 	assert.True(t, res, "Expected MigrationAssessmentDone flag to be true")
 
-	// verify the MSR.MigrationAssessmentDoneViaExportSchema flag is set to true
+	// verify the MSR.MigrationAssessmentDoneViaExportSchema flag is set to false
 	metaDB = initMetaDB(exportDir)
 	res, err = IsMigrationAssessmentDoneViaExportSchema()
 	if err != nil {

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -53,18 +53,19 @@ type MigrationStatusRecord struct {
 	ExportDataSourceDebeziumStarted bool `json:"ExportDataSourceDebeziumStarted"`
 	ExportDataTargetDebeziumStarted bool `json:"ExportDataTargetDebeziumStarted"`
 
-	YBCDCStreamID                    string            `json:"YBCDCStreamID"`
-	EndMigrationRequested            bool              `json:"EndMigrationRequested"`
-	PGReplicationSlotName            string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	PGPublicationName                string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	YBReplicationSlotName            string            `json:"YBReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	YBPublicationName                string            `json:"YBPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
-	SnapshotMechanism                string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump, ora2pg)
-	SourceRenameTablesMap            map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
-	TargetRenameTablesMap            map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
-	IsExportTableListSet             bool              `json:"IsExportTableListSet"`
-	MigrationAssessmentDone          bool              `json:"MigrationAssessmentDone"`
-	AssessmentRecommendationsApplied bool              `json:"AssessmentRecommendationsApplied"`
+	YBCDCStreamID                          string            `json:"YBCDCStreamID"`
+	EndMigrationRequested                  bool              `json:"EndMigrationRequested"`
+	PGReplicationSlotName                  string            `json:"PGReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	PGPublicationName                      string            `json:"PGPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	YBReplicationSlotName                  string            `json:"YBReplicationSlotName"` // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	YBPublicationName                      string            `json:"YBPublicationName"`     // of the format voyager_<migrationUUID> (with replace "-" -> "_")
+	SnapshotMechanism                      string            `json:"SnapshotMechanism"`     // one of (debezium, pg_dump, ora2pg)
+	SourceRenameTablesMap                  map[string]string `json:"SourceRenameTablesMap"` // map of source table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
+	TargetRenameTablesMap                  map[string]string `json:"TargetRenameTablesMap"` // map of target table.Qualified.Unquoted -> table.Qualified.Unquoted for renaming the leaf partitions to root table in case of PG migration
+	IsExportTableListSet                   bool              `json:"IsExportTableListSet"`
+	MigrationAssessmentDone                bool              `json:"MigrationAssessmentDone"`
+	AssessmentRecommendationsApplied       bool              `json:"AssessmentRecommendationsApplied"`
+	MigrationAssessmentDoneViaExportSchema bool              `json:"MigrationAssessmentDoneViaExportSchema"`
 
 	ImportDataFileFlagFileTableMapping string `json:"ImportDataFileFlagFileTableMapping"` // Import data file command's file_table_mapping flag
 	ImportDataFileFlagDataDir          string `json:"ImportDataFileFlagDataDir"`          // Import data file command's data-dir flag

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -20,7 +20,6 @@ import (
 	"database/sql"
 	_ "embed"
 	"fmt"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/ybversion"
 	"io"
 	"math"
 	"net/http"
@@ -28,6 +27,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/ybversion"
 
 	"github.com/samber/lo"
 

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -37,6 +37,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/exp/slices"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -884,4 +886,24 @@ func SliceLastElement[T any](slice []T) (T, bool) {
 		return zeroValue, false
 	}
 	return slice[len(slice)-1], true
+}
+
+// GetCommonFlags returns the list of *pflag.Flag that are registered
+// on both cmdA and cmdB.
+func GetCommonFlags(cmdA, cmdB *cobra.Command) []*pflag.Flag {
+	var common []*pflag.Flag
+	cmdA.Flags().VisitAll(func(f *pflag.Flag) {
+		if cmdB.Flags().Lookup(f.Name) != nil {
+			common = append(common, f)
+		}
+	})
+
+	// also return common persistent flags like --export-dir --yes
+	cmdA.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if cmdB.PersistentFlags().Lookup(f.Name) != nil {
+			common = append(common, f)
+		}
+	})
+
+	return common
 }

--- a/yb-voyager/test/utils/cmdutils.go
+++ b/yb-voyager/test/utils/cmdutils.go
@@ -34,6 +34,8 @@ func RunVoyagerCommmand(container testcontainers.TestContainer,
 	cmdName string, cmdArgs []string,
 	doDuringCmd func(),
 ) error {
+	fmt.Printf("Running voyager command: %s %s\n", cmdName, strings.Join(cmdArgs, " "))
+
 	// Gather DB connection info
 	host, port, err := container.GetHostPort()
 	if err != nil {


### PR DESCRIPTION
### Describe the changes in this pull request
Handling start clean with export schema via `MigrationAssessmentDoneViaExportSchema` in MSR
 - internally assess will run only if the export schema is first
 - on second run, it will internally check and skip assess

Now MSR maintains two status for assessment - `MigrationAssessmentDone` and `MigrationAssessmentDoneViaExportSchema`
one is set via assess, second is set when assess is executed from export schema.


Cases/Behaviour:
1. If user run assess-migration then export schema then behaviour is same as before.

2. If user first run export schema(assess ran internally), then running assess command would need `--start-clean` as input before removing the reports generated by former.

3. If user rerun export with `--start-clean` then we should rerun the `assess` or reuse last run.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Yes, console output of export schema cmd would change.

1. Normal
<img width="1913" alt="image" src="https://github.com/user-attachments/assets/10fe8ced-5876-43ba-a562-6566c3fd52df" />

2. If assessment during export schema fails.
<img width="968" alt="image" src="https://github.com/user-attachments/assets/4789b20d-aeac-4e61-bdad-1b43f9568488" />





### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No not expected, added a new flag in MSR which shouldn't cause any errors.

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
