### PR TITLE
Update test cases for get-data-migration-report as per ErrorPolicy changes

### DIFF
--- a/migtests/tests/pg/datatypes/data-migration-report-live-migration-fallf.json
+++ b/migtests/tests/pg/datatypes/data-migration-report-live-migration-fallf.json
@@ -10,7 +10,8 @@
         "exported_inserts": 1,
         "exported_updates": 8,
         "exported_deletes": 1,
-        "final_row_count": 3
+        "final_row_count": 3,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"num_types\"",
@@ -23,7 +24,8 @@
         "exported_inserts": 2,
         "exported_updates": 5,
         "exported_deletes": 2,
-        "final_row_count": 3
+        "final_row_count": 3,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"num_types\"",
@@ -36,7 +38,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 3
+        "final_row_count": 3,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"decimal_types\"",
@@ -49,7 +52,8 @@
         "exported_inserts": 1,
         "exported_updates": 8,
         "exported_deletes": 0,
-        "final_row_count": 4
+        "final_row_count": 4,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"decimal_types\"",
@@ -62,7 +66,8 @@
         "exported_inserts": 2,
         "exported_updates": 6,
         "exported_deletes": 2,
-        "final_row_count": 4
+        "final_row_count": 4,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"decimal_types\"",
@@ -75,7 +80,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 4
+        "final_row_count": 4,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datatypes1\"",
@@ -88,7 +94,8 @@
         "exported_inserts": 1,
         "exported_updates": 1,
         "exported_deletes": 1,
-        "final_row_count": 3
+        "final_row_count": 3,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datatypes1\"",
@@ -101,7 +108,8 @@
         "exported_inserts": 2,
         "exported_updates": 6,
         "exported_deletes": 3,
-        "final_row_count": 2
+        "final_row_count": 2,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datatypes1\"",
@@ -114,7 +122,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 2
+        "final_row_count": 2,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datetime_type\"",
@@ -127,7 +136,8 @@
         "exported_inserts": 2,
         "exported_updates": 1,
         "exported_deletes": 2,
-        "final_row_count": 3
+        "final_row_count": 3,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datetime_type\"",
@@ -140,7 +150,8 @@
         "exported_inserts": 1,
         "exported_updates": 2,
         "exported_deletes": 3,
-        "final_row_count": 1
+        "final_row_count": 1,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datetime_type\"",
@@ -153,7 +164,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 1
+        "final_row_count": 1,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datetime_type2\"",
@@ -166,7 +178,8 @@
         "exported_inserts": 1,
         "exported_updates": 0,
         "exported_deletes": 1,
-        "final_row_count": 2
+        "final_row_count": 2,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datetime_type2\"",
@@ -179,7 +192,8 @@
         "exported_inserts": 1,
         "exported_updates": 1,
         "exported_deletes": 0,
-        "final_row_count": 3
+        "final_row_count": 3,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datetime_type2\"",
@@ -192,7 +206,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 3
+        "final_row_count": 3,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datatypes2\"",
@@ -205,7 +220,8 @@
         "exported_inserts": 2,
         "exported_updates": 1,
         "exported_deletes": 0,
-        "final_row_count": 5
+        "final_row_count": 5,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datatypes2\"",
@@ -218,7 +234,8 @@
         "exported_inserts": 3,
         "exported_updates": 2,
         "exported_deletes": 2,
-        "final_row_count": 6
+        "final_row_count": 6,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"datatypes2\"",
@@ -231,7 +248,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 6
+        "final_row_count": 6,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"null_and_default\"",
@@ -244,7 +262,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 2
+        "final_row_count": 2,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"null_and_default\"",
@@ -257,7 +276,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 2
+        "final_row_count": 2,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"null_and_default\"",
@@ -270,7 +290,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 2
+        "final_row_count": 2,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"hstore_example\"",
@@ -283,7 +304,8 @@
         "exported_inserts": 3,
         "exported_updates": 5,
         "exported_deletes": 0,
-        "final_row_count": 16
+        "final_row_count": 16,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"hstore_example\"",
@@ -296,7 +318,8 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 16
+        "final_row_count": 16,
+        "errored_imported_snapshot_rows": 0
     },
     {
         "table_name": "public.\"hstore_example\"",
@@ -309,6 +332,7 @@
         "exported_inserts": 0,
         "exported_updates": 0,
         "exported_deletes": 0,
-        "final_row_count": 16
+        "final_row_count": 16,
+        "errored_imported_snapshot_rows": 0
     }
 ]

