### PR TITLE
Changed run-guardrails-checks to a command specific flag and allowing  log-level in command sections as well as global section in config file

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -28,7 +28,7 @@ const (
 )
 
 var allowedGlobalConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"export-dir", "log-level", "send-diagnostics", "run-guardrails-checks",
+	"export-dir", "log-level", "send-diagnostics",
 	"profile",
 	// environment variables keys
 	"control-plane-type", "yugabyted-db-conn-string", "java-home",
@@ -56,6 +56,7 @@ var allowedTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedAssessMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"iops-capture-interval", "target-db-version", "assessment-metadata-dir",
 	"invoked-by-export-schema",
 	// environment variables keys
@@ -63,12 +64,14 @@ var allowedAssessMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedAnalyzeSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level",
 	"output-format", "target-db-version",
 	// environment variables keys
 	"report-unsupported-plpgsql-objects",
 )
 
 var allowedExportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"use-orafce", "comments-on-objects", "object-type-list", "exclude-object-type-list",
 	"skip-recommendations", "assessment-report-path",
 	"assess-schema-before-export",
@@ -77,6 +80,7 @@ var allowedExportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedExportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"disable-pb", "exclude-table-list", "table-list", "exclude-table-list-file-path",
 	"table-list-file-path", "parallel-jobs", "export-type",
 	// environment variables keys
@@ -84,6 +88,7 @@ var allowedExportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedExportDataFromTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level",
 	"disable-pb", "exclude-table-list", "table-list", "exclude-table-list-file-path",
 	"table-list-file-path", "transaction-ordering",
 	// environment variables keys
@@ -91,15 +96,18 @@ var allowedExportDataFromTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"continue-on-error", "object-type-list", "exclude-object-type-list", "straight-order",
 	"ignore-exist", "enable-orafce",
 )
 
 var allowedFinalizeSchemaPostDataImportConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"continue-on-error", "ignore-exist", "refresh-mviews",
 )
 
 var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"batch-size", "parallel-jobs", "enable-adaptive-parallelism", "adaptive-parallelism-max",
 	"skip-replication-checks",
 	"disable-pb", "max-retries", "exclude-table-list", "table-list",
@@ -117,6 +125,7 @@ var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"parallel-jobs", "disable-pb",
 	// environment variables keys
 	"num-event-channels", "event-channel-size", "max-events-per-batch",
@@ -124,6 +133,7 @@ var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level", "run-guardrails-checks",
 	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb", "max-retries",
 	// environment variables keys
 	"ybvoyager-max-colocated-batches-in-progress", "num-event-channels",
@@ -132,6 +142,7 @@ var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[strin
 )
 
 var allowedImportDataFileConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level",
 	"disable-pb", "max-retries", "enable-upsert", "use-public-ip", "target-endpoints",
 	"batch-size", "parallel-jobs", "enable-adaptive-parallelism", "adaptive-parallelism-max",
 	"format", "delimiter", "data-dir", "file-table-map", "has-header", "escape-char",
@@ -149,10 +160,12 @@ var allowedInitCutoverToTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedArchiveChangesConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level",
 	"delete-changes-without-archiving", "fs-utilization-threshold", "move-to",
 )
 
 var allowedEndMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
+	"log-level",
 	"backup-schema-files", "backup-data-files", "save-migration-reports", "backup-log-files",
 	"backup-dir",
 )

--- a/yb-voyager/config-templates/live-migration-with-fall-back.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-back.yaml
@@ -14,12 +14,6 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                  
 
-### Run guardrails checks before the command is run. 
-### Note - This is only valid for PostgreSQL source database.
-### Accepted values - (true, false, yes, no, 1, 0)
-### Default - true
-# run-guardrails-checks: true  
-
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
 
@@ -175,7 +169,19 @@ assess-migration:
 
   ### Directory path where assessment metadata like source DB metadata and statistics are stored. 
   ### Optional flag, if not provided, it will be assumed to be present at default path inside the export directory.
-  # assessment-metadata-dir: <assessment-metadata-dir>     
+  # assessment-metadata-dir: <assessment-metadata-dir> 
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info     
 
 # ----------------------------------------------------------
 # Export Schema Configuration
