### PR TITLE
[DB-18025][Sizing Calc] Exclude redundant indexes from import time calculation. 

### DIFF
--- a/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.html
+++ b/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.html
@@ -878,6 +878,7 @@
                         <tr><td class="centered-cell">Optimal select connections per node</td><td class="centered-cell">8</td></tr>
                         <tr><td class="centered-cell">Optimal insert connections per node</td><td class="centered-cell">12</td></tr>
                         <tr><td class="centered-cell">Estimated time taken for data import </td><td class="centered-cell">1 min</td></tr>
+                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding Redundant Indexes)</td><td class="centered-cell">1 min</td></tr>
                     </table>
                     <h3>Reasoning:</h3>
                     <p class="spaced-words">Recommended instance type with 4 vCPU and 16 GiB memory could fit 78 objects (74 tables/materialized views and 4 explicit/implicit indexes) with 192.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.</p>

--- a/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.html
+++ b/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.html
@@ -878,7 +878,7 @@
                         <tr><td class="centered-cell">Optimal select connections per node</td><td class="centered-cell">8</td></tr>
                         <tr><td class="centered-cell">Optimal insert connections per node</td><td class="centered-cell">12</td></tr>
                         <tr><td class="centered-cell">Estimated time taken for data import </td><td class="centered-cell">1 min</td></tr>
-                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding Redundant Indexes)</td><td class="centered-cell">1 min</td></tr>
+                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding redundant indexes)</td><td class="centered-cell">1 min</td></tr>
                     </table>
                     <h3>Reasoning:</h3>
                     <p class="spaced-words">Recommended instance type with 4 vCPU and 16 GiB memory could fit 78 objects (74 tables/materialized views and 4 explicit/implicit indexes) with 192.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.</p>

--- a/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
@@ -141,7 +141,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild1AssessmentReport.json
+++ b/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild1AssessmentReport.json
@@ -70,7 +70,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 0
+			"EstimatedTimeInMinForImport": 0,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 0
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild2AssessmentReport.json
+++ b/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild2AssessmentReport.json
@@ -100,7 +100,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/adventureworks/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/adventureworks/expected_files/expectedAssessmentReport.json
@@ -151,7 +151,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 0
+			"EstimatedTimeInMinForImport": 0,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 0
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
@@ -60,7 +60,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 2
+			"EstimatedTimeInMinForImport": 2,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 2
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/assessment-report-test-uqc/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test-uqc/expectedAssessmentReport.json
@@ -70,7 +70,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/assessment-report-test-with-tdb/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test-with-tdb/expectedAssessmentReport.json
@@ -219,7 +219,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -219,7 +219,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.html
+++ b/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.html
@@ -570,6 +570,7 @@
                         <tr><td class="centered-cell">Optimal select connections per node</td><td class="centered-cell">8</td></tr>
                         <tr><td class="centered-cell">Optimal insert connections per node</td><td class="centered-cell">12</td></tr>
                         <tr><td class="centered-cell">Estimated time taken for data import </td><td class="centered-cell">1 min</td></tr>
+                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding Redundant Indexes)</td><td class="centered-cell">1 min</td></tr>
                     </table>
                     <h3>Reasoning:</h3>
                     <p class="spaced-words">Recommended instance type with 4 vCPU and 16 GiB memory could fit 6 objects (4 tables/materialized views and 2 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Rest 4 objects (1 tables/materialized views and 3 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec need to be migrated as range partitioned tables. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.</p>

--- a/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.html
+++ b/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.html
@@ -570,7 +570,7 @@
                         <tr><td class="centered-cell">Optimal select connections per node</td><td class="centered-cell">8</td></tr>
                         <tr><td class="centered-cell">Optimal insert connections per node</td><td class="centered-cell">12</td></tr>
                         <tr><td class="centered-cell">Estimated time taken for data import </td><td class="centered-cell">1 min</td></tr>
-                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding Redundant Indexes)</td><td class="centered-cell">1 min</td></tr>
+                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding redundant indexes)</td><td class="centered-cell">1 min</td></tr>
                     </table>
                     <h3>Reasoning:</h3>
                     <p class="spaced-words">Recommended instance type with 4 vCPU and 16 GiB memory could fit 6 objects (4 tables/materialized views and 2 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Rest 4 objects (1 tables/materialized views and 3 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec need to be migrated as range partitioned tables. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.</p>

--- a/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.json
@@ -73,7 +73,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
@@ -241,7 +241,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 0
+			"EstimatedTimeInMinForImport": 0,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 0
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/omnibus/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/omnibus/expected_files/expectedAssessmentReport.json
@@ -486,7 +486,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/osm/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/osm/expected_files/expectedAssessmentReport.json
@@ -59,7 +59,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/pgtbrus/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/pgtbrus/expected_files/expectedAssessmentReport.json
@@ -73,7 +73,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 1
+			"EstimatedTimeInMinForImport": 1,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 1
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
@@ -370,8 +370,9 @@
 			"MemoryPerInstance": 32,
 			"OptimalSelectConnectionsPerNode": 16,
 			"OptimalInsertConnectionsPerNode": 24,
-			"EstimatedTimeInMinForImport": 0
-		},
+			"EstimatedTimeInMinForImport": 0,
+            "EstimatedTimeInMinForImportWithoutRedundantIndexes": 0
+        },
 		"FailureReasoning": ""
 	},
 	"AssessmentIssues": [

--- a/migtests/tests/pg/sakila/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/sakila/expected_files/expectedAssessmentReport.json
@@ -111,7 +111,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 0
+			"EstimatedTimeInMinForImport": 0,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 0
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/sample-is/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/sample-is/expected_files/expectedAssessmentReport.json
@@ -69,7 +69,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 0
+			"EstimatedTimeInMinForImport": 0,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 0
 		},
 		"FailureReasoning": ""
 	},

--- a/migtests/tests/pg/stackexchange/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/stackexchange/expected_files/expectedAssessmentReport.json
@@ -75,7 +75,8 @@
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 8,
 			"OptimalInsertConnectionsPerNode": 12,
