### PR TITLE
reword LB_WARN_MSG to remove reference to 'parallel-jobs'

### DIFF
--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -959,8 +959,8 @@ func logDiscrepancyInEventBatchIfAny(batch *EventBatch, rowsAffectedInserts, row
 //==============================================================================
 
 const (
-	LB_WARN_MSG = "--target-db-host is a load balancer IP which will be used to create connections for data import.\n" +
-		"\t To control the parallelism and servers used, refer to help for --parallel-jobs and --target-endpoints flags.\n"
+	LB_WARN_MSG = "--target-db-host was detected as a load balancer IP which will be used to create connections for data import.\n" +
+		"\t To explicitly specify the servers to be used, refer to the `target-endpoints` flag.\n"
 
 	GET_YB_SERVERS_QUERY = "SELECT host, port, num_connections, node_type, cloud, region, zone, public_ip FROM yb_servers()"
 )


### PR DESCRIPTION
### Describe the changes in this pull request
Removed the reference to "parallel-jobs" because we have adaptive parallelism. 
This msg is to just mention about the "target-endpoints". 
A future PR will also add a note to the user to refer to "parallel-jobs" or "adaptive-parallelism-max" in case we were unable to fetch cores information. 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
