### PR TITLE
Added an option in the pg grant script to choose between tranferring ownership of tables to voyager user or just grant the original owner to voyager user

### DIFF
--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -148,75 +148,126 @@ GRANT pg_read_all_stats to :voyager_user;
     FROM is_rds
     \gexec
 
-    -- Create a replication group
     \echo ''
-    \echo '--- Creating Replication Group ---'
-    CREATE ROLE :replication_group;
+    \echo 'Choose how to grant permissions for the selected schema(s): ' :schema_list
+    \echo 'Note: For live migration, CREATE PUBLICATION requires table ownership; choose one option to ensure the migration user has required ownership.'
+    \echo '  - yes: Transfer ownership of ALL tables to replication group ' :replication_group ', and add original owners + ' :voyager_user ' to that group.'
+    \echo '  - no:  Keep ownership unchanged; grant each tables original owner role to ' :voyager_user ' (excluding rdsadmin).'
+    \prompt 'Enter choice (yes/no): ' transfer_choice
+    \if :transfer_choice
+        -- Option 1: Grant ownership of all tables in the specified schemas to the specified replication group. The migration user and the original owner of the tables will be added to the replication group.
+        \echo ''
+        \echo '--- Creating Replication Group ---'
+        CREATE ROLE :replication_group;
+        
+        \echo ''
+        \echo 'Transferring ownership of all tables in the specified schemas to the specified replication group. The migration user and the original owner of the tables will be added to the replication group.'
+        
+        \echo ''
+        \echo '--- Adding Original Owner to Replication Group ---'
+        DO $$
+        DECLARE
+            tableowner TEXT;
+            schema_list TEXT[] := string_to_array(current_setting('myvars.schema_list'), ',');  -- Convert the schema list to an array
+            replication_group TEXT := current_setting('myvars.replication_group');  -- Get the replication group from settings
+        BEGIN
+            -- Generate the GRANT statements and execute them dynamically
+            FOR tableowner IN
+                SELECT DISTINCT t.tableowner
+                FROM pg_catalog.pg_tables t
+                WHERE t.schemaname = ANY (schema_list)  -- Use the schema_list variable
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM pg_roles r
+                    WHERE r.rolname = t.tableowner
+                        AND pg_has_role(t.tableowner, replication_group, 'USAGE')  -- Use the replication_group variable
+                )
+            LOOP
+                -- Display the GRANT statement
+                RAISE NOTICE 'Granting role: GRANT % TO %;', replication_group, tableowner;
+        
+                -- Execute the GRANT statement
+                EXECUTE format('GRANT %I TO %I;', replication_group, tableowner);
+            END LOOP;
+        END $$;
+        
+        \echo ''
+        \echo '--- Adding User to Replication Group ---'
+        GRANT :replication_group TO :voyager_user;
+        
+        \echo ''
+        \echo '--- Transferring Ownership of Tables to Replication Group ---'
+        DO $$
+        DECLARE
+            r RECORD;
+        BEGIN
+            FOR r IN
+                SELECT table_schema, '"' || table_name || '"' AS t_name
+                FROM information_schema.tables
+                WHERE table_schema = ANY(string_to_array(current_setting('myvars.schema_list'), ',')::text[])
+            LOOP
+                EXECUTE 'ALTER TABLE ' || r.table_schema || '.' || r.t_name || ' OWNER TO ' || current_setting('myvars.replication_group');
+            END LOOP;
+        END $$;
 
-    -- Prompt the user to let them know that ownership of the tables will be transferred to the replication group and proceed only if they confirm
-    \echo ''
-    \echo 'Transferring ownership of all tables in the specified schemas to the specified replication group. The migration user and the original owner of the tables will be added to the replication group.'
-    -- Only 'yes' or 'no' are valid inputs. 'y' and 'n' are not valid inputs.
-    \prompt 'Proceed with the transfer of ownership? (yes/no): ' proceed
-
-    \if :proceed
-        \echo 'Proceeding with the transfer of ownership...'
     \else
