### PR TITLE
Added config file tests for import data to source replica and fixed oracle flags handling in the same command

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -630,8 +630,9 @@ func bindCobraFlagsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigFlagOver
 				ConfigKey: configKey,
 				Value:     val,
 			})
-		} else if configKey = SourceDBConfigPrefix + f.Name; strings.HasPrefix(f.Name, OracleDBFlagPrefix) && v.IsSet(configKey) {
-			// Handle oracle db type flags, since they are also prefixed with source but are special cases
+		} else if configKey = SourceDBConfigPrefix + f.Name; strings.HasPrefix(f.Name, OracleDBFlagPrefix) && v.IsSet(configKey) && configKeyPrefix != "import-data-to-source-replica" {
+			// Handle oracle db type flags in source config, since they are also prefixed with source but are special cases
+			// This oracle db flags should be taken from the source section only in all commands except import-data-to-source-replica
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {
@@ -658,6 +659,20 @@ func bindCobraFlagsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigFlagOver
 			})
 		} else if configKey = SourceReplicaDBConfigPrefix + strings.TrimPrefix(f.Name, SourceReplicaDBFlagPrefix); strings.HasPrefix(f.Name, SourceReplicaDBFlagPrefix) && v.IsSet(configKey) {
 			// Handle source-replica db type flags
+			val := v.GetString(configKey)
+			err := cmd.Flags().Set(f.Name, val)
+			if err != nil {
+				bindErr = err
+				return
+			}
+			overrides = append(overrides, ConfigFlagOverride{
+				FlagName:  f.Name,
+				ConfigKey: configKey,
+				Value:     val,
+			})
+		} else if configKey = SourceReplicaDBConfigPrefix + f.Name; strings.HasPrefix(f.Name, OracleDBFlagPrefix) && v.IsSet(configKey) && configKeyPrefix == "import-data-to-source-replica" {
+			// Handle oracle db type flags in source-replica config, since they are also prefixed with source-replica but are special cases
+			// The oracle db flags should be taken from the source-replica section only in import-data-to-source-replica command
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {

--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -624,13 +624,25 @@ func bindCobraFlagsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigFlagOver
 			})
 		} else if slices.Contains(commandsUsingSourceReplicaConfig, commandNameKey) {
 			// Handle source-replica config flags
-			bindSourceReplicaFlags(cmd, v, f, commandNameKey, &bindErr, &overrides)
+			err := bindSourceReplicaFlags(cmd, v, f, commandNameKey, &overrides)
+			if err != nil {
+				bindErr = err
+				return
+			}
 		} else if slices.Contains(commandsUsingSourceConfig, commandNameKey) {
 			// Handle source config flags
-			bindSourceFlags(cmd, v, f, commandNameKey, &bindErr, &overrides)
+			err := bindSourceFlags(cmd, v, f, commandNameKey, &overrides)
+			if err != nil {
+				bindErr = err
+				return
+			}
 		} else if slices.Contains(commandsUsingTargetConfig, commandNameKey) {
 			// Handle target config flags
-			bindTargetFlags(cmd, v, f, commandNameKey, &bindErr, &overrides)
+			err := bindTargetFlags(cmd, v, f, commandNameKey, &overrides)
+			if err != nil {
+				bindErr = err
+				return
+			}
 		}
 		// If the flag is not set in viper, do nothing and leave it as is
 		// This allows the flag to retain its default value or the value set by the user in the command line
@@ -639,7 +651,7 @@ func bindCobraFlagsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigFlagOver
 	return overrides, bindErr
 }
 
