### PR TITLE
Add primary key recommendation for tables with UNIQUE NOT NULL columns

### DIFF
--- a/yb-voyager/cmd/analyzeSchema.go
+++ b/yb-voyager/cmd/analyzeSchema.go
@@ -1152,8 +1152,12 @@ func checkerMisc(detectPerfOptimizationIssues bool) {
 	if detectPerfOptimizationIssues {
 		fkIssues := parserIssueDetector.DetectMissingForeignKeyIndexes()
 
+		// Detect PK recommendation when UNIQUE+NOT NULL exists but PK is missing
+		pkRecs := parserIssueDetector.DetectPrimaryKeyRecommendations()
+
 		// Convert QueryIssues to AnalyzeSchemaIssues and add to report
-		for _, issue := range fkIssues {
+		issues := append(fkIssues, pkRecs...)
+		for _, issue := range issues {
 			analyzeIssue := convertIssueInstanceToAnalyzeIssue(issue, "", false, true)
 			schemaAnalysisReport.Issues = append(schemaAnalysisReport.Issues, analyzeIssue)
 		}

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -1115,6 +1115,7 @@ func fetchUnsupportedPGFeaturesFromSchemaReport(schemaAnalysisReport utils.Schem
 	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.HOTSPOTS_ON_TIMESTAMP_PK_UK_ISSUE, "", queryissue.HOTSPOTS_ON_TIMESTAMP_PK_UK, schemaAnalysisReport, false))
 	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.FOREIGN_KEY_DATATYPE_MISMATCH_ISSUE_NAME, "", queryissue.FOREIGN_KEY_DATATYPE_MISMATCH, schemaAnalysisReport, false))
 	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.MISSING_FOREIGN_KEY_INDEX_ISSUE_NAME, "", queryissue.MISSING_FOREIGN_KEY_INDEX, schemaAnalysisReport, false))
+	unsupportedFeatures = append(unsupportedFeatures, getUnsupportedFeaturesFromSchemaAnalysisReport(queryissue.MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_ISSUE_NAME, "", queryissue.MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL, schemaAnalysisReport, false))
 
 	return lo.Filter(unsupportedFeatures, func(f UnsupportedFeature, _ int) bool {
 		return len(f.Objects) > 0

--- a/yb-voyager/cmd/callhome_payload_builder.go
+++ b/yb-voyager/cmd/callhome_payload_builder.go
@@ -245,6 +245,26 @@ func anonymizeIssueDetailsForCallhome(details map[string]interface{}) map[string
 			} else {
 				anonymizedDetails[key] = value
 			}
+		} else if key == "PrimaryKeyColumnOptions" {
+			if pkOptions, ok := value.([][]string); ok {
+				var anonymizedOptions [][]string
+				for _, option := range pkOptions {
+					var anonymizedOption []string
+					for _, columnName := range option {
+						anonymizedColumn, err := anonymizer.AnonymizeQualifiedColumnName(columnName)
+						if err != nil {
+							log.Warnf("failed to anonymize PK column name %s: %v", columnName, err)
+							anonymizedOption = append(anonymizedOption, "column_xxx")
+						} else {
+							anonymizedOption = append(anonymizedOption, anonymizedColumn)
+						}
+					}
+					anonymizedOptions = append(anonymizedOptions, anonymizedOption)
+				}
+				anonymizedDetails[key] = anonymizedOptions
+			} else {
+				anonymizedDetails[key] = value
+			}
 		} else {
 			// Non-sensitive keys are kept as-is
 			anonymizedDetails[key] = value

--- a/yb-voyager/src/query/queryissue/constants.go
+++ b/yb-voyager/src/query/queryissue/constants.go
@@ -477,7 +477,7 @@ Note: If the table is created as colocated, this hotspot concern can safely be i
 	// Recommend PK when UNIQUE + all NOT NULL but no PK exists
 	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL             = "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL"
 	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_ISSUE_NAME  = "Missing primary key for table when unique and not null columns exist"
-	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_DESCRIPTION = "PostgreSQL's table storage is heap-oriented, however, YugabyteDB's table storage is index-oriented. So, a table without a primary key is viable in PostgreSQL but isn't in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures."
+	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_DESCRIPTION = "YugabyteDB's table storage is index-oriented. So, a table without a primary key is not viable in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures."
 )
 
 // Object types

--- a/yb-voyager/src/query/queryissue/constants.go
+++ b/yb-voyager/src/query/queryissue/constants.go
@@ -476,8 +476,8 @@ Note: If the table is created as colocated, this hotspot concern can safely be i
 
 	// Recommend PK when UNIQUE + all NOT NULL but no PK exists
 	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL             = "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL"
-	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_ISSUE_NAME  = "Recommend adding primary key on unique NOT NULL column(s)"
-	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_DESCRIPTION = "Table has a UNIQUE constraint on column(s) that are all NOT NULL but does not define a PRIMARY KEY. Consider creating a primary key on these column(s) to improve data integrity and performance."
+	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_ISSUE_NAME  = "Missing primary key for table when unique and not null columns exist"
+	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_DESCRIPTION = "PostgreSQL's table storage is heap-oriented, however, YugabyteDB's table storage is index-oriented. So, a table without a primary key is viable in PostgreSQL but isn't in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures."
 )
 
 // Object types

