### PR TITLE
[DB-17591]: Fix error message if start clean is required in assess-migration command

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -353,7 +353,7 @@ func assessMigration() (err error) {
 
 	err = handleStartCleanIfNeededForAssessMigration(assessmentMetadataDirFlag != "")
 	if err != nil {
-		return fmt.Errorf("failed to handle start clean for assess migration: %w", err)
+		return err
 	}
 	utils.PrintAndLog("Assessing for migration to target YugabyteDB version %s\n", targetDbVersion)
 
@@ -672,7 +672,7 @@ func handleStartCleanIfNeededForAssessMigration(metadataDirPassedByUser bool) er
 		utils.CleanDir(filepath.Join(assessmentDir, "dbs"))
 		err := ClearMigrationAssessmentDone()
 		if err != nil {
-			return fmt.Errorf("failed to clear migration assessment done in MSR: %w", err)
+			return fmt.Errorf("failed to start clean for assess migration: %w", err)
 		}
 	} else if assessmentFilesExists { // if not startClean but assessment files already exist
 		return fmt.Errorf("assessment metadata or reports files already exist in the assessment directory: '%s'. Use the --start-clean flag to clear the directory before proceeding.", assessmentDir)


### PR DESCRIPTION
### Describe the changes in this pull request
fixed error message to not say failed to start clean when it is not even tried.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
