### PR TITLE
Fix: Only import data cmd should set on-primary-key-conflict flag in metaDB

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -97,10 +97,15 @@ func validateImportFlags(cmd *cobra.Command, importerRole string) error {
 	validateParallelismFlags()
 	validateTruncateTablesFlag()
 
-	err = validateOnPrimaryKeyConflictFlag()
+	return nil
+}
+
+func validateImportDataFlags() error {
+	err := validateOnPrimaryKeyConflictFlag()
 	if err != nil {
 		return fmt.Errorf("error validating --on-primary-key-conflict flag: %w", err)
 	}
+
 	return nil
 }
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -101,6 +101,11 @@ var importDataCmd = &cobra.Command{
 		if err != nil {
 			utils.ErrExit("Error validating import flags: %s", err.Error())
 		}
+
+		err = validateImportDataFlags()
+		if err != nil {
+			utils.ErrExit("Error validating import data flags: %s", err.Error())
+		}
 	},
 	Run: importDataCommandFn,
 }


### PR DESCRIPTION
### Describe the changes in this pull request
- previously it was getting set by import schema as per default value and import data never able to set it to IGNORE

- Only setting and checking this flag in import data cmd workflow


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
