### PR TITLE
Added code to automatically invoke the 'import data to source' and 'export data from target' commands, taking into account the configuration file.

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -98,7 +98,7 @@ var allowedFinalizeSchemaPostDataImportConfigKeys = mapset.NewThreadUnsafeSet[st
 var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"batch-size", "parallel-jobs", "enable-adaptive-parallelism", "adaptive-parallelism-max",
 	"skip-replication-checks",
-	"disable-pb", "exclude-table-list", "table-list",
+	"disable-pb", "max-retries", "exclude-table-list", "table-list",
 	"exclude-table-list-file-path", "table-list-file-path", "enable-upsert", "use-public-ip",
 	"target-endpoints", "truncate-tables",
 	// environment variables keys
@@ -109,14 +109,14 @@ var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"parallel-jobs", "disable-pb",
+	"parallel-jobs", "disable-pb", "max-retries",
 	// environment variables keys
 	"num-event-channels", "event-channel-size", "max-events-per-batch",
 	"max-interval-between-batches", "max-batch-size-bytes",
 )
 
 var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb",
+	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb", "max-retries",
 	// environment variables keys
 	"ybvoyager-max-colocated-batches-in-progress", "num-event-channels",
 	"event-channel-size", "max-events-per-batch", "max-interval-between-batches",
@@ -124,7 +124,7 @@ var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[strin
 )
 
 var allowedImportDataFileConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"disable-pb", "enable-upsert", "use-public-ip", "target-endpoints",
+	"disable-pb", "max-retries", "enable-upsert", "use-public-ip", "target-endpoints",
 	"batch-size", "parallel-jobs", "enable-adaptive-parallelism", "adaptive-parallelism-max",
 	"format", "delimiter", "data-dir", "file-table-map", "has-header", "escape-char",
 	"quote-char", "file-opts", "null-string", "truncate-tables",

--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -13,8 +13,6 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
-var InMemoryConfigFile map[string]interface{}
-
 const (
 	// Flag name prefixes (used in CLI flags)
 	SourceDBFlagPrefix = "source-"
@@ -255,9 +253,6 @@ func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, []EnvVarSetViaConfig,
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to bind environment variables to viper: %w", err)
 	}
-
-	// Set the in-memory config file for later use
-	InMemoryConfigFile = v.AllSettings()
 
 	return overrides, envVarsSetViaConfig, envVarsAlreadyExported, nil
 }
@@ -676,4 +671,103 @@ func setToAliasPrefixIfSet(configKeyPrefix string, v *viper.Viper) string {
 		}
 	}
 	return configKeyPrefix
