### PR TITLE
Fix frequent restart read required error in test automation framework from YB server

### DIFF
--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -169,7 +169,9 @@ main() {
 	run_ysql ${TARGET_DB_NAME} "\di"
 	run_ysql ${TARGET_DB_NAME} "\dft" 
 
-	step "Sleeping before read queries in validations script to let tablets safe time get updated(updated every 1sec)"
+	# Sleep for 1100ms: spans at least one full 500ms Raft heartbeat plus 500ms skew,
+	# so that tablet safe‐time ≥ (now – skew) and we avoid “restart read required”.
+	step "Sleeping before read queries in validations script to let tablets safe time get updated"
 	sleep 1.1
 
 	step "Run validations."

--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -169,6 +169,9 @@ main() {
 	run_ysql ${TARGET_DB_NAME} "\di"
 	run_ysql ${TARGET_DB_NAME} "\dft" 
 
+	step "Sleeping before read queries in validations script to let tablets safe time get updated(updated every 1sec)"
+	sleep 1.1
+
 	step "Run validations."
 	if [[ "${EXPORT_TABLE_LIST}" != "" && -x "${TEST_DIR}/validate-with-table-list" ]]; then
 		"${TEST_DIR}/validate-with-table-list"


### PR DESCRIPTION
### Describe the changes in this pull request

**RCA**
[pg-indexes test schema:  11 tables, 11 indexes, multiples tables with 100k rows each] For each test validations, we are starting a single transaction and firing count(*) for all tables Which in result might lead to reading each tablet, given tablets are large in number - the probability of hitting it is high with single transaction. So, our transaction is failing on SELECT query because the tablet being read for that table didn't get update safe time(multiple possible reason).

Error message:
`psycopg2.errors.SerializationFailure: Restart read required at: { read: { physical: 1747314423169478 } local_limit: { physical: 1747314423169468 logical: 4095 } global_limit: <min> in_txn_limit: <max> serial_no: 0 } (query layer retry isn't possible because data was already sent, if this is the read committed isolation (or) the first statement in repeatable read/ serializable isolation`

Here, notice that read: { physical: 1747314423169478 } is the transaction read time local_limit: { physical: 1747314423169468 logical: 4095 } is safe time for the tablet. where read > local_limit

**Fix**
1. Add a sleep of 1.1 sec before validations so that all tablet's safe time gets updated for sure. [assuming it updates every 1 sec, screenshot attached below]
2. Statement level txn(autocommit=true) - this is a generic guideline also i guess for YB and a proper fix, but we decided to do later because:
    - Validate our understanding of safe time scenario. (test run over few days/weeks without failure would confirm that)
    - Updated tests written with assumption of autocommit=false.


**This PR has 1 from the above 2 suggested fixes**
Refer https://github.com/yugabyte/yb-voyager/pull/2626 for the other change...

Sleep for 1100ms: spans at least one full 500ms Raft heartbeat plus 500ms skew,
so that tablet safe‐time ≥ (now – skew) and we avoid “restart read required”.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