--- a/migtests/tests/pg/multiple-schemas/data-migration-report-live-migration-fallb.json
+++ b/migtests/tests/pg/multiple-schemas/data-migration-report-live-migration-fallb.json
@@ -10,7 +10,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1
+    "final_row_count": 1,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"ext_test\"",
@@ -23,7 +24,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1
+    "final_row_count": 1,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"tt\"",
@@ -36,7 +38,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 4,
-    "final_row_count": 1
+    "final_row_count": 1,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"tt\"",
@@ -49,7 +52,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 1,
-    "final_row_count": 1
+    "final_row_count": 1,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"audit\"",
@@ -62,7 +66,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 6
+    "final_row_count": 6,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"audit\"",
@@ -75,7 +80,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 6
+    "final_row_count": 6,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"recipients\"",
@@ -88,7 +94,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 2
+    "final_row_count": 2,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"recipients\"",
@@ -101,7 +108,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 2
+    "final_row_count": 2,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"session_log\"",
@@ -114,7 +122,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 0
+    "final_row_count": 0,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "public.\"session_log\"",
@@ -127,7 +136,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 0
+    "final_row_count": 0,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"ext_test\"",
@@ -140,7 +150,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1
+    "final_row_count": 1,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"ext_test\"",
@@ -153,7 +164,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1
+    "final_row_count": 1,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"tt\"",
@@ -166,7 +178,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 6
+    "final_row_count": 6,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"tt\"",
@@ -179,7 +192,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 6
+    "final_row_count": 6,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"audit\"",
@@ -192,7 +206,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 6
+    "final_row_count": 6,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"audit\"",
@@ -205,7 +220,8 @@
     "exported_inserts": 1,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 6
+    "final_row_count": 6,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"recipients\"",
@@ -218,7 +234,8 @@
     "exported_inserts": 2,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 3
+    "final_row_count": 3,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"recipients\"",
@@ -231,7 +248,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 3
+    "final_row_count": 3,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"session_log\"",
@@ -244,7 +262,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 0
+    "final_row_count": 0,
+    "errored_imported_snapshot_rows": 0
     },
     {
     "table_name": "schema2.\"session_log\"",
@@ -257,6 +276,7 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 0
+    "final_row_count": 0,
+    "errored_imported_snapshot_rows": 0
     }
 ]

--- a/migtests/tests/pg/partitions/data-migration-report-live-migration.json
+++ b/migtests/tests/pg/partitions/data-migration-report-live-migration.json
@@ -10,7 +10,8 @@
     "exported_inserts": 5,
     "exported_updates": 0,
     "exported_deletes": 3,
-    "final_row_count": 1002
+    "final_row_count": 1002,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"customers\"",
@@ -23,7 +24,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1002
+    "final_row_count": 1002,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"sales_region\"",
@@ -36,7 +38,8 @@
     "exported_inserts": 2,
     "exported_updates": 2,
     "exported_deletes": 2,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"sales_region\"",
@@ -49,7 +52,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"test_partitions_sequences\"",
@@ -62,7 +66,8 @@
     "exported_inserts": 2,
     "exported_updates": 2,
     "exported_deletes": 2,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"test_partitions_sequences\"",
@@ -75,7 +80,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "p1.\"sales_region\"",
@@ -88,7 +94,8 @@
     "exported_inserts": 2,
     "exported_updates": 2,
     "exported_deletes": 2,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "p1.\"sales_region\"",
@@ -101,7 +108,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"sales\"",
@@ -114,7 +122,8 @@
     "exported_inserts": 2,
     "exported_updates": 2,
     "exported_deletes": 1,
-    "final_row_count": 1001
+    "final_row_count": 1001,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"sales\"",
@@ -127,7 +136,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1001
+    "final_row_count": 1001,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"range_columns_partition_test\"",
@@ -140,7 +150,8 @@
     "exported_inserts": 3,
     "exported_updates": 0,
     "exported_deletes": 1,
