### PR TITLE
Handling for constraint violation error from PK vs UK

### DIFF
--- a/yb-voyager/cmd/importDataFileTaskImporter.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter.go
@@ -318,6 +318,11 @@ func getImportBatchArgsProto(tableNameTup sqlname.NameTuple, filePath string) *t
 		utils.ErrExit("if required quote primary key column names: %s", err)
 	}
 
+	pkConstraintName, err := tdb.GetPrimaryKeyConstraintName(tableNameTup)
+	if err != nil {
+		utils.ErrExit("getting primary key constraint name for table %s: %s", tableNameTup.ForMinOutput(), err)
+	}
+
 	// If `columns` is unset at this point, no attribute list is passed in the COPY command.
 	fileFormat := dataFileDescriptor.FileFormat
 
@@ -331,6 +336,7 @@ func getImportBatchArgsProto(tableNameTup sqlname.NameTuple, filePath string) *t
 		TableNameTup:      tableNameTup,
 		Columns:           columns,
 		PrimaryKeyColumns: pkColumns,
+		PKConstraintName:  pkConstraintName,
 		PKConflictAction:  tconf.OnPrimaryKeyConflictAction,
 		FileFormat:        fileFormat,
 		Delimiter:         dataFileDescriptor.Delimiter,

--- a/yb-voyager/cmd/import_data_test.go
+++ b/yb-voyager/cmd/import_data_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -831,6 +832,180 @@ CREATE TABLE public.foo (
 	// Compare the full table data between Postgres and YugabyteDB.
 	if err := testutils.CompareTableData(ctx, pgConn, ybConn, "public.foo", "id"); err != nil {
 		t.Errorf("Table data mismatch between Postgres and YugabyteDB: %v", err)
+	}
+}
+
+// Test to ensure that only unique constraint violation errors by Primary Key are ignored
+// If caused by other constraints, the import should fail and not retry/ignore
+// Testing with custom csv file with import data file command
+func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintViolationErrorExit(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a temporary export directory.
+	exportDir = testutils.CreateTempExportDir()
+	defer testutils.RemoveTempExportDir(exportDir)
+
+	// Start YugabyteDB container.
+	yugabytedbContainer := testcontainers.NewTestContainer("yugabytedb", nil)
+	if err := yugabytedbContainer.Start(ctx); err != nil {
+		utils.ErrExit("Failed to start YugabyteDB container: %v", err)
+	}
+
+	createSchemaSQL := `CREATE SCHEMA IF NOT EXISTS test_schema;`
+	dropSchemaSQL := `DROP SCHEMA IF EXISTS test_schema CASCADE;`
+	createTableSQL := `CREATE TABLE test_schema.test_data (
+		id SERIAL PRIMARY KEY,
+		name TEXT,
+		email TEXT UNIQUE
+	);`
+
+	// create csv file with header + data in /tmp/test_data_%s.csv using random uuid
+	dataFilePath := filepath.Join("/tmp", fmt.Sprintf("test_data_%s.csv", uuid.NewString()))
+	t.Logf("Generated Data file path: %s", dataFilePath)
+
+	// create and write data to the csv file
+	f, err := os.Create(dataFilePath)
+	if err != nil {
+		t.Fatalf("Error creating data file: %v", err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(dataFilePath)
+	}()
+
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{"id", "name", "email"}); err != nil { // write header
+		t.Fatalf("Error writing CSV header: %v", err)
+	}
+	for i := 1; i <= 100; i++ {
+		w.Write([]string{
+			fmt.Sprintf("%d", i),
+			fmt.Sprintf("user%d", i),
+			fmt.Sprintf("user%d@gmail.com", i),
+		})
+	}
+	// insert one more row with duplicate email to trigger unique constraint violation
+	w.Write([]string{
+		fmt.Sprintf("%d", 101),
+		"user101",
+		fmt.Sprintf("user100@gmail.com"), // duplicate email
+	})
+
+	w.Flush() // flush the writer to ensure all data is written
+	if err := w.Error(); err != nil {
+		t.Fatalf("Error flushing CSV writer: %v", err)
+	}
+
+	// create the table in YugabyteDB
+	yugabytedbContainer.ExecuteSqls(createSchemaSQL, createTableSQL)
+	defer yugabytedbContainer.ExecuteSqls(dropSchemaSQL)
+
+	// now run import data file command using this data file
+	importDataFileCmdArgs := []string{
+		"--export-dir", exportDir,
+		"--disable-pb", "true",
+		"--batch-size", "26",
+		"--target-db-schema", "test_schema",
+		"--on-primary-key-conflict", "IGNORE",
+		"--data-dir", filepath.Dir(dataFilePath),
+		"--file-table-map", fmt.Sprintf("%s:test_schema.test_data", filepath.Base(dataFilePath)),
+		"--format", "CSV",
+		"--has-header", "true",
+		"--truncate-splits", "false",
+		"--yes",
+	}
+
+	// TODO: planning to enhance RunVoyagerCommand to return the actual error messages, currently it returns a exit status
+	_, err = testutils.RunVoyagerCommand(yugabytedbContainer, "import data file", importDataFileCmdArgs, nil, false)
+	if err == nil {
+		t.Fatalf(`Expected import command to fail due to "unique constraint violation", but it succeeded`)
+	} else {
+		t.Logf("Import command failed as expected with error: %v", err)
+	}
+}
+
+// Similar to the above test, but with a unique constraint violation on primary key which should be ignored
+func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintViolationErrorIgnore(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a temporary export directory.
+	exportDir = testutils.CreateTempExportDir()
+	defer testutils.RemoveTempExportDir(exportDir)
+
+	// Start YugabyteDB container.
+	yugabytedbContainer := testcontainers.NewTestContainer("yugabytedb", nil)
+	if err := yugabytedbContainer.Start(ctx); err != nil {
+		utils.ErrExit("Failed to start YugabyteDB container: %v", err)
+	}
+
+	createSchemaSQL := `CREATE SCHEMA IF NOT EXISTS test_schema;`
+	dropSchemaSQL := `DROP SCHEMA IF EXISTS test_schema CASCADE;`
+	createTableSQL := `CREATE TABLE test_schema.test_data (
+		id SERIAL PRIMARY KEY,
+		name TEXT,
+		email TEXT UNIQUE
+	);`
+
+	// create csv file with header + data in /tmp/test_data_%s.csv using random uuid
+	dataFilePath := filepath.Join("/tmp", fmt.Sprintf("test_data_%s.csv", uuid.NewString()))
+	t.Logf("Generated Data file path: %s", dataFilePath)
+
+	// create and write data to the csv file
+	f, err := os.Create(dataFilePath)
+	if err != nil {
+		t.Fatalf("Error creating data file: %v", err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(dataFilePath)
+	}()
+
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{"id", "name", "email"}); err != nil { // write header
+		t.Fatalf("Error writing CSV header: %v", err)
+	}
+	for i := 1; i <= 100; i++ {
+		w.Write([]string{
+			fmt.Sprintf("%d", i),
+			fmt.Sprintf("user%d", i),
+			fmt.Sprintf("user%d@gmail.com", i),
+		})
+	}
+	// insert one more row with duplicate id(PK)
+	w.Write([]string{
+		fmt.Sprintf("%d", 100), // duplicate id
+		"user101",
+		fmt.Sprintf("user101@gmail.com"),
+	})
+
+	w.Flush() // flush the writer to ensure all data is written
+	if err := w.Error(); err != nil {
+		t.Fatalf("Error flushing CSV writer: %v", err)
+	}
+
+	// create the table in YugabyteDB
+	yugabytedbContainer.ExecuteSqls(createSchemaSQL, createTableSQL)
+	defer yugabytedbContainer.ExecuteSqls(dropSchemaSQL)
+
+	// now run import data file command using this data file
+	importDataFileCmdArgs := []string{
+		"--export-dir", exportDir,
+		"--disable-pb", "true",
+		"--batch-size", "10",
+		"--target-db-schema", "test_schema",
+		"--on-primary-key-conflict", "IGNORE",
+		"--data-dir", filepath.Dir(dataFilePath),
+		"--file-table-map", fmt.Sprintf("%s:test_schema.test_data", filepath.Base(dataFilePath)),
+		"--format", "CSV",
+		"--has-header", "true",
+		"--yes",
+	}
+
+	_, err = testutils.RunVoyagerCommand(yugabytedbContainer, "import data file", importDataFileCmdArgs, nil, false)
+	if err != nil {
+		t.Fatalf("Import command failed unexpectedly: %v", err)
+	} else {
+		t.Logf("Import command succeeded as expected, ignoring unique constraint violation on primary key")
 	}
 }
 

