### PR TITLE
Fix mgi and rna tests for some miss in PR #2896

### DIFF
--- a/migtests/tests/pg/mgi/replacement_dir/tables/INDEXES_table.sql
+++ b/migtests/tests/pg/mgi/replacement_dir/tables/INDEXES_table.sql
@@ -158,15 +158,11 @@ CREATE INDEX all_cre_cache_idx_celltype_term_key ON mgd.all_cre_cache USING btre
 
 CREATE INDEX all_cre_cache_idx_clustered ON mgd.all_cre_cache USING btree (_allele_key ASC, _emapa_term_key, _stage_key, _assay_key, expressed);
 
-ALTER TABLE mgd.all_cre_cache CLUSTER ON all_cre_cache_idx_clustered;
-
 CREATE INDEX all_cre_cache_idx_emapa_term_key ON mgd.all_cre_cache USING btree (_emapa_term_key ASC);
 
 CREATE INDEX all_cre_cache_idx_stage_key ON mgd.all_cre_cache USING btree (_stage_key ASC);
 
 CREATE INDEX all_knockout_cache_idx_clustered ON mgd.all_knockout_cache USING btree (_allele_key ASC);
-
-ALTER TABLE mgd.all_knockout_cache CLUSTER ON all_knockout_cache_idx_clustered;
 
 CREATE UNIQUE INDEX all_knockout_cache_idx_marker_key ON mgd.all_knockout_cache USING btree (_marker_key ASC);
 