-    "final_row_count": 8
+    "final_row_count": 8,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"range_columns_partition_test\"",
@@ -153,7 +164,8 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 8
+    "final_row_count": 8,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"emp\"",
@@ -166,7 +178,8 @@
     "exported_inserts": 1,
     "exported_updates": 2,
     "exported_deletes": 1,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   },
   {
     "table_name": "public.\"emp\"",
@@ -179,6 +192,7 @@
     "exported_inserts": 0,
     "exported_updates": 0,
     "exported_deletes": 0,
-    "final_row_count": 1000
+    "final_row_count": 1000,
+    "errored_imported_snapshot_rows": 0
   }
 ]

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -87,18 +87,18 @@ var getDataMigrationReportCmd = &cobra.Command{
 }
 
 type rowData struct {
-	TableName            string `json:"table_name"`
-	DBType               string `json:"db_type"`
-	ExportedSnapshotRows int64  `json:"exported_snapshot_rows"`
-	ImportedSnapshotRows int64  `json:"imported_snapshot_rows"`
-	ErroredSnapshotRows  int64  `json:"errored_snapshot_rows"`
-	ImportedInserts      int64  `json:"imported_inserts"`
-	ImportedUpdates      int64  `json:"imported_updates"`
-	ImportedDeletes      int64  `json:"imported_deletes"`
-	ExportedInserts      int64  `json:"exported_inserts"`
-	ExportedUpdates      int64  `json:"exported_updates"`
-	ExportedDeletes      int64  `json:"exported_deletes"`
-	FinalRowCount        int64  `json:"final_row_count"`
+	TableName                   string `json:"table_name"`
+	DBType                      string `json:"db_type"`
+	ExportedSnapshotRows        int64  `json:"exported_snapshot_rows"`
+	ImportedSnapshotRows        int64  `json:"imported_snapshot_rows"`
+	ErroredImportedSnapshotRows int64  `json:"errored_imported_snapshot_rows"`
+	ImportedInserts             int64  `json:"imported_inserts"`
+	ImportedUpdates             int64  `json:"imported_updates"`
+	ImportedDeletes             int64  `json:"imported_deletes"`
+	ExportedInserts             int64  `json:"exported_inserts"`
+	ExportedUpdates             int64  `json:"exported_updates"`
+	ExportedDeletes             int64  `json:"exported_deletes"`
+	FinalRowCount               int64  `json:"final_row_count"`
 }
 
 var reportData []*rowData
@@ -247,7 +247,7 @@ func getDataMigrationReportCmdFn(msr *metadb.MigrationStatusRecord) {
 		row := rowData{}
 		updateExportedSnapshotRowsInTheRow(msr, &row, nameTup, dbzmNameTupToRowCount, exportedPGSnapshotRowsMap)
 		row.ImportedSnapshotRows = 0
-		row.ErroredSnapshotRows = 0
+		row.ErroredImportedSnapshotRows = 0
 		row.TableName = nameTup.ForKey()
 		row.DBType = "source"
 		err := updateExportedEventsCountsInTheRow(&row, nameTup, sourceExportedEventsMap, targetExportedEventsMap) //source OUT counts
@@ -328,7 +328,7 @@ func addRowInTheTable(uitbl *uitable.Table, row rowData, nameTup sqlname.NameTup
 		reportData = append(reportData, &row)
 		return
 	}
-	uitbl.AddRow(row.TableName, row.DBType, row.ExportedSnapshotRows, row.ImportedSnapshotRows, row.ErroredSnapshotRows, row.ExportedInserts, row.ExportedUpdates, row.ExportedDeletes, row.ImportedInserts, row.ImportedUpdates, row.ImportedDeletes, getFinalRowCount(row))
+	uitbl.AddRow(row.TableName, row.DBType, row.ExportedSnapshotRows, row.ImportedSnapshotRows, row.ErroredImportedSnapshotRows, row.ExportedInserts, row.ExportedUpdates, row.ExportedDeletes, row.ImportedInserts, row.ImportedUpdates, row.ImportedDeletes, getFinalRowCount(row))
 }
 
 func updateExportedSnapshotRowsInTheRow(msr *metadb.MigrationStatusRecord, row *rowData, nameTup sqlname.NameTuple, dbzmSnapshotRowCount *utils.StructMap[sqlname.NameTuple, int64], exportedSnapshotPGRowsMap *utils.StructMap[sqlname.NameTuple, int64]) error {
@@ -389,7 +389,7 @@ func updateImportedEventsCountsInTheRow(row *rowData, tableNameTup sqlname.NameT
 	if importerRole != SOURCE_DB_IMPORTER_ROLE {
 		rowCountPair, _ := snapshotImportedRowsMap.Get(tableNameTup)
 		row.ImportedSnapshotRows = rowCountPair.Imported
-		row.ErroredSnapshotRows = rowCountPair.Errored
+		row.ErroredImportedSnapshotRows = rowCountPair.Errored
 	}
 
 	eventCounter, _ := eventsImportedMap.Get(tableNameTup)


### PR DESCRIPTION
### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