-			"EstimatedTimeInMinForImport": 0
+			"EstimatedTimeInMinForImport": 0,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 0
 		},
 		"FailureReasoning": ""
 	},

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -484,7 +484,7 @@ func convertAssessmentIssueToYugabyteDAssessmentIssue(ar AssessmentReport) []Ass
 func runAssessment() error {
 	log.Infof("running assessment for migration from '%s' to YugabyteDB", source.DBType)
 
-	err := migassessment.SizingAssessment(targetDbVersion, &source.DBType)
+	err := migassessment.SizingAssessment(targetDbVersion, source.DBType)
 	if err != nil {
 		log.Errorf("failed to perform sizing and sharding assessment: %v", err)
 		return fmt.Errorf("failed to perform sizing and sharding assessment: %w", err)

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -484,7 +484,7 @@ func convertAssessmentIssueToYugabyteDAssessmentIssue(ar AssessmentReport) []Ass
 func runAssessment() error {
 	log.Infof("running assessment for migration from '%s' to YugabyteDB", source.DBType)
 
-	err := migassessment.SizingAssessment(targetDbVersion)
+	err := migassessment.SizingAssessment(targetDbVersion, &source.DBType)
 	if err != nil {
 		log.Errorf("failed to perform sizing and sharding assessment: %v", err)
 		return fmt.Errorf("failed to perform sizing and sharding assessment: %w", err)

--- a/yb-voyager/cmd/assessMigrationCommand_test.go
+++ b/yb-voyager/cmd/assessMigrationCommand_test.go
@@ -100,6 +100,7 @@ END $$;`)
 			OptimalSelectConnectionsPerNode: 8,
 			OptimalInsertConnectionsPerNode: 12,
 			EstimatedTimeInMinForImport:     1,
+			EstimatedTimeInMinForImportWithoutRedundantIndexes: 1,
 		},
 		FailureReasoning: "",
 	}

--- a/yb-voyager/cmd/callhome_payload_builder.go
+++ b/yb-voyager/cmd/callhome_payload_builder.go
@@ -131,6 +131,7 @@ func packAndSendAssessMigrationPayload(status string, errMsg error) {
 			OptimalSelectConnectionsPerNode: sizingRecommedation.OptimalSelectConnectionsPerNode,
 			OptimalInsertConnectionsPerNode: sizingRecommedation.OptimalInsertConnectionsPerNode,
 			EstimatedTimeInMinForImport:     sizingRecommedation.EstimatedTimeInMinForImport,
+			EstimatedTimeInMinForImportWithoutRedundantIndexes: sizingRecommedation.EstimatedTimeInMinForImportWithoutRedundantIndexes,
 		}
 	}
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1266,8 +1266,9 @@ Version History
 1.3: Moved Sizing, TableIndexStats, Notes, fields out from depcreated AssessmentJsonReport field to top level struct
 1.4: Removed field 'ParallelVoyagerJobs` from sizing recommendation
 1.5: Changed type of the Details field from json.RawMessage to map[string]interface{}
+1.6: Add EstimatedTimeInMinForImportWithoutRedundantIndexes in SizingRecommendation struct
 */
-var ASSESS_MIGRATION_YBD_PAYLOAD_VERSION = "1.5"
+var ASSESS_MIGRATION_YBD_PAYLOAD_VERSION = "1.6"
 
 // TODO: decouple this struct from utils.AnalyzeSchemaIssue struct, right now its tightly coupled;
 // Similarly for migassessment.SizingAssessmentReport and migassessment.TableIndexStats

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1396,9 +1396,10 @@ func (ar *AssessmentReport) GetClusterSizingRecommendation() string {
 		return ar.Sizing.FailureReasoning
 	}
 
-	return fmt.Sprintf("Num Nodes: %f, vCPU per instance: %d, Memory per instance: %d, Estimated Import Time: %f minutes",
+	return fmt.Sprintf("Num Nodes: %f, vCPU per instance: %d, Memory per instance: %d, Estimated Import Time: %f minutes, Estimated Import Time Without Redundant Indexes: %f minutes",
 		ar.Sizing.SizingRecommendation.NumNodes, ar.Sizing.SizingRecommendation.VCPUsPerInstance,
-		ar.Sizing.SizingRecommendation.MemoryPerInstance, ar.Sizing.SizingRecommendation.EstimatedTimeInMinForImport)
+		ar.Sizing.SizingRecommendation.MemoryPerInstance, ar.Sizing.SizingRecommendation.EstimatedTimeInMinForImport,
+		ar.Sizing.SizingRecommendation.EstimatedTimeInMinForImportWithoutRedundantIndexes)
 }
 
 func (ar *AssessmentReport) GetTotalTableRowCount() int64 {

--- a/yb-voyager/cmd/common_test.go
+++ b/yb-voyager/cmd/common_test.go
@@ -63,15 +63,16 @@ func TestAssessmentReportStructs(t *testing.T) {
 			name:       "Validate SizingRecommendation Struct Definition",
 			actualType: reflect.TypeOf(migassessment.SizingRecommendation{}),
 			expectedType: struct {
-				ColocatedTables                 []string
-				ColocatedReasoning              string
-				ShardedTables                   []string
-				NumNodes                        float64
-				VCPUsPerInstance                int
-				MemoryPerInstance               int
-				OptimalSelectConnectionsPerNode int64
-				OptimalInsertConnectionsPerNode int64
-				EstimatedTimeInMinForImport     float64
+				ColocatedTables                                    []string
+				ColocatedReasoning                                 string
+				ShardedTables                                      []string
+				NumNodes                                           float64
+				VCPUsPerInstance                                   int
+				MemoryPerInstance                                  int
+				OptimalSelectConnectionsPerNode                    int64
+				OptimalInsertConnectionsPerNode                    int64
+				EstimatedTimeInMinForImport                        float64
+				EstimatedTimeInMinForImportWithoutRedundantIndexes float64
 			}{},
 		},
 		{

--- a/yb-voyager/cmd/common_test.go
+++ b/yb-voyager/cmd/common_test.go
@@ -215,6 +215,7 @@ func TestAssessmentReportJson(t *testing.T) {
 				OptimalSelectConnectionsPerNode: 10,
 				OptimalInsertConnectionsPerNode: 10,
 				EstimatedTimeInMinForImport:     10,
+				EstimatedTimeInMinForImportWithoutRedundantIndexes: 10,
 			},
 			FailureReasoning: "Test failure reasoning",
 		},
@@ -359,7 +360,8 @@ func TestAssessmentReportJson(t *testing.T) {
 			"MemoryPerInstance": 16,
 			"OptimalSelectConnectionsPerNode": 10,
 			"OptimalInsertConnectionsPerNode": 10,
-			"EstimatedTimeInMinForImport": 10
+			"EstimatedTimeInMinForImport": 10,
+			"EstimatedTimeInMinForImportWithoutRedundantIndexes": 10
 		},
 		"FailureReasoning": "Test failure reasoning"
 	},

--- a/yb-voyager/cmd/templates/migration_assessment_report.template
+++ b/yb-voyager/cmd/templates/migration_assessment_report.template
@@ -466,6 +466,7 @@
                         <tr><td class="centered-cell">Optimal select connections per node</td><td class="centered-cell">{{ if eq .OptimalSelectConnectionsPerNode 0 }}--{{ else }}{{ .OptimalSelectConnectionsPerNode }}{{ end }}</td></tr>
                         <tr><td class="centered-cell">Optimal insert connections per node</td><td class="centered-cell">{{ if eq .OptimalInsertConnectionsPerNode 0 }}--{{ else }}{{ .OptimalInsertConnectionsPerNode }}{{ end }}</td></tr>
                         <tr><td class="centered-cell">Estimated time taken for data import </td><td class="centered-cell">{{ .EstimatedTimeInMinForImport }} min</td></tr>
+                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding Redundant Indexes)</td><td class="centered-cell">{{ .EstimatedTimeInMinForImportWithoutRedundantIndexes }} min</td></tr>
                     </table>
                     <h3>Reasoning:</h3>
                     <p class="spaced-words">{{ .ColocatedReasoning }}</p>

--- a/yb-voyager/cmd/templates/migration_assessment_report.template
+++ b/yb-voyager/cmd/templates/migration_assessment_report.template
@@ -466,7 +466,7 @@
                         <tr><td class="centered-cell">Optimal select connections per node</td><td class="centered-cell">{{ if eq .OptimalSelectConnectionsPerNode 0 }}--{{ else }}{{ .OptimalSelectConnectionsPerNode }}{{ end }}</td></tr>
                         <tr><td class="centered-cell">Optimal insert connections per node</td><td class="centered-cell">{{ if eq .OptimalInsertConnectionsPerNode 0 }}--{{ else }}{{ .OptimalInsertConnectionsPerNode }}{{ end }}</td></tr>
                         <tr><td class="centered-cell">Estimated time taken for data import </td><td class="centered-cell">{{ .EstimatedTimeInMinForImport }} min</td></tr>
-                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding Redundant Indexes)</td><td class="centered-cell">{{ .EstimatedTimeInMinForImportWithoutRedundantIndexes }} min</td></tr>
+                        <tr><td class="centered-cell">Estimated time taken for data import (Excluding redundant indexes)</td><td class="centered-cell">{{ .EstimatedTimeInMinForImportWithoutRedundantIndexes }} min</td></tr>
                     </table>
                     <h3>Reasoning:</h3>
                     <p class="spaced-words">{{ .ColocatedReasoning }}</p>

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -158,15 +158,16 @@ func NewAssessmentIssueCallhome(category string, categoryDesc string, issueType 
 }
 
 type SizingCallhome struct {
-	NumColocatedTables              int     `json:"num_colocated_tables"`
-	ColocatedReasoning              string  `json:"colocated_reasoning"`
-	NumShardedTables                int     `json:"num_sharded_tables"`
-	NumNodes                        float64 `json:"num_nodes"`
-	VCPUsPerInstance                int     `json:"vcpus_per_instance"`
-	MemoryPerInstance               int     `json:"memory_per_instance"`
-	OptimalSelectConnectionsPerNode int64   `json:"optimal_select_connections_per_node"`
-	OptimalInsertConnectionsPerNode int64   `json:"optimal_insert_connections_per_node"`
-	EstimatedTimeInMinForImport     float64 `json:"estimated_time_in_min_for_import"`
+	NumColocatedTables                                 int     `json:"num_colocated_tables"`
+	ColocatedReasoning                                 string  `json:"colocated_reasoning"`
+	NumShardedTables                                   int     `json:"num_sharded_tables"`
+	NumNodes                                           float64 `json:"num_nodes"`
+	VCPUsPerInstance                                   int     `json:"vcpus_per_instance"`
+	MemoryPerInstance                                  int     `json:"memory_per_instance"`
+	OptimalSelectConnectionsPerNode                    int64   `json:"optimal_select_connections_per_node"`
+	OptimalInsertConnectionsPerNode                    int64   `json:"optimal_insert_connections_per_node"`
+	EstimatedTimeInMinForImport                        float64 `json:"estimated_time_in_min_for_import"`
+	EstimatedTimeInMinForImportWithoutRedundantIndexes float64 `json:"estimated_time_in_min_for_import_without_redundant_indexes"`
 }
 
 type ObjectSizingStats struct {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -114,8 +114,9 @@ Version History
 1.5: Added AnonymizedDDLs field in AssessMigrationPhasePayload struct
 1.6: Added ObjectName field in AssessmentIssueCallhome struct
 1.7 Changed NumShardedTables and NumColocatedTables to ShardedTables and ColocatedTables respectively with anonymized names
+1.8 Added EstimatedTimeInMinForImportWithoutRedundantIndexes to SizingCallhome
 */
-var ASSESS_MIGRATION_CALLHOME_PAYLOAD_VERSION = "1.7"
+var ASSESS_MIGRATION_CALLHOME_PAYLOAD_VERSION = "1.8"
 
 type AssessMigrationPhasePayload struct {
 	PayloadVersion                 string                    `json:"payload_version"`

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -111,15 +111,16 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate SizingCallhome Struct Definition",
 			actualType: reflect.TypeOf(SizingCallhome{}),
 			expectedType: struct {
-				NumColocatedTables              int     `json:"num_colocated_tables"`
-				ColocatedReasoning              string  `json:"colocated_reasoning"`
-				NumShardedTables                int     `json:"num_sharded_tables"`
-				NumNodes                        float64 `json:"num_nodes"`
-				VCPUsPerInstance                int     `json:"vcpus_per_instance"`
-				MemoryPerInstance               int     `json:"memory_per_instance"`
-				OptimalSelectConnectionsPerNode int64   `json:"optimal_select_connections_per_node"`
-				OptimalInsertConnectionsPerNode int64   `json:"optimal_insert_connections_per_node"`
-				EstimatedTimeInMinForImport     float64 `json:"estimated_time_in_min_for_import"`
+				NumColocatedTables                                 int     `json:"num_colocated_tables"`
+				ColocatedReasoning                                 string  `json:"colocated_reasoning"`
+				NumShardedTables                                   int     `json:"num_sharded_tables"`
+				NumNodes                                           float64 `json:"num_nodes"`
+				VCPUsPerInstance                                   int     `json:"vcpus_per_instance"`
+				MemoryPerInstance                                  int     `json:"memory_per_instance"`
+				OptimalSelectConnectionsPerNode                    int64   `json:"optimal_select_connections_per_node"`
+				OptimalInsertConnectionsPerNode                    int64   `json:"optimal_insert_connections_per_node"`
+				EstimatedTimeInMinForImport                        float64 `json:"estimated_time_in_min_for_import"`
+				EstimatedTimeInMinForImportWithoutRedundantIndexes float64 `json:"estimated_time_in_min_for_import_without_redundant_indexes"`
 			}{},
 		},
 		{

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -61,12 +61,6 @@ type TableIndexStats struct {
 	SizeInBytes     *int64  `json:"SizeInBytes"`
 }
 
-type RedundantIndex struct {
-	SchemaName string `db:"redundant_schema_name"`
-	TableName  string `db:"redundant_table_name"`
-	IndexName  string `db:"redundant_index_name"`
-}
-
 var GetSourceMetadataDBFilePath = func() string {
 	return filepath.Join(AssessmentDir, "dbs", "assessment.db")
 }

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -61,12 +61,22 @@ type TableIndexStats struct {
 	SizeInBytes     *int64  `json:"SizeInBytes"`
 }
 
+type RedundantIndex struct {
+	SchemaName string `db:"redundant_schema_name"`
+	TableName  string `db:"redundant_table_name"`
+	IndexName  string `db:"redundant_index_name"`
+}
+
 var GetSourceMetadataDBFilePath = func() string {
 	return filepath.Join(AssessmentDir, "dbs", "assessment.db")
 }
 
 func GetTableIndexStatName() string {
 	return TABLE_INDEX_STATS
+}
+
+func GetTableRedundantIndexesName() string {
+	return REDUNDANT_INDEXES
 }
 
 func InitAssessmentDB() error {

--- a/yb-voyager/src/migassessment/common.go
+++ b/yb-voyager/src/migassessment/common.go
@@ -28,15 +28,16 @@ type Record map[string]any
 var SizingReport = &SizingAssessmentReport{}
 
 type SizingRecommendation struct {
-	ColocatedTables                 []string
-	ColocatedReasoning              string
-	ShardedTables                   []string
-	NumNodes                        float64
-	VCPUsPerInstance                int
-	MemoryPerInstance               int
-	OptimalSelectConnectionsPerNode int64
-	OptimalInsertConnectionsPerNode int64
-	EstimatedTimeInMinForImport     float64
+	ColocatedTables                                    []string
+	ColocatedReasoning                                 string
+	ShardedTables                                      []string
+	NumNodes                                           float64
+	VCPUsPerInstance                                   int
+	MemoryPerInstance                                  int
+	OptimalSelectConnectionsPerNode                    int64
+	OptimalInsertConnectionsPerNode                    int64
+	EstimatedTimeInMinForImport                        float64
+	EstimatedTimeInMinForImportWithoutRedundantIndexes float64
 }
 
 type SizingAssessmentReport struct {

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -158,10 +158,11 @@ var SourceMetadataObjectTypesToUse = []string{
 	"materialized view",
 }
 
-func SizingAssessment(targetDbVersion *ybversion.YBVersion) error {
+func SizingAssessment(targetDbVersion *ybversion.YBVersion, sourceDBType *string) error {
 
 	log.Infof("loading metadata files for sharding assessment")
-	sourceTableMetadata, sourceIndexMetadata, sourceUniqueIndexeMetadata, _, err := loadSourceMetadata(GetSourceMetadataDBFilePath())
+	sourceTableMetadata, sourceIndexMetadata, sourceUniqueIndexeMetadata, _, err := loadSourceMetadata(GetSourceMetadataDBFilePath(), sourceDBType)
+
 	if err != nil {
 		SizingReport.FailureReasoning = fmt.Sprintf("failed to load source metadata: %v", err)
 		return fmt.Errorf("failed to load source metadata: %w", err)
@@ -910,12 +911,12 @@ Returns:
 	[]SourceDBMetadata: all index objects from source db after filtering out redundant indexes.
 	float64: total size of source db
 */
-func loadSourceMetadata(filePath string) ([]SourceDBMetadata, []SourceDBMetadata, []SourceDBMetadata, float64, error) {
+func loadSourceMetadata(filePath string, sourceDBType *string) ([]SourceDBMetadata, []SourceDBMetadata, []SourceDBMetadata, float64, error) {
 	SourceMetaDB, err := utils.ConnectToSqliteDatabase(filePath)
 	if err != nil {
 		return nil, nil, nil, 0.0, fmt.Errorf("cannot connect to source metadata database: %w", err)
 	}
-	return getSourceMetadata(SourceMetaDB)
+	return getSourceMetadata(SourceMetaDB, sourceDBType)
 }
 
 /*
@@ -1347,14 +1348,14 @@ Returns:
 	[]SourceDBMetadata: Metadata for source database indexes after filtering out redundant indexes.
 	float64: The total size of the source database in gigabytes.
 */
-func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata, []SourceDBMetadata, float64, error) {
+func getSourceMetadata(sourceDB *sql.DB, sourceDBType *string) ([]SourceDBMetadata, []SourceDBMetadata, []SourceDBMetadata, float64, error) {
 	// get source database tables, indexes and total size
 	sourceTableMetadata, sourceIndexMetadata, totalSourceDBSize, err := getSourceMetadataTableIndexStats(sourceDB, GetTableIndexStatName())
 	if err != nil {
 		return nil, nil, nil, 0.0, fmt.Errorf("failed read source metadata table %v: %w", GetTableIndexStatName(), err)
 	}
 	// get source database redundant indexes
-	redundantIndexes, err := getSourceMetadataRedundantIndexes(sourceDB, GetTableRedundantIndexesName())
+	redundantIndexes, err := getSourceMetadataRedundantIndexes(sourceDB, GetTableRedundantIndexesName(), sourceDBType)
 	var uniqueSourceIndexMetadata []SourceDBMetadata
 	if err != nil {
 		log.Warnf("failed to read redundant indexes from %v: %v, continuing without filtering redundant indexes", GetTableRedundantIndexesName(), err)
@@ -1362,7 +1363,7 @@ func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata
 		uniqueSourceIndexMetadata = sourceIndexMetadata
 	} else {
 		// filter out all redudant indexes from sourceIndexMetadata
-		uniqueSourceIndexMetadata = filterRedundantIndexes(sourceIndexMetadata, redundantIndexes)
+		uniqueSourceIndexMetadata = filterRedundantIndexes(sourceIndexMetadata, redundantIndexes, sourceDBType)
 	}
 
 	if err := sourceDB.Close(); err != nil {
@@ -1446,7 +1447,7 @@ Returns:
 
 	[]SourceDBMetadata: Filtered slice with redundant indexes removed
 */
-func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantIndexes []RedundantIndex) []SourceDBMetadata {
+func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantIndexes []utils.RedundantIndexesInfo, sourceDBType *string) []SourceDBMetadata {
 	if len(redundantIndexes) == 0 {
 		return sourceIndexMetadata
 	}
@@ -1454,8 +1455,8 @@ func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantInd
 	// Create a map for efficient lookup of redundant indexes
 	redundantMap := make(map[string]bool)
 	for _, ri := range redundantIndexes {
-		// Create a key in the format: schema_name.table_name.index_name
-		key := fmt.Sprintf("%s.%s.%s", ri.SchemaName, ri.TableName, ri.IndexName)
+		// Use the helper method to get fully qualified index name
+		key := ri.GetRedundantIndexCatalogObjectName()
 		redundantMap[key] = true
 	}
 
@@ -1471,10 +1472,20 @@ func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantInd
 			} else {
 				tableName = indexMetadata.ParentTableName.String // Fallback to full string
 			}
+		} else {
+			// If parent table name is not valid, include the index (can't match against redundant list)
+			filteredIndexes = append(filteredIndexes, indexMetadata)
+			continue
 		}
 
-		// Create key to check against redundant indexes
-		key := fmt.Sprintf("%s.%s.%s", indexMetadata.SchemaName, tableName, indexMetadata.ObjectName)
+		// Create a temporary RedundantIndexesInfo to use the same helper method for consistent formatting
+		tempRedundantInfo := utils.RedundantIndexesInfo{
+			DBType:              *sourceDBType,
+			RedundantSchemaName: indexMetadata.SchemaName,
+			RedundantTableName:  tableName,
+			RedundantIndexName:  indexMetadata.ObjectName,
+		}
+		key := tempRedundantInfo.GetRedundantIndexCatalogObjectName()
 
 		// Only include index if it's not in the redundant list
 		if !redundantMap[key] {
@@ -1492,7 +1503,7 @@ func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantInd
 
 /*
 getSourceMetadataRedundantIndexes fetches redundant indexes from the redundant_indexes table using the provided database connection.
-It returns a slice of RedundantIndex structs containing schema, table, and index names.
+It returns a slice of RedundantIndexesInfo structs containing schema, table, and index names.
 
 Parameters:
 
@@ -1501,10 +1512,10 @@ Parameters:
 
 Returns:
 
-	[]RedundantIndex: Slice of redundant index information from the database
+	[]utils.RedundantIndexesInfo: Slice of redundant index information from the database
 	error: Error if any issue occurs during the query
 */
-func getSourceMetadataRedundantIndexes(sourceDB *sql.DB, sourceTableName string) ([]RedundantIndex, error) {
+func getSourceMetadataRedundantIndexes(sourceDB *sql.DB, sourceTableName string, sourceDBType *string) ([]utils.RedundantIndexesInfo, error) {
 	log.Infof("fetching redundant indexes from %q table", sourceTableName)
 	query := fmt.Sprintf(`SELECT redundant_schema_name, redundant_table_name, redundant_index_name FROM %s`, sourceTableName)
 	rows, err := sourceDB.Query(query)
@@ -1513,12 +1524,14 @@ func getSourceMetadataRedundantIndexes(sourceDB *sql.DB, sourceTableName string)
 	}
 	defer rows.Close()
 
-	redundantIndexes := make([]RedundantIndex, 0)
+	redundantIndexes := make([]utils.RedundantIndexesInfo, 0)
 	for rows.Next() {
-		var ri RedundantIndex
-		if err := rows.Scan(&ri.SchemaName, &ri.TableName, &ri.IndexName); err != nil {
+		var ri utils.RedundantIndexesInfo
+		if err := rows.Scan(&ri.RedundantSchemaName, &ri.RedundantTableName, &ri.RedundantIndexName); err != nil {
 			return nil, fmt.Errorf("error scanning redundant index row: %w", err)
 		}
+		// Set the DBType to enable proper object name generation
+		ri.DBType = *sourceDBType
 		redundantIndexes = append(redundantIndexes, ri)
 	}
 

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/ybversion"
@@ -1479,13 +1480,9 @@ func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantInd
 		}
 
 		// Create a temporary RedundantIndexesInfo to use the same helper method for consistent formatting
-		tempRedundantInfo := utils.RedundantIndexesInfo{
-			DBType:              sourceDBType,
-			RedundantSchemaName: indexMetadata.SchemaName,
-			RedundantTableName:  tableName,
-			RedundantIndexName:  indexMetadata.ObjectName,
-		}
-		key := tempRedundantInfo.GetRedundantIndexCatalogObjectName()
+		indexSqlName := sqlname.NewObjectNameQualifiedWithTableName(sourceDBType, "",
+			indexMetadata.ObjectName, indexMetadata.SchemaName, tableName)
+		key := indexSqlName.Qualified.Unquoted
 
 		// Only include index if it's not in the redundant list
 		if !redundantMap[key] {

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -1509,13 +1509,8 @@ func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantInd
 		// Only include index if it's not in the redundant list
 		if !redundantMap[key] {
 			filteredIndexes = append(filteredIndexes, indexMetadata)
-		} else {
-			log.Infof("Filtered out redundant index: %s", key)
 		}
 	}
-
-	log.Infof("Filtered out %d redundant indexes from %d total indexes",
-		len(sourceIndexMetadata)-len(filteredIndexes), len(sourceIndexMetadata))
 
 	return filteredIndexes
 }

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -161,7 +161,7 @@ var SourceMetadataObjectTypesToUse = []string{
 func SizingAssessment(targetDbVersion *ybversion.YBVersion) error {
 
 	log.Infof("loading metadata files for sharding assessment")
-	sourceTableMetadata, sourceIndexMetadata, _, err := loadSourceMetadata(GetSourceMetadataDBFilePath())
+	sourceTableMetadata, sourceIndexMetadata, sourceUniqueIndexeMetadata, _, err := loadSourceMetadata(GetSourceMetadataDBFilePath())
 	if err != nil {
 		SizingReport.FailureReasoning = fmt.Sprintf("failed to load source metadata: %v", err)
 		return fmt.Errorf("failed to load source metadata: %w", err)
@@ -273,7 +273,7 @@ func SizingAssessment(targetDbVersion *ybversion.YBVersion) error {
 	// calculate time taken for colocated import
 	numNodesImportTimeDivisorColocated := 1.0
 	importTimeForColocatedObjects, err := calculateTimeTakenForImport(
-		finalSizingRecommendation.ColocatedTables, sourceIndexMetadata, colocatedLoadTimes,
+		finalSizingRecommendation.ColocatedTables, sourceUniqueIndexeMetadata, colocatedLoadTimes,
 		indexImpactOnLoadTimeCommon, columnsImpactOnLoadTimeCommon, COLOCATED, numNodesImportTimeDivisorColocated)
 	if err != nil {
 		SizingReport.FailureReasoning = fmt.Sprintf("calculate time taken for colocated data import: %v", err)
@@ -287,7 +287,7 @@ func SizingAssessment(targetDbVersion *ybversion.YBVersion) error {
 
 	// calculate time taken for sharded import
 	importTimeForShardedObjects, err := calculateTimeTakenForImport(
-		finalSizingRecommendation.ShardedTables, sourceIndexMetadata, shardedLoadTimes,
+		finalSizingRecommendation.ShardedTables, sourceUniqueIndexeMetadata, shardedLoadTimes,
 		indexImpactOnLoadTimeCommon, columnsImpactOnLoadTimeCommon, SHARDED, numNodesImportTimeDivisorSharded)
 	if err != nil {
 		SizingReport.FailureReasoning = fmt.Sprintf("calculate time taken for sharded data import: %v", err)
@@ -907,12 +907,13 @@ Returns:
 
 	[]SourceDBMetadata: all table objects from source db
 	[]SourceDBMetadata: all index objects from source db
+	[]SourceDBMetadata: all index objects from source db after filtering out redundant indexes.
 	float64: total size of source db
 */
-func loadSourceMetadata(filePath string) ([]SourceDBMetadata, []SourceDBMetadata, float64, error) {
+func loadSourceMetadata(filePath string) ([]SourceDBMetadata, []SourceDBMetadata, []SourceDBMetadata, float64, error) {
 	SourceMetaDB, err := utils.ConnectToSqliteDatabase(filePath)
 	if err != nil {
-		return nil, nil, 0.0, fmt.Errorf("cannot connect to source metadata database: %w", err)
+		return nil, nil, nil, 0.0, fmt.Errorf("cannot connect to source metadata database: %w", err)
 	}
 	return getSourceMetadata(SourceMetaDB)
 }
@@ -948,9 +949,10 @@ minutes and returned.
 Parameters:
 
 	tables: A slice containing metadata for the database objects to be migrated.
-	sourceIndexMetadata: A slice containing metadata for the indexes of the database objects to be migrated.
+	sourceUniqueIndexeMetadata: A slice containing metadata for the indexes of the database objects to be migrated.
 	loadTimes: Experiment data for impact of load times on tables
-	indexImpacts: Data containing impact of indexes on load time.
+	indexImpactData: Data containing impact of indexes on load time.
+	numColumnImpactData: Data containing impact of number of columns on load time.
 	objectType: COLOCATED or SHARDED
 	numNodesImportTimeDivisorCommon: Divisor for impact of number of nodes on import time.
 
@@ -960,7 +962,7 @@ Returns:
 	error: Error if any
 */
 func calculateTimeTakenForImport(tables []SourceDBMetadata,
-	sourceIndexMetadata []SourceDBMetadata, loadTimes []ExpDataLoadTime,
+	sourceUniqueIndexeMetadata []SourceDBMetadata, loadTimes []ExpDataLoadTime,
 	indexImpactData []ExpDataLoadTimeIndexImpact, numColumnImpactData []ExpDataLoadTimeColumnsImpact,
 	objectType string, numNodesImportTimeDivisorCommon float64) (float64, error) {
 	var importTime float64
@@ -975,7 +977,7 @@ func calculateTimeTakenForImport(tables []SourceDBMetadata,
 
 		// get multiplication factor for every table based on the number of indexes
 		loadTimeMultiplicationFactorWrtIndexes := getMultiplicationFactorForImportTimeBasedOnIndexes(table,
-			sourceIndexMetadata, indexImpactData, objectType)
+			sourceUniqueIndexeMetadata, indexImpactData, objectType)
 		// get multiplication factor for every table based on the number of columns in the table
 		loadTimeMultiplicationFactorWrtNumColumns := getMultiplicationFactorForImportTimeBasedOnNumColumns(table,
 			numColumnImpactData, objectType)
@@ -1234,19 +1236,20 @@ of indexes on the table.
 Parameters:
 
 	table: Metadata for the database table for which the multiplication factor is to be calculated.
-	sourceIndexMetadata: A slice containing metadata for the indexes in the database.
+	sourceUniqueIndexeMetadata: A slice containing metadata for the unique indexes in the database.
+	indexImpacts: Experimental data containing impact of indexes on load time.
 	objectType: COLOCATED or SHARDED
 
 Returns:
 
 	float64: The multiplication factor for import time based on the number of indexes on the table.
 */
-func getMultiplicationFactorForImportTimeBasedOnIndexes(table SourceDBMetadata, sourceIndexMetadata []SourceDBMetadata,
+func getMultiplicationFactorForImportTimeBasedOnIndexes(table SourceDBMetadata, sourceUniqueIndexeMetadata []SourceDBMetadata,
 	indexImpacts []ExpDataLoadTimeIndexImpact, objectType string) float64 {
 	var numberOfIndexesOnTable float64 = 0
 	var multiplicationFactor float64 = 1
 
-	for _, index := range sourceIndexMetadata {
+	for _, index := range sourceUniqueIndexeMetadata {
 		if index.ParentTableName.Valid && index.ParentTableName.String == (table.SchemaName+"."+table.ObjectName) {
 			numberOfIndexesOnTable += 1
 		}
@@ -1283,6 +1286,7 @@ number of columns on the table.
 Parameters:
 
 	table: Metadata for the database table for which the multiplication factor is to be calculated.
+	columnImpacts: Experimental data containing impact of number of columns on load time.
 	objectType: COLOCATED or SHARDED
 
 Returns:
@@ -1334,15 +1338,41 @@ func getMultiplicationFactorForImportTimeBasedOnNumColumns(table SourceDBMetadat
 }
 
 /*
-getSourceMetadata retrieves metadata for source database tables and indexes along with the total size of the source
-database.
+getSourceMetadata retrieves metadata for source database tables, indexes, redundant indexes along with the total
+size of the source database.
 Returns:
 
 	[]SourceDBMetadata: Metadata for source database tables.
 	[]SourceDBMetadata: Metadata for source database indexes.
+	[]SourceDBMetadata: Metadata for source database indexes after filtering out redundant indexes.
 	float64: The total size of the source database in gigabytes.
 */
-func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata, float64, error) {
+func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata, []SourceDBMetadata, float64, error) {
+	// get source database tables, indexes and total size
+	sourceTableMetadata, sourceIndexMetadata, totalSourceDBSize, err := getSourceMetadataTableIndexStats(sourceDB, GetTableIndexStatName())
+	if err != nil {
+		return nil, nil, nil, 0.0, fmt.Errorf("failed read source metadata table %v: %w", GetTableIndexStatName(), err)
+	}
+	// get source database redundant indexes
+	redundantIndexes, err := getSourceMetadataRedundantIndexes(sourceDB, GetTableRedundantIndexesName())
+	var uniqueSourceIndexMetadata []SourceDBMetadata
+	if err != nil {
+		log.Warnf("failed to read redundant indexes from %v: %v, continuing without filtering redundant indexes", GetTableRedundantIndexesName(), err)
+		// If we can't get redundant indexes, just use all indexes without filtering
+		uniqueSourceIndexMetadata = sourceIndexMetadata
+	} else {
+		// filter out all redudant indexes from sourceIndexMetadata
+		uniqueSourceIndexMetadata = filterRedundantIndexes(sourceIndexMetadata, redundantIndexes)
+	}
+
+	if err := sourceDB.Close(); err != nil {
+		log.Warnf("failed to close connection to sourceDB metadata")
+	}
+
+	return sourceTableMetadata, sourceIndexMetadata, uniqueSourceIndexMetadata, totalSourceDBSize, nil
+}
+
+func getSourceMetadataTableIndexStats(sourceDB *sql.DB, sourceTableName string) ([]SourceDBMetadata, []SourceDBMetadata, float64, error) {
 	// Construct the WHERE clause dynamically using LIKE
 	var likeConditions []string
 	for _, pattern := range SourceMetadataObjectTypesToUse {
@@ -1364,10 +1394,10 @@ func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata
 		FROM %v 
 		WHERE %s
 		ORDER BY IFNULL(size_in_bytes, 0) ASC
-	`, GetTableIndexStatName(), whereClause)
+	`, sourceTableName, whereClause)
 	rows, err := sourceDB.Query(query)
 	if err != nil {
-		return nil, nil, 0.0, fmt.Errorf("failed to query source metadata with query [%s]: %w", query, err)
+		return nil, nil, 0.0, fmt.Errorf("failed to query source metadata table: %v with query [%s]: %w", sourceTableName, query, err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
@@ -1399,17 +1429,6 @@ func getSourceMetadata(sourceDB *sql.DB) ([]SourceDBMetadata, []SourceDBMetadata
 		return nil, nil, 0.0, fmt.Errorf("failed to query source metadata with query [%s]: %w", query, err)
 	}
 
-	// Filter out redundant indexes using the existing sourceDB connection
-	redundantIndexes, err := fetchRedundantIndexes(sourceDB)
-	if err != nil {
-		log.Warnf("failed to fetch redundant indexes: %v", err)
-	} else {
-		sourceIndexMetadata = filterRedundantIndexes(sourceIndexMetadata, redundantIndexes)
-	}
-
-	if err := sourceDB.Close(); err != nil {
-		log.Warnf("failed to close connection to sourceDB metadata")
-	}
 	return sourceTableMetadata, sourceIndexMetadata, totalSourceDBSize, nil
 }
 
@@ -1472,21 +1491,22 @@ func filterRedundantIndexes(sourceIndexMetadata []SourceDBMetadata, redundantInd
 }
 
 /*
-fetchRedundantIndexes fetches redundant indexes from the redundant_indexes table using the provided database connection.
+getSourceMetadataRedundantIndexes fetches redundant indexes from the redundant_indexes table using the provided database connection.
 It returns a slice of RedundantIndex structs containing schema, table, and index names.
 
 Parameters:
 
 	sourceDB: Database connection to query the redundant_indexes table
+	sourceTableName: Name of the table containing redundant index information
 
 Returns:
 
 	[]RedundantIndex: Slice of redundant index information from the database
 	error: Error if any issue occurs during the query
 */
-func fetchRedundantIndexes(sourceDB *sql.DB) ([]RedundantIndex, error) {
-	log.Infof("fetching redundant indexes from %q table", GetTableRedundantIndexesName())
-	query := fmt.Sprintf(`SELECT redundant_schema_name, redundant_table_name, redundant_index_name FROM %s`, GetTableRedundantIndexesName())
+func getSourceMetadataRedundantIndexes(sourceDB *sql.DB, sourceTableName string) ([]RedundantIndex, error) {
+	log.Infof("fetching redundant indexes from %q table", sourceTableName)
+	query := fmt.Sprintf(`SELECT redundant_schema_name, redundant_table_name, redundant_index_name FROM %s`, sourceTableName)
 	rows, err := sourceDB.Query(query)
 	if err != nil {
 		return nil, fmt.Errorf("error querying redundant indexes-%s: %w", query, err)
@@ -1840,7 +1860,7 @@ Parameters:
   - targetNumNodes: the target number of nodes to calculate the scaling ratio for
 
 Returns:
-  - returns the relative import time divisor based on throughput scaling with number of nodes
+  - float64: the relative import time divisor based on throughput scaling with number of nodes
 */
 func findNumNodesThroughputScalingImportTimeDivisor(numNodesImpactData []ExpDataLoadTimeNumNodesImpact, targetNumNodes float64) float64 {
 	// Check if the slice is empty

--- a/yb-voyager/src/migassessment/sizing.go
+++ b/yb-voyager/src/migassessment/sizing.go
@@ -97,18 +97,19 @@ type ExpDataLoadTimeNumNodesImpact struct {
 }
 
 type IntermediateRecommendation struct {
-	ColocatedTables                 []SourceDBMetadata
-	ShardedTables                   []SourceDBMetadata
-	ColocatedSize                   float64
-	ShardedSize                     float64
-	NumNodes                        float64
-	VCPUsPerInstance                int
-	MemoryPerCore                   int
-	OptimalSelectConnectionsPerNode int64
-	OptimalInsertConnectionsPerNode int64
-	EstimatedTimeInMinForImport     float64
-	FailureReasoning                string
-	CoresNeeded                     float64
+	ColocatedTables                                    []SourceDBMetadata
+	ShardedTables                                      []SourceDBMetadata
+	ColocatedSize                                      float64
+	ShardedSize                                        float64
+	NumNodes                                           float64
+	VCPUsPerInstance                                   int
+	MemoryPerCore                                      int
+	OptimalSelectConnectionsPerNode                    int64
+	OptimalInsertConnectionsPerNode                    int64
+	EstimatedTimeInMinForImport                        float64
+	EstimatedTimeInMinForImportWithoutRedundantIndexes float64
+	FailureReasoning                                   string
+	CoresNeeded                                        float64
 }
 
 type ExperimentDataAvailableYbVersion struct {
@@ -162,7 +163,7 @@ var SourceMetadataObjectTypesToUse = []string{
 func SizingAssessment(targetDbVersion *ybversion.YBVersion, sourceDBType string) error {
 
 	log.Infof("loading metadata files for sharding assessment")
-	sourceTableMetadata, sourceIndexMetadata, sourceUniqueIndexeMetadata, _, err := loadSourceMetadata(GetSourceMetadataDBFilePath(), sourceDBType)
+	sourceTableMetadata, sourceIndexMetadata, sourceUniqueIndexesMetadata, _, err := loadSourceMetadata(GetSourceMetadataDBFilePath(), sourceDBType)
 
 	if err != nil {
 		SizingReport.FailureReasoning = fmt.Sprintf("failed to load source metadata: %v", err)
@@ -274,8 +275,8 @@ func SizingAssessment(targetDbVersion *ybversion.YBVersion, sourceDBType string)
 
 	// calculate time taken for colocated import
 	numNodesImportTimeDivisorColocated := 1.0
-	importTimeForColocatedObjects, err := calculateTimeTakenForImport(
-		finalSizingRecommendation.ColocatedTables, sourceUniqueIndexeMetadata, colocatedLoadTimes,
+	importTimeForColocatedObjects, importTimeForColocatedObjectsWithoutRedundantIndexes, err := calculateTimeTakenForImport(
+		finalSizingRecommendation.ColocatedTables, sourceUniqueIndexesMetadata, sourceIndexMetadata, colocatedLoadTimes,
 		indexImpactOnLoadTimeCommon, columnsImpactOnLoadTimeCommon, COLOCATED, numNodesImportTimeDivisorColocated)
 	if err != nil {
 		SizingReport.FailureReasoning = fmt.Sprintf("calculate time taken for colocated data import: %v", err)
@@ -288,8 +289,8 @@ func SizingAssessment(targetDbVersion *ybversion.YBVersion, sourceDBType string)
 		findNumNodesThroughputScalingImportTimeDivisor(numNodesImpactOnLoadTimeSharded, finalSizingRecommendation.NumNodes))
 
 	// calculate time taken for sharded import
-	importTimeForShardedObjects, err := calculateTimeTakenForImport(
-		finalSizingRecommendation.ShardedTables, sourceUniqueIndexeMetadata, shardedLoadTimes,
+	importTimeForShardedObjects, importTimeForShardedObjectsWithoutRedundantIndexes, err := calculateTimeTakenForImport(
+		finalSizingRecommendation.ShardedTables, sourceUniqueIndexesMetadata, sourceIndexMetadata, shardedLoadTimes,
 		indexImpactOnLoadTimeCommon, columnsImpactOnLoadTimeCommon, SHARDED, numNodesImportTimeDivisorSharded)
 	if err != nil {
 		SizingReport.FailureReasoning = fmt.Sprintf("calculate time taken for sharded data import: %v", err)
@@ -308,6 +309,7 @@ func SizingAssessment(targetDbVersion *ybversion.YBVersion, sourceDBType string)
 		OptimalInsertConnectionsPerNode: finalSizingRecommendation.OptimalInsertConnectionsPerNode,
 		ColocatedReasoning:              reasoning,
 		EstimatedTimeInMinForImport:     importTimeForColocatedObjects + importTimeForShardedObjects,
+		EstimatedTimeInMinForImportWithoutRedundantIndexes: importTimeForColocatedObjectsWithoutRedundantIndexes + importTimeForShardedObjectsWithoutRedundantIndexes,
 	}
 	SizingReport.SizingRecommendation = *sizingRecommendation
 
@@ -429,8 +431,9 @@ func findNumNodesNeededBasedOnThroughputRequirement(sourceIndexMetadata []Source
 			ColocatedSize:                   previousRecommendation.ColocatedSize,
 			ShardedSize:                     previousRecommendation.ShardedSize,
 			EstimatedTimeInMinForImport:     previousRecommendation.EstimatedTimeInMinForImport,
-			FailureReasoning:                previousRecommendation.FailureReasoning,
-			CoresNeeded:                     neededCores,
+			EstimatedTimeInMinForImportWithoutRedundantIndexes: previousRecommendation.EstimatedTimeInMinForImportWithoutRedundantIndexes,
+			FailureReasoning: previousRecommendation.FailureReasoning,
+			CoresNeeded:      neededCores,
 		}
 	}
 	// Return updated recommendation map
@@ -602,7 +605,8 @@ func checkShardedTableLimit(sourceIndexMetadata []SourceDBMetadata, shardedLimit
 				ColocatedSize:                   0,
 				ShardedSize:                     0,
 				EstimatedTimeInMinForImport:     previousRecommendation.EstimatedTimeInMinForImport,
-				FailureReasoning:                failureReasoning,
+				EstimatedTimeInMinForImportWithoutRedundantIndexes: previousRecommendation.EstimatedTimeInMinForImportWithoutRedundantIndexes,
+				FailureReasoning: failureReasoning,
 			}
 		}
 	}
@@ -684,6 +688,7 @@ func shardingBasedOnOperations(sourceIndexMetadata []SourceDBMetadata,
 			ColocatedSize:                   cumulativeColocatedSizeSum,
 			ShardedSize:                     cumulativeSizeSharded,
 			EstimatedTimeInMinForImport:     previousRecommendation.EstimatedTimeInMinForImport,
+			EstimatedTimeInMinForImportWithoutRedundantIndexes: previousRecommendation.EstimatedTimeInMinForImportWithoutRedundantIndexes,
 		}
 	}
 	// Return updated recommendation map
@@ -763,6 +768,7 @@ func shardingBasedOnTableSizeAndCount(sourceTableMetadata []SourceDBMetadata,
 			ColocatedSize:                   cumulativeColocatedSizeSum,
 			ShardedSize:                     cumulativeSizeSharded,
 			EstimatedTimeInMinForImport:     previousRecommendation.EstimatedTimeInMinForImport,
+			EstimatedTimeInMinForImportWithoutRedundantIndexes: previousRecommendation.EstimatedTimeInMinForImportWithoutRedundantIndexes,
 		}
 	}
 	// Return updated recommendation map
@@ -947,11 +953,13 @@ calculateTimeTakenForImport estimates the time taken for import of tables.
 It queries experimental data to find import time estimates for similar object sizes and configurations. For every table
 , it tries to find out how much time it would table for importing that table. The function adjusts the
 import time on that table by multiplying it by factor based on the indexes. The import time is also converted to
-minutes and returned.
+minutes and returned. This function calculates two different import times: one with all indexes (including redundant)
+and one with only unique indexes (excluding redundant).
 Parameters:
 
 	tables: A slice containing metadata for the database objects to be migrated.
-	sourceUniqueIndexeMetadata: A slice containing metadata for the indexes of the database objects to be migrated.
+	sourceUniqueIndexesMetadata: A slice containing metadata for unique indexes only.
+	sourceAllIndexesMetadata: A slice containing metadata for all indexes including redundant ones.
 	loadTimes: Experiment data for impact of load times on tables
 	indexImpactData: Data containing impact of indexes on load time.
 	numColumnImpactData: Data containing impact of number of columns on load time.
@@ -960,14 +968,17 @@ Parameters:
 
 Returns:
 
-	float64: The estimated time taken for import in minutes.
+	float64: The estimated time taken for import in minutes with all indexes.
+	float64: The estimated time taken for import in minutes without redundant indexes.
 	error: Error if any
 */
 func calculateTimeTakenForImport(tables []SourceDBMetadata,
-	sourceUniqueIndexeMetadata []SourceDBMetadata, loadTimes []ExpDataLoadTime,
-	indexImpactData []ExpDataLoadTimeIndexImpact, numColumnImpactData []ExpDataLoadTimeColumnsImpact,
-	objectType string, numNodesImportTimeDivisorCommon float64) (float64, error) {
-	var importTime float64
+	sourceUniqueIndexesMetadata []SourceDBMetadata, sourceAllIndexesMetadata []SourceDBMetadata,
+	loadTimes []ExpDataLoadTime, indexImpactData []ExpDataLoadTimeIndexImpact,
+	numColumnImpactData []ExpDataLoadTimeColumnsImpact,
+	objectType string, numNodesImportTimeDivisorCommon float64) (float64, float64, error) {
+	var importTimeWithAllIndexes float64
+	var importTimeWithoutRedundantIndexes float64
 
 	// we need to calculate the time taken for import for every table.
 	// For every index, the time taken for import increases.
@@ -977,20 +988,30 @@ func calculateTimeTakenForImport(tables []SourceDBMetadata,
 		tableSize := lo.Ternary(table.Size.Valid, table.Size.Float64, 0)
 		rowsInTable := lo.Ternary(table.RowCount.Valid, table.RowCount.Float64, 0)
 
-		// get multiplication factor for every table based on the number of indexes
-		loadTimeMultiplicationFactorWrtIndexes := getMultiplicationFactorForImportTimeBasedOnIndexes(table,
-			sourceUniqueIndexeMetadata, indexImpactData, objectType)
+		// get multiplication factor for every table based on all indexes (including redundant)
+		loadTimeMultiplicationFactorWrtAllIndexes := getMultiplicationFactorForImportTimeBasedOnIndexes(table,
+			sourceAllIndexesMetadata, indexImpactData, objectType)
+
+		// get multiplication factor for every table based on unique indexes only (excluding redundant)
+		loadTimeMultiplicationFactorWrtUniqueIndexes := getMultiplicationFactorForImportTimeBasedOnIndexes(table,
+			sourceUniqueIndexesMetadata, indexImpactData, objectType)
+
 		// get multiplication factor for every table based on the number of columns in the table
 		loadTimeMultiplicationFactorWrtNumColumns := getMultiplicationFactorForImportTimeBasedOnNumColumns(table,
 			numColumnImpactData, objectType)
 
 		tableImportTimeSec := findImportTimeFromExpDataLoadTime(loadTimes, tableSize, rowsInTable)
-		// add maximum import time to total import time by converting it to minutes
-		importTime += (loadTimeMultiplicationFactorWrtIndexes * loadTimeMultiplicationFactorWrtNumColumns * tableImportTimeSec) / 60
+
+		// add import time with all indexes to total import time by converting it to minutes
+		importTimeWithAllIndexes += (loadTimeMultiplicationFactorWrtAllIndexes * loadTimeMultiplicationFactorWrtNumColumns * tableImportTimeSec) / 60
+
+		// add import time without redundant indexes to total import time by converting it to minutes
+		importTimeWithoutRedundantIndexes += (loadTimeMultiplicationFactorWrtUniqueIndexes * loadTimeMultiplicationFactorWrtNumColumns * tableImportTimeSec) / 60
 	}
 
 	// divide the total import time by the divisor for number of nodes.
-	return math.Ceil(importTime / numNodesImportTimeDivisorCommon), nil
+	return math.Ceil(importTimeWithAllIndexes / numNodesImportTimeDivisorCommon),
+		math.Ceil(importTimeWithoutRedundantIndexes / numNodesImportTimeDivisorCommon), nil
 }
 
 /*
@@ -1238,7 +1259,7 @@ of indexes on the table.
 Parameters:
 
 	table: Metadata for the database table for which the multiplication factor is to be calculated.
-	sourceUniqueIndexeMetadata: A slice containing metadata for the unique indexes in the database.
+	sourceUniqueIndexesMetadata: A slice containing metadata for the unique indexes in the database.
 	indexImpacts: Experimental data containing impact of indexes on load time.
 	objectType: COLOCATED or SHARDED
 
@@ -1246,12 +1267,12 @@ Returns:
 
 	float64: The multiplication factor for import time based on the number of indexes on the table.
 */
-func getMultiplicationFactorForImportTimeBasedOnIndexes(table SourceDBMetadata, sourceUniqueIndexeMetadata []SourceDBMetadata,
+func getMultiplicationFactorForImportTimeBasedOnIndexes(table SourceDBMetadata, sourceUniqueIndexesMetadata []SourceDBMetadata,
 	indexImpacts []ExpDataLoadTimeIndexImpact, objectType string) float64 {
 	var numberOfIndexesOnTable float64 = 0
 	var multiplicationFactor float64 = 1
 
-	for _, index := range sourceUniqueIndexeMetadata {
+	for _, index := range sourceUniqueIndexesMetadata {
 		if index.ParentTableName.Valid && index.ParentTableName.String == (table.SchemaName+"."+table.ObjectName) {
 			numberOfIndexesOnTable += 1
 		}

--- a/yb-voyager/src/migassessment/sizing_test.go
+++ b/yb-voyager/src/migassessment/sizing_test.go
@@ -1009,8 +1009,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex_Colocat
 	}
 
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(colocatedTables,
-		sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(colocatedTables,
+		sourceIndexMetadata, sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1018,8 +1018,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex_Colocat
 	// Define expected results
 	// Calculated as table0: 1 * ((1134 * 23) / 19) / 60
 	expectedTime := 23.0
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1063,8 +1066,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithOneIndex_Colocat
 	}
 
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(colocatedTables,
-		sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(colocatedTables,
+		sourceIndexMetadata, sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1072,8 +1075,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithOneIndex_Colocat
 	// Define expected results
 	// Calculated as table0: 1.77777 * ((1461 * 23) / 19) / 60
 	expectedTime := 53.0 // double the time required when there are no indexes.
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1117,8 +1123,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithFiveIndexes_Colo
 		},
 	}
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(colocatedTables,
-		sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnsImpact, COLOCATED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(colocatedTables,
+		sourceIndexMetadata, sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnsImpact, COLOCATED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1126,8 +1132,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithFiveIndexes_Colo
 	// Define expected results
 	// Calculated as table0: 4.66666 * ((1461 * 23) / 19) / 60
 	expectedTime := 138.0
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1161,8 +1170,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex_Sharded
 		},
 	}
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(shardedTables, sourceIndexMetadata,
-		shardedLoadTimes, indexImpacts, columnsImpact, SHARDED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(shardedTables, sourceIndexMetadata,
+		sourceIndexMetadata, shardedLoadTimes, indexImpacts, columnsImpact, SHARDED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1170,8 +1179,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex_Sharded
 	// Define expected results
 	// Calculated as table0: 1 * ((1134 * 23) / 19) / 60
 	expectedTime := 23.0
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1209,8 +1221,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithOneIndex_Sharded
 		},
 	}
 	// Call the function
-	estimatedTime, err :=
-		calculateTimeTakenForImport(shardedTables, sourceIndexMetadata, shardedLoadTimes,
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err :=
+		calculateTimeTakenForImport(shardedTables, sourceIndexMetadata, sourceIndexMetadata, shardedLoadTimes,
 			indexImpacts, columnsImpact, SHARDED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -1220,8 +1232,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithOneIndex_Sharded
 	// Calculated as table0: 1.76 * ((1134 * 23) / 19) / 60
 	expectedTime := 41.0 // double the time required when there are no indexes.
 
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1265,8 +1280,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithFiveIndexes_Shar
 		},
 	}
 	// Call the function
-	estimatedTime, err :=
-		calculateTimeTakenForImport(shardedTables, sourceIndexMetadata, shardedLoadTimes,
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err :=
+		calculateTimeTakenForImport(shardedTables, sourceIndexMetadata, sourceIndexMetadata, shardedLoadTimes,
 			indexImpacts, columnsImpact, SHARDED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -1276,8 +1291,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithFiveIndexes_Shar
 	// Calculated as table0: 4.6 * ((1134 * 23) / 19) / 60
 	expectedTime := 106.0
 
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1312,8 +1330,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex5Columns
 	}
 
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(colocatedTables,
-		sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(colocatedTables,
+		sourceIndexMetadata, sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1322,8 +1340,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex5Columns
 	// Calculated as table0: 1 * ((1134 * 23) / 19) / 60
 	expectedTime := 23.0
 
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1363,8 +1384,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex40Column
 	}
 
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(colocatedTables,
-		sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(colocatedTables,
+		sourceIndexMetadata, sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1373,8 +1394,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex40Column
 	// Calculated as table0: 1.57 * ((1134 * 23) / 19) / 60
 	expectedTime := 36.0
 
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1414,8 +1438,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex100Colum
 	}
 
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(colocatedTables,
-		sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(colocatedTables,
+		sourceIndexMetadata, sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1425,8 +1449,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex100Colum
 	// Calculated as table0: 4.13 * ((1134 * 23) / 19) / 60
 	expectedTime := 95.0
 
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -1466,8 +1493,8 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex250Colum
 	}
 
 	// Call the function
-	estimatedTime, err := calculateTimeTakenForImport(colocatedTables,
-		sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
+	estimatedTimeWithAllIndexes, estimatedTimeWithoutRedundantIndexes, err := calculateTimeTakenForImport(colocatedTables,
+		sourceIndexMetadata, sourceIndexMetadata, colocatedLoadTimes, indexImpacts, columnImpacts, COLOCATED, 1.0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1477,8 +1504,11 @@ func TestCalculateTimeTakenForImport_ValidateImportTimeTableWithoutIndex250Colum
 	// Calculated as table0: 6.45 * ((1134 * 23) / 19) / 60
 	expectedTime := 148.0
 
-	if estimatedTime != expectedTime {
-		t.Errorf("calculateTimeTakenForImport() = (%v), want (%v)", estimatedTime, expectedTime)
+	if estimatedTimeWithAllIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() with all indexes = (%v), want (%v)", estimatedTimeWithAllIndexes, expectedTime)
+	}
+	if estimatedTimeWithoutRedundantIndexes != expectedTime {
+		t.Errorf("calculateTimeTakenForImport() without redundant indexes = (%v), want (%v)", estimatedTimeWithoutRedundantIndexes, expectedTime)
 	}
 
 }
@@ -2184,9 +2214,9 @@ func TestGetSourceMetadataWithRedundantIndexFiltering(t *testing.T) {
 		"schema_name", "object_name", "row_count", "reads_per_second", "writes_per_second",
 		"is_index", "parent_table_name", "size_in_bytes", "column_count",
 	}).
-		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5). // table
+		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5).        // table
 		AddRow("schema1", "idx1", nil, 5, 2, true, "schema1.table1", 512*1024*1024, 2). // index (should be filtered)
-		AddRow("schema1", "idx2", nil, 3, 1, true, "schema1.table1", 256*1024*1024, 1) // index (should remain)
+		AddRow("schema1", "idx2", nil, 3, 1, true, "schema1.table1", 256*1024*1024, 1)  // index (should remain)
 
 	mock.ExpectQuery(regexp.QuoteMeta(strings.ReplaceAll(metadataQuery, "\n\t\t", " "))).WillReturnRows(metadataRows)
 
@@ -2251,7 +2281,7 @@ func TestGetSourceMetadataWithRedundantIndexError(t *testing.T) {
 		"schema_name", "object_name", "row_count", "reads_per_second", "writes_per_second",
 		"is_index", "parent_table_name", "size_in_bytes", "column_count",
 	}).
-		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5). // table
+		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5).       // table
 		AddRow("schema1", "idx1", nil, 5, 2, true, "schema1.table1", 512*1024*1024, 2) // index
 
 	mock.ExpectQuery(regexp.QuoteMeta(strings.ReplaceAll(metadataQuery, "\n\t\t", " "))).WillReturnRows(metadataRows)

--- a/yb-voyager/src/migassessment/sizing_test.go
+++ b/yb-voyager/src/migassessment/sizing_test.go
@@ -106,7 +106,7 @@ func TestGetSourceMetadata_SuccessReadingSourceMetadata(t *testing.T) {
 	redundantIndexQuery := fmt.Sprintf(`SELECT redundant_schema_name, redundant_table_name, redundant_index_name FROM %s`, GetTableRedundantIndexesName())
 	mock.ExpectQuery(regexp.QuoteMeta(redundantIndexQuery)).WillReturnRows(redundantIndexRows)
 
-	sourceTableMetadata, sourceIndexMetadata, _, totalSourceDBSize, err := getSourceMetadata(db, &SourceDBType)
+	sourceTableMetadata, sourceIndexMetadata, _, totalSourceDBSize, err := getSourceMetadata(db, SourceDBType)
 	// assert if there are errors
 	assert.NoError(t, err)
 	// check if the total tables are equal to expected tables
@@ -127,7 +127,7 @@ func TestGetSourceMetadata_QueryErrorIfTableDoesNotExistOrColumnsUnavailable(t *
 	db, mock := createMockDB(t)
 	mock.ExpectQuery(AssessmentDbSelectQuery).WillReturnError(errors.New("query error"))
 
-	_, _, _, _, err := getSourceMetadata(db, &SourceDBType)
+	_, _, _, _, err := getSourceMetadata(db, SourceDBType)
 	assert.Error(t, err)
 	// check if the error returned contains the expected string
 	assert.Contains(t, err.Error(), "failed to query source metadata")
@@ -142,7 +142,7 @@ func TestGetSourceMetadata_RowScanError(t *testing.T) {
 		RowError(1, errors.New("row scan error"))
 	mock.ExpectQuery(AssessmentDbSelectQuery).WillReturnRows(rows)
 
-	_, _, _, _, err := getSourceMetadata(db, &SourceDBType)
+	_, _, _, _, err := getSourceMetadata(db, SourceDBType)
 	assert.Error(t, err)
 	// check if the error is as expected
 	assert.Contains(t, err.Error(), "failed to read from result set of query source metadata")
@@ -159,7 +159,7 @@ func TestGetSourceMetadata_NoRows(t *testing.T) {
 	redundantIndexQuery := fmt.Sprintf(`SELECT redundant_schema_name, redundant_table_name, redundant_index_name FROM %s`, GetTableRedundantIndexesName())
 	mock.ExpectQuery(regexp.QuoteMeta(redundantIndexQuery)).WillReturnRows(redundantIndexRows)
 
-	sourceTableMetadata, sourceIndexMetadata, _, totalSourceDBSize, err := getSourceMetadata(db, &SourceDBType)
+	sourceTableMetadata, sourceIndexMetadata, _, totalSourceDBSize, err := getSourceMetadata(db, SourceDBType)
 
 	assert.NoError(t, err)
 	//  since there is no mock data, all the fields are expected to be empty
@@ -1945,7 +1945,7 @@ func TestFetchRedundantIndexes(t *testing.T) {
 
 			// Execute the function
 			sourceDBType := constants.POSTGRESQL
-			result, err := getSourceMetadataRedundantIndexes(db, GetTableRedundantIndexesName(), &sourceDBType)
+			result, err := getSourceMetadataRedundantIndexes(db, GetTableRedundantIndexesName(), sourceDBType)
 
 			// Assert results
 			if tt.expectError {
@@ -1979,7 +1979,7 @@ func TestFetchRedundantIndexesQueryError(t *testing.T) {
 
 	// Execute the function
 	sourceDBType := constants.POSTGRESQL
-	result, err := getSourceMetadataRedundantIndexes(db, GetTableRedundantIndexesName(), &sourceDBType)
+	result, err := getSourceMetadataRedundantIndexes(db, GetTableRedundantIndexesName(), sourceDBType)
 
 	// Assert error
 	assert.Error(t, err)
@@ -2134,7 +2134,7 @@ func TestFilterRedundantIndexes(t *testing.T) {
 				SourceDBType = originalSourceDBType // Restore original value
 			}()
 
-			result := filterRedundantIndexes(tt.sourceIndexMetadata, tt.redundantIndexes, &SourceDBType)
+			result := filterRedundantIndexes(tt.sourceIndexMetadata, tt.redundantIndexes, SourceDBType)
 
 			// Assert the count of filtered indexes
 			assert.Equal(t, tt.expectedFilteredCount, len(result))
@@ -2184,9 +2184,9 @@ func TestGetSourceMetadataWithRedundantIndexFiltering(t *testing.T) {
 		"schema_name", "object_name", "row_count", "reads_per_second", "writes_per_second",
 		"is_index", "parent_table_name", "size_in_bytes", "column_count",
 	}).
-		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5).        // table
+		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5). // table
 		AddRow("schema1", "idx1", nil, 5, 2, true, "schema1.table1", 512*1024*1024, 2). // index (should be filtered)
-		AddRow("schema1", "idx2", nil, 3, 1, true, "schema1.table1", 256*1024*1024, 1)  // index (should remain)
+		AddRow("schema1", "idx2", nil, 3, 1, true, "schema1.table1", 256*1024*1024, 1) // index (should remain)
 
 	mock.ExpectQuery(regexp.QuoteMeta(strings.ReplaceAll(metadataQuery, "\n\t\t", " "))).WillReturnRows(metadataRows)
 
@@ -2201,7 +2201,7 @@ func TestGetSourceMetadataWithRedundantIndexFiltering(t *testing.T) {
 	mock.ExpectClose()
 
 	// Execute the function
-	tables, indexes, filteredIndexes, totalSize, err := getSourceMetadata(db, &SourceDBType)
+	tables, indexes, filteredIndexes, totalSize, err := getSourceMetadata(db, SourceDBType)
 
 	// Assert results
 	assert.NoError(t, err)
@@ -2251,7 +2251,7 @@ func TestGetSourceMetadataWithRedundantIndexError(t *testing.T) {
 		"schema_name", "object_name", "row_count", "reads_per_second", "writes_per_second",
 		"is_index", "parent_table_name", "size_in_bytes", "column_count",
 	}).
-		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5).       // table
+		AddRow("schema1", "table1", 1000, 10, 5, false, nil, 1024*1024*1024, 5). // table
 		AddRow("schema1", "idx1", nil, 5, 2, true, "schema1.table1", 512*1024*1024, 2) // index
 
 	mock.ExpectQuery(regexp.QuoteMeta(strings.ReplaceAll(metadataQuery, "\n\t\t", " "))).WillReturnRows(metadataRows)
@@ -2264,7 +2264,7 @@ func TestGetSourceMetadataWithRedundantIndexError(t *testing.T) {
 	mock.ExpectClose()
 
 	// Execute the function
-	tables, indexes, _, totalSize, err := getSourceMetadata(db, &SourceDBType)
+	tables, indexes, _, totalSize, err := getSourceMetadata(db, SourceDBType)
 
 	// Assert results - should continue despite redundant index error
 	assert.NoError(t, err)


### PR DESCRIPTION
### Describe the changes in this pull request
Currently, sizing calculator uses number of indexes on the table to calculate the increase in import time. Import time increases with increase in number of indexes on the table. However, there are cases when the indexes are redundant/duplicate i.e. same set of columns used to create multiple indexes on the same table.
In such cases, import time is not really affected. Hence, sizing calculator needs to be updated to exclude such indexes from import time calculation.

- added code to read ```redundant_indexes``` table
- added code to create a slice which contain only unique indexes(filtered out redundant indexes) ```sourceUniqueIndexeMetadata``` . This filters out based on following match ```sourceSchema.tableName.IndexName == redundantIndexSchema.redundantIndexTableName.redundantIndexName```
- pass down sourceDBType to sizing calculator as it is required for using some functions from utils.
- For now, we're only using this uniqueSourceIndexMetadata for calculating multiplicationFactorWrtNumIndexes.
- Added estimated time for import without redundant indexes in assessment report json, html template. 
- Added unit testss
- Fixed/updated existing integration tests with the new field.
- updated callhome slice to include the new field.

### Respective JIRA: https://yugabyte.atlassian.net/browse/DB-18025 and github task: https://github.com/yugabyte/yb-voyager/issues/2983 
### Describe if there are any user-facing changes
NA
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
CI jobs + unit tests
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  Yes |
| Callhome Json                                             |  Yes |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