--- a/migtests/tests/pg/rna/expected_files/expected_failed.sql
+++ b/migtests/tests/pg/rna/expected_files/expected_failed.sql
@@ -2318,13 +2318,13 @@ CREATE INDEX "xref_p27_deleted$last" ON rnacen.xref_p27_deleted USING btree (las
 ERROR: relation "rnacen.xref_p27_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p27_deleted$taxid" ON rnacen.xref_p27_deleted USING btree (taxid);
+CREATE INDEX "xref_p27_deleted$taxid" ON rnacen.xref_p27_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p27_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p27_deleted$upi" ON rnacen.xref_p27_deleted USING btree (upi);
+CREATE INDEX "xref_p27_deleted$upi" ON rnacen.xref_p27_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p27_not_deleted" does not exist (SQLSTATE 42P01)

--- a/migtests/tests/pg/rna/expected_files/expected_failed.sql
+++ b/migtests/tests/pg/rna/expected_files/expected_failed.sql
@@ -1022,13 +1022,13 @@ CREATE INDEX "xref_p10_deleted$last" ON rnacen.xref_p10_deleted USING btree (las
 ERROR: relation "rnacen.xref_p10_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p10_deleted$taxid" ON rnacen.xref_p10_deleted USING btree (taxid);
+CREATE INDEX "xref_p10_deleted$taxid" ON rnacen.xref_p10_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p10_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p10_deleted$upi" ON rnacen.xref_p10_deleted USING btree (upi);
+CREATE INDEX "xref_p10_deleted$upi" ON rnacen.xref_p10_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p10_not_deleted" does not exist (SQLSTATE 42P01)
@@ -1958,13 +1958,13 @@ CREATE INDEX "xref_p22_deleted$last" ON rnacen.xref_p22_deleted USING btree (las
 ERROR: relation "rnacen.xref_p22_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p22_deleted$taxid" ON rnacen.xref_p22_deleted USING btree (taxid);
+CREATE INDEX "xref_p22_deleted$taxid" ON rnacen.xref_p22_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p22_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p22_deleted$upi" ON rnacen.xref_p22_deleted USING btree (upi);
+CREATE INDEX "xref_p22_deleted$upi" ON rnacen.xref_p22_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p22_not_deleted" does not exist (SQLSTATE 42P01)
@@ -1994,13 +1994,13 @@ CREATE INDEX "xref_p22_not_deleted$last" ON rnacen.xref_p22_not_deleted USING bt
 ERROR: relation "rnacen.xref_p22_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p22_not_deleted$taxid" ON rnacen.xref_p22_not_deleted USING btree (taxid);
+CREATE INDEX "xref_p22_not_deleted$taxid" ON rnacen.xref_p22_not_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p22_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p22_not_deleted$upi" ON rnacen.xref_p22_not_deleted USING btree (upi);
+CREATE INDEX "xref_p22_not_deleted$upi" ON rnacen.xref_p22_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p23_deleted" does not exist (SQLSTATE 42P01)
@@ -2390,13 +2390,13 @@ CREATE INDEX "xref_p28_deleted$last" ON rnacen.xref_p28_deleted USING btree (las
 ERROR: relation "rnacen.xref_p28_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p28_deleted$taxid" ON rnacen.xref_p28_deleted USING btree (taxid);
+CREATE INDEX "xref_p28_deleted$taxid" ON rnacen.xref_p28_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p28_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p28_deleted$upi" ON rnacen.xref_p28_deleted USING btree (upi);
+CREATE INDEX "xref_p28_deleted$upi" ON rnacen.xref_p28_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p28_not_deleted" does not exist (SQLSTATE 42P01)
@@ -2426,13 +2426,13 @@ CREATE INDEX "xref_p28_not_deleted$last" ON rnacen.xref_p28_not_deleted USING bt
 ERROR: relation "rnacen.xref_p28_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p28_not_deleted$taxid" ON rnacen.xref_p28_not_deleted USING btree (taxid);
+CREATE INDEX "xref_p28_not_deleted$taxid" ON rnacen.xref_p28_not_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p28_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p28_not_deleted$upi" ON rnacen.xref_p28_not_deleted USING btree (upi);
+CREATE INDEX "xref_p28_not_deleted$upi" ON rnacen.xref_p28_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p29_deleted" does not exist (SQLSTATE 42P01)
@@ -2462,13 +2462,13 @@ CREATE INDEX "xref_p29_deleted$last" ON rnacen.xref_p29_deleted USING btree (las
 ERROR: relation "rnacen.xref_p29_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p29_deleted$taxid" ON rnacen.xref_p29_deleted USING btree (taxid);
+CREATE INDEX "xref_p29_deleted$taxid" ON rnacen.xref_p29_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p29_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p29_deleted$upi" ON rnacen.xref_p29_deleted USING btree (upi);
+CREATE INDEX "xref_p29_deleted$upi" ON rnacen.xref_p29_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p29_not_deleted" does not exist (SQLSTATE 42P01)
@@ -2498,13 +2498,13 @@ CREATE INDEX "xref_p29_not_deleted$last" ON rnacen.xref_p29_not_deleted USING bt
 ERROR: relation "rnacen.xref_p29_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p29_not_deleted$taxid" ON rnacen.xref_p29_not_deleted USING btree (taxid);
+CREATE INDEX "xref_p29_not_deleted$taxid" ON rnacen.xref_p29_not_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p29_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p29_not_deleted$upi" ON rnacen.xref_p29_not_deleted USING btree (upi);
+CREATE INDEX "xref_p29_not_deleted$upi" ON rnacen.xref_p29_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p2_deleted" does not exist (SQLSTATE 42P01)
@@ -4622,13 +4622,13 @@ CREATE INDEX "xref_p5_deleted$last" ON rnacen.xref_p5_deleted USING btree (last 
 ERROR: relation "rnacen.xref_p5_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p5_deleted$taxid" ON rnacen.xref_p5_deleted USING btree (taxid);
+CREATE INDEX "xref_p5_deleted$taxid" ON rnacen.xref_p5_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p5_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p5_deleted$upi" ON rnacen.xref_p5_deleted USING btree (upi);
+CREATE INDEX "xref_p5_deleted$upi" ON rnacen.xref_p5_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p5_not_deleted" does not exist (SQLSTATE 42P01)
@@ -4658,13 +4658,13 @@ CREATE INDEX "xref_p5_not_deleted$last" ON rnacen.xref_p5_not_deleted USING btre
 ERROR: relation "rnacen.xref_p5_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p5_not_deleted$taxid" ON rnacen.xref_p5_not_deleted USING btree (taxid);
+CREATE INDEX "xref_p5_not_deleted$taxid" ON rnacen.xref_p5_not_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p5_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p5_not_deleted$upi" ON rnacen.xref_p5_not_deleted USING btree (upi);
+CREATE INDEX "xref_p5_not_deleted$upi" ON rnacen.xref_p5_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p6_deleted" does not exist (SQLSTATE 42P01)

--- a/migtests/tests/pg/rna/expected_files/expected_failed.sql
+++ b/migtests/tests/pg/rna/expected_files/expected_failed.sql
@@ -1025,12 +1025,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p10_deleted$taxid" ON rnacen.xref_p10_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p10_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p10_deleted$upi" ON rnacen.xref_p10_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p10_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -1059,12 +1053,6 @@ ERROR: relation "rnacen.xref_p10_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p10_not_deleted$taxid" ON rnacen.xref_p10_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p10_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p10_not_deleted$upi" ON rnacen.xref_p10_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p11_deleted" does not exist (SQLSTATE 42P01)
@@ -1159,7 +1147,7 @@ CREATE INDEX "xref_p12_deleted$dbid" ON rnacen.xref_p12_deleted USING btree (dbi
 /*
 ERROR: relation "rnacen.xref_p12_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/  
+*/
 CREATE INDEX "xref_p12_deleted$last" ON rnacen.xref_p12_deleted USING btree (last ASC);
 
 /*
@@ -1241,12 +1229,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p13_deleted$taxid" ON rnacen.xref_p13_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p13_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p13_deleted$upi" ON rnacen.xref_p13_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p13_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -1275,12 +1257,6 @@ ERROR: relation "rnacen.xref_p13_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p13_not_deleted$taxid" ON rnacen.xref_p13_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p13_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p13_not_deleted$upi" ON rnacen.xref_p13_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p14_deleted" does not exist (SQLSTATE 42P01)
@@ -1673,12 +1649,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p19_deleted$taxid" ON rnacen.xref_p19_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p19_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p19_deleted$upi" ON rnacen.xref_p19_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p19_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -1707,12 +1677,6 @@ ERROR: relation "rnacen.xref_p19_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p19_not_deleted$taxid" ON rnacen.xref_p19_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p19_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p19_not_deleted$upi" ON rnacen.xref_p19_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p1_deleted" does not exist (SQLSTATE 42P01)
@@ -1889,12 +1853,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p21_deleted$taxid" ON rnacen.xref_p21_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p21_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p21_deleted$upi" ON rnacen.xref_p21_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p21_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -1923,12 +1881,6 @@ ERROR: relation "rnacen.xref_p21_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p21_not_deleted$taxid" ON rnacen.xref_p21_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p21_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p21_not_deleted$upi" ON rnacen.xref_p21_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p22_deleted" does not exist (SQLSTATE 42P01)
@@ -1961,12 +1913,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p22_deleted$taxid" ON rnacen.xref_p22_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p22_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p22_deleted$upi" ON rnacen.xref_p22_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p22_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -1995,12 +1941,6 @@ ERROR: relation "rnacen.xref_p22_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p22_not_deleted$taxid" ON rnacen.xref_p22_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p22_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p22_not_deleted$upi" ON rnacen.xref_p22_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p23_deleted" does not exist (SQLSTATE 42P01)
@@ -2321,12 +2261,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p27_deleted$taxid" ON rnacen.xref_p27_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p27_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p27_deleted$upi" ON rnacen.xref_p27_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p27_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -2354,13 +2288,7 @@ CREATE INDEX "xref_p27_not_deleted$last" ON rnacen.xref_p27_not_deleted USING bt
 ERROR: relation "rnacen.xref_p27_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
-CREATE INDEX "xref_p27_not_deleted$taxid" ON rnacen.xref_p27_not_deleted USING btree (taxid);
-
-/*
-ERROR: relation "rnacen.xref_p27_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p27_not_deleted$upi" ON rnacen.xref_p27_not_deleted USING btree (upi);
+CREATE INDEX "xref_p27_not_deleted$taxid" ON rnacen.xref_p27_not_deleted USING btree (taxid ASC);
 
 /*
 ERROR: relation "rnacen.xref_p28_deleted" does not exist (SQLSTATE 42P01)
@@ -2393,12 +2321,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p28_deleted$taxid" ON rnacen.xref_p28_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p28_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p28_deleted$upi" ON rnacen.xref_p28_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p28_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -2427,12 +2349,6 @@ ERROR: relation "rnacen.xref_p28_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p28_not_deleted$taxid" ON rnacen.xref_p28_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p28_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p28_not_deleted$upi" ON rnacen.xref_p28_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p29_deleted" does not exist (SQLSTATE 42P01)
@@ -2465,12 +2381,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p29_deleted$taxid" ON rnacen.xref_p29_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p29_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p29_deleted$upi" ON rnacen.xref_p29_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p29_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -2499,12 +2409,6 @@ ERROR: relation "rnacen.xref_p29_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p29_not_deleted$taxid" ON rnacen.xref_p29_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p29_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p29_not_deleted$upi" ON rnacen.xref_p29_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p2_deleted" does not exist (SQLSTATE 42P01)
@@ -4625,12 +4529,6 @@ File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/IND
 CREATE INDEX "xref_p5_deleted$taxid" ON rnacen.xref_p5_deleted USING btree (taxid ASC);
 
 /*
-ERROR: relation "rnacen.xref_p5_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p5_deleted$upi" ON rnacen.xref_p5_deleted USING btree (upi ASC);
-
-/*
 ERROR: relation "rnacen.xref_p5_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
@@ -4659,12 +4557,6 @@ ERROR: relation "rnacen.xref_p5_not_deleted" does not exist (SQLSTATE 42P01)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
 */
 CREATE INDEX "xref_p5_not_deleted$taxid" ON rnacen.xref_p5_not_deleted USING btree (taxid ASC);
-
-/*
-ERROR: relation "rnacen.xref_p5_not_deleted" does not exist (SQLSTATE 42P01)
-File :/home/ubuntu/yb-voyager/migtests/tests/pg/rna/export-dir/schema/tables/INDEXES_table.sql
-*/
-CREATE INDEX "xref_p5_not_deleted$upi" ON rnacen.xref_p5_not_deleted USING btree (upi ASC);
 
 /*
 ERROR: relation "rnacen.xref_p6_deleted" does not exist (SQLSTATE 42P01)


### PR DESCRIPTION
### Describe the changes in this pull request
jenkins https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/6041/

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