--- a/yb-voyager/src/query/queryissue/constants.go
+++ b/yb-voyager/src/query/queryissue/constants.go
@@ -473,6 +473,11 @@ Note: If the table is created as colocated, this hotspot concern can safely be i
 
 	MISSING_FOREIGN_KEY_INDEX_ISSUE_NAME  = "Missing index on foreign key columns"
 	MISSING_FOREIGN_KEY_INDEX_DESCRIPTION = "Foreign key columns do not have a proper index. The index must include all foreign key columns as leading columns (either in exact order, any permutation, or as a prefix of a composite index). This can cause performance issues during DML operations on the referenced table."
+
+	// Recommend PK when UNIQUE + all NOT NULL but no PK exists
+	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL             = "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL"
+	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_ISSUE_NAME  = "Recommend adding primary key on unique NOT NULL column(s)"
+	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_DESCRIPTION = "Table has a UNIQUE constraint on column(s) that are all NOT NULL but does not define a PRIMARY KEY. Consider creating a primary key on these column(s) to improve data integrity and performance."
 )
 
 // Object types

--- a/yb-voyager/src/query/queryissue/detectors_ddl.go
+++ b/yb-voyager/src/query/queryissue/detectors_ddl.go
@@ -129,7 +129,7 @@ func (d *TableIssueDetector) DetectIssues(obj queryparser.DDLObject) ([]QueryIss
 					obj.GetObjectType(),
 					table.GetObjectName(),
 					c.Columns,
-					d.tableMetadata,
+					d.tablesMetadata,
 					&issues,
 				)
 
@@ -285,9 +285,9 @@ func (d *TableIssueDetector) DetectIssues(obj queryparser.DDLObject) ([]QueryIss
 	return issues, nil
 }
 
