### PR TITLE
[DB-16868] Missing metadata and inconsistent table partition's data file after data export

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -107,7 +107,8 @@ func updateFilePaths(source *srcdb.Source, exportDir string, tablesProgressMetad
 			targetTableName := tname
 			// required if PREFIX_PARTITION is set in ora2pg.conf file
 			if tablesProgressMetadata[key].IsPartition {
-				targetTableName = tablesProgressMetadata[key].ParentTable + "_" + targetTableName
+				_, parentTable := tablesProgressMetadata[key].ParentTable.ForCatalogQuery()
+				targetTableName = parentTable  + "_" + targetTableName
 			}
 			tablesProgressMetadata[key].InProgressFilePath = filepath.Join(exportDir, "data", "tmp_"+targetTableName+"_data.sql")
 			tablesProgressMetadata[key].FinalFilePath = filepath.Join(exportDir, "data", targetTableName+"_data.sql")

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -442,9 +442,12 @@ func (pg *PostgreSQL) getExportedColumnsMap(
 
 	result := make(map[string][]string)
 	for _, tableMetadata := range tablesMetadata {
-		tableName := tableMetadata.TableName
 		// using minqualified and minquoted as used for data file naems and in console UI
-		result[tableName.ForMinOutput()] = pg.getExportedColumnsListForTable(exportDir, tableMetadata.TableName)
+		rootTable := tableMetadata.TableName
+		if tableMetadata.IsPartition {
+			rootTable = tableMetadata.ParentTable
+		}
+		result[rootTable.ForMinOutput()] = pg.getExportedColumnsListForTable(exportDir, rootTable)
 	}
 	return result
 }

--- a/yb-voyager/src/utils/commonVariables.go
+++ b/yb-voyager/src/utils/commonVariables.go
@@ -40,7 +40,7 @@ type TableProgressMetadata struct {
 	CountTotalRows       int64
 	FileOffsetToContinue int64 // This might be removed later
 	IsPartition          bool
-	ParentTable          string
+	ParentTable          sqlname.NameTuple
 	//timeTakenByLast1000Rows int64; TODO: for ESTIMATED time calculation
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request
The dataFileDescriptor metadata was messed up.
Tried to do the minimal changes so that any existing functionality is not affected.
Let me know if there is a better way to do it.


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
NA

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Existing end to end resumption tests should pass for `on-primary-key-conflict=IGNORE`

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