--- a/yb-voyager/cmd/import_data_test.go
+++ b/yb-voyager/cmd/import_data_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -667,7 +666,7 @@ CREATE table test_schema.test_data (
 		t.Fatalf("failed to create directory %q: %v", dataDir, err)
 	}
 
-	f, err := os.Create(dataFilePath)
+	f, err := os.Create(dataFilePath) // truncate or create new
 	if err != nil {
 		t.Fatalf("Error creating data file: %v", err)
 	}
@@ -859,9 +858,14 @@ func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintVi
 		email TEXT UNIQUE
 	);`
 
-	// create csv file with header + data in /tmp/test_data_%s.csv using random uuid
-	dataFilePath := filepath.Join("/tmp", fmt.Sprintf("test_data_%s.csv", uuid.NewString()))
-	t.Logf("Generated Data file path: %s", dataFilePath)
+	// generate CSV file with header + data in /tmp/data-dir/test_data.csv
+	dataFilePath := filepath.Join("/tmp", "data-dir", "test_data.csv")
+
+	// Ensure the directory exists
+	dataDir := filepath.Dir(dataFilePath)
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("failed to create directory %q: %v", dataDir, err)
+	}
 
 	// create and write data to the csv file
 	f, err := os.Create(dataFilePath)
@@ -904,10 +908,10 @@ func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintVi
 	importDataFileCmdArgs := []string{
 		"--export-dir", exportDir,
 		"--disable-pb", "true",
-		"--batch-size", "26",
+		"--batch-size", "10",
 		"--target-db-schema", "test_schema",
 		"--on-primary-key-conflict", "IGNORE",
-		"--data-dir", filepath.Dir(dataFilePath),
+		"--data-dir", dataDir,
 		"--file-table-map", fmt.Sprintf("%s:test_schema.test_data", filepath.Base(dataFilePath)),
 		"--format", "CSV",
 		"--has-header", "true",
@@ -946,9 +950,14 @@ func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintVi
 		email TEXT UNIQUE
 	);`
 
