### PR TITLE
Fixed error messages mentioning post-snapshot-import instead of finalize-schema-post-data-import and marked the required flags as deprecated

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -280,12 +280,9 @@ func registerImportSchemaFlags(cmd *cobra.Command) {
 		"enable Orafce extension on target(if source db type is Oracle)")
 
 	// --post-snapshot-import and --refresh-mviews flags will now be handled by the command post-data-import-finalize-schema
-	// Not removing these flags and just hiding them for backward compatibility.
-	cmd.Flags().MarkHidden("post-snapshot-import")
+	// Not removing these flags and just deprecating them for backward compatibility.
 	cmd.Flags().MarkDeprecated("post-snapshot-import",
 		"use the command 'finalize-schema-post-data-import' instead. \nFor more details, refer to the documentation: \nhttps://docs.yugabyte.com/preview/yugabyte-voyager/reference/schema-migration/finalize-schema-post-data-import/\n")
-
-	cmd.Flags().MarkHidden("refresh-mviews")
 	cmd.Flags().MarkDeprecated("refresh-mviews",
 		"it is no longer supported in the 'import schema' command. Use the 'finalize-schema-post-data-import' command instead. \nFor more details, refer to the documentation: \nhttps://docs.yugabyte.com/preview/yugabyte-voyager/reference/schema-migration/finalize-schema-post-data-import/\n")
 

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -282,7 +282,13 @@ func registerImportSchemaFlags(cmd *cobra.Command) {
 	// --post-snapshot-import and --refresh-mviews flags will now be handled by the command post-data-import-finalize-schema
 	// Not removing these flags and just hiding them for backward compatibility.
 	cmd.Flags().MarkHidden("post-snapshot-import")
+	cmd.Flags().MarkDeprecated("post-snapshot-import",
+		"use the command 'finalize-schema-post-data-import' instead. \nFor more details, refer to the documentation: \nhttps://docs.yugabyte.com/preview/yugabyte-voyager/reference/schema-migration/finalize-schema-post-data-import/\n")
+
 	cmd.Flags().MarkHidden("refresh-mviews")
+	cmd.Flags().MarkDeprecated("refresh-mviews",
+		"it is no longer supported in the 'import schema' command. Use the 'finalize-schema-post-data-import' command instead. \nFor more details, refer to the documentation: \nhttps://docs.yugabyte.com/preview/yugabyte-voyager/reference/schema-migration/finalize-schema-post-data-import/\n")
+
 }
 
 func validateTargetPortRange() {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -766,7 +766,7 @@ func importData(importFileTasks []*ImportFileTask, errorPolicy importdata.ErrorP
 		if !msr.IsSnapshotExportedViaDebezium() {
 			errImport := executePostSnapshotImportSqls()
 			if errImport != nil {
-				utils.ErrExit("Error in importing post-snapshot-import sql: %v", err)
+				utils.ErrExit("Error in importing finalize-schema-post-data-import sql: %v", err)
 			}
 		} else {
 			status, err := dbzm.ReadExportStatus(filepath.Join(exportDir, "data", "export_status.json"))

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -231,13 +231,13 @@ func importSchema() error {
 	if flagPostSnapshotImport {
 		err = importSchemaInternal(exportDir, []string{"TABLE"}, nil)
 		if err != nil {
-			return fmt.Errorf("failed to import schema for TABLEs in post-snapshot-import phase: %s", err)
+			return fmt.Errorf("failed to import schema for TABLEs in finalize-schema-post-data-import phase: %s", err)
 		}
 		if flagRefreshMViews {
 			refreshMViews(conn)
 		}
 	} else {
-		utils.PrintAndLog("\nNOTE: Materialized Views are not populated by default. To populate them, pass --refresh-mviews while executing `import schema --post-snapshot-import`.")
+		utils.PrintAndLog("\nNOTE: Materialized Views are not populated by default. To populate them, pass --refresh-mviews while executing `finalize-schema-post-data-import`.")
 	}
 
 	importSchemaCompleteEvent := createImportSchemaCompletedEvent()

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -231,7 +231,7 @@ func importSchema() error {
 	if flagPostSnapshotImport {
 		err = importSchemaInternal(exportDir, []string{"TABLE"}, nil)
 		if err != nil {
-			return fmt.Errorf("failed to import schema for TABLEs in finalize-schema-post-data-import phase: %s", err)
+			return fmt.Errorf("failed to import schema for TABLEs: %s", err)
 		}
 		if flagRefreshMViews {
 			refreshMViews(conn)


### PR DESCRIPTION
### Describe the changes in this pull request
1. Fixed messages that still mentioned post-snapshot-import
2. Marked the --post-snapshot-import and --refresh-mviews flags in import schema as deprecated with a custom error message.
Fixes: [Modify the link to the documentation of finalize-schema-post-data-import to the correct link once it is available in the deprecation message for the flags --post-snapshot-import in import schema.](https://yugabyte.atlassian.net/browse/DB-16384?atlOrigin=eyJpIjoiY2QxNDY4MWIyMTQyNDE0MmJlMTZjNjc4ZTY5ZGQ0MDIiLCJwIjoiaiJ9)

Example output:
```
Flag --post-snapshot-import has been deprecated, use the command 'finalize-schema-post-data-import' instead. 
For more details, refer to the documentation: 
https://docs.yugabyte.com/preview/yugabyte-voyager/reference/schema-migration/finalize-schema-post-data-import/

Flag --refresh-mviews has been deprecated, it is no longer supported in the 'import schema' command. Use the 'finalize-schema-post-data-import' command instead. 
For more details, refer to the documentation: 
https://docs.yugabyte.com/preview/yugabyte-voyager/reference/schema-migration/finalize-schema-post-data-import/
```

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  4. Were there any changes to the configuration?
  5. Has the installation process changed? 
  6. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              | No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