@@ -211,7 +217,19 @@ export-schema:
   # skip-recommendations: false  
 
   ### Path to the generated assessment report file(JSON format) to be used for applying recommendation to exported schema                       
-  # assessment-report-path: <assessment-report-path>        
+  # assessment-report-path: <assessment-report-path>  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info       
 
 # ----------------------------------------------------------
 # Analyze Schema Configuration
@@ -228,7 +246,13 @@ analyze-schema:
 
   ### Target YugabyteDB version to analyze schema for (in format A.B.C.D). 
   ### Default - latest stable version i.e. 2024.2.2.3                                        
-  target-db-version: 2024.2.2.3                           
+  target-db-version: 2024.2.2.3  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                          
                                       
                                   
 # ----------------------------------------------------------
@@ -267,7 +291,19 @@ import-schema:
   ### Note - This is only valid for Oracle source database.
   ### Accepted values (true, false, yes, no, 1, 0) 
   ### Default - true
-  # enable-orafce: true   
+  # enable-orafce: true  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info  
 
 # ----------------------------------------------------------
 # Export Data Configuration
@@ -302,7 +338,19 @@ export-data-from-source:
   ### Disable progress bar/stats during data export  
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false                                             
+  # disable-pb: false  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                            
 
 # ---------------------------------------------------------
 # Import Data Configuration
@@ -372,6 +420,18 @@ import-data-to-target:
   ### Default - false
   # enable-upsert: false  
 
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
+
 # ---------------------------------------------------------
 # Archive Changes
 # ---------------------------------------------------------
@@ -397,7 +457,13 @@ archive-changes:
 
   ### Disk utilization threshold in percentage
   ### Default - 70
-  # fs-utilization-threshold: 70
+  # fs-utilization-threshold: 70 
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
 
 # ---------------------------------------------------------
 # Intitiate cutover to target
@@ -445,6 +511,18 @@ finalize-schema-post-data-import:
   ### Default - false
   refresh-mviews: false  
 
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
+
 # ---------------------------------------------------------
 # Export Data from Target
 # ---------------------------------------------------------
@@ -467,6 +545,12 @@ export-data-from-target:
   ### Default - true
   # transaction-ordering: true 
 
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
+
 # ---------------------------------------------------------
 # Import data to source
 # ---------------------------------------------------------
@@ -484,7 +568,19 @@ import-data-to-source:
   ### Disable progress bar/stats during data import 
   ### Accepted values (true, false, yes, no, 0, 1)
   ### Default - false
-  disable-pb: false                                     
+  disable-pb: false  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                    
 
 # ---------------------------------------------------------
 # End Migration Configuration
@@ -517,7 +613,13 @@ end-migration:
   
   ### Backup directory is where all the backup files of schema, data, logs and reports will be saved
   ### Note: Mandatory if any of the following flags are set to true or yes or 1: --backup-data-files, --backup-log-files, --backup-schema-files, --save-migration-reports.
-  # backup-dir: <backup-dir-path>                             
+  # backup-dir: <backup-dir-path>  
+  
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                            
 
 # ---------------------------------------------------------
 # Config File End

--- a/yb-voyager/config-templates/live-migration-with-fall-back.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-back.yaml
@@ -294,7 +294,6 @@ import-schema:
   # enable-orafce: true  
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  
@@ -421,7 +420,6 @@ import-data-to-target:
   # enable-upsert: false  
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  
@@ -512,7 +510,6 @@ finalize-schema-post-data-import:
   refresh-mviews: false  
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  

--- a/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
@@ -14,12 +14,6 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                  
 
-### Run guardrails checks before the command is run. 
-### Note - This is only valid for PostgreSQL source database.
-### Accepted values - (true, false, yes, no, 1, 0)
-### Default - true
-# run-guardrails-checks: true  
-
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
 
@@ -235,7 +229,19 @@ assess-migration:
 
   ### Directory path where assessment metadata like source DB metadata and statistics are stored. 
   ### Optional flag, if not provided, it will be assumed to be present at default path inside the export directory.
