### PR TITLE
[Voyager] [DB-16745] Removed `latest_stable_test` from github  and migrated it to jenkins run.

### DIFF
--- a/.github/workflows/issue-tests.yml
+++ b/.github/workflows/issue-tests.yml
@@ -58,8 +58,9 @@ jobs:
         cd yb-voyager
         go test -v ./... -tags 'issues_integration'
 
-    - name: Test Latest Stable YB Version
-      if: ${{ matrix.version == 'LATEST_STABLE' }}
-      run: |
-        cd yb-voyager
-        go test -v ./... -tags 'yb_version_latest_stable'
+    # - name: Test Latest Stable YB Version
+    #   if: ${{ matrix.version == 'LATEST_STABLE' }}
+    #   run: |
+    #     cd yb-voyager
+    #     go test -v ./... -tags 'yb_version_latest_stable'
+


### PR DESCRIPTION
### Describe the changes in this pull request
Moving latest_stable_test.go from github to jenkins.

Corresponding jenkins run : [link](https://jenkins.dev.yugabyte.com/blue/organizations/jenkins/users%2Fyb-voyager-testing%2Fyb-voyager-testing-pipeline-test/detail/yb-voyager-testing-pipeline-test/1221/pipeline/157/)


Jenkins pipeline changes: [link](https://github.com/yugabyte/jenkins-helpers/pull/1050)