+}
+
+/*
+readAndValidateConfigFile reads the config file and validates it.
+This functions is called only by readConfigFileAndGetExportDataFromTargetKeys and readConfigFileAndGetImportDataToSourceKeys functions.
+It returns a Viper instance if the config file is set and found, or an error if there are issues with the file.
+It does the following:
+1. If the config file is set, it reads the file using Viper.
+2. If the file is read successfully, it validates the config file for allowed keys and sections.
+3. If the cfgFile variable is empty or an error occurs while reading the file, it returns nil for the Viper instance.
+4. If the config file is read and validated successfully, it returns the Viper instance.
+*/
+func readAndValidateConfigFile() (*viper.Viper, error) {
+	if cfgFile == "" {
+		return nil, nil
+	}
+
+	v := viper.New()
+	v.SetConfigFile(cfgFile)
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	// Validate the config file for allowed keys and sections
+	err := validateConfigFile(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+/*
+readConfigFileAndGetExportDataFromTargetKeys reads the config file and returns the export-data-from-target keys.
+It returns a slice of strings containing the keys that are set in the config file.
+It does the following:
+1. It calls readAndValidateConfigFile to read the config file and validate it.
+2. If and error occurs in this, it returns an error and a nil slice.
+3. If viper instance is nil, it returns an empty slice.
+4. If the config file is read and validated successfully, it returns a slice of strings containing the keys that are set in the config file.
+*/
+func readConfigFileAndGetExportDataFromTargetKeys() ([]string, error) {
+	v, err := readAndValidateConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read and validate config file: %w", err)
+	}
+	if v == nil {
+		return []string{}, nil
+	}
+
+	// Get the export-data-from-target keys that are set in the config file
+	exportDataFromTargetKeys := []string{}
+	keyPrefix := "export-data-from-target."
+	for _, key := range v.AllKeys() {
+		if strings.HasPrefix(key, keyPrefix) && v.IsSet(key) {
+			// Extract the key name after the prefix
+			key = strings.TrimPrefix(key, keyPrefix)
+			key = strings.TrimSpace(key)
+			// Add the key to the list
+			exportDataFromTargetKeys = append(exportDataFromTargetKeys, key)
+		}
+	}
+
+	return exportDataFromTargetKeys, nil
+}
+
+/*
+readConfigFileAndGetImportDataToSourceKeys reads the config file and returns the import-data-to-source keys.
+It returns a slice of strings containing the keys that are set in the config file.
+It does the following:
+1. It calls readAndValidateConfigFile to read the config file and validate it.
+2. If and error occurs in this, it returns an error and a nil slice.
+3. If viper instance is nil, it returns an empty slice.
+4. If the config file is read and validated successfully, it returns a slice of strings containing the keys that are set in the config file.
+*/
+func readConfigFileAndGetImportDataToSourceKeys() ([]string, error) {
+	v, err := readAndValidateConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read and validate config file: %w", err)
+	}
+	if v == nil {
+		return []string{}, nil
+	}
+
+	// Get the import-data-to-source keys that are set in the config file
+	importDataToSourceKeys := []string{}
+	keyPrefix := "import-data-to-source."
+	for _, key := range v.AllKeys() {
+		if strings.HasPrefix(key, keyPrefix) && v.IsSet(key) {
+			// Extract the key name after the prefix
+			key = strings.TrimPrefix(key, keyPrefix)
+			key = strings.TrimSpace(key)
+			// Add the key to the list
+			importDataToSourceKeys = append(importDataToSourceKeys, key)
+		}
+	}
+
+	return importDataToSourceKeys, nil
 }

--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -13,6 +13,8 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
+var InMemoryConfigFile map[string]interface{}
+
 const (
 	// Flag name prefixes (used in CLI flags)
 	SourceDBFlagPrefix = "source-"
@@ -253,6 +255,9 @@ func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, []EnvVarSetViaConfig,
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to bind environment variables to viper: %w", err)
 	}
+
+	// Set the in-memory config file for later use
+	InMemoryConfigFile = v.AllSettings()
 
 	return overrides, envVarsSetViaConfig, envVarsAlreadyExported, nil
 }

