### PR TITLE
Added CASCADE clause to TRUNCATE TABLE statements used in YB and PG

### DIFF
--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -390,7 +390,7 @@ func (pg *TargetPostgreSQL) TruncateTables(tables []sqlname.NameTuple) error {
 		return nt.ForUserQuery()
 	})
 	commaSeparatedTableNames := strings.Join(tableNames, ", ")
-	query := fmt.Sprintf("TRUNCATE TABLE %s", commaSeparatedTableNames)
+	query := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", commaSeparatedTableNames)
 	_, err := pg.Exec(query)
 	if err != nil {
 		return fmt.Errorf("truncate tables with query %q: %w", query, err)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -567,7 +567,7 @@ func (yb *TargetYugabyteDB) TruncateTables(tables []sqlname.NameTuple) error {
 		return nt.ForUserQuery()
 	})
 	commaSeparatedTableNames := strings.Join(tableNames, ", ")
-	query := fmt.Sprintf("TRUNCATE TABLE %s", commaSeparatedTableNames)
+	query := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", commaSeparatedTableNames)
 	_, err := yb.Exec(query)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Describe the changes in this pull request
Fixes: https://yugabyte.atlassian.net/browse/DB-17442?atlOrigin=eyJpIjoiZDY1MzllMzIxYWQ3NDM0YmFhMTY0NWFjMjc1ZmU3NjgiLCJwIjoiaiJ9

Added the CASCADE clause only the YB and PG TRUNCATE stataments.

Oracle's TRUNCATE ... CASCADE only applies when foreign key relationships use ON DELETE CASCADE and requires parent-child truncation order. Since Voyager issues separate TRUNCATE statements for each table without resolving dependencies, using CASCADE has no effect and is unnecessary for Oracle.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