-	// create csv file with header + data in /tmp/test_data_%s.csv using random uuid
-	dataFilePath := filepath.Join("/tmp", fmt.Sprintf("test_data_%s.csv", uuid.NewString()))
-	t.Logf("Generated Data file path: %s", dataFilePath)
+	// generate CSV file with header + data in /tmp/data-dir/test_data.csv
+	dataFilePath := filepath.Join("/tmp", "data-dir", "test_data.csv")
+
+	// Ensure the directory exists
+	dataDir := filepath.Dir(dataFilePath)
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("failed to create directory %q: %v", dataDir, err)
+	}
 
 	// create and write data to the csv file
 	f, err := os.Create(dataFilePath)
@@ -994,7 +1003,7 @@ func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintVi
 		"--batch-size", "10",
 		"--target-db-schema", "test_schema",
 		"--on-primary-key-conflict", "IGNORE",
-		"--data-dir", filepath.Dir(dataFilePath),
+		"--data-dir", dataDir,
 		"--file-table-map", fmt.Sprintf("%s:test_schema.test_data", filepath.Base(dataFilePath)),
 		"--format", "CSV",
 		"--has-header", "true",

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -199,6 +199,25 @@ func (tdb *TargetOracleDB) GetPrimaryKeyColumns(table sqlname.NameTuple) ([]stri
 	return columns, nil
 }
 
