### PR TITLE
[DB-17859]: Objects are abstracted differently in different contexts during callhome schema anonymisation

### DIFF
--- a/yb-voyager/src/anon/sql_anonymizer.go
+++ b/yb-voyager/src/anon/sql_anonymizer.go
@@ -316,19 +316,13 @@ func (a *SqlAnonymizer) identifierNodesProcessor(msg protoreflect.Message) (err 
 			return fmt.Errorf("expected TypeName, got %T", msg.Interface())
 		}
 
-		// Only anonymize if it's not a built-in type
-		if !IsBuiltinType(tn) {
-			// get string node sval from TypeName
-			for i, node := range tn.Names {
-				str := node.GetString_()
-				if str == nil || str.Sval == "" {
-					continue
-				}
-				str.Sval, err = a.registry.GetHash(TYPE_KIND_PREFIX, str.Sval)
-				if err != nil {
-					return fmt.Errorf("anon typename[%d]=%q lookup: %w", i, str.Sval, err)
-				}
-			}
+		if IsBuiltinType(tn) {
+			return nil
+		}
+
+		err = a.anonymizeStringNodes(tn.Names, TYPE_KIND_PREFIX)
+		if err != nil {
+			return fmt.Errorf("anon typename: %w", err)
 		}
 
 	/*

--- a/yb-voyager/src/anon/sql_anonymizer_test.go
+++ b/yb-voyager/src/anon/sql_anonymizer_test.go
@@ -263,6 +263,22 @@ func TestSameTokenForSameObjectName(t *testing.T) {
 			sql1: "SELECT password FROM accounts",
 			sql2: "UPDATE accounts SET password = 'constant1'",
 		},
+		{
+			name: "consistent schema token across type definition and usage",
+			identifiers: []struct{ kind, raw string }{
+				{SCHEMA_KIND_PREFIX, "public"},
+				{TYPE_KIND_PREFIX, "address_type"},
+				{TABLE_KIND_PREFIX, "combined_tbl"},
+				{COLUMN_KIND_PREFIX, "id"},
+				{COLUMN_KIND_PREFIX, "address"},
+				{COLUMN_KIND_PREFIX, "street"},
+				{COLUMN_KIND_PREFIX, "city"},
+				{COLUMN_KIND_PREFIX, "state"},
+				{COLUMN_KIND_PREFIX, "zip_code"},
+			},
+			sql1: `CREATE TYPE public.address_type AS (street varchar, city varchar, state varchar, zip_code varchar)`,
+			sql2: `CREATE TABLE public.combined_tbl (id int NOT NULL, address public.address_type)`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
### Describe the changes in this pull request
fixes https://yugabyte.atlassian.net/browse/DB-17859
- bug was not only in column names of CREATE TABLE, fixed it (nothing major was missing)

##### Bug Example:
1. Original Schema:
```
CREATE TYPE public.address_type AS (
	street character varying(100),
	city character varying(50),
	state character varying(50),
	zip_code character varying(10)
);

CREATE TABLE public.combined_tbl (
    id integer NOT NULL,
    c cidr,
    maddr macaddr,
    maddr8 macaddr8,
    lsn pg_lsn,
    inds3 interval day to second(3),
    d daterange,
    bitt bit(13),
    bittv bit varying(15),
    address public.address_type,
    raster public.lo,
    arr_enum public.enum_kind[] NOT NULL,
    data public.hstore,
    xml_data xml[]
);

```

2. Anonymized Schema
```
CREATE TYPE schema_a847fd30c879bff0.type_88a3dec259f67c74 AS (
    col_3466897df462c5cd varchar(100),
    col_1e0ccc7015800773 varchar(50),
    col_2eab316c0e5ae16e varchar(50),
    col_ea96328ccf6d5160 varchar(10)
);

CREATE TABLE schema_a847fd30c879bff0.table_822f0cfaa023efb7 (
    col_441c20197171d69a int NOT NULL,
    col_873f02c041c56b82 cidr,
    col_dcbad60fa1276fdf macaddr,
    col_c70bcdeb1aceb09d macaddr8,
    col_5bcf2bca7bf31d76 type_35fd10939bf5441d,
    col_63b33e68b58c75c9 interval day to second(3),
    col_6d53143dd252e623 daterange,
    col_ac5ba53247a7b14d pg_catalog.bit(13),
    col_e7df4200fa7165f0 pg_catalog.varbit(15),
    col_934b3e3c3b9eca2b type_b6578d20b4f02ddf.type_88a3dec259f67c74,
    col_e121b2d6b1973541 type_b6578d20b4f02ddf.type_ba2491ee4a890d66,
    col_f6b26c2a282b6dd3 type_b6578d20b4f02ddf.type_7f4fceef2b4362e6[] NOT NULL,
    col_83197a08d62a66fc type_b6578d20b4f02ddf.type_5d2f5120c0b7a5b4,
    col_7edbe254a27b9d20 xml[]
);
```

Here if you notice `address, raster, arr_enum etc` columns datatype in CREATE TABLE is anonymized with wrong prefix as (`type_*.type_*`)




### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
NA

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Added unit test

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