-        \echo 'Aborting the script.'
-        \q
+        -- Option 2: Grant the original owners of the tables to the migration user
+        -- Count rdsadmin-owned tables in selected schemas and expose as psql variable
+        SELECT COUNT(*) AS rdsadmin_owned_table_count
+        FROM pg_catalog.pg_tables t
+        WHERE t.schemaname = ANY(string_to_array(current_setting('myvars.schema_list'), ',')::text[])
+        AND t.tableowner = 'rdsadmin';
+        \gset
+
+        -- If any found, warn per-table and prompt to proceed
+        \if :rdsadmin_owned_table_count
+            \echo ''
+            DO $$
+            DECLARE
+                r RECORD;
+            BEGIN
+                FOR r IN
+                    SELECT t.schemaname, t.tablename
+                    FROM pg_catalog.pg_tables t
+                    WHERE t.schemaname = ANY(string_to_array(current_setting('myvars.schema_list'), ',')::text[])
+                    AND t.tableowner = 'rdsadmin'
+                LOOP
+                    RAISE WARNING 'Table %.% is owned by rdsadmin; cannot grant this role to %.',
+                        r.schemaname, r.tablename, current_setting('myvars.voyager_user');
+                END LOOP;
+            END $$;
+
+            \echo 'Found ' :rdsadmin_owned_table_count ' rdsadmin-owned table(s) in the selected schema(s).'
+            \echo 'These tables are owned by rdsadmin; role membership cannot be granted to the migration user.'
+            \prompt 'Proceed anyway? We will not be granting ownership to the migration user for these tables. (yes/no): ' proceed
+            \if :proceed
+            \else
+                \echo 'Aborting as requested.'
+                \q
+            \endif
+        \endif
+
+        \echo ''
+        \echo '--- Granting the original owners of the tables to the migration user ---'
+        DO $$
+        DECLARE
+            owner_name TEXT;
+        BEGIN
+            FOR owner_name IN
+                SELECT DISTINCT t.tableowner
+                FROM pg_catalog.pg_tables t
+                WHERE t.schemaname = ANY(string_to_array(current_setting('myvars.schema_list'), ',')::text[])
+                AND t.tableowner <> current_setting('myvars.voyager_user')
+                AND t.tableowner NOT IN ('rdsadmin')
+            LOOP
+                RAISE NOTICE 'Granting role: GRANT % TO %;', owner_name, current_setting('myvars.voyager_user');
+                EXECUTE format('GRANT %I TO %I;', owner_name, current_setting('myvars.voyager_user'));
+            END LOOP;
+        END $$;
+
     \endif
 
-    -- Add the original owner of the tables to the group
-    \echo ''
-    \echo '--- Adding Original Owner to Replication Group ---'
-    DO $$
-    DECLARE
-        tableowner TEXT;
-        schema_list TEXT[] := string_to_array(current_setting('myvars.schema_list'), ',');  -- Convert the schema list to an array
-        replication_group TEXT := current_setting('myvars.replication_group');  -- Get the replication group from settings
-    BEGIN
-        -- Generate the GRANT statements and execute them dynamically
-        FOR tableowner IN
-            SELECT DISTINCT t.tableowner
-            FROM pg_catalog.pg_tables t
-            WHERE t.schemaname = ANY (schema_list)  -- Use the schema_list variable
-            AND NOT EXISTS (
-                SELECT 1
-                FROM pg_roles r
-                WHERE r.rolname = t.tableowner
-                    AND pg_has_role(t.tableowner, replication_group, 'USAGE')  -- Use the replication_group variable
-            )
-        LOOP
-            -- Display the GRANT statement
-            RAISE NOTICE 'Granting role: GRANT % TO %;', replication_group, tableowner;
-
-            -- Execute the GRANT statement
-            EXECUTE format('GRANT %I TO %I;', replication_group, tableowner);
-        END LOOP;
-    END $$;
-
-    -- Add the user ybvoyager to the replication group
-    \echo ''
-    \echo '--- Adding User to Replication Group ---'
-    GRANT :replication_group TO :voyager_user;
-
-    -- Transfer ownership of the tables to the replication group
-    \echo ''
-    \echo '--- Transferring Ownership of Tables to Replication Group ---'
-    DO $$
-    DECLARE
-        r RECORD;
-    BEGIN
-        FOR r IN
-            SELECT table_schema, '"' || table_name || '"' AS t_name
-            FROM information_schema.tables
-            WHERE table_schema = ANY(string_to_array(current_setting('myvars.schema_list'), ',')::text[])
-        LOOP
-            EXECUTE 'ALTER TABLE ' || r.table_schema || '.' || r.t_name || ' OWNER TO ' || current_setting('myvars.replication_group');
-        END LOOP;
-    END $$;
-
-    -- Grant CREATE permission on the specified database to the specified user
+     -- Grant CREATE permission on the specified database to the specified user
     \echo ''
     \echo '--- Granting CREATE Permission on Database ---'
     DO $$