+// Implementing this for completion but not used in Oracle fall-forward/fall-back
+// This info is only used in fast path import of batches(Target YugabyteDB)
+func (tdb *TargetOracleDB) GetPrimaryKeyConstraintName(table sqlname.NameTuple) (string, error) {
+	sname, tname := table.ForCatalogQuery()
+	query := fmt.Sprintf(`SELECT CONSTRAINT_NAME FROM ALL_CONSTRAINTS WHERE TABLE_NAME = '%s' AND OWNER = '%s' AND CONSTRAINT_TYPE = 'P'`, tname, sname)
+	row := tdb.QueryRow(query)
+
+	var constraintName string
+	err := row.Scan(&constraintName)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil // No primary key constraint found
+		}
+		return "", fmt.Errorf("failed to get primary key constraint name: %w", err)
+	}
+
+	return constraintName, nil
+}
+
 func (tdb *TargetOracleDB) GetNonEmptyTables(tables []sqlname.NameTuple) []sqlname.NameTuple {
 	result := []sqlname.NameTuple{}
 

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -325,7 +325,7 @@ outer:
 
 // GetPrimaryKeyColumns returns the subset of `columns` that belong to the
 // primary‑key definition of the given table.
-// Implementing this for completion but not used in Oracle fall-forward/fall-back
+// Implementing this for completion but not used in Postgres fall-forward/fall-back
 // This info is only used in fast path import of batches(Target YugabyteDB)
 func (pg *TargetPostgreSQL) GetPrimaryKeyColumns(table sqlname.NameTuple) ([]string, error) {
 	var primaryKeyColumns []string

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -325,6 +325,8 @@ outer:
 
 // GetPrimaryKeyColumns returns the subset of `columns` that belong to the
 // primary‑key definition of the given table.
+// Implementing this for completion but not used in Oracle fall-forward/fall-back
+// This info is only used in fast path import of batches(Target YugabyteDB)
 func (pg *TargetPostgreSQL) GetPrimaryKeyColumns(table sqlname.NameTuple) ([]string, error) {
 	var primaryKeyColumns []string
 	schemaName, tableName := table.ForCatalogQuery()
@@ -356,6 +358,29 @@ func (pg *TargetPostgreSQL) GetPrimaryKeyColumns(table sqlname.NameTuple) ([]str
 	}
 
 	return primaryKeyColumns, nil
+}
+
+// Implementing this for completion but not used in Oracle fall-forward/fall-back
+// This info is only used in fast path import of batches(Target YugabyteDB)
+func (pg *TargetPostgreSQL) GetPrimaryKeyConstraintName(table sqlname.NameTuple) (string, error) {
+	schemaName, tableName := table.ForCatalogQuery()
+	query := fmt.Sprintf(`
+		SELECT constraint_name
+		FROM information_schema.table_constraints
+		WHERE table_schema = '%s'
+			AND table_name = '%s'
+			AND constraint_type = 'PRIMARY KEY';`, schemaName, tableName)
+
+	var constraintName string
+	err := pg.QueryRow(query).Scan(&constraintName)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil // No primary key constraint found
+		}
+		return "", fmt.Errorf("query PK constraint name for %s.%s: %w", schemaName, tableName, err)
+	}
+
+	return constraintName, nil
 }
 
 func (pg *TargetPostgreSQL) GetNonEmptyTables(tables []sqlname.NameTuple) []sqlname.NameTuple {

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -43,6 +43,7 @@ type TargetDB interface {
 	ImportBatch(batch Batch, args *ImportBatchArgs, exportDir string, tableSchema map[string]map[string]string, isRecoveryCandidate bool) (int64, error)
 	QuoteAttributeNames(tableNameTup sqlname.NameTuple, columns []string) ([]string, error)
 	GetPrimaryKeyColumns(table sqlname.NameTuple) ([]string, error)
+	GetPrimaryKeyConstraintName(tableNameTup sqlname.NameTuple) (string, error)
 	ExecuteBatch(migrationUUID uuid.UUID, batch *EventBatch) error
 	GetListOfTableAttributes(tableNameTup sqlname.NameTuple) ([]string, error)
 	QuoteAttributeName(tableNameTup sqlname.NameTuple, columnName string) (string, error)
@@ -98,11 +99,12 @@ func NewTargetDB(tconf *TargetConf) TargetDB {
 // ======================= ImportBatchArgs ====================
 
 type ImportBatchArgs struct {
-	FilePath          string
-	TableNameTup      sqlname.NameTuple
-	Columns           []string
-	PrimaryKeyColumns []string // TODO: Implement
-	PKConflictAction  string
+	FilePath                 string
+	TableNameTup             sqlname.NameTuple
+	Columns                  []string
+	PrimaryKeyColumns        []string
+	PKConstraintName string
+	PKConflictAction         string
 
 	FileFormat string
 	HasHeader  bool
@@ -154,7 +156,6 @@ func (args *ImportBatchArgs) GetPGCopyStatement() string {
 	}
 	return fmt.Sprintf(`COPY %s %s FROM STDIN WITH (%s)`, args.TableNameTup.ForUserQuery(), columns, strings.Join(options, ", "))
 }
-
 
 /*
 TODOs:

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -550,6 +550,9 @@ func (yb *TargetYugabyteDB) importBatchFast(conn *pgx.Conn, batch Batch, args *I
 
 		Lets say the importBatchFastRecover fails with some trasient DB error. In that case,
 		caller(fileTaskImporter.importBatch() function) takes care of retrying with importBatchFastRecover
+
+		The violation error will be because of PK in this code path, not Non-PK table with unique constraint.
+		Even if table has PK + UK on different columns, violation will be on PK for sure, given that the data is existing on source database with same schema
 	*/
 	if err != nil && strings.Contains(err.Error(), VIOLATES_UNIQUE_CONSTRAINT_ERROR) {
 		log.Infof("falling back to importBatchFastRecover for batch %q", batch.GetFilePath())

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -272,6 +272,28 @@ func (yb *TargetYugabyteDB) InitConnPool() error {
 	return nil
 }
 
+/*
+Example:
+ERROR:  duplicate key value violates unique constraint "orders_pkey"
+DETAIL:  Key (col1, col2)=(1, 2) already exists.
+*/
+const VIOLATES_UNIQUE_CONSTRAINT_ERROR = `violates unique constraint "%s"`
+const SYNTAX_ERROR = "syntax error at"
+const RPC_MSG_LIMIT_ERROR = "Sending too long RPC message"
+const INVALID_INPUT_SYNTAX_ERROR = "invalid input syntax"
+
+var NonRetryCopyErrors = []string{
+	INVALID_INPUT_SYNTAX_ERROR,
+	VIOLATES_UNIQUE_CONSTRAINT_ERROR,
+	SYNTAX_ERROR,
+}
+
+func (yb *TargetYugabyteDB) IsNonRetryableCopyError(err error) bool {
+	NonRetryCopyErrorsYB := NonRetryCopyErrors
+	NonRetryCopyErrorsYB = append(NonRetryCopyErrorsYB, RPC_MSG_LIMIT_ERROR)
+	return err != nil && utils.ContainsAnySubstringFromSlice(NonRetryCopyErrorsYB, err.Error())
+}
+
 func (yb *TargetYugabyteDB) GetAllSchemaNamesRaw() ([]string, error) {
 	query := "SELECT schema_name FROM information_schema.schemata"
 	rows, err := yb.Query(query)
@@ -446,6 +468,28 @@ func (yb *TargetYugabyteDB) GetPrimaryKeyColumns(table sqlname.NameTuple) ([]str
 	return primaryKeyColumns, nil
 }
 
+// GetPrimaryKeyConstraintName returns the name of the primary key constraint for the given table.
+// If the table does not have a primary key, it returns an empty string and no error
+func (yb *TargetYugabyteDB) GetPrimaryKeyConstraintName(table sqlname.NameTuple) (string, error) {
+	schemaName, tableName := table.ForCatalogQuery()
+	query := fmt.Sprintf(`
+		SELECT constraint_name
+		FROM information_schema.table_constraints
+		WHERE table_schema = '%s'
+			AND table_name = '%s'
+			AND constraint_type = 'PRIMARY KEY';`, schemaName, tableName)
+
+	var constraintName string
+	err := yb.QueryRow(query).Scan(&constraintName)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil // No primary key constraint found
+		}
+		return "", fmt.Errorf("query PK constraint name for %s.%s: %w", schemaName, tableName, err)
+	}
+	return constraintName, nil
+}
+
 func (yb *TargetYugabyteDB) GetNonEmptyTables(tables []sqlname.NameTuple) []sqlname.NameTuple {
 	result := []sqlname.NameTuple{}
 
@@ -554,7 +598,8 @@ func (yb *TargetYugabyteDB) importBatchFast(conn *pgx.Conn, batch Batch, args *I
 		The violation error will be because of PK in this code path, not Non-PK table with unique constraint.
 		Even if table has PK + UK on different columns, violation will be on PK for sure, given that the data is existing on source database with same schema
 	*/
-	if err != nil && strings.Contains(err.Error(), VIOLATES_UNIQUE_CONSTRAINT_ERROR) {
+	expectedErr := fmt.Sprintf(VIOLATES_UNIQUE_CONSTRAINT_ERROR, args.PKConstraintName)
+	if err != nil && strings.Contains(err.Error(), expectedErr) {
 		log.Infof("falling back to importBatchFastRecover for batch %q", batch.GetFilePath())
 		return yb.importBatchFastRecover(conn, batch, args)
 	}
@@ -672,7 +717,8 @@ func (yb *TargetYugabyteDB) importBatchFastRecover(conn *pgx.Conn, batch Batch, 
 		res, err := conn.PgConn().CopyFrom(context.Background(), singleLineReader, copyCommand)
 		if err != nil {
 			// Ignore err if VIOLATES_UNIQUE_CONSTRAINT_ERROR only
-			if strings.Contains(err.Error(), VIOLATES_UNIQUE_CONSTRAINT_ERROR) {
+			expectedErr := fmt.Sprintf(VIOLATES_UNIQUE_CONSTRAINT_ERROR, args.PKConstraintName)
+			if strings.Contains(err.Error(), expectedErr) {
 				// logging lineNum might not be useful as batches are truncated later on
 				log.Debugf("ignoring error %q for line=%q in batch %q", err.Error(), line, batch.GetFilePath())
 				rowsIgnored++ // increment before continuing to next line
@@ -743,23 +789,6 @@ func (yb *TargetYugabyteDB) GetListOfTableAttributes(nt sqlname.NameTuple) ([]st
 		result = append(result, colName)
 	}
 	return result, nil
-}
-
-const INVALID_INPUT_SYNTAX_ERROR = "invalid input syntax"
-const VIOLATES_UNIQUE_CONSTRAINT_ERROR = "violates unique constraint"
-const SYNTAX_ERROR = "syntax error at"
-const RPC_MSG_LIMIT_ERROR = "Sending too long RPC message"
-
-var NonRetryCopyErrors = []string{
-	INVALID_INPUT_SYNTAX_ERROR,
-	VIOLATES_UNIQUE_CONSTRAINT_ERROR,
-	SYNTAX_ERROR,
-}
-
-func (yb *TargetYugabyteDB) IsNonRetryableCopyError(err error) bool {
-	NonRetryCopyErrorsYB := NonRetryCopyErrors
-	NonRetryCopyErrorsYB = append(NonRetryCopyErrorsYB, RPC_MSG_LIMIT_ERROR)
-	return err != nil && utils.ContainsAnySubstringFromSlice(NonRetryCopyErrorsYB, err.Error())
 }
 
 func (yb *TargetYugabyteDB) RestoreSequences(sequencesLastVal map[string]int64) error {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -595,9 +595,6 @@ func (yb *TargetYugabyteDB) importBatchFast(conn *pgx.Conn, batch Batch, args *I
 
 		Lets say the importBatchFastRecover fails with some trasient DB error. In that case,
 		caller(fileTaskImporter.importBatch() function) takes care of retrying with importBatchFastRecover
-
-		The violation error will be because of PK in this code path, not Non-PK table with unique constraint.
-		Even if table has PK + UK on different columns, violation will be on PK for sure, given that the data is existing on source database with same schema
 	*/
 	expectedErr := fmt.Sprintf(VIOLATES_UNIQUE_CONSTRAINT_ERROR_RETRYABLE_FAST_PATH, args.PKConstraintName)
 	if err != nil && strings.Contains(err.Error(), expectedErr) {

--- a/yb-voyager/src/tgtdb/yugabytedb_test.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_test.go
@@ -192,3 +192,55 @@ func TestYugabyteGetNonEmptyTables(t *testing.T) {
 	log.Infof("non empty tables: %+v\n", actualTables)
 	testutils.AssertEqualNameTuplesSlice(t, expectedTables, actualTables)
 }
+
+func TestGetPrimaryKeyConstraintName(t *testing.T) {
+	testYugabyteDBTarget.ExecuteSqls(
+		`CREATE SCHEMA test_schema;`,
+		`CREATE TABLE test_schema.foo (
+			id INT PRIMARY KEY,
+			name TEXT
+		);`,
+		`CREATE TABLE test_schema.bar (
+			id INT,
+			name TEXT,
+			CONSTRAINT bar_primary_key PRIMARY KEY (id)
+		);`,
+		`CREATE TABLE test_schema.baz (
+			id INT,
+			name TEXT
+		);`,
+		`CREATE TABLE test_schema."CASE_sensitive" (
+			id INT,
+			name TEXT,
+			CONSTRAINT "CASE_sensitive_pkey" PRIMARY KEY (id)
+		);`,
+	)
+	defer testYugabyteDBTarget.ExecuteSqls(`DROP SCHEMA test_schema CASCADE;`)
+
+	tests := []struct {
+		table          sqlname.NameTuple
+		expectedPKName string
+	}{
+		{
+			table:          sqlname.NameTuple{CurrentName: sqlname.NewObjectName(POSTGRESQL, "test_schema", "test_schema", "foo")},
+			expectedPKName: "foo_pkey",
+		},
+		{
+			table:          sqlname.NameTuple{CurrentName: sqlname.NewObjectName(POSTGRESQL, "test_schema", "test_schema", "bar")},
+			expectedPKName: "bar_primary_key",
+		},
+		{
+			table:          sqlname.NameTuple{CurrentName: sqlname.NewObjectName(POSTGRESQL, "test_schema", "test_schema", "baz")},
+			expectedPKName: "",
+		},
+		{
+			table:          sqlname.NameTuple{CurrentName: sqlname.NewObjectName(POSTGRESQL, "test_schema", "test_schema", "CASE_sensitive")},
+			expectedPKName: "CASE_sensitive_pkey",
+		},
+	}
+	for _, tt := range tests {
+		pkName, err := testYugabyteDBTarget.GetPrimaryKeyConstraintName(tt.table)
+		assert.NoError(t, err)
+		assert.Equal(t, tt.expectedPKName, pkName, fmt.Sprintf("Expected primary key name for table %q to be %q", tt.table.CurrentName, tt.expectedPKName))
+	}
+}

--- a/yb-voyager/test/utils/cmdutils.go
+++ b/yb-voyager/test/utils/cmdutils.go
@@ -88,6 +88,7 @@ func RunVoyagerCommand(container testcontainers.TestContainer,
 
 	// If we want synchronous behavior, wait for the command to finish.
 	if !async {
+		// cmd.Wait() err only tells you that the child exited with a non-zero code; not the actual error.
 		if err := cmd.Wait(); err != nil {
 			return nil, fmt.Errorf("voyager command exited with error: %w", err)
 		}


### PR DESCRIPTION
### Describe the changes in this pull request
- Unique Constraint violation check response from voyager is based on the on primary key conflict mode
  - `ERROR`: All errors whether due to Primary Key or Unique Key, should be non retryable and error out
  - `IGNORE`: If the error is due to Primary Key conflict only then ignore it since user has selected that mode. Otherwise for unique key case it will non retry and error.
  
Moreover the overall check for violation is much more strict now.
i.e. when ignoring we check the expected primary key constraint name in the error msg

Syntax: `violates unique constraint "%s"`
Here we check with the specific primary key constraint name that is expected for that batch
  

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
--> Unit tests added 

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