-  # assessment-metadata-dir: <assessment-metadata-dir>     
+  # assessment-metadata-dir: <assessment-metadata-dir>    
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info  
 
 # ----------------------------------------------------------
 # Export Schema Configuration
@@ -271,7 +277,19 @@ export-schema:
   # skip-recommendations: false  
 
   ### Path to the generated assessment report file(JSON format) to be used for applying recommendation to exported schema                       
-  # assessment-report-path: <assessment-report-path>        
+  # assessment-report-path: <assessment-report-path>
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info         
 
 # ----------------------------------------------------------
 # Analyze Schema Configuration
@@ -288,7 +306,13 @@ analyze-schema:
 
   ### Target YugabyteDB version to analyze schema for (in format A.B.C.D). 
   ### Default - latest stable version i.e. 2024.2.2.3                                       
-  target-db-version: 2024.2.2.3                           
+  target-db-version: 2024.2.2.3 
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                           
                                       
                                   
 # ----------------------------------------------------------
@@ -327,7 +351,19 @@ import-schema:
   ### Note - This is only valid for Oracle source database.
   ### Accepted values (true, false, yes, no, 1, 0) 
   ### Default - true
-  # enable-orafce: true   
+  # enable-orafce: true 
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info   
 
 # ----------------------------------------------------------
 # Export Data Configuration
@@ -362,7 +398,19 @@ export-data-from-source:
   ### Disable progress bar/stats during data export  
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false                                            
+  # disable-pb: false  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                           
 
 # ---------------------------------------------------------
 # Import Data Configuration
@@ -430,7 +478,19 @@ import-data-to-target:
   ### If a table has secondary indexes, setting this flag to true may lead to corruption of the indexes. 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # enable-upsert: false  
+  # enable-upsert: false
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info   
 
 # ---------------------------------------------------------
 # Import data to source-replica
@@ -461,6 +521,18 @@ import-data-to-source-replica:
   ### Default - false
   # disable-pb: false
 
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
+
 # ---------------------------------------------------------
 # Archive Changes
 # ---------------------------------------------------------
@@ -487,6 +559,12 @@ archive-changes:
   ### Disk utilization threshold in percentage
   ### Default - 70
   # fs-utilization-threshold: 70
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
   
 # ---------------------------------------------------------
 # Intitiate cutover to target
@@ -532,7 +610,19 @@ finalize-schema-post-data-import:
   ### Refreshes the materialised views on target during post snapshot import phase  
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  refresh-mviews: false     
+  refresh-mviews: false   
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info   
 
 # ---------------------------------------------------------
 # Export Data from Target
@@ -554,7 +644,13 @@ export-data-from-target:
   ### Note: This is applicable only when exporting data from target YugabyteDB using the gRPC connector.
   ### Accepted values (true, false, yes, no, 0, 1) 
   ### Default - true
-  # transaction-ordering: true
+  # transaction-ordering: true 
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
 
 # ---------------------------------------------------------
 # End Migration Configuration
@@ -587,7 +683,13 @@ end-migration:
   
   ### Backup directory is where all the backup files of schema, data, logs and reports will be saved
   ### Note: Mandatory if any of the following flags are set to true or yes or 1: --backup-data-files, --backup-log-files, --backup-schema-files, --save-migration-reports.
-  # backup-dir: <backup-dir-path>                             
+  # backup-dir: <backup-dir-path> 
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                             
 
 # ---------------------------------------------------------
 # Config File End

--- a/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
@@ -354,7 +354,6 @@ import-schema:
   # enable-orafce: true 
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  
@@ -481,7 +480,6 @@ import-data-to-target:
   # enable-upsert: false
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  
@@ -613,7 +611,6 @@ finalize-schema-post-data-import:
   refresh-mviews: false   
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -294,7 +294,6 @@ import-schema:
   # enable-orafce: true  
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  
@@ -421,7 +420,6 @@ import-data-to-target:
   # enable-upsert: false 
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  
@@ -505,7 +503,6 @@ finalize-schema-post-data-import:
   refresh-mviews: false
 
   ### Run guardrails checks before the command is run. 
