### PR TITLE
Fixed pg/mgi and pg/rna tests that were failing due to the new missing foreign key index issues

### DIFF
--- a/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
@@ -1,7 +1,7 @@
 {
 	"VoyagerVersion": "IGNORED",
 	"MigrationComplexity": "MEDIUM",
-	"MigrationComplexityExplanation": "Found 197 Level 1 issue(s), 0 Level 2 issue(s) and 0 Level 3 issue(s), resulting in MEDIUM migration complexity",
+	"MigrationComplexityExplanation": "Found 243 Level 1 issue(s), 0 Level 2 issue(s) and 0 Level 3 issue(s), resulting in MEDIUM migration complexity",
 	"SchemaSummary": {
 		"Description": "Objects that will be created on the target YugabyteDB.",
 		"DbName": "test_mgd",
@@ -25,7 +25,7 @@
 			{
 				"ObjectType": "TABLE",
 				"TotalCount": 175,
-				"InvalidCount": 62,
+				"InvalidCount": 74,
 				"ObjectNames": "mgd.acc_accession, mgd.acc_accessionmax, mgd.acc_accessionreference, mgd.acc_actualdb, mgd.acc_logicaldb, mgd.acc_mgitype, mgd.all_allele, mgd.all_allele_cellline, mgd.all_cellline, mgd.all_cellline_derivation, mgd.mgi_user, mgd.prb_strain, mgd.voc_term, mgd.mgi_organism, mgd.mgi_relationship, mgd.mrk_marker, mgd.all_allele_mutation, mgd.voc_annot, mgd.bib_citation_cache, mgd.gxd_allelepair, mgd.voc_annottype, mgd.all_cre_cache, mgd.all_knockout_cache, mgd.all_label, mgd.gxd_allelegenotype, mgd.mgi_reference_assoc, mgd.all_variant, mgd.all_variant_sequence, mgd.bib_refs, mgd.gxd_expression, mgd.gxd_index, mgd.img_image, mgd.mgi_refassoctype, mgd.mgi_synonym, mgd.mgi_synonymtype, mgd.mld_expts, mgd.mld_notes, mgd.mrk_do_cache, mgd.mrk_reference, mgd.mrk_strainmarker, mgd.prb_reference, mgd.prb_source, mgd.voc_evidence, mgd.bib_books, mgd.bib_workflow_status, mgd.bib_notes, mgd.gxd_assay, mgd.gxd_specimen, mgd.bib_workflow_data, mgd.bib_workflow_relevance, mgd.bib_workflow_tag, mgd.crs_cross, mgd.crs_matrix, mgd.crs_progeny, mgd.crs_references, mgd.crs_typings, mgd.dag_closure, mgd.dag_dag, mgd.dag_edge, mgd.dag_label, mgd.dag_node, mgd.voc_vocabdag, mgd.go_tracking, mgd.gxd_antibody, mgd.gxd_antigen, mgd.gxd_antibodyalias, mgd.gxd_antibodymarker, mgd.gxd_antibodyprep, mgd.gxd_gellane, mgd.gxd_insituresult, mgd.gxd_insituresultimage, mgd.gxd_assaytype, mgd.gxd_assaynote, mgd.gxd_gelband, mgd.gxd_gelrow, mgd.gxd_genotype, mgd.gxd_gellanestructure, mgd.gxd_theilerstage, mgd.voc_annotheader, mgd.gxd_htexperiment, mgd.gxd_htexperimentvariable, mgd.gxd_htrawsample, mgd.gxd_htsample, mgd.gxd_htsample_rnaseq, mgd.gxd_htsample_rnaseqcombined, mgd.gxd_htsample_rnaseqset, mgd.gxd_htsample_rnaseqset_cache, mgd.gxd_htsample_rnaseqsetmember, mgd.gxd_index_stages, mgd.gxd_isresultcelltype, mgd.img_imagepane, mgd.gxd_isresultstructure, mgd.gxd_probeprep, mgd.prb_probe, mgd.img_imagepane_assoc, mgd.mgi_note, mgd.map_coord_collection, mgd.map_coord_feature, mgd.map_coordinate, mgd.mrk_chromosome, mgd.mgi_dbinfo, mgd.mgi_keyvalue, mgd.mgi_notetype, mgd.mgi_organism_mgitype, mgd.mgi_property, mgd.mgi_propertytype, mgd.mgi_relationship_category, mgd.mgi_relationship_property, mgd.mgi_set, mgd.mgi_setmember, mgd.mgi_setmember_emapa, mgd.mgi_translation, mgd.mgi_translationtype, mgd.voc_vocab, mgd.mld_assay_types, mgd.mld_concordance, mgd.mld_contig, mgd.mld_contigprobe, mgd.mld_expt_marker, mgd.mld_expt_notes, mgd.mld_fish, mgd.mld_fish_region, mgd.mld_hit, mgd.mld_hybrid, mgd.mld_insitu, mgd.mld_isregion, mgd.mld_matrix, mgd.mld_mc2point, mgd.mld_mcdatalist, mgd.mld_ri, mgd.mld_ri2point, mgd.mld_ridata, mgd.mld_statistics, mgd.mrk_types, mgd.mrk_biotypemapping, mgd.mrk_cluster, mgd.mrk_clustermember, mgd.mrk_current, mgd.mrk_history, mgd.mrk_label, mgd.mrk_location_cache, mgd.mrk_status, mgd.mrk_mcv_cache, mgd.mrk_mcv_count_cache, mgd.mrk_notes, mgd.prb_alias, mgd.prb_allele, mgd.prb_allele_strain, mgd.prb_marker, mgd.prb_notes, mgd.prb_ref_notes, mgd.prb_rflv, mgd.prb_tissue, mgd.prb_strain_genotype, mgd.prb_strain_marker, mgd.ri_riset, mgd.ri_summary, mgd.ri_summary_expt_ref, mgd.seq_allele_assoc, mgd.seq_coord_cache, mgd.seq_genemodel, mgd.seq_genetrap, mgd.seq_marker_cache, mgd.seq_probe_cache, mgd.seq_sequence, mgd.seq_sequence_assoc, mgd.seq_sequence_raw, mgd.seq_source_assoc, mgd.voc_allele_cache, mgd.voc_annot_count_cache, mgd.voc_evidence_property, mgd.voc_marker_cache, mgd.voc_term_emapa, mgd.voc_term_emaps, mgd.wks_rosetta"
 			},
 			{
@@ -3076,6 +3076,788 @@
 			"SqlStatement": "acc_accession.accID%TYPE",
 			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#type-syntax-is-not-supported",
 			"MinimumVersionsFixedIn": null
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.acc_actualdb",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.acc_actualdb._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.acc_actualdb",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.acc_actualdb._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.acc_logicaldb",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.acc_logicaldb._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.acc_logicaldb",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.acc_logicaldb._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.acc_mgitype",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.acc_mgitype._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.acc_mgitype",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.acc_mgitype._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.all_allele",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.all_allele._approvedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.all_allele",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.all_allele._refs_key",
+				"ReferencedTableName": "mgd.bib_refs"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.all_cre_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.all_cre_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.all_cre_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.all_cre_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.all_knockout_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.all_knockout_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.all_knockout_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.all_knockout_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.crs_references",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.crs_references._refs_key",
+				"ReferencedTableName": "mgd.bib_refs"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.gxd_htrawsample",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.gxd_htrawsample._experiment_key",
+				"ReferencedTableName": "mgd.gxd_htexperiment"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._evidencevocab_key",
+				"ReferencedTableName": "mgd.voc_vocab"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._mgitype_key_1",
+				"ReferencedTableName": "mgd.acc_mgitype"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._mgitype_key_2",
+				"ReferencedTableName": "mgd.acc_mgitype"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._qualifiervocab_key",
+				"ReferencedTableName": "mgd.voc_vocab"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._relationshipdag_key",
+				"ReferencedTableName": "mgd.dag_dag"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_relationship_category",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_relationship_category._relationshipvocab_key",
+				"ReferencedTableName": "mgd.voc_vocab"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mgi_setmember",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mgi_setmember._set_key",
+				"ReferencedTableName": "mgd.mgi_set"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_chromosome",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_chromosome._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_chromosome",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_chromosome._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_cluster",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_cluster._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_cluster",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_cluster._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_label",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_label._orthologorganism_key",
+				"ReferencedTableName": "mgd.mgi_organism"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_location_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_location_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_location_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_location_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_mcv_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_mcv_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_mcv_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_mcv_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_mcv_count_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_mcv_count_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_coord_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_coord_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_coord_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_coord_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_genetrap",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_genetrap._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_genetrap",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_genetrap._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_marker_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_marker_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_marker_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_marker_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_probe_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_probe_cache._createdby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_probe_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_probe_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.seq_sequence",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.seq_sequence._organism_key",
+				"ReferencedTableName": "mgd.mgi_organism"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.voc_allele_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.voc_allele_cache._term_key",
+				"ReferencedTableName": "mgd.voc_term"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.voc_annot_count_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.voc_annot_count_cache._term_key",
+				"ReferencedTableName": "mgd.voc_term"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.voc_vocab",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.voc_vocab._logicaldb_key",
+				"ReferencedTableName": "mgd.acc_logicaldb"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "mgd.mrk_mcv_count_cache",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "mgd.mrk_mcv_count_cache._modifiedby_key",
+				"ReferencedTableName": "mgd.mgi_user"
+			}
 		}
 	],
 	"TableIndexStats": [

--- a/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
@@ -31,7 +31,7 @@
 			{
 				"ObjectType": "TABLE",
 				"TotalCount": 290,
-				"InvalidCount": 220,
+				"InvalidCount": 229,
 				"ObjectNames": "rnacen.auth_group, rnacen.auth_group_permissions, rnacen.auth_permission, rnacen.auth_user, rnacen.auth_user_groups, rnacen.auth_user_user_permissions, rnacen.bad_precompute, rnacen.blog, rnacen.corsheaders_corsmodel, rnacen.cpat_results, rnacen.django_admin_log, rnacen.django_content_type, rnacen.django_migrations, rnacen.django_session, rnacen.django_site, rnacen.ensembl_assembly, rnacen.ensembl_compara, rnacen.ensembl_coordinate_systems, rnacen.ensembl_import_tracking, rnacen.ensembl_karyotype, rnacen.ensembl_pseudogene_exons, rnacen.ensembl_pseudogene_regions, rnacen.go_term_annotations, rnacen.go_term_publication_map, rnacen.insdc_so_term_mapping, rnacen.litscan_sentence_id_counts, rnacen.litscan_statistics, rnacen.litsumm_summaries, rnacen.load_compara, rnacen.load_ensembl_pseudogenes, rnacen.load_genome_mapping_attempted, rnacen.load_karyotypes, rnacen.load_model_assignments, rnacen.load_qa_rfam_attempted, rnacen.load_ref_pubmed, rnacen.load_rfam_go_terms, rnacen.load_rnc_coordinates, rnacen.load_rnc_secondary_structure, rnacen.load_rnc_text_mining, rnacen.load_secondary_layout, rnacen.r2dt_results, rnacen.load_secondary_layout_models, rnacen.load_traveler_attempted, rnacen.old_summaries, rnacen.ontology_terms, rnacen.pipeline_tracking_genome_mapping, rnacen.pipeline_tracking_qa_scan, rnacen.pipeline_tracking_traveler, rnacen.protein_info, rnacen.publications, rnacen.qa_status, rnacen.r2dt_models, rnacen.release_stats, rnacen.rfam_analyzed_sequences, rnacen.rfam_clans, rnacen.rfam_go_terms, rnacen.rfam_model_hits, rnacen.rfam_models, rnacen.rna, rnacen.rnc_accession_sequence_feature, rnacen.rnc_accession_sequence_region, rnacen.rnc_accessions, rnacen.rnc_chemical_components, rnacen.rnc_database, rnacen.rnc_database_json_stats, rnacen.rnc_database_references, rnacen.rnc_feedback_overlap, rnacen.rnc_feedback_target_assemblies, rnacen.rnc_gene_status, rnacen.rnc_import_tracker, rnacen.rnc_interactions, rnacen.rnc_locus, rnacen.rnc_locus_members, rnacen.rnc_modifications, rnacen.rnc_reference_map, rnacen.rnc_references, rnacen.rnc_related_sequences, rnacen.rnc_relationship_types, rnacen.rnc_release, rnacen.rnc_rna_precomputed, rnacen.rnc_secondary_structure, rnacen.rnc_sequence_exons, rnacen.rnc_sequence_feature_providers, rnacen.rnc_sequence_feature_types, rnacen.rnc_sequence_features, rnacen.rnc_sequence_regions, rnacen.xref, rnacen.rnc_taxonomy, rnacen.temp_bad_is_active, rnacen.validate_layout_counts, rnacen.validate_layout_hits, rnacen.xref_not_unique, rnacen.xref_p10_deleted, rnacen.xref_p10_not_deleted, rnacen.xref_p11_deleted, rnacen.xref_p11_deleted_old, rnacen.xref_p11_not_deleted, rnacen.xref_p11_not_deleted_old, rnacen.xref_p12_deleted, rnacen.xref_p12_deleted_old, rnacen.xref_p12_not_deleted, rnacen.xref_p12_not_deleted_old, rnacen.xref_p13_deleted, rnacen.xref_p13_not_deleted, rnacen.xref_p14_deleted, rnacen.xref_p14_deleted_old, rnacen.xref_p14_not_deleted, rnacen.xref_p14_not_deleted_old, rnacen.xref_p15_deleted, rnacen.xref_p15_deleted_old, rnacen.xref_p15_not_deleted, rnacen.xref_p15_not_deleted_old, rnacen.xref_p16_deleted, rnacen.xref_p16_deleted_old, rnacen.xref_p16_not_deleted, rnacen.xref_p16_not_deleted_old, rnacen.xref_p17_deleted, rnacen.xref_p17_deleted_old, rnacen.xref_p17_not_deleted, rnacen.xref_p17_not_deleted_old, rnacen.xref_p18_deleted, rnacen.xref_p18_deleted_old, rnacen.xref_p18_not_deleted, rnacen.xref_p18_not_deleted_old, rnacen.xref_p19_deleted, rnacen.xref_p19_not_deleted, rnacen.xref_p1_deleted, rnacen.xref_p1_deleted_old, rnacen.xref_p1_not_deleted, rnacen.xref_p1_not_deleted_old, rnacen.xref_p20_deleted, rnacen.xref_p20_deleted_old, rnacen.xref_p20_not_deleted, rnacen.xref_p20_not_deleted_old, rnacen.xref_p21_deleted, rnacen.xref_p21_not_deleted, rnacen.xref_p22_deleted, rnacen.xref_p22_not_deleted, rnacen.xref_p23_deleted, rnacen.xref_p23_deleted_old, rnacen.xref_p23_not_deleted, rnacen.xref_p23_not_deleted_old, rnacen.xref_p24_deleted, rnacen.xref_p24_deleted_old, rnacen.xref_p24_not_deleted, rnacen.xref_p24_not_deleted_old, rnacen.xref_p25_deleted, rnacen.xref_p25_deleted_old, rnacen.xref_p25_not_deleted, rnacen.xref_p25_not_deleted_old, rnacen.xref_p26_deleted, rnacen.xref_p26_deleted_old, rnacen.xref_p26_not_deleted, rnacen.xref_p26_not_deleted_old, rnacen.xref_p27_deleted, rnacen.xref_p27_not_deleted, rnacen.xref_p28_deleted, rnacen.xref_p28_not_deleted, rnacen.xref_p29_deleted, rnacen.xref_p29_not_deleted, rnacen.xref_p2_deleted, rnacen.xref_p2_deleted_old, rnacen.xref_p2_not_deleted, rnacen.xref_p2_not_deleted_old, rnacen.xref_p30_deleted, rnacen.xref_p30_deleted_old, rnacen.xref_p30_not_deleted, rnacen.xref_p30_not_deleted_old, rnacen.xref_p31_deleted, rnacen.xref_p31_deleted_old, rnacen.xref_p31_not_deleted, rnacen.xref_p31_not_deleted_old, rnacen.xref_p32_deleted, rnacen.xref_p32_not_deleted, rnacen.xref_p33_deleted, rnacen.xref_p33_deleted_old, rnacen.xref_p33_not_deleted, rnacen.xref_p33_not_deleted_old, rnacen.xref_p34_deleted, rnacen.xref_p34_deleted_old, rnacen.xref_p34_not_deleted, rnacen.xref_p34_not_deleted_old, rnacen.xref_p35_deleted, rnacen.xref_p35_deleted_old, rnacen.xref_p35_not_deleted, rnacen.xref_p35_not_deleted_old, rnacen.xref_p36_deleted, rnacen.xref_p36_deleted_old, rnacen.xref_p36_not_deleted, rnacen.xref_p36_not_deleted_old, rnacen.xref_p37_deleted, rnacen.xref_p37_deleted_old, rnacen.xref_p37_not_deleted, rnacen.xref_p37_not_deleted_old, rnacen.xref_p38_deleted, rnacen.xref_p38_deleted_old, rnacen.xref_p38_not_deleted, rnacen.xref_p38_not_deleted_old, rnacen.xref_p39_deleted, rnacen.xref_p39_deleted_old, rnacen.xref_p39_not_deleted, rnacen.xref_p39_not_deleted_old, rnacen.xref_p3_deleted, rnacen.xref_p3_deleted_old, rnacen.xref_p3_not_deleted, rnacen.xref_p3_not_deleted_old, rnacen.xref_p40_deleted, rnacen.xref_p40_deleted_old, rnacen.xref_p40_not_deleted, rnacen.xref_p40_not_deleted_old, rnacen.xref_p41_deleted, rnacen.xref_p41_deleted_old, rnacen.xref_p41_not_deleted, rnacen.xref_p41_not_deleted_old, rnacen.xref_p42_deleted, rnacen.xref_p42_deleted_old, rnacen.xref_p42_not_deleted, rnacen.xref_p42_not_deleted_old, rnacen.xref_p43_deleted, rnacen.xref_p43_deleted_old, rnacen.xref_p43_not_deleted, rnacen.xref_p43_not_deleted_old, rnacen.xref_p44_deleted, rnacen.xref_p44_deleted_old, rnacen.xref_p44_not_deleted, rnacen.xref_p44_not_deleted_old, rnacen.xref_p45_deleted, rnacen.xref_p45_deleted_old, rnacen.xref_p45_not_deleted, rnacen.xref_p45_not_deleted_old, rnacen.xref_p46_deleted, rnacen.xref_p46_deleted_old, rnacen.xref_p46_not_deleted, rnacen.xref_p46_not_deleted_old, rnacen.xref_p47_deleted, rnacen.xref_p47_deleted_old, rnacen.xref_p47_not_deleted, rnacen.xref_p47_not_deleted_old, rnacen.xref_p48_deleted, rnacen.xref_p48_deleted_old, rnacen.xref_p48_not_deleted, rnacen.xref_p48_not_deleted_old, rnacen.xref_p49_deleted, rnacen.xref_p49_deleted_old, rnacen.xref_p49_not_deleted, rnacen.xref_p49_not_deleted_old, rnacen.xref_p4_deleted, rnacen.xref_p4_deleted_old, rnacen.xref_p4_not_deleted, rnacen.xref_p4_not_deleted_old, rnacen.xref_p50_deleted, rnacen.xref_p50_deleted_old, rnacen.xref_p50_not_deleted, rnacen.xref_p50_not_deleted_old, rnacen.xref_p51_deleted, rnacen.xref_p51_deleted_old, rnacen.xref_p51_not_deleted, rnacen.xref_p51_not_deleted_old, rnacen.xref_p52_deleted, rnacen.xref_p52_deleted_old, rnacen.xref_p52_not_deleted, rnacen.xref_p52_not_deleted_old, rnacen.xref_p53_deleted, rnacen.xref_p53_deleted_old, rnacen.xref_p53_not_deleted, rnacen.xref_p53_not_deleted_old, rnacen.xref_p54_deleted, rnacen.xref_p54_not_deleted, rnacen.xref_p55_deleted, rnacen.xref_p55_deleted_old, rnacen.xref_p55_not_deleted, rnacen.xref_p55_not_deleted_old, rnacen.xref_p5_deleted, rnacen.xref_p5_not_deleted, rnacen.xref_p6_deleted, rnacen.xref_p6_deleted_old, rnacen.xref_p6_not_deleted, rnacen.xref_p6_not_deleted_old, rnacen.xref_p7_deleted, rnacen.xref_p7_deleted_old, rnacen.xref_p7_not_deleted, rnacen.xref_p7_not_deleted_old, rnacen.xref_p8_deleted, rnacen.xref_p8_deleted_old, rnacen.xref_p8_not_deleted, rnacen.xref_p8_not_deleted_old, rnacen.xref_p9_deleted, rnacen.xref_p9_deleted_old, rnacen.xref_p9_not_deleted, rnacen.xref_p9_not_deleted_old"
 			},
 			{
@@ -14303,6 +14303,499 @@
 				"ColumnType": "integer",
 				"ReferencedColumnName": "rnacen.rnc_release.id",
 				"ReferencedColumnType": "bigint"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.ensembl_pseudogene_regions",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.ensembl_pseudogene_regions.assembly_id",
+				"ReferencedTableName": "rnacen.ensembl_assembly"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_sequence_features",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_sequence_features.feature_provider",
+				"ReferencedTableName": "rnacen.rnc_sequence_feature_providers"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_feedback_target_assemblies",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_feedback_target_assemblies.assembly_id",
+				"ReferencedTableName": "rnacen.ensembl_assembly"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_feedback_target_assemblies",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_feedback_target_assemblies.dbid",
+				"ReferencedTableName": "rnacen.rnc_database"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_sequence_features",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_sequence_features.feature_name",
+				"ReferencedTableName": "rnacen.rnc_sequence_feature_types"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_sequence_features",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_sequence_features.taxid",
+				"ReferencedTableName": "rnacen.rnc_taxonomy"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.go_term_annotations",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.go_term_annotations.evidence_code",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.go_term_annotations",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.go_term_annotations.ontology_term_id",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.go_term_publication_map",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.go_term_publication_map.reference_id",
+				"ReferencedTableName": "rnacen.rnc_references"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.insdc_so_term_mapping",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.insdc_so_term_mapping.so_term_id",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rfam_go_terms",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rfam_go_terms.ontology_term_id",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rfam_model_hits",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rfam_model_hits.rnc_sequence_features_id",
+				"ReferencedTableName": "rnacen.rnc_sequence_features"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rfam_models",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rfam_models.so_rna_type",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_accession_sequence_region",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_accession_sequence_region.region_id",
+				"ReferencedTableName": "rnacen.rnc_sequence_regions"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_accessions",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_accessions.rna_type",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_accession_sequence_feature",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_accession_sequence_feature.rnc_sequence_feature_id",
+				"ReferencedTableName": "rnacen.rnc_sequence_features"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_database_references",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_database_references.reference_id",
+				"ReferencedTableName": "rnacen.rnc_references"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_feedback_overlap",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_feedback_overlap.assembly_id",
+				"ReferencedTableName": "rnacen.ensembl_assembly"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_gene_status",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_gene_status.assembly_id",
+				"ReferencedTableName": "rnacen.ensembl_assembly"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_import_tracker",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_import_tracker.db_id",
+				"ReferencedTableName": "rnacen.rnc_database"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_interactions",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_interactions.urs_taxid",
+				"ReferencedTableName": "rnacen.rnc_rna_precomputed"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_locus_members",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_locus_members.locus_id",
+				"ReferencedTableName": "rnacen.rnc_locus"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_locus_members",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_locus_members.urs_taxid",
+				"ReferencedTableName": "rnacen.rnc_rna_precomputed"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_rna_precomputed",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_rna_precomputed.last_release",
+				"ReferencedTableName": "rnacen.rnc_release"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_rna_precomputed",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_rna_precomputed.so_rna_type",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.r2dt_models",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.r2dt_models.so_term_id",
+				"ReferencedTableName": "rnacen.ontology_terms"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_sequence_features",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_sequence_features.accession",
+				"ReferencedTableName": "rnacen.rnc_accessions"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.rnc_taxonomy",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.rnc_taxonomy.replaced_by",
+				"ReferencedTableName": "rnacen.rnc_taxonomy"
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_FOREIGN_KEY_INDEX",
+			"Name": "Missing index on foreign key columns",
+			"Description": "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "rnacen.validate_layout_counts",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-foreign-key-indexes",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"ForeignKeyColumnNames": "rnacen.validate_layout_counts.name",
+				"ReferencedTableName": "rnacen.rna"
 			}
 		}
 	],


### PR DESCRIPTION
### Describe the changes in this pull request
Fixed pg/rna and pg/mgi tests

Jenkins Run: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/5875/

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
None

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Jenkins

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
