### PR TITLE
Masked the password values when logging the env vars/flags set using config file

### DIFF
--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -163,10 +163,18 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 		}
 		// Log the env variables already set in the environment by the user
 		for envVar, val := range envVarsAlreadyExported {
+			// If the env variable is SOURCE_DB_PASSWORD, TARGET_DB_PASSWORD, or SOURCE_REPLICA_DB_PASSWORD, mask the value
+			if envVar == "SOURCE_DB_PASSWORD" || envVar == "TARGET_DB_PASSWORD" || envVar == "SOURCE_REPLICA_DB_PASSWORD" {
+				val = "********"
+			}
 			log.Infof("Environment variable '%s' already set with value '%s'\n", envVar, val)
 		}
 		// Log the env variables set from the config file
 		for _, val := range envVarsSetViaConfig {
+			// If the env variable is SOURCE_DB_PASSWORD, TARGET_DB_PASSWORD, or SOURCE_REPLICA_DB_PASSWORD, mask the value
+			if val.EnvVar == "SOURCE_DB_PASSWORD" || val.EnvVar == "TARGET_DB_PASSWORD" || val.EnvVar == "SOURCE_REPLICA_DB_PASSWORD" {
+				val.Value = "********"
+			}
 			log.Infof("Environment variable '%s' set from config key '%s' with value '%s'\n", val.EnvVar, val.ConfigKey, val.Value)
 		}
 

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -56,6 +56,18 @@ var (
 	callHomeErrorOrCompletePayloadSent bool
 )
 
+var envVarValuesToObfuscateInLogs = []string{
+	"SOURCE_DB_PASSWORD",
+	"TARGET_DB_PASSWORD",
+	"SOURCE_REPLICA_DB_PASSWORD",
+}
+
+var configKeyValuesToObfuscateInLogs = []string{
+	"source.db-password",
+	"target.db-password",
+	"source-replica.db-password",
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "yb-voyager",
 	Short: "A CLI based migration engine to migrate complete database(schema + data) from some source database to YugabyteDB",
@@ -159,24 +171,21 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 
 		// Log the flag values set from the config file
 		for _, f := range overrides {
-			// If the config key is source.db-password, target.db-password, or source-replica.db-password, mask the value
-			if f.ConfigKey == "source.db-password" || f.ConfigKey == "target.db-password" || f.ConfigKey == "source-replica.db-password" {
+			if slices.Contains(configKeyValuesToObfuscateInLogs, f.ConfigKey) {
 				f.Value = "********"
 			}
 			log.Infof("Flag '%s' set from config key '%s' with value '%s'\n", f.FlagName, f.ConfigKey, f.Value)
 		}
 		// Log the env variables already set in the environment by the user
 		for envVar, val := range envVarsAlreadyExported {
-			// If the env variable is SOURCE_DB_PASSWORD, TARGET_DB_PASSWORD, or SOURCE_REPLICA_DB_PASSWORD, mask the value
-			if envVar == "SOURCE_DB_PASSWORD" || envVar == "TARGET_DB_PASSWORD" || envVar == "SOURCE_REPLICA_DB_PASSWORD" {
+			if slices.Contains(envVarValuesToObfuscateInLogs, envVar) {
 				val = "********"
 			}
 			log.Infof("Environment variable '%s' already set with value '%s'\n", envVar, val)
 		}
 		// Log the env variables set from the config file
 		for _, val := range envVarsSetViaConfig {
-			// If the env variable is SOURCE_DB_PASSWORD, TARGET_DB_PASSWORD, or SOURCE_REPLICA_DB_PASSWORD, mask the value
-			if val.EnvVar == "SOURCE_DB_PASSWORD" || val.EnvVar == "TARGET_DB_PASSWORD" || val.EnvVar == "SOURCE_REPLICA_DB_PASSWORD" {
+			if slices.Contains(envVarValuesToObfuscateInLogs, val.EnvVar) {
 				val.Value = "********"
 			}
 			log.Infof("Environment variable '%s' set from config key '%s' with value '%s'\n", val.EnvVar, val.ConfigKey, val.Value)

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -159,6 +159,10 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 
 		// Log the flag values set from the config file
 		for _, f := range overrides {
+			// If the config key is source.db-password, target.db-password, or source-replica.db-password, mask the value
+			if f.ConfigKey == "source.db-password" || f.ConfigKey == "target.db-password" || f.ConfigKey == "source-replica.db-password" {
+				f.Value = "********"
+			}
 			log.Infof("Flag '%s' set from config key '%s' with value '%s'\n", f.FlagName, f.ConfigKey, f.Value)
 		}
 		// Log the env variables already set in the environment by the user


### PR DESCRIPTION
### Describe the changes in this pull request
Masked the password values when logging the env vars/flags set using config file
Fixes:[ Passwords are being stored in the log files post config file implementation](https://yugabyte.atlassian.net/browse/DB-17381?atlOrigin=eyJpIjoiNGI0YzJjYjJkNzRkNDYwY2ExOWRjMDc2YjQ5MWY0MmEiLCJwIjoiaiJ9)

Example:
```
2025-06-26 16:00:35.340905 INFO root.go:166 Flag 'source-db-password' set from config key 'source.db-password' with value '********'

2025-06-26 16:00:35.340955 INFO root.go:182 Environment variable 'SOURCE_DB_PASSWORD' set from config key 'source.db-password' with value '********'

2025-06-26 16:00:35.340964 INFO root.go:182 Environment variable 'TARGET_DB_PASSWORD' set from config key 'target.db-password' with value '********'
```

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              | No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