-  ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
   # run-guardrails-checks: true  

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -12,13 +12,7 @@ export-dir: <export-dir-path>
 ### Log level for yb-voyager 
 ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
 ### Default - info
-log-level: info                  
-
-### Run guardrails checks before the command is run. 
-### Note - This is only valid for PostgreSQL source database.
-### Accepted values - (true, false, yes, no, 1, 0)
-### Default - true
-# run-guardrails-checks: true  
+log-level: info                    
 
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
@@ -175,7 +169,19 @@ assess-migration:
 
   ### Directory path where assessment metadata like source DB metadata and statistics are stored. 
   ### Optional flag, if not provided, it will be assumed to be present at default path inside the export directory.
-  # assessment-metadata-dir: <assessment-metadata-dir>     
+  # assessment-metadata-dir: <assessment-metadata-dir>  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info    
 
 # ----------------------------------------------------------
 # Export Schema Configuration
@@ -211,7 +217,19 @@ export-schema:
   # skip-recommendations: false  
 
   ### Path to the generated assessment report file(JSON format) to be used for applying recommendation to exported schema                       
-  # assessment-report-path: <assessment-report-path>        
+  # assessment-report-path: <assessment-report-path> 
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info        
 
 # ----------------------------------------------------------
 # Analyze Schema Configuration
@@ -228,7 +246,13 @@ analyze-schema:
 
   ### Target YugabyteDB version to analyze schema for (in format A.B.C.D). 
   ### Default - latest stable version i.e. 2024.2.2.3                                        
-  target-db-version: 2024.2.2.3                           
+  target-db-version: 2024.2.2.3  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                           
                                       
                                   
 # ----------------------------------------------------------
@@ -267,7 +291,19 @@ import-schema:
   ### Note - This is only valid for Oracle source database.
   ### Accepted values (true, false, yes, no, 1, 0) 
   ### Default - true
-  # enable-orafce: true   
+  # enable-orafce: true  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info  
 
 # ----------------------------------------------------------
 # Export Data Configuration
@@ -302,7 +338,19 @@ export-data-from-source:
   ### Disable progress bar/stats during data export  
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false                                               
+  # disable-pb: false  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                              
 
 # ---------------------------------------------------------
 # Import Data Configuration
@@ -370,7 +418,19 @@ import-data-to-target:
   ### If a table has secondary indexes, setting this flag to true may lead to corruption of the indexes. 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # enable-upsert: false    
+  # enable-upsert: false 
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info    
 
 # ---------------------------------------------------------
 # Archive Changes
@@ -398,6 +458,12 @@ archive-changes:
   ### Disk utilization threshold in percentage
   ### Default - 70
   # fs-utilization-threshold: 70
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
   
 # ---------------------------------------------------------
 # Intitiate cutover to target
@@ -436,7 +502,19 @@ finalize-schema-post-data-import:
   ### Refreshes the materialised views on target during post snapshot import phase  
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  refresh-mviews: false                                       
+  refresh-mviews: false
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                        
 
 # ---------------------------------------------------------
 # End Migration Configuration
@@ -469,7 +547,13 @@ end-migration:
   
   ### Backup directory is where all the backup files of schema, data, logs and reports will be saved
   ### Note: Mandatory if any of the following flags are set to true or yes or 1: --backup-data-files, --backup-log-files, --backup-schema-files, --save-migration-reports.
-  # backup-dir: <backup-dir-path>                             
+  # backup-dir: <backup-dir-path> 
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                              
 
 # ---------------------------------------------------------
 # Config File End

--- a/yb-voyager/config-templates/offline-migration.yaml
+++ b/yb-voyager/config-templates/offline-migration.yaml
@@ -14,12 +14,6 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                  
 
-### Run guardrails checks before the command is run. 
-### Note - This is only valid for PostgreSQL source database.
-### Accepted values - (true, false, yes, no, 1, 0)
-### Default - true
-# run-guardrails-checks: true  
-
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
 
