### PR TITLE
[DB-17936][Sizing Calc]: update cores needed with the addition of a node

### DIFF
--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -408,6 +408,7 @@ func findNumNodesNeededBasedOnThroughputRequirement(sourceIndexMetadata []Source
 		// Add it explicitly.
 		if len(previousRecommendation.ColocatedTables) > 0 {
 			nodesNeeded += 1
+			neededCores += float64(previousRecommendation.VCPUsPerInstance)
 		}
 
 		// Assumption: minimum required replication is 3, so minimum nodes recommended would be 3.

--- a/yb-voyager/src/migassessment/sizing_test.go
+++ b/yb-voyager/src/migassessment/sizing_test.go
@@ -757,6 +757,99 @@ func TestFindNumNodesNeededBasedOnThroughputRequirement_NeedMoreNodes(t *testing
 	assert.Equal(t, updatedRecommendation[4].NumNodes, float64(15))
 }
 
+// validate that when colocated tables exist, 1 additional node and corresponding cores are added
+func TestFindNumNodesNeededBasedOnThroughputRequirement_WithColocatedTablesAddsOneNode(t *testing.T) {
+	// Define test data
+	var sourceIndexMetadata []SourceDBMetadata
+	shardedThroughput := []ExpDataThroughput{
+		{
+			numCores:                   sql.NullFloat64{Float64: 4},
+			maxSupportedSelectsPerCore: sql.NullFloat64{Float64: 1000},
+			maxSupportedInsertsPerCore: sql.NullFloat64{Float64: 500},
+		},
+	}
+
+	recommendation := map[int]IntermediateRecommendation{
+		4: {
+			ColocatedTables: []SourceDBMetadata{
+				{
+					ObjectName: "colocated_table1", Size: sql.NullFloat64{Float64: 10.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 100},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 50},
+				},
+			},
+			ShardedTables: []SourceDBMetadata{
+				{
+					ObjectName: "sharded_table1", Size: sql.NullFloat64{Float64: 20.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 8000},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000},
+				},
+			},
+			VCPUsPerInstance: 4,
+			MemoryPerCore:    4,
+		},
+	}
+
+	// Run the function
+	updatedRecommendation :=
+		findNumNodesNeededBasedOnThroughputRequirement(sourceIndexMetadata, shardedThroughput, recommendation)
+
+	// With colocated tables present, expect +1 node and +4 cores (VCPUsPerInstance)
+	// Base calculation: (8000/1000 + 4000/500) = 16 cores needed -> 4 nodes needed
+	// With colocated tables: 4 + 1 = 5 nodes, 16 + 4 = 20 cores needed
+	// Minimum enforcement: max(5, 3) = 5 nodes, max(20, 12) = 20 cores
+	expectedNumNodes := float64(5)
+	expectedCoresNeeded := float64(20)
+
+	// Check the results
+	recommendationToVerify := updatedRecommendation[4]
+	assert.Equal(t, expectedNumNodes, recommendationToVerify.NumNodes)
+	assert.Equal(t, expectedCoresNeeded, recommendationToVerify.CoresNeeded)
+}
+
+// validate that when no colocated tables exist, no additional node/cores are added
+func TestFindNumNodesNeededBasedOnThroughputRequirement_WithoutColocatedTablesNoExtraNode(t *testing.T) {
+	// Define test data
+	var sourceIndexMetadata []SourceDBMetadata
+	shardedThroughput := []ExpDataThroughput{
+		{
+			numCores:                   sql.NullFloat64{Float64: 4},
+			maxSupportedSelectsPerCore: sql.NullFloat64{Float64: 1000},
+			maxSupportedInsertsPerCore: sql.NullFloat64{Float64: 500},
+		},
+	}
+
+	recommendation := map[int]IntermediateRecommendation{
+		4: {
+			ColocatedTables: []SourceDBMetadata{}, // No colocated tables
+			ShardedTables: []SourceDBMetadata{
+				{
+					ObjectName: "sharded_table1", Size: sql.NullFloat64{Float64: 20.0, Valid: true},
+					ReadsPerSec:  sql.NullInt64{Valid: true, Int64: 8000},
+					WritesPerSec: sql.NullInt64{Valid: true, Int64: 4000},
+				},
+			},
+			VCPUsPerInstance: 4,
+			MemoryPerCore:    4,
+		},
+	}
+
+	// Run the function
+	updatedRecommendation :=
+		findNumNodesNeededBasedOnThroughputRequirement(sourceIndexMetadata, shardedThroughput, recommendation)
+
+	// Without colocated tables, no extra node/cores should be added
+	// Base calculation: (8000/1000 + 4000/500) = 16 cores needed -> 4 nodes needed
+	// No colocated tables: just 4 nodes, cores: 16 cores
+	expectedNumNodes := float64(4)
+	expectedCoresNeeded := float64(16)
+
+	// Check the results
+	recommendationToVerify := updatedRecommendation[4]
+	assert.Equal(t, expectedNumNodes, recommendationToVerify.NumNodes)
+	assert.Equal(t, expectedCoresNeeded, recommendationToVerify.CoresNeeded)
+}
+
 /*
 ===== 	Test functions to test findNumNodesNeededBasedOnTabletsRequired function	=====
 */


### PR DESCRIPTION
### Describe the changes in this pull request
- Fixed bug https://github.com/yugabyte/yb-voyager/issues/2962 
- update the neededCores as one node is added when there are colocated+sharded tables.

### Respective JIRA: https://yugabyte.atlassian.net/browse/DB-17936

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
CI jobs
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
