### PR TITLE
Fix: Do not skip HSTORE for logical connector as unsupported datatypes in export data from target

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -236,6 +236,15 @@ func exportData() bool {
 		log.Errorf("error getting database size: %v", err) //can just log as this is used for call-home only
 	}
 
+	msr, err := metaDB.GetMigrationStatusRecord()
+	if err != nil {
+		utils.ErrExit("error getting migration status record: %v", err)
+	}
+
+	if source.DBType == YUGABYTEDB {
+		source.IsYBGrpcConnector = msr.UseYBgRPCConnector
+	}
+
 	res := source.DB().CheckSchemaExists()
 	if !res {
 		utils.ErrExit("schema does not exist : %q", source.Schema)
@@ -295,7 +304,7 @@ func exportData() bool {
 		}
 	})
 
-	msr, err := metaDB.GetMigrationStatusRecord()
+	msr, err = metaDB.GetMigrationStatusRecord()
 	if err != nil {
 		utils.ErrExit("get migration status record: %v", err)
 	}

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -60,8 +60,8 @@ func GetPGLiveMigrationUnsupportedDatatypes() []string {
 }
 
 func GetPGLiveMigrationWithFFOrFBUnsupportedDatatypes() []string {
-	//TODO: add connector specific handling 
-	unsupportedDataTypesForDbzmYBOnly, _ := lo.Difference(GetYugabyteUnsupportedDatatypesDbzmWithGrpcConnector(), PostgresUnsupportedDataTypes)
+	//TODO: add connector specific handling
+	unsupportedDataTypesForDbzmYBOnly, _ := lo.Difference(GetYugabyteUnsupportedDatatypesDbzm(true), PostgresUnsupportedDataTypes)
 	liveMigrationWithFForFBUnsupportedDatatypes, _ := lo.Difference(unsupportedDataTypesForDbzmYBOnly, GetPGLiveMigrationUnsupportedDatatypes())
 	return liveMigrationWithFForFBUnsupportedDatatypes
 }
@@ -107,13 +107,11 @@ This query returns all types of sequences attached to the tables -
 1. SERIAL/BIGSERIAL datatypes
 2. DEFAULT nextval()
 
-the change in this query  from the above query is this line 
+the change in this query  from the above query is this line
 
-LEFT JOIN pg_class seq ON seq.oid = dep.refobjid AND seq.relkind = 'S' 
+LEFT JOIN pg_class seq ON seq.oid = dep.refobjid AND seq.relkind = 'S'
 
-where the join is happening with `dep.refobjid` which helps in getting the default nextval cases as 
-
-
+where the join is happening with `dep.refobjid` which helps in getting the default nextval cases as
 */
 const FETCH_COLUMN_SEQUENCES_DEFAULT_QUERY_TEMPLATE = `SELECT
 	(tn.nspname || '.' || t.relname)  AS table_name,

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -60,7 +60,8 @@ func GetPGLiveMigrationUnsupportedDatatypes() []string {
 }
 
 func GetPGLiveMigrationWithFFOrFBUnsupportedDatatypes() []string {
-	unsupportedDataTypesForDbzmYBOnly, _ := lo.Difference(YugabyteUnsupportedDataTypesForDbzm, PostgresUnsupportedDataTypes)
+	//TODO: add connector specific handling 
+	unsupportedDataTypesForDbzmYBOnly, _ := lo.Difference(GetYugabyteUnsupportedDatatypesDbzmWithGrpcConnector(), PostgresUnsupportedDataTypes)
 	liveMigrationWithFForFBUnsupportedDatatypes, _ := lo.Difference(unsupportedDataTypesForDbzmYBOnly, GetPGLiveMigrationUnsupportedDatatypes())
 	return liveMigrationWithFForFBUnsupportedDatatypes
 }

--- a/yb-voyager/src/srcdb/source.go
+++ b/yb-voyager/src/srcdb/source.go
@@ -58,6 +58,7 @@ type Source struct {
 	StrExportObjectTypeList  string        `json:"str_export_object_type_list"`
 	StrExcludeObjectTypeList string        `json:"str_exclude_object_type_list"`
 	RunGuardrailsChecks      utils.BoolStr `json:"run_guardrails_checks"`
+	IsYBGrpcConnector        bool          `json:"-"`
 
 	ExportObjectTypeList []string `json:"-"`
 	sourceDB             SourceDB `json:"-"`


### PR DESCRIPTION
…

### Describe the changes in this pull request
Not skipping the `HSTORE` datatype column's data in export data from target case for fall-forward/fall-back case.
fixes #2202 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
With the logical connector during fall-forward/fallback workflow, data HSTORE datatype column will be exported. 

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              |  No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  | No |
