### PR TITLE
Fix: send source password to assess-migration run internally in export schema if its not set via cli flag

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -375,9 +375,8 @@ func IsMigrationAssessmentDoneViaExportSchema() (bool, error) {
 
 func ClearMigrationAssessmentDone() error {
 	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-		if record.MigrationAssessmentDone {
-			record.MigrationAssessmentDone = false
-		}
+		record.MigrationAssessmentDone = false
+		record.MigrationAssessmentDoneViaExportSchema = false
 	})
 	if err != nil {
 		return fmt.Errorf("failed to clear migration status record with migration assessment done flag: %w", err)

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -240,10 +240,15 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 
 	var assessFlagsWithValues []string
 	commonFlags := utils.GetCommonFlags(exportSchemaCmd, assessMigrationCmd)
+	isSourcePasswordSetViaFlag := false
 	for _, flag := range commonFlags {
 		// don't pass start-clean flag to assess-migration command here
 		if flag.Name == "start-clean" || !flag.Changed {
 			continue
+		}
+
+		if flag.Name == "source-db-password" && flag.Changed {
+			isSourcePasswordSetViaFlag = true
 		}
 
 		// bool flags: --flag=value
@@ -258,6 +263,12 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 				flag.Value.String(),
 			)
 		}
+	}
+
+	if !isSourcePasswordSetViaFlag {
+		assessFlagsWithValues = append(assessFlagsWithValues,
+			"--source-db-password", source.Password,
+		)
 	}
 
 	// Append --yes=true(irrespective) at the end to override any --yes=false if set in export schema cmd

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -246,8 +246,8 @@ func runAssessMigrationCmdBeforExportSchemaIfRequired(exportSchemaCmd *cobra.Com
 			continue
 		}
 
-		if flag.Name == "source-db-password" && flag.Changed {
-			//Setting it in env variable
+		if flag.Name == "source-db-password" {
+			//Skip this flag to set in cli completely and set it in env variable only
 			continue
 		}
 


### PR DESCRIPTION
1. Clear migration flags from the migration status record on cleanup.

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
