### PR TITLE
Fix migration_type sent during end-migration phase in exit/error scenario to callhome

### DIFF
--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -109,7 +109,10 @@ func packAndSendEndMigrationPayload(status string, errorMsg string) {
 		return
 	}
 	payload := createCallhomePayload()
-	if streamChangesMode {
+	streamChangesMode, err := checkStreamingMode()
+	if err != nil {
+		log.Errorf("callhome: error while checking migration type: %w\n", err)
+	} else if streamChangesMode {
 		payload.MigrationType = LIVE_MIGRATION
 	} else {
 		payload.MigrationType = OFFLINE
@@ -126,7 +129,7 @@ func packAndSendEndMigrationPayload(status string, errorMsg string) {
 	payload.PhasePayload = callhome.MarshalledJsonString(endMigrationPayload)
 	payload.Status = status
 
-	err := callhome.SendPayload(&payload)
+	err = callhome.SendPayload(&payload)
 	if err == nil && (status == COMPLETE || status == ERROR) {
 		callHomeErrorOrCompletePayloadSent = true
 	}

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -109,9 +109,10 @@ func packAndSendEndMigrationPayload(status string, errorMsg string) {
 		return
 	}
 	payload := createCallhomePayload()
-	payload.MigrationType = OFFLINE
 	if streamChangesMode {
 		payload.MigrationType = LIVE_MIGRATION
+	} else {
+		payload.MigrationType = OFFLINE
 	}
 	payload.MigrationPhase = END_MIGRATION_PHASE
 	endMigrationPayload := callhome.EndMigrationPhasePayload{


### PR DESCRIPTION
### Describe the changes in this pull request
In case the end-migration command exits or errors out early, and the `streamChangesMode` is not populated at that time. The incorrect migration type is being sent to Callhome.  

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
no

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
manually 

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
