### PR TITLE
[DB-18036]: Add a provision to provide a specific salt for anonymisation to enable testing

### DIFF
--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -531,6 +531,20 @@ func initAnonymizer(metaDBInstance *metadb.MetaDB) error {
 }
 
 func loadOrGenerateAnonymisationSalt(metaDB *metadb.MetaDB) (string, error) {
+	// Check test deterministic anonymization mode
+	enableDet := utils.GetEnvAsBool("VOYAGER_ENABLE_DETERMINISTIC_ANON", false)
+	testSalt := os.Getenv("VOYAGER_TEST_ANON_SALT")
+
+	if enableDet {
+		if testSalt == "" {
+			return "", errors.New("VOYAGER_ENABLE_DETERMINISTIC_ANON is set but VOYAGER_TEST_ANON_SALT is empty")
+		}
+
+		log.Warn("Deterministic anonymization is enabled using a test salt")
+		fmt.Printf("Warning: Deterministic anonymization is enabled using a test salt\n")
+		return testSalt, nil
+	}
+
 	msr, err := metaDB.GetMigrationStatusRecord()
 	if err != nil {
 		return "", fmt.Errorf("error getting migration status record: %w", err)


### PR DESCRIPTION
### Describe the changes in this pull request

- to enable determinisitic anonymization for test, you need to set two env vars
- bool var:   VOYAGER_ENABLE_DETERMINISTIC_ANON as true
- string var: VOYAGER_TEST_ANON_SALT with actual salt as string


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
NA

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
To be done manually. cc @shubham-yb 

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
