### PR TITLE
Add --assess-schema-before-export flag to config file keys

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -66,6 +66,7 @@ var allowedAnalyzeSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
 var allowedExportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"use-orafce", "comments-on-objects", "object-type-list", "exclude-object-type-list",
 	"skip-recommendations", "assessment-report-path",
+	"assess-schema-before-export",
 	// environment variables keys
 	"ybvoyager-skip-merge-constraints-transformation",
 )

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -681,7 +681,7 @@ func TestExportSchemaConfigBinding_CLIOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(true), skipRecommendations, "Skip recommendations should be overridden by CLI")
 	assert.Equal(t, "/tmp/new-assessment-report", assessmentReportPath, "Assessment report path should be overridden by CLI")
 	assert.Equal(t, "true", os.Getenv("YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS"), "YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS should match the config")
-	assert.Equal(t, utils.BoolStr(false), assessSchemaBeforeExport, "assessSchemaBeforeExport should be overridden by CLI")
+	assert.Equal(t, utils.BoolStr(false), assessSchemaBeforeExport, "Assess schema before export should be overridden by CLI")
 }
 
 func TestExportSchemaConfigBinding_EnvOverridesConfig(t *testing.T) {
@@ -743,7 +743,7 @@ func TestExportSchemaConfigBinding_EnvOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(false), skipRecommendations, "Skip recommendations should match the config")
 	assert.Equal(t, "/tmp/assessment-report", assessmentReportPath, "Assessment report path should match the config")
 	assert.Equal(t, "true", os.Getenv("YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS"), "YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS should be overridden by env var")
-	assert.Equal(t, utils.BoolStr(true), assessSchemaBeforeExport, "assessSchemaBeforeExport should be overridden by CLI")
+	assert.Equal(t, utils.BoolStr(true), assessSchemaBeforeExport, "Assess schema before export should match the config")
 }
 
 ////////////////////////////// Analyze Schema Tests ////////////////////////////////

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -544,6 +544,7 @@ export-schema:
   skip-recommendations: false
   assessment-report-path: /tmp/assessment-report
   ybvoyager-skip-merge-constraints-transformation: true
+  assess-schema-before-export: true
 `, tmpExportDir)
 	configFile, configDir := setupConfigFile(t, configContent)
 	t.Cleanup(func() { os.RemoveAll(configDir) })
@@ -599,6 +600,7 @@ func TestExportSchemaConfigBinding_ConfigFileBinding(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(false), skipRecommendations, "Skip recommendations should match the config")
 	assert.Equal(t, "/tmp/assessment-report", assessmentReportPath, "Assessment report path should match the config")
 	assert.Equal(t, "true", os.Getenv("YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS"), "YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS should match the config")
+	assert.Equal(t, utils.BoolStr(true), assessSchemaBeforeExport, "Assess schema before export should match the config")
 }
 
 func TestExportSchemaConfigBinding_CLIOverridesConfig(t *testing.T) {
@@ -637,6 +639,7 @@ func TestExportSchemaConfigBinding_CLIOverridesConfig(t *testing.T) {
 		"--oracle-db-sid", "test_sid2",
 		"--oracle-home", "/path/to/oracle/home2",
 		"--oracle-tns-alias", "test_tns_alias2",
+		"--assess-schema-before-export", "false",
 	})
 	err := rootCmd.Execute()
 	require.NoError(t, err)
@@ -678,6 +681,7 @@ func TestExportSchemaConfigBinding_CLIOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(true), skipRecommendations, "Skip recommendations should be overridden by CLI")
 	assert.Equal(t, "/tmp/new-assessment-report", assessmentReportPath, "Assessment report path should be overridden by CLI")
 	assert.Equal(t, "true", os.Getenv("YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS"), "YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS should match the config")
+	assert.Equal(t, utils.BoolStr(false), assessSchemaBeforeExport, "assessSchemaBeforeExport should be overridden by CLI")
 }
 
 func TestExportSchemaConfigBinding_EnvOverridesConfig(t *testing.T) {
@@ -739,6 +743,7 @@ func TestExportSchemaConfigBinding_EnvOverridesConfig(t *testing.T) {
 	assert.Equal(t, utils.BoolStr(false), skipRecommendations, "Skip recommendations should match the config")
 	assert.Equal(t, "/tmp/assessment-report", assessmentReportPath, "Assessment report path should match the config")
 	assert.Equal(t, "true", os.Getenv("YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS"), "YB_VOYAGER_SKIP_MERGE_CONSTRAINTS_TRANSFORMATIONS should be overridden by env var")
+	assert.Equal(t, utils.BoolStr(true), assessSchemaBeforeExport, "assessSchemaBeforeExport should be overridden by CLI")
 }
 
 ////////////////////////////// Analyze Schema Tests ////////////////////////////////


### PR DESCRIPTION
### Describe the changes in this pull request
Follow up PR for this (https://github.com/yugabyte/yb-voyager/pull/2560) to add flag `--assess-schema-before-export` to config file.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
