### PR TITLE
Add SQLSTATE-based filtering for non retryable errors for data import operations

### DIFF
--- a/yb-voyager/cmd/importDataFileTaskImporter_test.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build unit
 
 /*
 Copyright (c) YugabyteDB, Inc.
@@ -18,12 +18,20 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/jackc/pgconn"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
+	testcontainers "github.com/yugabyte/yb-voyager/yb-voyager/test/containers"
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
 
@@ -277,4 +285,357 @@ func TestTaskImportErrorsOutWithAbortErrorPolicy(t *testing.T) {
 		}
 		workerPool.Wait()
 	})
+}
+
+// ------------------------------------------------------------------------------------------------
+// Import Batch Retryable Error Detection Tests
+// ------------------------------------------------------------------------------------------------
+
+type testCase struct {
+	name              string
+	errorType         string
+	expectedRetryable bool
+	description       string
+	dataGenerator     func() string
+}
+
+func createTestCases() []testCase {
+	return []testCase{
+		{
+			name:              "numeric_field_overflow",
+			errorType:         "22003",
+			expectedRetryable: false,
+			description:       "Should not retry numeric overflow errors",
+			dataGenerator:     createNumericOverflowData,
+		},
+		{
+			name:              "string_data_right_truncation",
+			errorType:         "22001",
+			expectedRetryable: false,
+			description:       "Should not retry string truncation errors",
+			dataGenerator:     createStringTruncationData,
+		},
+		{
+			name:              "unique_constraint_violation",
+			errorType:         "23505",
+			expectedRetryable: false,
+			description:       "Should not retry unique constraint violations",
+			dataGenerator:     createUniqueConstraintViolationData,
+		},
+		{
+			name:              "not_null_violation",
+			errorType:         "23502",
+			expectedRetryable: false,
+			description:       "Should not retry not null violations",
+			dataGenerator:     createNotNullViolationData,
+		},
+		{
+			name:              "check_constraint_violation",
+			errorType:         "23514",
+			expectedRetryable: false,
+			description:       "Should not retry check constraint violations",
+			dataGenerator:     createCorruptedCopyData,
+		},
+		{
+			name:              "valid_data",
+			errorType:         "valid",
+			expectedRetryable: true, // Should succeed, so no retry needed
+			description:       "Should handle valid data successfully",
+			dataGenerator:     createValidData,
+		},
+	}
+}
+
+func createTestTableWithConstraints(t *testing.T, container testcontainers.TestContainer) {
+	createSchemaSQL := `CREATE SCHEMA IF NOT EXISTS test_schema;`
+
+	createTableSQL := `
+	CREATE TABLE test_schema.error_test_table (
+		id SERIAL PRIMARY KEY,
+		small_int_col SMALLINT,           -- For numeric overflow (22003)
+		varchar_col VARCHAR(10),          -- For string truncation (22001)
+		unique_col VARCHAR(50) UNIQUE,    -- For unique constraint (23505)
+		not_null_col VARCHAR(50) NOT NULL, -- For not null violation (23502)
+		check_col INTEGER CHECK (check_col > 0) -- For check constraint (23514)
+	);`
+
+	container.ExecuteSqls(createSchemaSQL, createTableSQL)
+}
+
+func createNumericOverflowData() string {
+	// Data that will cause SMALLINT overflow (max 32767)
+	return "101\t99999\ttest\tunique101\ttest\t100\n" // 99999 > 32767
+}
+
+func createStringTruncationData() string {
+	// Data that will cause VARCHAR(10) truncation
+	return "102\t100\tvery_long_string_that_exceeds_ten_characters\tunique102\ttest\t100\n"
+}
+
+func createUniqueConstraintViolationData() string {
+	// Data with duplicate unique values
+	return "103\t100\ttest\tduplicate_value\ttest\t100\n104\t200\ttest2\tduplicate_value\ttest2\t200\n"
+}
+
+func createNotNullViolationData() string {
+	// Data with NULL in not null column
+	return "105\t100\ttest\tunique105\t\ttest\t100\n" // Empty string for not_null_col
+}
+
+func createCorruptedCopyData() string {
+	// Create data that will cause a check constraint violation (SQLSTATE 23514)
+	return "106\t100\ttest\tunique106\ttest\t-100\n" // -100 violates CHECK (check_col > 0)
+}
+
+func createValidData() string {
+	// Valid data that should import successfully
+	return "999\t100\ttest\tunique999\ttest\t100\n"
+}
+
+func createBatchFromData(t *testing.T, data string, tableName sqlname.NameTuple) *Batch {
+	// Create temporary batch file
+	tempDir := t.TempDir()
+	batchFilePath := filepath.Join(tempDir, "test_batch.sql")
+
+	err := os.WriteFile(batchFilePath, []byte(data), 0644)
+	require.NoError(t, err, "Failed to create batch file")
+
+	return &Batch{
+		Number:       1,
+		TableNameTup: tableName,
+		SchemaName:   tableName.CurrentName.SchemaName,
+		FilePath:     batchFilePath,
+		BaseFilePath: batchFilePath,
+		OffsetStart:  0,
+		OffsetEnd:    int64(len(data)),
+		RecordCount:  1,
+		ByteCount:    int64(len(data)),
+		Interrupted:  false,
+	}
+}
+
+func createTargetYugabyteDB(t *testing.T, container testcontainers.TestContainer) *tgtdb.TargetYugabyteDB {
+	// Get container connection details
+	host, port, err := container.GetHostPort()
+	require.NoError(t, err, "Failed to get container host/port")
+
+	config := container.GetConfig()
+
+	// Create TargetConf
+	tconf := &tgtdb.TargetConf{
+		Host:         host,
+		Port:         port,
+		User:         config.User,
+		Password:     config.Password,
+		DBName:       config.DBName,
+		Schema:       "public", // Set default schema
+		TargetDBType: tgtdb.YUGABYTEDB,
+	}
+
+	// Create and initialize target database
+	targetDB := tgtdb.NewTargetDB(tconf).(*tgtdb.TargetYugabyteDB)
+	err = targetDB.Init()
+	require.NoError(t, err, "Failed to initialize target database")
+
+	// Initialize connection pool
+	err = targetDB.InitConnPool()
+	require.NoError(t, err, "Failed to initialize connection pool")
+
+	return targetDB
+}
+
+func testErrorDetection(t *testing.T, targetDB *tgtdb.TargetYugabyteDB, tc testCase) {
+	// Create batch with erroneous data
+	tableName := sqlname.NameTuple{CurrentName: sqlname.NewObjectName(tgtdb.YUGABYTEDB, "test_schema", "test_schema", "error_test_table")}
+	batch := createBatchFromData(t, tc.dataGenerator(), tableName)
+
+	// Create import batch args
+	args := &tgtdb.ImportBatchArgs{
+		TableNameTup:       tableName,
+		Columns:            []string{"id", "small_int_col", "varchar_col", "unique_col", "not_null_col", "check_col"},
+		PrimaryKeyColumns:  []string{"id"},
+		PKConflictAction:   "ERROR",
+		FileFormat:         "csv",
+		HasHeader:          false,
+		Delimiter:          "\t",
+		NullString:         "",
+		RowsPerTransaction: 1000,
+	}
+
+	// Call ImportBatch method
+	_, err, _ := targetDB.ImportBatch(batch, args, "", nil, false)
+
+	// For valid data, we expect no error
+	if tc.errorType == "valid" {
+		assert.NoError(t, err, "Valid data should import successfully")
+		return
+	}
+
+	// Check if error is retryable
+	isRetryable := !targetDB.IsNonRetryableCopyError(err)
+
+	// Debug output
+	t.Logf("=== DEBUG: %s ===", tc.name)
+	t.Logf("Expected retryable: %v", tc.expectedRetryable)
+	t.Logf("Actual retryable: %v", isRetryable)
+	t.Logf("Expected SQLSTATE: %s", tc.errorType)
+	if err != nil {
+		t.Logf("Actual error: %v", err)
+		// Try to extract SQLSTATE code from error
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			t.Logf("SQLSTATE code: %s", pgErr.Code)
+			t.Logf("SQLSTATE message: %s", pgErr.Message)
+		} else {
+			t.Logf("Error is not a pgconn.PgError, type: %T", err)
+		}
+	} else {
+		t.Logf("No error returned (this should not happen for error test cases)")
+	}
+	t.Logf("IsNonRetryableCopyError result: %v", !isRetryable)
+	t.Logf("==================")
+
+	// Assert expected behavior
+	assert.Equal(t, tc.expectedRetryable, isRetryable, tc.description)
+}
+
+func TestImportBatchErrorDetection_YugabyteDB(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup YB container
+	ybContainer := testcontainers.NewTestContainer("yugabytedb", nil)
+	err := ybContainer.Start(ctx)
+	require.NoError(t, err, "Failed to start YugabyteDB container")
+	defer ybContainer.Terminate(ctx)
+
+	// Create target database instance
+	targetDB := createTargetYugabyteDB(t, ybContainer)
+
+	// Create Voyager schema and metadata tables
+	err = targetDB.CreateVoyagerSchema()
+	require.NoError(t, err, "Failed to create Voyager schema")
+
+	// Create test table
+	createTestTableWithConstraints(t, ybContainer)
+
+	// Run test cases
+	testCases := createTestCases()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testErrorDetection(t, targetDB, tc)
+		})
+	}
+}
+
+func TestImportBatchErrorDetection_PostgreSQL(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup PG container
+	pgContainer := testcontainers.NewTestContainer("postgresql", nil)
+	err := pgContainer.Start(ctx)
+	require.NoError(t, err, "Failed to start PostgreSQL container")
+	defer pgContainer.Terminate(ctx)
+
+	// Create target database instance
+	targetDB := createTargetPostgreSQL(t, pgContainer)
+
+	// Create Voyager schema and metadata tables
+	err = targetDB.CreateVoyagerSchema()
+	require.NoError(t, err, "Failed to create Voyager schema")
+
+	// Create test table
+	createTestTableWithConstraints(t, pgContainer)
+
+	// Run test cases
+	testCases := createTestCases()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testErrorDetectionPG(t, targetDB, tc)
+		})
+	}
+}
+
+func createTargetPostgreSQL(t *testing.T, container testcontainers.TestContainer) *tgtdb.TargetPostgreSQL {
+	// Get container connection details
+	host, port, err := container.GetHostPort()
+	require.NoError(t, err, "Failed to get container host/port")
+
+	config := container.GetConfig()
+
+	// Create TargetConf
+	tconf := &tgtdb.TargetConf{
+		Host:         host,
+		Port:         port,
+		User:         config.User,
+		Password:     config.Password,
+		DBName:       config.DBName,
+		Schema:       "public", // Set default schema
+		TargetDBType: tgtdb.POSTGRESQL,
+	}
+
+	// Create and initialize target database
+	targetDB := tgtdb.NewTargetDB(tconf).(*tgtdb.TargetPostgreSQL)
+	err = targetDB.Init()
+	require.NoError(t, err, "Failed to initialize target database")
+
+	// Initialize connection pool
+	err = targetDB.InitConnPool()
+	require.NoError(t, err, "Failed to initialize connection pool")
+
+	return targetDB
+}
+
+func testErrorDetectionPG(t *testing.T, targetDB *tgtdb.TargetPostgreSQL, tc testCase) {
+	// Create batch with erroneous data
+	tableName := sqlname.NameTuple{CurrentName: sqlname.NewObjectName(tgtdb.POSTGRESQL, "test_schema", "test_schema", "error_test_table")}
+	batch := createBatchFromData(t, tc.dataGenerator(), tableName)
+
+	// Create import batch args
+	args := &tgtdb.ImportBatchArgs{
+		TableNameTup:       tableName,
+		Columns:            []string{"id", "small_int_col", "varchar_col", "unique_col", "not_null_col", "check_col"},
+		PrimaryKeyColumns:  []string{"id"},
+		PKConflictAction:   "ERROR",
+		FileFormat:         "csv",
+		HasHeader:          false,
+		Delimiter:          "\t",
+		NullString:         "",
+		RowsPerTransaction: 1000,
+	}
+
+	// Call ImportBatch method
+	_, err, _ := targetDB.ImportBatch(batch, args, "", nil, false)
+
+	// For valid data, we expect no error
+	if tc.errorType == "valid" {
+		assert.NoError(t, err, "Valid data should import successfully")
+		return
+	}
+
+	// Check if error is retryable
+	isRetryable := !targetDB.IsNonRetryableCopyError(err)
+
+	// Debug output
+	t.Logf("=== DEBUG: %s ===", tc.name)
+	t.Logf("Expected retryable: %v", tc.expectedRetryable)
+	t.Logf("Actual retryable: %v", isRetryable)
+	t.Logf("Expected SQLSTATE: %s", tc.errorType)
+	if err != nil {
+		t.Logf("Actual error: %v", err)
+		// Try to extract SQLSTATE code from error
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			t.Logf("SQLSTATE code: %s", pgErr.Code)
+			t.Logf("SQLSTATE message: %s", pgErr.Message)
+		} else {
+			t.Logf("Error is not a pgconn.PgError, type: %T", err)
+		}
+	} else {
+		t.Logf("No error returned (this should not happen for error test cases)")
+	}
+	t.Logf("IsNonRetryableCopyError result: %v", !isRetryable)
+	t.Logf("==================")
+
+	// Assert expected behavior
+	assert.Equal(t, tc.expectedRetryable, isRetryable, tc.description)
 }

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -508,7 +508,7 @@ func (pg *TargetPostgreSQL) IsNonRetryableCopyError(err error) bool {
 	}
 
 	// String pattern matching for non-retryable errors
-	// Kepts this for safety so that we dont disrupt the already existing checks
+	// Kept this for safety so that we dont disrupt the already existing checks
 	return utils.ContainsAnySubstringFromSlice(NonRetryCopyErrors, err.Error())
 }
 

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -503,7 +503,7 @@ func (pg *TargetPostgreSQL) IsNonRetryableCopyError(err error) bool {
 
 	// SQLSTATE-based filtering for non-retryable errors
 	// This should ideally cover all the non-retryable errors
-	if isDataIntegrityOrConstraintError(err) {
+	if IsPgErrorCodeNonRetryable(err) {
 		return true
 	}
 

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -305,7 +305,6 @@ var NonRetryCopyErrors = []string{
 //
 // SQLSTATE Class 22: Data Exception (e.g., 22003=numeric overflow, 22P02=invalid syntax)
 // SQLSTATE Class 23: Integrity Constraint Violation (e.g., 23502=not null, 23505=unique)
-// SQLSTATE Class 42: Syntax Error or Access Rule Violation (e.g., 42601=syntax error)
 // Postgres Error Codes: https://www.postgresql.org/docs/current/errcodes-appendix.html
 func isDataIntegrityOrConstraintError(err error) bool {
 	if err == nil {
@@ -317,18 +316,7 @@ func isDataIntegrityOrConstraintError(err error) bool {
 	if errors.As(err, &pgErr) {
 		code := pgErr.Code
 
-		// Class 22: Data Exception
-		if strings.HasPrefix(code, "22") {
-			return true
-		}
-
-		// Class 23: Integrity Constraint Violation
-		if strings.HasPrefix(code, "23") {
-			return true
-		}
-
-		// Class 42: Syntax Error or Access Rule Violation
-		if strings.HasPrefix(code, "42") {
+		if strings.HasPrefix(code, "22") || strings.HasPrefix(code, "23") {
 			return true
 		}
 	}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -336,7 +336,7 @@ func (yb *TargetYugabyteDB) IsNonRetryableCopyError(err error) bool {
 	}
 
 	// String pattern matching for non-retryable errors
-	// Kepts this for safety so that we dont disrupt the already existing checks
+	// Kept this for safety so that we dont disrupt the already existing checks
 	NonRetryCopyErrorsYB := NonRetryCopyErrors
 	NonRetryCopyErrorsYB = append(NonRetryCopyErrorsYB, RPC_MSG_LIMIT_ERROR)
 	return utils.ContainsAnySubstringFromSlice(NonRetryCopyErrorsYB, err.Error())

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -300,10 +300,58 @@ var NonRetryCopyErrors = []string{
 	SYNTAX_ERROR,
 }
 
+// isDataIntegrityOrConstraintError checks if an error is a data integrity or constraint violation or syntax error
+// by examining the SQLSTATE code.
+//
+// SQLSTATE Class 22: Data Exception (e.g., 22003=numeric overflow, 22P02=invalid syntax)
+// SQLSTATE Class 23: Integrity Constraint Violation (e.g., 23502=not null, 23505=unique)
+// SQLSTATE Class 42: Syntax Error or Access Rule Violation (e.g., 42601=syntax error)
+// Postgres Error Codes: https://www.postgresql.org/docs/current/errcodes-appendix.html
+func isDataIntegrityOrConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check pgx v4 errors
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		code := pgErr.Code
+
+		// Class 22: Data Exception
+		if strings.HasPrefix(code, "22") {
+			return true
+		}
+
+		// Class 23: Integrity Constraint Violation
+		if strings.HasPrefix(code, "23") {
+			return true
+		}
+
+		// Class 42: Syntax Error or Access Rule Violation
+		if strings.HasPrefix(code, "42") {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (yb *TargetYugabyteDB) IsNonRetryableCopyError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// SQLSTATE-based filtering for non-retryable errors
+	// This should ideally cover all the non-retryable errors
+	if isDataIntegrityOrConstraintError(err) {
+		return true
+	}
+
+	// String pattern matching for non-retryable errors
+	// Kepts this for safety so that we dont disrupt the already existing checks
 	NonRetryCopyErrorsYB := NonRetryCopyErrors
 	NonRetryCopyErrorsYB = append(NonRetryCopyErrorsYB, RPC_MSG_LIMIT_ERROR)
-	return err != nil && utils.ContainsAnySubstringFromSlice(NonRetryCopyErrorsYB, err.Error())
+	return utils.ContainsAnySubstringFromSlice(NonRetryCopyErrorsYB, err.Error())
 }
 
 func (yb *TargetYugabyteDB) checkIfPrimaryKeyViolationError(err error, pkConstraintNames []string) bool {


### PR DESCRIPTION
### Describe the changes in this pull request
This PR adds functionality to filter non-retryable errors based on SQLSTATE error codes during import.

**Key Changes:**
- Enhanced `IsNonRetryableCopyError` function to classify `Class 22 (Data Exception)` and `Class 23 (Integrity Constraint Violation)` and `Class 42 (Syntax Errors)` SQLSTATE codes as non-retryable
- Added test coverage for these error classifications including numeric overflow, string truncation, unique violations, check violations, and invalid data format errors

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Yeah, the import wont retry for the class of errors we have added 

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually and unit tests

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