-func detectForeignKeyDatatypeMismatch(objectType string, objectName string, columnList []string, tableMetadata map[string]*TableMetadata, issues *[]QueryIssue) {
+func detectForeignKeyDatatypeMismatch(objectType string, objectName string, columnList []string, tablesMetadata map[string]*TableMetadata, issues *[]QueryIssue) {
 	for _, col := range columnList {
-		tm, ok := tableMetadata[objectName]
+		tm, ok := tablesMetadata[objectName]
 		if !ok {
 			continue
 		}
@@ -1058,7 +1058,7 @@ func (aid *AlterTableIssueDetector) DetectIssues(obj queryparser.DDLObject) ([]Q
 				obj.GetObjectType(),
 				alter.GetObjectName(),
 				alter.ConstraintColumns,
-				aid.tableMetadata,
+				aid.tablesMetadata,
 				&issues,
 			)
 

--- a/yb-voyager/src/query/queryissue/issues_perf.go
+++ b/yb-voyager/src/query/queryissue/issues_perf.go
@@ -18,6 +18,7 @@ package queryissue
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/samber/lo"
 
@@ -235,4 +236,22 @@ func NewMissingForeignKeyIndexIssue(objectType string, objectName string, sqlSta
 	}
 
 	return newQueryIssue(issue, objectType, objectName, sqlStatement, details)
+}
+
+// NewMissingPrimaryKeyWhenUniqueNotNullIssue returns a recommendation to add a PK when a UNIQUE constraint's columns are all NOT NULL
+var missingPrimaryKeyWhenUniqueNotNullIssue = issue.Issue{
+	Name:        MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_ISSUE_NAME,
+	Type:        MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL,
+	Impact:      constants.IMPACT_LEVEL_1,
+	Description: MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL_DESCRIPTION,
+	DocsLink:    "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+}
+
+func NewMissingPrimaryKeyWhenUniqueNotNullIssue(objectType string, objectName string, columns []string) QueryIssue {
+	issue := missingPrimaryKeyWhenUniqueNotNullIssue
+	details := map[string]interface{}{
+		"ColumnNames":  strings.Join(columns, ", "),
+		"SuggestedDDL": fmt.Sprintf("ALTER TABLE %s ADD PRIMARY KEY (%s)", objectName, strings.Join(columns, ", ")),
+	}
+	return newQueryIssue(issue, objectType, objectName, "", details)
 }

--- a/yb-voyager/src/query/queryissue/issues_perf.go
+++ b/yb-voyager/src/query/queryissue/issues_perf.go
@@ -18,7 +18,6 @@ package queryissue
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/samber/lo"
 
@@ -247,11 +246,10 @@ var missingPrimaryKeyWhenUniqueNotNullIssue = issue.Issue{
 	DocsLink:    "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
 }
 
-func NewMissingPrimaryKeyWhenUniqueNotNullIssue(objectType string, objectName string, columns []string) QueryIssue {
+func NewMissingPrimaryKeyWhenUniqueNotNullIssue(objectType string, objectName string, options [][]string) QueryIssue {
 	issue := missingPrimaryKeyWhenUniqueNotNullIssue
 	details := map[string]interface{}{
-		"ColumnNames":  strings.Join(columns, ", "),
-		"SuggestedDDL": fmt.Sprintf("ALTER TABLE %s ADD PRIMARY KEY (%s)", objectName, strings.Join(columns, ", ")),
+		"PrimaryKeyColumnOptions": options,
 	}
 	return newQueryIssue(issue, objectType, objectName, "", details)
 }

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -489,7 +489,7 @@ func (p *ParserIssueDetector) ParseAndProcessDDL(query string) error {
 				p.tableUniqueConstraints[qualifiedTable] = append(p.tableUniqueConstraints[qualifiedTable], append([]string{}, alter.ConstraintColumns...))
 			}
 		}
-		// Track NOT NULL alters (multiple subcommands supported)
+		// Track NOT NULL alter commands
 		if len(alter.SetNotNullColumns) > 0 {
 			qualifiedTable := alter.GetObjectName()
 			if _, ok := p.tableNotNullColumns[qualifiedTable]; !ok {

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -935,7 +935,13 @@ func (p *ParserIssueDetector) DetectPrimaryKeyRecommendations() []QueryIssue {
 			if !allNN {
 				continue
 			}
-			options = append(options, cols)
+
+			// Create fully qualified column names for this option
+			qualifiedCols := make([]string, len(cols))
+			for i, col := range cols {
+				qualifiedCols[i] = fmt.Sprintf("%s.%s", table, col)
+			}
+			options = append(options, qualifiedCols)
 		}
 		if len(options) > 0 {
 			issues = append(issues, NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", table, options))

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -614,22 +614,21 @@ func (p *ParserIssueDetector) ParseAndProcessDDL(query string) error {
 			}
 		}
 		// Track NOT NULL alter commands
+		// TODO:
+		// Currently we are not processing if there are multiple columns under multiple alter commands in the same query
+		// Add support for this
 		if len(alter.SetNotNullColumns) > 0 {
 			qualifiedTable := alter.GetObjectName()
 			tm := p.getOrCreateTableMetadata(qualifiedTable)
-			for _, col := range alter.SetNotNullColumns {
-				if colMeta, exists := tm.Columns[col]; exists {
-					colMeta.IsNotNull = true
-				}
+			if colMeta, exists := tm.Columns[alter.SetNotNullColumns]; exists {
+				colMeta.IsNotNull = true
 			}
 		}
 		if len(alter.DropNotNullColumns) > 0 {
 			qualifiedTable := alter.GetObjectName()
 			tm := p.getOrCreateTableMetadata(qualifiedTable)
-			for _, col := range alter.DropNotNullColumns {
-				if colMeta, exists := tm.Columns[col]; exists {
-					colMeta.IsNotNull = false
-				}
+			if colMeta, exists := tm.Columns[alter.DropNotNullColumns]; exists {
+				colMeta.IsNotNull = false
 			}
 		}
 

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -1023,6 +1023,8 @@ func (p *ParserIssueDetector) DetectPrimaryKeyRecommendations() []QueryIssue {
 	var issues []QueryIssue
 
 	// Skip for partitioned or inherited tables, as PK rules differ
+	// TODO: Remove this skip and add a proper check for PK rules: the columns suggested should contain the partition key columns
+	// https://yugabyte.atlassian.net/browse/DB-18077
 	shouldSkip := func(table string) bool {
 		partitionedTables := p.getPartitionedTablesMap()
 		partitionedFrom := p.getPartitionedFrom()
@@ -1050,6 +1052,9 @@ func (p *ParserIssueDetector) DetectPrimaryKeyRecommendations() []QueryIssue {
 
 		// Collect all qualifying UNIQUE column sets where all columns are NOT NULL
 		var options [][]string
+		// Currently we only detect PK recommendations for UNIQUE constraints
+		// TODO: We should also consider UNIQUE INDEXES for PK recommendations
+		// https://yugabyte.atlassian.net/browse/DB-18078
 		for _, uniqueCols := range tm.GetUniqueConstraints() {
 			allNN := true
 			for _, col := range uniqueCols {

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -921,8 +921,9 @@ func (p *ParserIssueDetector) DetectPrimaryKeyRecommendations() []QueryIssue {
 			continue // PK already present
 		}
 		notNulls := p.tableNotNullColumns[table]
-		// Find the smallest qualifying UNIQUE column set
-		var best []string
+
+		// Collect all qualifying UNIQUE column sets
+		var options [][]string
 		for _, cols := range uLists {
 			allNN := true
 			for _, c := range cols {
@@ -934,13 +935,10 @@ func (p *ParserIssueDetector) DetectPrimaryKeyRecommendations() []QueryIssue {
 			if !allNN {
 				continue
 			}
-			if len(best) == 0 || len(cols) < len(best) {
-				best = cols
-			}
+			options = append(options, cols)
 		}
-		if len(best) > 0 {
-			// Create recommendation
-			issues = append(issues, NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", table, best))
+		if len(options) > 0 {
+			issues = append(issues, NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", table, options))
 		}
 	}
 	return issues

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -617,17 +617,17 @@ func (p *ParserIssueDetector) ParseAndProcessDDL(query string) error {
 		// TODO:
 		// Currently we are not processing if there are multiple columns under multiple alter commands in the same query
 		// Add support for this
-		if len(alter.SetNotNullColumns) > 0 {
+		if alter.SetNotNullColumn != "" {
 			qualifiedTable := alter.GetObjectName()
 			tm := p.getOrCreateTableMetadata(qualifiedTable)
-			if colMeta, exists := tm.Columns[alter.SetNotNullColumns]; exists {
+			if colMeta, exists := tm.Columns[alter.SetNotNullColumn]; exists {
 				colMeta.IsNotNull = true
 			}
 		}
-		if len(alter.DropNotNullColumns) > 0 {
+		if alter.DropNotNullColumn != "" {
 			qualifiedTable := alter.GetObjectName()
 			tm := p.getOrCreateTableMetadata(qualifiedTable)
-			if colMeta, exists := tm.Columns[alter.DropNotNullColumns]; exists {
+			if colMeta, exists := tm.Columns[alter.DropNotNullColumn]; exists {
 				colMeta.IsNotNull = false
 			}
 		}

--- a/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
@@ -2425,14 +2425,14 @@ func runPKRec(t *testing.T, name string, ddls []string, expected []QueryIssue) {
 		expS := pkrecSort(expected)
 
 		// Print test name and recommendations for debugging
-		fmt.Printf("\n=== Test: %s ===\n", name)
-		if len(gotS) == 0 {
-			fmt.Printf("No recommendations\n")
-		} else {
-			for i, rec := range gotS {
-				fmt.Printf("Recommendation %d: %+v\n", i+1, rec)
-			}
-		}
+		// fmt.Printf("\n=== Test: %s ===\n", name)
+		// if len(gotS) == 0 {
+		// 	fmt.Printf("No recommendations\n")
+		// } else {
+		// 	for i, rec := range gotS {
+		// 		fmt.Printf("Recommendation %d: %+v\n", i+1, rec)
+		// 	}
+		// }
 
 		if diff := cmp.Diff(expS, gotS); diff != "" {
 			t.Fatalf("PK recommendations mismatch (-want +got):\n%s\nExpected (objects): %s\nActual   (objects): %s\nExpected (pretty):  %s\nActual   (pretty):  %s", diff, z(expS), z(gotS), pkrecString(expS), pkrecString(gotS))

--- a/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
@@ -2449,12 +2449,12 @@ func TestPKRec_CommonRunner(t *testing.T) {
 		{
 			name:     "PKREC: Simple UNIQUE(a) with a NOT NULL, no PK",
 			ddls:     []string{`CREATE TABLE t1 (a int NOT NULL, b text, UNIQUE(a));`},
-			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t1", [][]string{{"a"}})},
+			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t1", [][]string{{"t1.a"}})},
 		},
 		{
 			name:     "PKREC: Composite UNIQUE(a,b) both NOT NULL",
 			ddls:     []string{`CREATE TABLE t2 (a int NOT NULL, b text NOT NULL, c text, UNIQUE(a,b));`},
-			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t2", [][]string{{"a", "b"}})},
+			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t2", [][]string{{"t2.a", "t2.b"}})},
 		},
 		{
 			name: "PKREC: Multiple ALTER SET NOT NULL then UNIQUE(a,b)",
@@ -2463,7 +2463,7 @@ func TestPKRec_CommonRunner(t *testing.T) {
 				`ALTER TABLE t3 ALTER COLUMN a SET NOT NULL, ALTER COLUMN b SET NOT NULL;`,
 				`ALTER TABLE t3 ADD CONSTRAINT uq_t3 UNIQUE (a,b);`,
 			},
-			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t3", [][]string{{"a", "b"}})},
+			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t3", [][]string{{"t3.a", "t3.b"}})},
 		},
 		{
 			name: "PKREC: DROP NOT NULL cancels composite UNIQUE(a,b)",
@@ -2483,7 +2483,7 @@ func TestPKRec_CommonRunner(t *testing.T) {
 		{
 			name:     "PKREC: Aggregate all qualifying UNIQUE sets",
 			ddls:     []string{`CREATE TABLE t6 (a int NOT NULL, b int NOT NULL, UNIQUE(a,b), UNIQUE(a));`},
-			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t6", [][]string{{"a"}, {"a", "b"}})},
+			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t6", [][]string{{"t6.a"}, {"t6.a", "t6.b"}})},
 		},
 		{
 			name:     "PKREC: UNIQUE with nullable column -> no recommendation",

--- a/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
@@ -2416,7 +2416,8 @@ func TestPKRec_CommonRunner(t *testing.T) {
 			name: "PKREC: Multiple ALTER SET NOT NULL then UNIQUE(a,b)",
 			ddls: []string{
 				`CREATE TABLE t3 (a int, b int);`,
-				`ALTER TABLE t3 ALTER COLUMN a SET NOT NULL, ALTER COLUMN b SET NOT NULL;`,
+				`ALTER TABLE t3 ALTER COLUMN a SET NOT NULL;`,
+				`ALTER TABLE t3 ALTER COLUMN b SET NOT NULL;`,
 				`ALTER TABLE t3 ADD CONSTRAINT uq_t3 UNIQUE (a,b);`,
 			},
 			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "t3", [][]string{{"t3.a", "t3.b"}})},
@@ -2425,7 +2426,8 @@ func TestPKRec_CommonRunner(t *testing.T) {
 			name: "PKREC: DROP NOT NULL cancels composite UNIQUE(a,b)",
 			ddls: []string{
 				`CREATE TABLE t4 (a int, b int);`,
-				`ALTER TABLE t4 ALTER COLUMN a SET NOT NULL, ALTER COLUMN b SET NOT NULL;`,
+				`ALTER TABLE t4 ALTER COLUMN a SET NOT NULL;`,
+				`ALTER TABLE t4 ALTER COLUMN b SET NOT NULL;`,
 				`ALTER TABLE t4 ALTER COLUMN b DROP NOT NULL;`,
 				`ALTER TABLE t4 ADD CONSTRAINT uq_t4 UNIQUE (a,b);`,
 			},

--- a/yb-voyager/src/query/queryissue/query_issue.go
+++ b/yb-voyager/src/query/queryissue/query_issue.go
@@ -78,6 +78,7 @@ var PerformanceOptimizationIssues = []string{
 	HOTSPOTS_ON_TIMESTAMP_PK_UK,
 	FOREIGN_KEY_DATATYPE_MISMATCH,
 	MISSING_FOREIGN_KEY_INDEX,
+	MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL,
 }
 
 var UnsupportedSystemColumnsIssueTypes = []string{

--- a/yb-voyager/src/query/queryparser/ddl_processor.go
+++ b/yb-voyager/src/query/queryparser/ddl_processor.go
@@ -757,112 +757,113 @@ func (atProcessor *AlterTableProcessor) Process(parseTree *pg_query.ParseResult)
 	alter := &AlterTable{
 		SchemaName: alterNode.AlterTableStmt.Relation.Schemaname,
 		TableName:  alterNode.AlterTableStmt.Relation.Relname,
+		AlterType:  alterNode.AlterTableStmt.Cmds[0].GetAlterTableCmd().GetSubtype(),
 	}
 
-	// Alter statements can have multiple subcommands, so we need to parse all of them
+	// TODO: Alter statements can have multiple subcommands, but currently we are only processing the first one
 	// Example:
 	// ALTER TABLE ONLY public.device_events
 	// ALTER COLUMN device_id SET NOT NULL;
 	// ALTER COLUMN device_name DROP NOT NULL;
 	// ALTER COLUMN device_type SET NOT NULL;
-	// Parse all alter commands; retain subtype of the first cmd for AlterType
-	cmds := alterNode.AlterTableStmt.Cmds
-	if len(cmds) == 0 {
-		return alter, nil
-	}
-	alter.AlterType = cmds[0].GetAlterTableCmd().GetSubtype()
+	// Add support for multiple alter commands in the same query
 
-	for idx, node := range cmds {
-		cmd := node.GetAlterTableCmd()
-		switch cmd.GetSubtype() {
-		case pg_query.AlterTableType_AT_SetOptions:
+	// Parse specific alter command
+	cmd := alterNode.AlterTableStmt.Cmds[0].GetAlterTableCmd()
+	switch alter.AlterType {
+	case pg_query.AlterTableType_AT_SetOptions:
+		/*
+			e.g. alter table test_1 alter column col1 set (attribute_option=value);
+			cmds:{alter_table_cmd:{subtype:AT_SetOptions name:"col1" def:{list:{items:{def_elem:{defname:"attribute_option"
+			arg:{type_name:{names:{string:{sval:"value"}} typemod:-1 location:263}} defaction:DEFELEM_UNSPEC location:246}}}}...
+
+			for set attribute issue we will the type of alter setting the options and in the 'def' definition field which has the
+			information of the type, we will check if there is any list which will only present in case there is syntax like <SubTYPE> (...)
+		*/
+		alter.NumSetAttributes = len(cmd.GetDef().GetList().GetItems())
+	case pg_query.AlterTableType_AT_AddConstraint:
+		alter.NumStorageOptions = len(cmd.GetDef().GetConstraint().GetOptions())
+		/*
+			e.g.
+				ALTER TABLE example2
+					ADD CONSTRAINT example2_pkey PRIMARY KEY (id);
+				tmts:{stmt:{alter_table_stmt:{relation:{relname:"example2"  inh:true  relpersistence:"p"  location:693}
+				cmds:{alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_PRIMARY  conname:"example2_pkey"
+				location:710  keys:{string:{sval:"id"}}}}  behavior:DROP_RESTRICT}}  objtype:OBJECT_TABLE}}  stmt_location:679  stmt_len:72}
+
+			e.g. ALTER TABLE ONLY public.meeting ADD CONSTRAINT no_time_overlap EXCLUDE USING gist (room_id WITH =, time_range WITH &&);
+			cmds:{alter_table_cmd:{subtype:AT_AddConstraint def:{constraint:{contype:CONSTR_EXCLUSION conname:"no_time_overlap" location:41
+			here again same checking the definition of the alter stmt if it has constraint and checking its type
+
+			e.g. ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE (email) DEFERRABLE;
+			alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_UNIQUE  conname:"users_email_key"
+			deferrable:true  location:196  keys:{string:{sval:"email"}}}}  behavior:DROP_RESTRICT}}  objtype:OBJECT_TABLE}}
+
+			similar to CREATE table 2nd case where constraint is at the end of column definitions mentioning the constraint only
+			so here as well while adding constraint checking the type of constraint and the deferrable field of it.
+
+			ALTER TABLE test ADD CONSTRAINT chk check (id<>'') NOT VALID;
+			stmts:{stmt:...subtype:AT_AddConstraint def:{constraint:{contype:CONSTR_CHECK conname:"chk" location:22
+			raw_expr:{a_expr:{kind:AEXPR_OP name:{string:{sval:"<>"}} lexpr:{column_ref:{fields:{string:{sval:"id"}} location:43}} rexpr:{a_const:{sval:{}
+			location:47}} location:45}} skip_validation:true}} behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:60}
+		*/
+		constraint := cmd.GetDef().GetConstraint()
+		alter.ConstraintType = constraint.Contype
+		alter.ConstraintName = constraint.Conname
+		alter.IsDeferrable = constraint.Deferrable
+		alter.ConstraintNotValid = constraint.SkipValidation // this is set for the NOT VALID clause
+		alter.ConstraintColumns = parseColumnsFromKeys(constraint.GetKeys())
+		if alter.ConstraintType == FOREIGN_CONSTR_TYPE {
 			/*
-				e.g. alter table test_1 alter column col1 set (attribute_option=value);
-				cmds:{alter_table_cmd:{subtype:AT_SetOptions name:"col1" def:{list:{items:{def_elem:{defname:"attribute_option"
-				arg:{type_name:{names:{string:{sval:"value"}} typemod:-1 location:263}} defaction:DEFELEM_UNSPEC location:246}}}}...
-
-				for set attribute issue we will the type of alter setting the options and in the 'def' definition field which has the
-				information of the type, we will check if there is any list which will only present in case there is syntax like <SubTYPE> (...)
+				alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_FOREIGN  conname:"fk"  initially_valid:true
+				pktable:{schemaname:"schema1"  relname:"abc"  inh:true  relpersistence:"p"
+				In case of FKs the reference table is in PKTable field and columns are in FkAttrs
 			*/
-			// only consider the first occurrence for counters; harmless if repeated
-			if idx == 0 {
-				alter.NumSetAttributes = len(cmd.GetDef().GetList().GetItems())
-			}
-		case pg_query.AlterTableType_AT_AddConstraint:
-			if idx == 0 {
-				/*
-					e.g.
-						ALTER TABLE example2
-							ADD CONSTRAINT example2_pkey PRIMARY KEY (id);
-						tmts:{stmt:{alter_table_stmt:{relation:{relname:"example2"  inh:true  relpersistence:"p"  location:693}
-						cmds:{alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_PRIMARY  conname:"example2_pkey"
-						location:710  keys:{string:{sval:"id"}}}}  behavior:DROP_RESTRICT}}  objtype:OBJECT_TABLE}}  stmt_location:679  stmt_len:72}
-
-					e.g. ALTER TABLE ONLY public.meeting ADD CONSTRAINT no_time_overlap EXCLUDE USING gist (room_id WITH =, time_range WITH &&);
-					cmds:{alter_table_cmd:{subtype:AT_AddConstraint def:{constraint:{contype:CONSTR_EXCLUSION conname:"no_time_overlap" location:41
-					here again same checking the definition of the alter stmt if it has constraint and checking its type
-
-					e.g. ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE (email) DEFERRABLE;
-					alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_UNIQUE  conname:"users_email_key"
-					deferrable:true  location:196  keys:{string:{sval:"email"}}}}  behavior:DROP_RESTRICT}}  objtype:OBJECT_TABLE}}
-
-					similar to CREATE table 2nd case where constraint is at the end of column definitions mentioning the constraint only
-					so here as well while adding constraint checking the type of constraint and the deferrable field of it.
-
-					ALTER TABLE test ADD CONSTRAINT chk check (id<>'') NOT VALID;
-					stmts:{stmt:...subtype:AT_AddConstraint def:{constraint:{contype:CONSTR_CHECK conname:"chk" location:22
-					raw_expr:{a_expr:{kind:AEXPR_OP name:{string:{sval:"<>"}} lexpr:{column_ref:{fields:{string:{sval:"id"}} location:43}} rexpr:{a_const:{sval:{}}
-					location:47}} location:45}} skip_validation:true}} behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:60}
-				*/
-				alter.NumStorageOptions = len(cmd.GetDef().GetConstraint().GetOptions())
-			}
-			constraint := cmd.GetDef().GetConstraint()
-			alter.ConstraintType = constraint.Contype
-			alter.ConstraintName = constraint.Conname
-			alter.IsDeferrable = constraint.Deferrable
-			alter.ConstraintNotValid = constraint.SkipValidation // this is set for the NOT VALID clause
-			alter.ConstraintColumns = parseColumnsFromKeys(constraint.GetKeys())
-			if alter.ConstraintType == FOREIGN_CONSTR_TYPE {
-				/*
-					alter_table_cmd:{subtype:AT_AddConstraint  def:{constraint:{contype:CONSTR_FOREIGN  conname:"fk"  initially_valid:true
-					pktable:{schemaname:"schema1"  relname:"abc"  inh:true  relpersistence:"p"
-					In case of FKs the reference table is in PKTable field and columns are in FkAttrs
-				*/
-				alter.ConstraintColumns = parseColumnsFromKeys(constraint.FkAttrs)
-				alter.ConstraintReferencedTable = utils.BuildObjectName(constraint.Pktable.Schemaname, constraint.Pktable.Relname)
-				alter.ConstraintReferencedColumns = parseColumnsFromKeys(constraint.PkAttrs)
-			}
-		case pg_query.AlterTableType_AT_DisableRule:
-			/*
-				e.g. ALTER TABLE example DISABLE example_rule;
-				cmds:{alter_table_cmd:{subtype:AT_DisableRule name:"example_rule" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}}
-				checking the subType is sufficient in this case
-			*/
-			alter.RuleName = cmd.Name
-		case pg_query.AlterTableType_AT_AttachPartition:
-			/*
-				e.g. ALTER TABLE ONLY public.device_events ATTACH PARTITION public.device_events_june2024 FOR VALUES FROM ('2024-06-01 00:00:00+00') TO ('2024-07-01 00:00:00+00');
-				stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events_pkey" inh:true relpersistence:"p" location:12}
-				cmds:{alter_table_cmd:{subtype:AT_AttachPartition def:{partition_cmd:{name:{schemaname:"public" relname:"device_events_june2024_pkey" inh:true relpersistence:"p" location:55}}}behavior:DROP_RESTRICT}} objtype:OBJECT_INDEX}} stmt_len:89
-			*/
-			partitionCmd := cmd.GetDef().GetPartitionCmd()
-			partitionChildTable := partitionCmd.GetName()
-			alter.PartitionedChild = utils.BuildObjectName(partitionChildTable.Schemaname, partitionChildTable.Relname)
-		case pg_query.AlterTableType_AT_SetNotNull:
-			/*
-				e.g. ALTER TABLE ONLY public.device_events ALTER COLUMN device_id SET NOT NULL;
-				stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events" inh:true relpersistence:"p" location:12}
-				cmds:{alter_table_cmd:{subtype:AT_SetNotNull name:"device_id" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:40}
-			*/
-			alter.SetNotNullColumns = append(alter.SetNotNullColumns, cmd.Name)
-		case pg_query.AlterTableType_AT_DropNotNull:
-			/*
-				e.g. ALTER TABLE ONLY public.device_events ALTER COLUMN device_id DROP NOT NULL;
-				stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events" inh:true relpersistence:"p" location:12}
-				cmds:{alter_table_cmd:{subtype:AT_DropNotNull name:"device_id" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:40}
-			*/
-			alter.DropNotNullColumns = append(alter.DropNotNullColumns, cmd.Name)
+			alter.ConstraintColumns = parseColumnsFromKeys(constraint.FkAttrs)
+			alter.ConstraintReferencedTable = utils.BuildObjectName(constraint.Pktable.Schemaname, constraint.Pktable.Relname)
+			alter.ConstraintReferencedColumns = parseColumnsFromKeys(constraint.PkAttrs)
 		}
+
+	case pg_query.AlterTableType_AT_DisableRule:
+		/*
+			e.g. ALTER TABLE example DISABLE example_rule;
+			cmds:{alter_table_cmd:{subtype:AT_DisableRule name:"example_rule" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}}
+			checking the subType is sufficient in this case
+		*/
+		alter.RuleName = cmd.Name
+		//case CLUSTER ON
+		/*
+			e.g. ALTER TABLE example CLUSTER ON idx;
+			stmt:{alter_table_stmt:{relation:{relname:"example" inh:true relpersistence:"p" location:13}
+			cmds:{alter_table_cmd:{subtype:AT_ClusterOn name:"idx" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:32
+
+		*/
+
+	case pg_query.AlterTableType_AT_AttachPartition:
+		/*
+			e.g. ALTER TABLE ONLY public.device_events ATTACH PARTITION public.device_events_june2024 FOR VALUES FROM ('2024-06-01 00:00:00+00') TO ('2024-07-01 00:00:00+00');
+			stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events_pkey" inh:true relpersistence:"p" location:12}
+			cmds:{alter_table_cmd:{subtype:AT_AttachPartition def:{partition_cmd:{name:{schemaname:"public" relname:"device_events_june2024_pkey" inh:true relpersistence:"p" location:55}}}behavior:DROP_RESTRICT}} objtype:OBJECT_INDEX}} stmt_len:89
+		*/
+		partitionCmd := cmd.GetDef().GetPartitionCmd()
+		partitionChildTable := partitionCmd.GetName()
+		alter.PartitionedChild = utils.BuildObjectName(partitionChildTable.Schemaname, partitionChildTable.Relname)
+
+	case pg_query.AlterTableType_AT_SetNotNull:
+		/*
+			e.g. ALTER TABLE ONLY public.device_events ALTER COLUMN device_id SET NOT NULL;
+			stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events" inh:true relpersistence:"p" location:12}
+			cmds:{alter_table_cmd:{subtype:AT_SetNotNull name:"device_id" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:40}
+		*/
+		alter.SetNotNullColumns = cmd.Name
+
+	case pg_query.AlterTableType_AT_DropNotNull:
+		/*
+			e.g. ALTER TABLE ONLY public.device_events ALTER COLUMN device_id DROP NOT NULL;
+			stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events" inh:true relpersistence:"p" location:12}
+			cmds:{alter_table_cmd:{subtype:AT_DropNotNull name:"device_id" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:40}
+		*/
+		alter.DropNotNullColumns = cmd.Name
 	}
 
 	return alter, nil
@@ -886,8 +887,8 @@ type AlterTable struct {
 	ConstraintColumns           []string
 	PartitionedChild            string // In case this is a partitioned table
 	// In case the ALTER TABLE contains multiple subcommands, collect all SET/DROP NOT NULL columns
-	SetNotNullColumns  []string
-	DropNotNullColumns []string
+	SetNotNullColumns  string
+	DropNotNullColumns string
 }
 
 func (a *AlterTable) GetObjectName() string {

--- a/yb-voyager/src/query/queryparser/ddl_processor.go
+++ b/yb-voyager/src/query/queryparser/ddl_processor.go
@@ -855,7 +855,7 @@ func (atProcessor *AlterTableProcessor) Process(parseTree *pg_query.ParseResult)
 			stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events" inh:true relpersistence:"p" location:12}
 			cmds:{alter_table_cmd:{subtype:AT_SetNotNull name:"device_id" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:40}
 		*/
-		alter.SetNotNullColumns = cmd.Name
+		alter.SetNotNullColumn = cmd.Name
 
 	case pg_query.AlterTableType_AT_DropNotNull:
 		/*
@@ -863,7 +863,7 @@ func (atProcessor *AlterTableProcessor) Process(parseTree *pg_query.ParseResult)
 			stmt:{alter_table_stmt:{relation:{schemaname:"public" relname:"device_events" inh:true relpersistence:"p" location:12}
 			cmds:{alter_table_cmd:{subtype:AT_DropNotNull name:"device_id" behavior:DROP_RESTRICT}} objtype:OBJECT_TABLE}} stmt_len:40}
 		*/
-		alter.DropNotNullColumns = cmd.Name
+		alter.DropNotNullColumn = cmd.Name
 	}
 
 	return alter, nil
@@ -887,8 +887,8 @@ type AlterTable struct {
 	ConstraintColumns           []string
 	PartitionedChild            string // In case this is a partitioned table
 	// In case the ALTER TABLE contains multiple subcommands, collect all SET/DROP NOT NULL columns
-	SetNotNullColumns  string
-	DropNotNullColumns string
+	SetNotNullColumn  string
+	DropNotNullColumn string
 }
 
 func (a *AlterTable) GetObjectName() string {


### PR DESCRIPTION
### Describe the changes in this pull request
This PR adds a new performance issue detection that recommends adding primary keys to tables with UNIQUE constraints on NOT NULL columns but no primary key defined.

The system now detects when a table has UNIQUE constraints on NOT NULL columns without a primary key and generates a performance recommendation to add a primary key on those columns. 

Changes include:
- Enhanced DDL parser to track NOT NULL constraints from CREATE TABLE and ALTER TABLE
- Added logic to analyze UNIQUE constraints and their column nullability  
- Implemented PK recommendation engine for qualifying UNIQUE NOT NULL columns
- Added comprehensive unit tests for various scenarios

<img width="2352" height="1690" alt="image" src="https://github.com/user-attachments/assets/8755ab59-8602-450a-a6fc-f943cff11918" />

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
New MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL performance issues will be reported in the assessment report.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
Yeah payload for the new issue:

```{\"category\":\"performance_optimizations\",\"category_description\":\"Recommendations to source schema or queries to optimize performance on YugabyteDB.\",\"type\":\"MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL\",\"name\":\"Recommend adding primary key on unique NOT NULL column(s)\",\"impact\":\"LEVEL_1\",\"object_type\":\"TABLE\",\"object_name\":\"\",\"details\":{\"PrimaryKeyColumnOptions\":[[\"schema_c5fe28962969d6b5.table_686a32fed783ef0a.col_6f5d29e3c494e279\"]]}}```

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
