### PR TITLE
Added config file unit tests for online migration commands

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -107,7 +107,7 @@ var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"parallel-jobs", "disable-pb", "max-retries",
+	"parallel-jobs", "disable-pb",
 	// environment variables keys
 	"num-event-channels", "event-channel-size", "max-events-per-batch",
 	"max-interval-between-batches", "max-batch-size-bytes",

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -2540,17 +2540,9 @@ func TestExportDataFromTargetConfigBinding_ConfigFileBinding(t *testing.T) {
 	assert.Equal(t, "9000", os.Getenv("YB_TSERVER_PORT"), "YB TServer port should match the config")
 	assert.Equal(t, "/path/to/tns/admin", os.Getenv("TNS_ADMIN"), "TNS admin should match the config")
 	// Assertions on target config
-	// assert.Equal(t, "2.1.1.1", source.Host, "Target host should match the config")
-	// assert.Equal(t, 5432, source.Port, "Target port should match the config")
-	// assert.Equal(t, "test_user", source.User, "Target user should match the config")
 	assert.Equal(t, "test_password", source.Password, "Target password should match the config")
-	// assert.Equal(t, "test_db", source.DBName, "Target DB name should match the config")
-	// assert.Equal(t, "public", source.Schema, "Target schema should match the config")
-	// assert.Equal(t, "/path/to/ssl-cert", source.SSLCertPath, "Target SSL cert should match the config")
 	assert.Equal(t, "require", source.SSLMode, "Target SSL mode should match the config")
-	// assert.Equal(t, "/path/to/ssl-key", source.SSLKey, "Target SSL key should match the config")
 	assert.Equal(t, "/path/to/ssl-root-cert", source.SSLRootCert, "Target SSL root cert should match the config")
-	// assert.Equal(t, "/path/to/ssl-crl", source.SSLCRL, "Target SSL CRL should match the config")
 	// Assertions on export-data config
 	assert.Equal(t, utils.BoolStr(true), disablePb, "Disable PB should match the config")
 	assert.Equal(t, "table1,table2", source.ExcludeTableList, "Exclude table list should match the config")

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -70,4 +70,6 @@ func init() {
 		"prepare for fallback by streaming changes from target DB back to source DB. Not applicable for fall-forward workflow.")
 	BoolVar(cutoverToTargetCmd.Flags(), &useYBgRPCConnector, "use-yb-grpc-connector", true,
 		"Use the gRPC connector for YB export (default: true). If set to false, the logical replication connector (supported in YB versions 2024.1.1+) is used. For this new logical replication based connector, ensure no ALTER TABLE commands causing table rewrites (e.g., adding primary keys) were present in the schema during import")
+	cutoverToCmd.PersistentFlags().StringVarP(&cfgFile, "config-file", "c", "",
+		"path of the config file which is used to set the various parameters for yb-voyager commands")
 }


### PR DESCRIPTION
### Describe the changes in this pull request
Added unit tests in config_tests.go for all the live migration related commands like import data to source, export data from target, archive changes, cutover to target and end migration.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
None

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
GH actions and unit tests

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
None

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
