### PR TITLE
Avoid panic if invalid control plane is set.

### DIFF
--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -49,6 +49,10 @@ func resetCmdAndEnvVars(cmd *cobra.Command) {
 			os.Unsetenv(envVar)
 		}
 	}
+	// override ErrExit to prevent the test from exiting because of some failed validations.
+	// We only care about testing whether the configuration and CLI flags are set correctly
+	utils.ErrExit = func(formatString string, args ...interface{}) {}
+
 }
 
 // The flags and the variables related to them need to be reset to their default values

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -102,7 +102,10 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 				go startPprofServer()
 			}
 			// no info/payload is collected/supported for assess-migration-bulk
-			setControlPlane("")
+			err = setControlPlane("")
+			if err != nil {
+				utils.ErrExit("ERROR: seting up control plane: %v", err)
+			}
 		} else {
 			validateExportDirFlag()
 			err := config.ValidateLogLevel()
@@ -148,7 +151,10 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			if perfProfile {
 				go startPprofServer()
 			}
-			setControlPlane(getControlPlaneType())
+			err = setControlPlane(getControlPlaneType())
+			if err != nil {
+				utils.ErrExit("ERROR: seting up control plane: %v", err)
+			}
 		}
 
 		// Log the flag values set from the config file
@@ -379,7 +385,7 @@ func metaDBIsCreated(exportDir string) bool {
 	return utils.FileOrFolderExists(filepath.Join(exportDir, "metainfo", "meta.db"))
 }
 
-func setControlPlane(cpType string) {
+func setControlPlane(cpType string) error {
 	switch cpType {
 	case "":
 		log.Infof("'CONTROL_PLANE_TYPE' environment variable not set. Setting cp to NoopControlPlane.")
@@ -387,15 +393,18 @@ func setControlPlane(cpType string) {
 	case YUGABYTED:
 		ybdConnString := os.Getenv("YUGABYTED_DB_CONN_STRING")
 		if ybdConnString == "" {
-			utils.ErrExit("'YUGABYTED_DB_CONN_STRING' environment variable needs to be set if 'CONTROL_PLANE_TYPE' is 'yugabyted'.")
+			return fmt.Errorf("'YUGABYTED_DB_CONN_STRING' environment variable needs to be set if 'CONTROL_PLANE_TYPE' is 'yugabyted'.")
 		}
 		controlPlane = yugabyted.New(exportDir)
 		log.Infof("Migration UUID %s", migrationUUID)
 		err := controlPlane.Init()
 		if err != nil {
-			utils.ErrExit("ERROR Failed to initialize the target DB for visualization. %s", err)
+			return fmt.Errorf("initialize the target DB for visualization. %s", err)
 		}
+	default:
+		return fmt.Errorf("invalid 'CONTROL_PLANE_TYPE': %q. Allowed values: %v", cpType, []string{YUGABYTED})
 	}
+	return nil
 }
 
 func getControlPlaneType() string {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -393,7 +393,7 @@ func setControlPlane(cpType string) error {
 	case YUGABYTED:
 		ybdConnString := os.Getenv("YUGABYTED_DB_CONN_STRING")
 		if ybdConnString == "" {
-			return fmt.Errorf("'YUGABYTED_DB_CONN_STRING' environment variable needs to be set if 'CONTROL_PLANE_TYPE' is 'yugabyted'.")
+			return fmt.Errorf("yugabyted-db-conn-string config param (or YUGABYTED_DB_CONN_STRING environment variable) needs to be set if control plane type is 'yugabyted'.")
 		}
 		controlPlane = yugabyted.New(exportDir)
 		log.Infof("Migration UUID %s", migrationUUID)
@@ -402,7 +402,7 @@ func setControlPlane(cpType string) error {
 			return fmt.Errorf("initialize the target DB for visualization. %s", err)
 		}
 	default:
-		return fmt.Errorf("invalid 'CONTROL_PLANE_TYPE': %q. Allowed values: %v", cpType, []string{YUGABYTED})
+		return fmt.Errorf("invalid value of control-plane-type (or CONTROL_PLANE_TYPE env var): %q. Allowed values: %v", cpType, []string{YUGABYTED})
 	}
 	return nil
 }

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -402,7 +402,7 @@ func setControlPlane(cpType string) error {
 			return fmt.Errorf("initialize the target DB for visualization. %s", err)
 		}
 	default:
-		return fmt.Errorf("invalid value of control-plane-type (or CONTROL_PLANE_TYPE env var): %q. Allowed values: %v", cpType, []string{YUGABYTED})
+		return fmt.Errorf("invalid value of control plane type: %q. Allowed values: %v", cpType, []string{YUGABYTED})
 	}
 	return nil
 }


### PR DESCRIPTION
### Describe the changes in this pull request
- Added proper validation in case an invalid control plane is provided. Previously, we would not create the `controlPlane` leading to a nil pointer panic. 
- The above validation was causing the config file tests to fail. (config file tests had control-plane-type set to yugabyte). Therefore, i added an override of `ErrExit` in config file tests to avoid the validation error. 
 An alternative approach could have been to set the `control-plane-type` to `yugabyted` properly in the config file tests, but that would require an actual YB db to be set up as the root command Run function will try to set up a connection to the control plane DB. requiring a DB to be set up for config file tests seems unnecessary, so I did not go with this approach. 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