--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -724,7 +724,7 @@ func readConfigFileAndGetExportDataFromTargetKeys() ([]string, error) {
 
 	// Get the export-data-from-target keys that are set in the config file
 	exportDataFromTargetKeys := []string{}
-	keyPrefix := "export-data-from-target."
+	const keyPrefix = "export-data-from-target."
 	for _, key := range v.AllKeys() {
 		if strings.HasPrefix(key, keyPrefix) && v.IsSet(key) {
 			// Extract the key name after the prefix
@@ -758,7 +758,7 @@ func readConfigFileAndGetImportDataToSourceKeys() ([]string, error) {
 
 	// Get the import-data-to-source keys that are set in the config file
 	importDataToSourceKeys := []string{}
-	keyPrefix := "import-data-to-source."
+	const keyPrefix = "import-data-to-source."
 	for _, key := range v.AllKeys() {
 		if strings.HasPrefix(key, keyPrefix) && v.IsSet(key) {
 			// Extract the key name after the prefix

--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -79,7 +79,7 @@ var allowedExportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 
 var allowedExportDataFromTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"disable-pb", "exclude-table-list", "table-list", "exclude-table-list-file-path",
-	"table-list-file-path",
+	"table-list-file-path", "transaction-ordering",
 	// environment variables keys
 	"yb-master-port", "queue-segment-max-bytes", "debezium-dist-dir",
 )
@@ -96,7 +96,7 @@ var allowedFinalizeSchemaPostDataImportConfigKeys = mapset.NewThreadUnsafeSet[st
 var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"batch-size", "parallel-jobs", "enable-adaptive-parallelism", "adaptive-parallelism-max",
 	"skip-replication-checks",
-	"disable-pb", "max-retries", "exclude-table-list", "table-list",
+	"disable-pb", "exclude-table-list", "table-list",
 	"exclude-table-list-file-path", "table-list-file-path", "enable-upsert", "use-public-ip",
 	"target-endpoints", "truncate-tables",
 	// environment variables keys
@@ -107,14 +107,14 @@ var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"parallel-jobs", "disable-pb", "max-retries",
+	"parallel-jobs", "disable-pb",
 	// environment variables keys
 	"num-event-channels", "event-channel-size", "max-events-per-batch",
 	"max-interval-between-batches", "max-batch-size-bytes",
 )
 
 var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb", "max-retries",
+	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb",
 	// environment variables keys
 	"ybvoyager-max-colocated-batches-in-progress", "num-event-channels",
 	"event-channel-size", "max-events-per-batch", "max-interval-between-batches",
@@ -122,7 +122,7 @@ var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[strin
 )
 
 var allowedImportDataFileConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"disable-pb", "max-retries", "enable-upsert", "use-public-ip", "target-endpoints",
+	"disable-pb", "enable-upsert", "use-public-ip", "target-endpoints",
 	"batch-size", "parallel-jobs", "enable-adaptive-parallelism", "adaptive-parallelism-max",
 	"format", "delimiter", "data-dir", "file-table-map", "has-header", "escape-char",
 	"quote-char", "file-opts", "null-string", "truncate-tables",
@@ -229,6 +229,7 @@ func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, []EnvVarSetViaConfig,
 
 	// If a config file is found, read it in.
 	if err := v.ReadInConfig(); err == nil {
+		cfgFile = v.ConfigFileUsed()
 		fmt.Println("Using config file:", color.BlueString(v.ConfigFileUsed()))
 	} else {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -1472,6 +1472,7 @@ import-data:
   adaptive-parallelism-max: 10
   skip-replication-checks: true
   disable-pb: true
+  max-retries: 3
   exclude-table-list: table1,table2
   table-list: table3,table4
   exclude-table-list-file-path: /tmp/exclude-tables.txt
@@ -1539,6 +1540,7 @@ func TestImportDataConfigBinding_ConfigFileBinding(t *testing.T) {
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
+	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1580,6 +1582,7 @@ func TestImportDataConfigBinding_CLIOverridesConfig(t *testing.T) {
 		"--adaptive-parallelism-max", "5",
 		"--skip-replication-checks", "false",
 		"--disable-pb", "false",
+		"--max-retries", "5",
 		"--exclude-table-list", "table5,table6",
 		"--table-list", "table7,table8",
 		"--exclude-table-list-file-path", "/tmp/new-exclude-tables.txt",
@@ -1634,6 +1637,7 @@ func TestImportDataConfigBinding_CLIOverridesConfig(t *testing.T) {
 	assert.Equal(t, 5, tconf.MaxParallelism, "Adaptive parallelism max should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), skipReplicationChecks, "Skip replication checks should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), disablePb, "Disable PB should be overridden by CLI")
+	assert.Equal(t, 5, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should be overridden by CLI")
 	assert.Equal(t, "table5,table6", tconf.ExcludeTableList, "Exclude table list for importing data should be overridden by CLI")
 	assert.Equal(t, "table7,table8", tconf.TableList, "Table list for importing data should be overridden by CLI")
 	assert.Equal(t, "/tmp/new-exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should be overridden by CLI")
@@ -1717,6 +1721,7 @@ func TestImportDataConfigBinding_EnvOverridesConfig(t *testing.T) {
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the env var")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
+	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1768,6 +1773,7 @@ import-data:
   adaptive-parallelism-max: 10
   skip-replication-checks: true
   disable-pb: true
+  max-retries: 3
   exclude-table-list: table1,table2
   table-list: table3,table4
   exclude-table-list-file-path: /tmp/exclude-tables.txt
@@ -1818,6 +1824,7 @@ import-data:
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
+	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1864,6 +1871,7 @@ import-data-to-target:
   adaptive-parallelism-max: 10
   skip-replication-checks: true
   disable-pb: true
+  max-retries: 3
   exclude-table-list: table1,table2
   table-list: table3,table4
   exclude-table-list-file-path: /tmp/exclude-tables.txt
@@ -1914,6 +1922,7 @@ import-data-to-target:
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
+	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1977,6 +1986,7 @@ import-data-file:
   enable-adaptive-parallelism: true
   adaptive-parallelism-max: 10
   disable-pb: true
+  max-retries: 3
   enable-upsert: true
   use-public-ip: true
   target-endpoints: endpoint1,endpoint2
@@ -2045,6 +2055,7 @@ func TestImportDataFileConfigBinding_ConfigFileBinding(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableYBAdaptiveParallelism, "Enable adaptive parallelism should match the config")
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
+	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableUpsert, "Enable upsert for importing data should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.UsePublicIP, "Use public IP for importing data should match the config")
 	assert.Equal(t, "endpoint1,endpoint2", tconf.TargetEndpoints, "Target endpoints for importing data should match the config")
@@ -2086,6 +2097,7 @@ func TestImportDataFileConfigBinding_CLIOverridesConfig(t *testing.T) {
 		"--enable-adaptive-parallelism", "false",
 		"--adaptive-parallelism-max", "5",
 		"--disable-pb", "false",
+		"--max-retries", "5",
 		"--enable-upsert", "false",
 		"--use-public-ip", "false",
 		"--target-endpoints", "endpoint3,endpoint4",
@@ -2144,6 +2156,7 @@ func TestImportDataFileConfigBinding_CLIOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(false), tconf.EnableYBAdaptiveParallelism, "Enable adaptive parallelism should be overridden by CLI")
 	assert.Equal(t, 5, tconf.MaxParallelism, "Adaptive parallelism max should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), disablePb, "Disable PB should be overridden by CLI")
+	assert.Equal(t, 5, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), tconf.EnableUpsert, "Enable upsert for importing data should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), tconf.UsePublicIP, "Use public IP for importing data should be overridden by CLI")
 	assert.Equal(t, "endpoint3,endpoint4", tconf.TargetEndpoints, "Target endpoints for importing data should be overridden by CLI")
@@ -2225,6 +2238,7 @@ func TestImportDataFileConfigBinding_EnvOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableYBAdaptiveParallelism, "Enable adaptive parallelism should match the config")
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
+	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableUpsert, "Enable upsert for importing data should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.UsePublicIP, "Use public IP for importing data should match the config")
 	assert.Equal(t, "endpoint1,endpoint2", tconf.TargetEndpoints, "Target endpoints for importing data should match the config")

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -1472,7 +1472,6 @@ import-data:
   adaptive-parallelism-max: 10
   skip-replication-checks: true
   disable-pb: true
-  max-retries: 3
   exclude-table-list: table1,table2
   table-list: table3,table4
   exclude-table-list-file-path: /tmp/exclude-tables.txt
@@ -1540,7 +1539,6 @@ func TestImportDataConfigBinding_ConfigFileBinding(t *testing.T) {
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
-	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1582,7 +1580,6 @@ func TestImportDataConfigBinding_CLIOverridesConfig(t *testing.T) {
 		"--adaptive-parallelism-max", "5",
 		"--skip-replication-checks", "false",
 		"--disable-pb", "false",
-		"--max-retries", "5",
 		"--exclude-table-list", "table5,table6",
 		"--table-list", "table7,table8",
 		"--exclude-table-list-file-path", "/tmp/new-exclude-tables.txt",
@@ -1637,7 +1634,6 @@ func TestImportDataConfigBinding_CLIOverridesConfig(t *testing.T) {
 	assert.Equal(t, 5, tconf.MaxParallelism, "Adaptive parallelism max should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), skipReplicationChecks, "Skip replication checks should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), disablePb, "Disable PB should be overridden by CLI")
-	assert.Equal(t, 5, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should be overridden by CLI")
 	assert.Equal(t, "table5,table6", tconf.ExcludeTableList, "Exclude table list for importing data should be overridden by CLI")
 	assert.Equal(t, "table7,table8", tconf.TableList, "Table list for importing data should be overridden by CLI")
 	assert.Equal(t, "/tmp/new-exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should be overridden by CLI")
@@ -1721,7 +1717,6 @@ func TestImportDataConfigBinding_EnvOverridesConfig(t *testing.T) {
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the env var")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
-	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1773,7 +1768,6 @@ import-data:
   adaptive-parallelism-max: 10
   skip-replication-checks: true
   disable-pb: true
-  max-retries: 3
   exclude-table-list: table1,table2
   table-list: table3,table4
   exclude-table-list-file-path: /tmp/exclude-tables.txt
@@ -1824,7 +1818,6 @@ import-data:
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
-	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1871,7 +1864,6 @@ import-data-to-target:
   adaptive-parallelism-max: 10
   skip-replication-checks: true
   disable-pb: true
-  max-retries: 3
   exclude-table-list: table1,table2
   table-list: table3,table4
   exclude-table-list-file-path: /tmp/exclude-tables.txt
@@ -1922,7 +1914,6 @@ import-data-to-target:
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), skipReplicationChecks, "Skip replication checks should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
-	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, "table1,table2", tconf.ExcludeTableList, "Exclude table list for importing data should match the config")
 	assert.Equal(t, "table3,table4", tconf.TableList, "Table list for importing data should match the config")
 	assert.Equal(t, "/tmp/exclude-tables.txt", excludeTableListFilePath, "Exclude table list file path for importing data should match the config")
@@ -1986,7 +1977,6 @@ import-data-file:
   enable-adaptive-parallelism: true
   adaptive-parallelism-max: 10
   disable-pb: true
-  max-retries: 3
   enable-upsert: true
   use-public-ip: true
   target-endpoints: endpoint1,endpoint2
@@ -2055,7 +2045,6 @@ func TestImportDataFileConfigBinding_ConfigFileBinding(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableYBAdaptiveParallelism, "Enable adaptive parallelism should match the config")
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
-	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableUpsert, "Enable upsert for importing data should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.UsePublicIP, "Use public IP for importing data should match the config")
 	assert.Equal(t, "endpoint1,endpoint2", tconf.TargetEndpoints, "Target endpoints for importing data should match the config")
@@ -2097,7 +2086,6 @@ func TestImportDataFileConfigBinding_CLIOverridesConfig(t *testing.T) {
 		"--enable-adaptive-parallelism", "false",
 		"--adaptive-parallelism-max", "5",
 		"--disable-pb", "false",
-		"--max-retries", "5",
 		"--enable-upsert", "false",
 		"--use-public-ip", "false",
 		"--target-endpoints", "endpoint3,endpoint4",
@@ -2156,7 +2144,6 @@ func TestImportDataFileConfigBinding_CLIOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(false), tconf.EnableYBAdaptiveParallelism, "Enable adaptive parallelism should be overridden by CLI")
 	assert.Equal(t, 5, tconf.MaxParallelism, "Adaptive parallelism max should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), disablePb, "Disable PB should be overridden by CLI")
-	assert.Equal(t, 5, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), tconf.EnableUpsert, "Enable upsert for importing data should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), tconf.UsePublicIP, "Use public IP for importing data should be overridden by CLI")
 	assert.Equal(t, "endpoint3,endpoint4", tconf.TargetEndpoints, "Target endpoints for importing data should be overridden by CLI")
@@ -2238,7 +2225,6 @@ func TestImportDataFileConfigBinding_EnvOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableYBAdaptiveParallelism, "Enable adaptive parallelism should match the config")
 	assert.Equal(t, 10, tconf.MaxParallelism, "Adaptive parallelism max should match the config")
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
-	assert.Equal(t, 3, EVENT_BATCH_MAX_RETRY_COUNT, "Max retries should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.EnableUpsert, "Enable upsert for importing data should match the config")
 	assert.Equal(t, utils.BoolStr(true), tconf.UsePublicIP, "Use public IP for importing data should match the config")
 	assert.Equal(t, "endpoint1,endpoint2", tconf.TargetEndpoints, "Target endpoints for importing data should match the config")

--- a/yb-voyager/cmd/cutoverStatus.go
+++ b/yb-voyager/cmd/cutoverStatus.go
@@ -43,6 +43,7 @@ var cutoverStatusCmd = &cobra.Command{
 func init() {
 	cutoverRootCmd.AddCommand(cutoverStatusCmd)
 	registerExportDirFlag(cutoverStatusCmd)
+	registerConfigFileFlag(cutoverStatusCmd)
 }
 
 func checkAndReportCutoverStatus() {

--- a/yb-voyager/cmd/cutoverToSource.go
+++ b/yb-voyager/cmd/cutoverToSource.go
@@ -36,4 +36,5 @@ var cutoverToSourceCmd = &cobra.Command{
 func init() {
 	cutoverToCmd.AddCommand(cutoverToSourceCmd)
 	registerExportDirFlag(cutoverToSourceCmd)
+	registerConfigFileFlag(cutoverToSourceCmd)
 }

--- a/yb-voyager/cmd/cutoverToSourceReplica.go
+++ b/yb-voyager/cmd/cutoverToSourceReplica.go
@@ -36,4 +36,5 @@ var cutoverToSourceReplicaCmd = &cobra.Command{
 func init() {
 	cutoverToCmd.AddCommand(cutoverToSourceReplicaCmd)
 	registerExportDirFlag(cutoverToSourceReplicaCmd)
+	registerConfigFileFlag(cutoverToSourceReplicaCmd)
 }

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -65,6 +65,7 @@ var cutoverToTargetCmd = &cobra.Command{
 func init() {
 	cutoverToCmd.AddCommand(cutoverToTargetCmd)
 	registerExportDirFlag(cutoverToTargetCmd)
+	registerConfigFileFlag(cutoverToTargetCmd)
 	BoolVar(cutoverToTargetCmd.Flags(), &prepareForFallBack, "prepare-for-fall-back", false,
 		"prepare for fallback by streaming changes from target DB back to source DB. Not applicable for fall-forward workflow.")
 	BoolVar(cutoverToTargetCmd.Flags(), &useYBgRPCConnector, "use-yb-grpc-connector", true,

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -424,6 +424,7 @@ func getFinalRowCount(row rowData) int64 {
 func init() {
 	getCommand.AddCommand(getDataMigrationReportCmd)
 	registerExportDirFlag(getDataMigrationReportCmd)
+	registerConfigFileFlag(getDataMigrationReportCmd)
 	getDataMigrationReportCmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
 		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
 	getDataMigrationReportCmd.Flags().StringVar(&reportOrStatusCmdOutputFormat, "output-format", "table",

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -293,6 +293,7 @@ func registerCommonGlobalFlags(cmd *cobra.Command) {
 	cmd.Flags().MarkHidden("profile")
 
 	registerExportDirFlag(cmd)
+	registerConfigFileFlag(cmd)
 
 	cmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
 		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
@@ -302,11 +303,11 @@ func registerCommonGlobalFlags(cmd *cobra.Command) {
 
 	BoolVar(cmd.Flags(), &callhome.SendDiagnostics, "send-diagnostics", true,
 		"enable or disable the 'send-diagnostics' feature that sends analytics data to YugabyteDB.(default true)")
+}
 
+func registerConfigFileFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&cfgFile, "config-file", "c", "",
 		"path of the config file which is used to set the various parameters for yb-voyager commands")
-
-	// Hide the config file flag from help
 	cmd.PersistentFlags().MarkHidden("config-file")
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request
- Enhanced the system to automatically invoke the **'import data to source'** and **'export data from target'** commands, utilizing the configuration file:

    - For command-specific flags, if a parameter is set in the config file, the flag is no longer passed along with the command invocation. Instead, the config file logic handles it when the command is executed.

- Implemented several refinements:
    - Removed the `max-retries` parameter from the config file, as it is marked as hidden in the CLI.
    - Updated the config file tests to reflect these changes.
    - Added the `transaction-ordering` parameter to the config file section for **'export data from target'**.

Example:
For this config file:
```
export-data-from-target:
  transaction-ordering: true
  disable-pb: true

import-data-to-source:
  parallel-jobs: 2
  disable-pb: true
```

The commands that are invoked are these:
`yb-voyager export data from target --export-dir /home/ubuntu/pg_export --send-diagnostics=false --log-level info --config-file /home/ubuntu/yb-voyager-config.yaml --table-list public."customers",public."orders",public."order_items",public."products" --target-ssl-mode disable`

`yb-voyager import data to source --export-dir /home/ubuntu/pg_export --send-diagnostics=false --log-level info --config-file /home/ubuntu/yb-voyager-config.yaml`

The params mentioned in the config file are not passed on as flags and are handled post the command starts.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
None

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
None

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