--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -244,14 +244,9 @@ GRANT pg_read_all_stats to :voyager_user;
                     END LOOP;
                 END $$;
 
-                \echo 'Found ' :rdsadmin_owned_table_count ' rdsadmin-owned table(s) in the selected schema(s).'
-                \echo 'These tables are owned by rdsadmin; role membership cannot be granted to the migration user.'
-                \prompt 'Proceed anyway? We will not be granting ownership to the migration user for these tables. (yes/no): ' proceed
-                \if :proceed
-                \else
-                    \echo 'Aborting as requested.'
-                    \q
-                \endif
+                \echo 'Found ' :rdsadmin_owned_table_count ' rdsadmin-owned table(s) in the selected schema(s). Role membership cannot be granted to the migration user for rdsadmin-owned tables.'
+                \echo 'Aborting. Use option 1 instead.'
+                \q
             \endif
 
             \echo ''

--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -230,7 +230,6 @@ GRANT pg_read_all_stats to :voyager_user;
                     FROM pg_catalog.pg_tables t
                     WHERE t.schemaname = ANY(string_to_array(current_setting('myvars.schema_list'), ',')::text[])
                     AND t.tableowner <> current_setting('myvars.voyager_user')
-                    AND t.tableowner NOT IN ('rdsadmin')
                 LOOP
                     RAISE NOTICE 'Granting role: GRANT % TO %;', owner_name, current_setting('myvars.voyager_user');
                     EXECUTE format('GRANT %I TO %I;', owner_name, current_setting('myvars.voyager_user'));

--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -152,7 +152,7 @@ GRANT pg_read_all_stats to :voyager_user;
     \echo 'Choose how to grant permissions for the selected schema(s): ' :schema_list
     \echo 'Note: For live migration, CREATE PUBLICATION requires table ownership; choose one option to ensure the migration user has required ownership.'
     \echo '  1) Transfer ownership of ALL tables to replication group ' :replication_group ', and add original owners + ' :voyager_user ' to that group.'
-    \echo '  2) Grant each table\'s original owner role to ' :voyager_user ' (excluding rdsadmin).'
+    \echo '  2) Grant each table\s original owner role to ' :voyager_user ' (excluding rdsadmin).'
     \prompt 'Enter choice (1/2): ' transfer_choice
     \o /dev/null
     SELECT 

--- a/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
+++ b/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -152,7 +152,7 @@ GRANT pg_read_all_stats to :voyager_user;
     \echo 'Choose how to grant permissions for the selected schema(s): ' :schema_list
     \echo 'Note: For live migration, CREATE PUBLICATION requires table ownership; choose one option to ensure the migration user has required ownership.'
     \echo '  1) Transfer ownership of ALL tables to replication group ' :replication_group ', and add original owners + ' :voyager_user ' to that group.'
-    \echo '  2) Grant each table\s original owner role to ' :voyager_user ' (excluding rdsadmin).'
+    \echo '  2) Grant original owner role of each table to ' :voyager_user
     \prompt 'Enter choice (1/2): ' transfer_choice
     \o /dev/null
     SELECT 

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -71,7 +71,7 @@ grant_user_permission_postgresql() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v is_live_migration=0 \
                                     -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -184,7 +184,7 @@ grant_permissions_for_live_migration_pg() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \
@@ -764,7 +764,7 @@ setup_fallback_environment() {
 		rm -f $TEMP_SCRIPT
 	    elif [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -71,7 +71,7 @@ grant_user_permission_postgresql() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v is_live_migration=0 \
                                     -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -184,7 +184,7 @@ grant_permissions_for_live_migration_pg() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \
@@ -764,7 +764,7 @@ setup_fallback_environment() {
 		rm -f $TEMP_SCRIPT
 	    elif [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -71,7 +71,7 @@ grant_user_permission_postgresql() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v is_live_migration=0 \
                                     -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -184,7 +184,7 @@ grant_permissions_for_live_migration_pg() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \
@@ -764,7 +764,7 @@ setup_fallback_environment() {
 		rm -f $TEMP_SCRIPT
 	    elif [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -71,7 +71,7 @@ grant_user_permission_postgresql() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v is_live_migration=0 \
                                     -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -184,7 +184,7 @@ grant_permissions_for_live_migration_pg() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \
@@ -764,7 +764,7 @@ setup_fallback_environment() {
 		rm -f $TEMP_SCRIPT
 	    elif [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -71,7 +71,7 @@ grant_user_permission_postgresql() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v is_live_migration=0 \
                                     -f /opt/yb-voyager/guardrails-scripts/yb-voyager-pg-grant-migration-permissions.sql
@@ -184,7 +184,7 @@ grant_permissions_for_live_migration_pg() {
 	db_name=$1
 	db_schema=$2
 	conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${db_name}"
-	echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+	echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${db_schema}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \
@@ -764,7 +764,7 @@ setup_fallback_environment() {
 		rm -f $TEMP_SCRIPT
 	    elif [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -87,7 +87,7 @@ main() {
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		#give fallback permissions for pg before starting as it is required for running snapshot validations where we insert data with ybvoyager user which will not have any usage permissions on sequences.
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -87,7 +87,7 @@ main() {
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		#give fallback permissions for pg before starting as it is required for running snapshot validations where we insert data with ybvoyager user which will not have any usage permissions on sequences.
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -87,7 +87,7 @@ main() {
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		#give fallback permissions for pg before starting as it is required for running snapshot validations where we insert data with ybvoyager user which will not have any usage permissions on sequences.
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -87,7 +87,7 @@ main() {
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		#give fallback permissions for pg before starting as it is required for running snapshot validations where we insert data with ybvoyager user which will not have any usage permissions on sequences.
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "yes" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "no" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -87,7 +87,7 @@ main() {
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
 		#give fallback permissions for pg before starting as it is required for running snapshot validations where we insert data with ybvoyager user which will not have any usage permissions on sequences.
 		conn_string="postgresql://${SOURCE_DB_ADMIN_USER}:${SOURCE_DB_ADMIN_PASSWORD}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
-		echo "1" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
+		echo "2" | psql "${conn_string}" -v voyager_user="${SOURCE_DB_USER}" \
                                     -v schema_list="${SOURCE_DB_SCHEMA}" \
                                     -v replication_group='replication_group' \
                                     -v is_live_migration=1 \


### PR DESCRIPTION
### Describe the changes in this pull request
Added a prompt in the yb-voyager-pg-grant-migration-permissions.sql script to choose one of the following options:
1) Proceed with the older method od transferring ownership of all the tables to a replication group and assign that replication group both to the original owner and the migration use
2) Grant the original owner of the table to the migration user

In case of granting original owner of the table to migration user, we give a warning for tables that are owned by rdsadmin since granting rdsadmin to a user fails. We don't grant rdsadmin to the users.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Yeah the users will see a new prompt in the yb-voyager-pg-grant-migration-permissions.sql script:
```
Choose how to grant permissions for the selected schema(s):  public
Note: For live migration, CREATE PUBLICATION requires table ownership; choose one option to ensure the migration user has required ownership.
  - yes: Transfer ownership of ALL tables to replication group  replication_group , and add original owners +  ybvoyager  to that group.
  - no:  Keep ownership unchanged; grant each tables original owner role to  ybvoyager  (excluding rdsadmin).
Enter choice (yes/no):
```

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually and GH tests

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