-func bindSourceReplicaFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, bindErr *error, overrides *[]ConfigFlagOverride) {
+func bindSourceReplicaFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, overrides *[]ConfigFlagOverride) error {
 	if strings.HasPrefix(f.Name, SourceReplicaDBFlagPrefix) {
 		configKey := SourceReplicaDBConfigPrefix + strings.TrimPrefix(f.Name, SourceReplicaDBFlagPrefix)
 		if v.IsSet(configKey) {
@@ -647,8 +659,7 @@ func bindSourceReplicaFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, c
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {
-				*bindErr = err
-				return
+				return err
 			}
 			*overrides = append(*overrides, ConfigFlagOverride{
 				FlagName:  f.Name,
@@ -664,8 +675,7 @@ func bindSourceReplicaFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, c
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {
-				*bindErr = err
-				return
+				return err
 			}
 			*overrides = append(*overrides, ConfigFlagOverride{
 				FlagName:  f.Name,
@@ -674,9 +684,10 @@ func bindSourceReplicaFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, c
 			})
 		}
 	}
+	return nil
 }
 
-func bindSourceFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, bindErr *error, overrides *[]ConfigFlagOverride) {
+func bindSourceFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, overrides *[]ConfigFlagOverride) error {
 	if strings.HasPrefix(f.Name, SourceDBFlagPrefix) {
 		configKey := SourceDBConfigPrefix + strings.TrimPrefix(f.Name, SourceDBFlagPrefix)
 		if v.IsSet(configKey) {
@@ -684,8 +695,7 @@ func bindSourceFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandN
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {
-				*bindErr = err
-				return
+				return err
 			}
 			*overrides = append(*overrides, ConfigFlagOverride{
 				FlagName:  f.Name,
@@ -701,8 +711,7 @@ func bindSourceFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandN
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {
-				*bindErr = err
-				return
+				return err
 			}
 			*overrides = append(*overrides, ConfigFlagOverride{
 				FlagName:  f.Name,
@@ -711,9 +720,10 @@ func bindSourceFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandN
 			})
 		}
 	}
+	return nil
 }
 
-func bindTargetFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, bindErr *error, overrides *[]ConfigFlagOverride) {
+func bindTargetFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, overrides *[]ConfigFlagOverride) error {
 	if strings.HasPrefix(f.Name, TargetDBFlagPrefix) {
 		configKey := TargetDBConfigPrefix + strings.TrimPrefix(f.Name, TargetDBFlagPrefix)
 		if v.IsSet(configKey) {
@@ -721,8 +731,7 @@ func bindTargetFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandN
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {
-				*bindErr = err
-				return
+				return err
 			}
 			*overrides = append(*overrides, ConfigFlagOverride{
 				FlagName:  f.Name,
@@ -731,6 +740,7 @@ func bindTargetFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandN
 			})
 		}
 	}
+	return nil
 }
 
 /*

--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -26,6 +27,10 @@ const (
 	TargetDBConfigPrefix        = "target."
 	SourceReplicaDBConfigPrefix = "source-replica."
 )
+
+var commandsUsingSourceReplicaConfig = []string{"import-data-to-source-replica"}
+var commandsUsingSourceConfig = []string{"assess-migration", "export-schema", "export-data", "export-data-from-source", "import-data-to-source"}
+var commandsUsingTargetConfig = []string{"import-schema", "import-data", "import-data-to-target", "import-data-file", "export-data-from-target", "finalize-schema-post-data-import"}
 
 var allowedGlobalConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"export-dir", "log-level", "send-diagnostics",
@@ -581,8 +586,8 @@ func bindCobraFlagsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigFlagOver
 	subCmdPath := strings.TrimPrefix(cmd.CommandPath(), cmd.Root().Name())
 	subCmdPath = strings.TrimSpace(subCmdPath) // remove leading space if any
 	// Replace spaces with hyphens
-	configKeyPrefix := strings.ReplaceAll(subCmdPath, " ", "-")
-	configKeyPrefix = setToAliasPrefixIfSet(configKeyPrefix, v)
+	commandNameKey := strings.ReplaceAll(subCmdPath, " ", "-")
+	commandNameKey = setToAliasPrefixIfSet(commandNameKey, v)
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		if bindErr != nil || f.Changed {
@@ -591,7 +596,7 @@ func bindCobraFlagsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigFlagOver
 
 		// Check for <command_path>.<flagname>
 		var configKey string
-		if configKey = configKeyPrefix + "." + f.Name; v.IsSet(configKey) {
+		if configKey = commandNameKey + "." + f.Name; v.IsSet(configKey) {
 			val := v.GetString(configKey)
 			err := cmd.Flags().Set(f.Name, val)
 			if err != nil {
@@ -617,79 +622,115 @@ func bindCobraFlagsToViper(cmd *cobra.Command, v *viper.Viper) ([]ConfigFlagOver
 				ConfigKey: configKey,
 				Value:     val,
 			})
-		} else if configKey = SourceDBConfigPrefix + strings.TrimPrefix(f.Name, SourceDBFlagPrefix); strings.HasPrefix(f.Name, SourceDBFlagPrefix) && v.IsSet(configKey) {
-			// Handle source db type flags
-			val := v.GetString(configKey)
-			err := cmd.Flags().Set(f.Name, val)
-			if err != nil {
-				bindErr = err
-				return
-			}
-			overrides = append(overrides, ConfigFlagOverride{
-				FlagName:  f.Name,
-				ConfigKey: configKey,
-				Value:     val,
-			})
-		} else if configKey = SourceDBConfigPrefix + f.Name; strings.HasPrefix(f.Name, OracleDBFlagPrefix) && v.IsSet(configKey) && configKeyPrefix != "import-data-to-source-replica" {
-			// Handle oracle db type flags in source config, since they are also prefixed with source but are special cases
-			// This oracle db flags should be taken from the source section only in all commands except import-data-to-source-replica
-			val := v.GetString(configKey)
-			err := cmd.Flags().Set(f.Name, val)
-			if err != nil {
-				bindErr = err
-				return
-			}
-			overrides = append(overrides, ConfigFlagOverride{
-				FlagName:  f.Name,
-				ConfigKey: configKey,
-				Value:     val,
-			})
-		} else if configKey = TargetDBConfigPrefix + strings.TrimPrefix(f.Name, TargetDBFlagPrefix); strings.HasPrefix(f.Name, TargetDBFlagPrefix) && v.IsSet(configKey) {
-			// Handle target db type flags
-			val := v.GetString(configKey)
-			err := cmd.Flags().Set(f.Name, val)
-			if err != nil {
-				bindErr = err
-				return
-			}
-			overrides = append(overrides, ConfigFlagOverride{
-				FlagName:  f.Name,
-				ConfigKey: configKey,
-				Value:     val,
-			})
-		} else if configKey = SourceReplicaDBConfigPrefix + strings.TrimPrefix(f.Name, SourceReplicaDBFlagPrefix); strings.HasPrefix(f.Name, SourceReplicaDBFlagPrefix) && v.IsSet(configKey) {
-			// Handle source-replica db type flags
-			val := v.GetString(configKey)
-			err := cmd.Flags().Set(f.Name, val)
-			if err != nil {
-				bindErr = err
-				return
-			}
-			overrides = append(overrides, ConfigFlagOverride{
-				FlagName:  f.Name,
-				ConfigKey: configKey,
-				Value:     val,
-			})
-		} else if configKey = SourceReplicaDBConfigPrefix + f.Name; strings.HasPrefix(f.Name, OracleDBFlagPrefix) && v.IsSet(configKey) && configKeyPrefix == "import-data-to-source-replica" {
-			// Handle oracle db type flags in source-replica config, since they are also prefixed with source-replica but are special cases
-			// The oracle db flags should be taken from the source-replica section only in import-data-to-source-replica command
-			val := v.GetString(configKey)
-			err := cmd.Flags().Set(f.Name, val)
-			if err != nil {
-				bindErr = err
-				return
-			}
-			overrides = append(overrides, ConfigFlagOverride{
-				FlagName:  f.Name,
-				ConfigKey: configKey,
-				Value:     val,
-			})
+		} else if slices.Contains(commandsUsingSourceReplicaConfig, commandNameKey) {
+			// Handle source-replica config flags
+			bindSourceReplicaFlags(cmd, v, f, commandNameKey, &bindErr, &overrides)
+		} else if slices.Contains(commandsUsingSourceConfig, commandNameKey) {
+			// Handle source config flags
+			bindSourceFlags(cmd, v, f, commandNameKey, &bindErr, &overrides)
+		} else if slices.Contains(commandsUsingTargetConfig, commandNameKey) {
+			// Handle target config flags
+			bindTargetFlags(cmd, v, f, commandNameKey, &bindErr, &overrides)
 		}
 		// If the flag is not set in viper, do nothing and leave it as is
 		// This allows the flag to retain its default value or the value set by the user in the command line
 	})
 
 	return overrides, bindErr
+}
+
+func bindSourceReplicaFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, bindErr *error, overrides *[]ConfigFlagOverride) {
+	if strings.HasPrefix(f.Name, SourceReplicaDBFlagPrefix) {
+		configKey := SourceReplicaDBConfigPrefix + strings.TrimPrefix(f.Name, SourceReplicaDBFlagPrefix)
+		if v.IsSet(configKey) {
+			// Handle source-replica db type flags
+			val := v.GetString(configKey)
+			err := cmd.Flags().Set(f.Name, val)
+			if err != nil {
+				*bindErr = err
+				return
+			}
+			*overrides = append(*overrides, ConfigFlagOverride{
+				FlagName:  f.Name,
+				ConfigKey: configKey,
+				Value:     val,
+			})
+		}
+	} else if strings.HasPrefix(f.Name, OracleDBFlagPrefix) {
+		configKey := SourceReplicaDBConfigPrefix + f.Name
+		if v.IsSet(configKey) {
+			// Handle oracle db type flags in source-replica config, since they are also prefixed with source-replica but are special cases
+			// The oracle db flags should be taken from the source-replica section only in import-data-to-source-replica command
+			val := v.GetString(configKey)
+			err := cmd.Flags().Set(f.Name, val)
+			if err != nil {
+				*bindErr = err
+				return
+			}
+			*overrides = append(*overrides, ConfigFlagOverride{
+				FlagName:  f.Name,
+				ConfigKey: configKey,
+				Value:     val,
+			})
+		}
+	}
+}
+
+func bindSourceFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, bindErr *error, overrides *[]ConfigFlagOverride) {
+	if strings.HasPrefix(f.Name, SourceDBFlagPrefix) {
+		configKey := SourceDBConfigPrefix + strings.TrimPrefix(f.Name, SourceDBFlagPrefix)
+		if v.IsSet(configKey) {
+			// Handle source db type flags
+			val := v.GetString(configKey)
+			err := cmd.Flags().Set(f.Name, val)
+			if err != nil {
+				*bindErr = err
+				return
+			}
+			*overrides = append(*overrides, ConfigFlagOverride{
+				FlagName:  f.Name,
+				ConfigKey: configKey,
+				Value:     val,
+			})
+		}
+	} else if strings.HasPrefix(f.Name, OracleDBFlagPrefix) {
+		configKey := SourceDBConfigPrefix + f.Name
+		if v.IsSet(configKey) {
+			// Handle oracle db type flags in source config, since they are also prefixed with source but are special cases
+			// This oracle db flags should be taken from the source section only in all commands except import-data-to-source-replica
+			val := v.GetString(configKey)
+			err := cmd.Flags().Set(f.Name, val)
+			if err != nil {
+				*bindErr = err
+				return
+			}
+			*overrides = append(*overrides, ConfigFlagOverride{
+				FlagName:  f.Name,
+				ConfigKey: configKey,
+				Value:     val,
+			})
+		}
+	}
+}
+
+func bindTargetFlags(cmd *cobra.Command, v *viper.Viper, f *pflag.Flag, commandNameKey string, bindErr *error, overrides *[]ConfigFlagOverride) {
+	if strings.HasPrefix(f.Name, TargetDBFlagPrefix) {
+		configKey := TargetDBConfigPrefix + strings.TrimPrefix(f.Name, TargetDBFlagPrefix)
+		if v.IsSet(configKey) {
+			// Handle target db type flags
+			val := v.GetString(configKey)
+			err := cmd.Flags().Set(f.Name, val)
+			if err != nil {
+				*bindErr = err
+				return
+			}
+			*overrides = append(*overrides, ConfigFlagOverride{
+				FlagName:  f.Name,
+				ConfigKey: configKey,
+				Value:     val,
+			})
+		}
+	}
 }
 
 /*

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -3358,7 +3358,6 @@ func setupImportDataToSourceReplicaContext(t *testing.T) *testContext {
 export-dir: %s
 log-level: info
 send-diagnostics: true
-run-guardrails-checks: false
 control-plane-type: yugabyte
 yugabyted-db-conn-string: postgres://test_user:test_password@localhost:5432/test_db?sslmode=require
 java-home: /path/to/java/home
@@ -3399,6 +3398,7 @@ source-replica:
   oracle-home: /path/to/oracle/home/source-replica
   oracle-tns-alias: test_tns_alias_source_replica
 import-data-to-source-replica:
+  run-guardrails-checks: false
   batch-size: 10000
   parallel-jobs: 5
   truncate-tables: true
@@ -3432,7 +3432,6 @@ func TestImportDataToSourceReplicaConfigBinding_ConfigFileBinding(t *testing.T) 
 	assert.Equal(t, ctx.tmpExportDir, exportDir, "Export directory should match the config")
 	assert.Equal(t, "info", config.LogLevel, "Log level should match the config")
 	assert.Equal(t, utils.BoolStr(true), callhome.SendDiagnostics, "Send diagnostics should match the config")
-	assert.Equal(t, utils.BoolStr(false), tconf.RunGuardrailsChecks, "Run guardrails checks should match the config")
 	assert.Equal(t, "yugabyte", os.Getenv("CONTROL_PLANE_TYPE"), "Control plane type should match the config")
 	assert.Equal(t, "postgres://test_user:test_password@localhost:5432/test_db?sslmode=require", os.Getenv("YUGABYTED_DB_CONN_STRING"), "Yugabyted DB connection string should match the config")
 	assert.Equal(t, "/path/to/java/home", os.Getenv("JAVA_HOME"), "Java home should match the config")
@@ -3456,6 +3455,7 @@ func TestImportDataToSourceReplicaConfigBinding_ConfigFileBinding(t *testing.T) 
 	assert.Equal(t, "/path/to/oracle/home/source-replica", tconf.OracleHome, "Source replica Oracle home should match the config")
 	assert.Equal(t, "test_tns_alias_source_replica", tconf.TNSAlias, "Source replica Oracle TNS alias should match the config")
 	// Assertions on import-data-to-source-replica config
+	assert.Equal(t, utils.BoolStr(false), tconf.RunGuardrailsChecks, "Run guardrails checks should match the config")
 	assert.Equal(t, int64(10000), batchSizeInNumRows, "Batch size should match the config")
 	assert.Equal(t, 5, tconf.Parallelism, "Parallel jobs should match the config")
 	assert.Equal(t, utils.BoolStr(true), truncateTables, "Truncate tables should match the config")
@@ -3511,7 +3511,6 @@ func TestImportDataToSourceReplicaConfigBinding_CLIOverridesConfig(t *testing.T)
 	assert.Equal(t, tmpExportDir, exportDir, "Export directory should be overridden by CLI")
 	assert.Equal(t, "debug", config.LogLevel, "Log level should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), callhome.SendDiagnostics, "Send diagnostics should be overridden by CLI")
-	assert.Equal(t, utils.BoolStr(true), tconf.RunGuardrailsChecks, "Run guardrails checks should be overridden by CLI")
 	assert.Equal(t, "yugabyte", os.Getenv("CONTROL_PLANE_TYPE"), "Control plane type should match the config")
 	assert.Equal(t, "postgres://test_user:test_password@localhost:5432/test_db?sslmode=require", os.Getenv("YUGABYTED_DB_CONN_STRING"), "Yugabyted DB connection string should match the config")
 	assert.Equal(t, "/path/to/java/home", os.Getenv("JAVA_HOME"), "Java home should match the config")
@@ -3535,6 +3534,7 @@ func TestImportDataToSourceReplicaConfigBinding_CLIOverridesConfig(t *testing.T)
 	assert.Equal(t, "/path/to/oracle/home/source-replica-2", tconf.OracleHome, "Source replica Oracle home should be overridden by CLI")
 	assert.Equal(t, "test_tns_alias_source_replica_2", tconf.TNSAlias, "Source replica Oracle TNS alias should be overridden by CLI")
 	// Assertions on import-data-to-source-replica config
+	assert.Equal(t, utils.BoolStr(true), tconf.RunGuardrailsChecks, "Run guardrails checks should be overridden by CLI")
 	assert.Equal(t, int64(20000), batchSizeInNumRows, "Batch size should be overridden by CLI")
 	assert.Equal(t, 3, tconf.Parallelism, "Parallel jobs should be overridden by CLI")
 	assert.Equal(t, utils.BoolStr(false), truncateTables, "Truncate tables should be overridden by CLI")
@@ -3580,7 +3580,6 @@ func TestImportDataToSourceReplicaConfigBinding_EnvOverridesConfig(t *testing.T)
 	assert.Equal(t, ctx.tmpExportDir, exportDir, "Export directory should match the config")
 	assert.Equal(t, "info", config.LogLevel, "Log level should match the config")
 	assert.Equal(t, utils.BoolStr(true), callhome.SendDiagnostics, "Send diagnostics should match the config")
-	assert.Equal(t, utils.BoolStr(false), tconf.RunGuardrailsChecks, "Run guardrails checks should match the config")
 	assert.Equal(t, "yugabyte2", os.Getenv("CONTROL_PLANE_TYPE"), "Control plane type should be overridden by env var")
 	assert.Equal(t, "postgres://test_user2:test_password2@localhost:5432/test_db?sslmode=require", os.Getenv("YUGABYTED_DB_CONN_STRING"), "Yugabyted DB connection string should be overridden by env var")
 	assert.Equal(t, "/path/to/java/home2", os.Getenv("JAVA_HOME"), "Java home should be overridden by env var")
@@ -3604,6 +3603,7 @@ func TestImportDataToSourceReplicaConfigBinding_EnvOverridesConfig(t *testing.T)
 	assert.Equal(t, "/path/to/oracle/home/source-replica", tconf.OracleHome, "Source replica Oracle home should match the config")
 	assert.Equal(t, "test_tns_alias_source_replica", tconf.TNSAlias, "Source replica Oracle TNS alias should match the config")
 	// Assertions on import-data-to-source-replica config
+	assert.Equal(t, utils.BoolStr(false), tconf.RunGuardrailsChecks, "Run guardrails checks should match the config")
 	assert.Equal(t, int64(10000), batchSizeInNumRows, "Batch size should match the config")
 	assert.Equal(t, 5, tconf.Parallelism, "Parallel jobs should match the config")
 	assert.Equal(t, utils.BoolStr(true), truncateTables, "Truncate tables should match the config")

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -3367,6 +3367,18 @@ local-call-home-service-port: 8080
 yb-tserver-port: 9000
 tns-admin: /path/to/tns/admin
 source:
+  name: test_source
+  db-host: source_host
+  db-port: 1522
+  db-user: test_user_source
+  db-password: test_password_source
+  db-name: test_db_source
+  db-schema: public_source
+  ssl-cert: /path/to/ssl-cert/source
+  ssl-mode: verify-full
+  ssl-key: /path/to/ssl-key/source
+  ssl-root-cert: /path/to/ssl-root-cert/source
+  ssl-crl: /path/to/ssl-crl/source
   oracle-db-sid: test_sid_source
   oracle-home: /path/to/oracle/home/source
   oracle-tns-alias: test_tns_alias_source


### PR DESCRIPTION
### Describe the changes in this pull request
Fixes: [Add tests for import data to source replica and fix the oracle related flags handling in source replica](https://yugabyte.atlassian.net/browse/DB-17118?atlOrigin=eyJpIjoiYjBmZDM5YmQyMWU3NGM1ZjhmM2UwYzZlMWQxMjNlYWUiLCJwIjoiaiJ9)
1) Added tests for import data to source replica
2) Added handling for oracle flags in source replica. They were clashing with the oracle flags in source, added code to resolve that as well.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manual and Unit tests

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  |  No |
