### PR TITLE
Bug fix[DB-17592]: Import data with --on-primary-key-conflict ignore fails if import to source replica is started before it

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -495,7 +495,7 @@ func validateOnPrimaryKeyConflictFlag() error {
 
 	// flag only applicable for import-data-to-target and import-data-file commands
 	// ignore for import-data-to-source-replica and import-data-to-source commands
-	if importerRole != TARGET_DB_IMPORTER_ROLE && importerRole != IMPORT_FILE_ROLE {
+	if !isPrimaryKeyConflictIgnoreModeValid() {
 		return nil
 	}
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1634,6 +1634,10 @@ func createInitialImportDataTableMetrics(tasks []*ImportFileTask) []*cp.UpdateIm
 }
 
 func saveOnPrimaryKeyConflictActionInMSR() {
+	if !isPrimaryKeyConflictIgnoreModeValid() {
+		return
+	}
+
 	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		record.OnPrimaryKeyConflictAction = tconf.OnPrimaryKeyConflictAction
 	})
@@ -1642,6 +1646,8 @@ func saveOnPrimaryKeyConflictActionInMSR() {
 func cleanMSRForImportDataStartClean() error {
 	if !startClean {
 		log.Infof("skipping cleaning migration status record for import data command start clean")
+		return nil
+	} else if !isPrimaryKeyConflictIgnoreModeValid() {
 		return nil
 	}
 
@@ -1658,6 +1664,10 @@ func cleanMSRForImportDataStartClean() error {
 		})
 	}
 	return nil
+}
+
+func isPrimaryKeyConflictIgnoreModeValid() bool {
+	return importerRole == IMPORT_FILE_ROLE || importerRole == TARGET_DB_IMPORTER_ROLE
 }
 
 func cleanStoredErrors(errorHandler importdata.ImportDataErrorHandler, tasks []*ImportFileTask) error {


### PR DESCRIPTION
### Describe the changes in this pull request
- added checks for importer Role wherever required in import data path

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