@@ -165,7 +159,19 @@ assess-migration:
 
   ### Directory path where assessment metadata like source DB metadata and statistics are stored. 
   ### Optional flag, if not provided, it will be assumed to be present at default path inside the export directory.
-  # assessment-metadata-dir: <assessment-metadata-dir>     
+  # assessment-metadata-dir: <assessment-metadata-dir>    
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info  
 
 # ----------------------------------------------------------
 # Export Schema Configuration
@@ -202,7 +208,19 @@ export-schema:
   # skip-recommendations: false  
 
   ### Path to the generated assessment report file(JSON format) to be used for applying recommendation to exported schema                       
-  # assessment-report-path: <assessment-report-path>        
+  # assessment-report-path: <assessment-report-path>   
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info       
 
 # ----------------------------------------------------------
 # Analyze Schema Configuration
@@ -219,7 +237,13 @@ analyze-schema:
 
   ### Target YugabyteDB version to analyze schema for (in format A.B.C.D). 
   ### Default - latest stable version i.e. 2024.2.2.3                                       
-  target-db-version: 2024.2.2.3                            
+  target-db-version: 2024.2.2.3  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                           
                                       
                                   
 # ----------------------------------------------------------
@@ -261,6 +285,18 @@ import-schema:
   ### Default - true
   # enable-orafce: true   
 
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true 
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info 
+
 # ----------------------------------------------------------
 # Export Data Configuration
 # ----------------------------------------------------------
@@ -298,7 +334,19 @@ export-data:
   ### For MySQL and Oracle, you can optionally speed up data export by setting the config parameter beta-fast-data-export: 1.
   ### In case this parameter is set, parallel-jobs has no effect and its value is fixed to 1. 
   ### Accepted values (true, false, yes, no, 1, 0)
-  # beta-fast-data-export: 0                                           
+  # beta-fast-data-export: 0 
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                            
 
 # ---------------------------------------------------------
 # Import Data Configuration
@@ -378,7 +426,19 @@ import-data:
   ### If a table has secondary indexes, setting this flag to true may lead to corruption of the indexes. 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # enable-upsert: false                                                                 
+  # enable-upsert: false  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                                                 
 
 # ---------------------------------------------------------
 # Finalize Schema Post Data Import Configuration
@@ -402,7 +462,19 @@ finalize-schema-post-data-import:
   ### Refreshes the materialised views on target during post snapshot import phase  
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  refresh-mviews: false                                       
+  refresh-mviews: false  
+
+  ### Run guardrails checks before the command is run. 
+  ### Note - This is only valid for PostgreSQL source database.
+  ### Accepted values - (true, false, yes, no, 1, 0)
+  ### Default - true
+  # run-guardrails-checks: true  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                                     
 
 # ---------------------------------------------------------
 # End Migration Configuration
@@ -435,7 +507,13 @@ end-migration:
   
   ### Backup directory is where all the backup files of schema, data, logs and reports will be saved
   ### Note: Mandatory if any of the following flags are set to true or yes or 1: --backup-data-files, --backup-log-files, --backup-schema-files, --save-migration-reports.
-  # backup-dir: <backup-dir-path>                             
+  # backup-dir: <backup-dir-path>  
+
+  ### Log level for the command
+  ### Note: This overrides the global log-level parameter for this command only.
+  ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
+  ### Default - info
+  # log-level: info                            
 
 # ---------------------------------------------------------
 # Config File End


### PR DESCRIPTION
### Describe the changes in this pull request
Fixes: [Allow overriding global flags on the command level in the config file](https://yugabyte.atlassian.net/browse/DB-16691?atlOrigin=eyJpIjoiYjAzZDBiOTNmNTE3NGJlZTk5MTFmYjJhMTZmMmIyNDUiLCJwIjoiaiJ9)
1. Changed run-guardrails-checks from a global level config parameter to a command specific parameter
2. Added log-level as a command specific sections too - users will be able to specify it at a global level or modify it for a specific command as well. The command specific flag value will take preference.
3. Made the required changes in config templates
4. Added a few unit tests too.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  5. Were there any changes to the configuration?
  6. Has the installation process changed? 
  7. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually, unit tests

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
