### PR TITLE
Removed the default config file path and env variable for passing config file, made yaml the default extension for the config file

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -217,9 +217,8 @@ initConfig initializes the configuration for the given Cobra command.
 */
 func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, []EnvVarSetViaConfig, map[string]string, error) {
 	v := viper.New()
+	v.SetConfigType("yaml")
 
-	// Precedence of which config file to use:
-	// CLI Flag > ENV Variable > Default config file in home directory
 	if cfgFile != "" {
 		// Use config file from the flag.
 		if !utils.FileOrFolderExists(cfgFile) {
@@ -233,20 +232,6 @@ func initConfig(cmd *cobra.Command) ([]ConfigFlagOverride, []EnvVarSetViaConfig,
 		cfgFile = filepath.Clean(cfgFile)
 
 		v.SetConfigFile(cfgFile)
-	} else if os.Getenv("YB_VOYAGER_CONFIG_FILE") != "" {
-		// passed as an ENV variable by the name YB_VOYAGER_CONFIG_FILE
-		v.SetConfigFile(os.Getenv("YB_VOYAGER_CONFIG_FILE"))
-	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		// Search config in home directory with name "yb-voyager-config" (without extension).
-		v.AddConfigPath(home)
-		v.SetConfigName("yb-voyager-config")
-		v.SetConfigType("yaml")
 	}
 
 	// If a config file is found, read it in.


### PR DESCRIPTION
### Describe the changes in this pull request
Fixes these:
- [Check if .yaml extension is required for the config file](https://yugabyte.atlassian.net/browse/DB-16803?atlOrigin=eyJpIjoiYjMyOTA3YTAwNWUxNDhlMmIyZGZkNmY1YjlkNDg2MGYiLCJwIjoiaiJ9)
- [Revisit the need of supporting a default config file ~/.yb-voyager.yaml](https://yugabyte.atlassian.net/browse/DB-16726?atlOrigin=eyJpIjoiMmIzOTViOGE4ODQwNDIyYWFjOTFmZjJlNDJlMzFkZjIiLCJwIjoiaiJ9)

- Removed the default config file 
- Removed the option to provide config file using ENV variable since we were not really using it
- Added a line to make yaml as the default config file format: Now even if the config file does not have an extension, it will be treated as a yaml file

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
