### PR TITLE
Refactor PK recommendation logic to properly handle partitioned tables

### DIFF
--- a/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
@@ -2,7 +2,7 @@
 	"VoyagerVersion": "main",
 	"TargetDBVersion": "2024.2.2.3",
 	"MigrationComplexity": "LOW",
-	"MigrationComplexityExplanation": "Found 14 Level 1 issue(s) and 0 Level 2 issue(s), resulting in LOW migration complexity",
+	"MigrationComplexityExplanation": "Found 19 Level 1 issue(s) and 0 Level 2 issue(s), resulting in LOW migration complexity",
 	"SchemaSummary": {
 		"Description": "Objects that will be created on the target YugabyteDB.",
 		"DbName": "pg_assessment_perf_optimizations",
@@ -20,9 +20,9 @@
 			},
 			{
 				"ObjectType": "TABLE",
-				"TotalCount": 10,
-				"InvalidCount": 0,
-				"ObjectNames": "public.tbl, public.\"Test_caseSensitive\", public.t, public.test_low_card, public.test_most_freq, public.test_multi_col_idx, public.users, test.t, test.t_low_most, test.test_mostcomm_status"
+				"TotalCount": 36,
+				"InvalidCount": 5,
+				"ObjectNames": "public.\"Test_caseSensitive\", public.parent_partitioned, public.child_partition_skipped, public.has_pk_already, public.multiple_unique_options, public.no_pk_nullable, public.no_pk_table, public.partitioned_multiple_unique, public.partitioned_multiple_unique_2023, public.partitioned_multiple_unique_2023_us, public.partitioned_no_pk, public.partitioned_no_pk_2023, public.partitioned_no_pk_2023_us, public.partitioned_no_unique, public.partitioned_no_unique_2023, public.partitioned_no_unique_2023_us, public.sales_hierarchy, public.sales_hierarchy_2023, public.sales_hierarchy_2023_q1, public.sales_hierarchy_2023_q1_us, public.sales_hierarchy_no_unique, public.sales_hierarchy_no_unique_2023, public.sales_hierarchy_no_unique_2023_q1, public.sales_hierarchy_no_unique_2023_q1_us, public.sales_with_mid_pk, public.sales_with_mid_pk_2024, public.sales_with_mid_pk_2024_asia, public.t, public.tbl, public.test_low_card, public.test_most_freq, public.test_multi_col_idx, public.users, test.t, test.t_low_most, test.test_mostcomm_status"
 			},
 			{
 				"ObjectType": "INDEX",
@@ -41,17 +41,28 @@
 	"Sizing": {
 		"SizingRecommendation": {
 			"ColocatedTables": [
+				"public.partitioned_no_unique_2023_us",
+				"public.sales_with_mid_pk_2024_asia",
 				"public.test_low_card",
+				"public.partitioned_multiple_unique_2023_us",
+				"public.no_pk_table",
+				"public.child_partition_skipped",
+				"public.sales_hierarchy_no_unique_2023_q1_us",
+				"public.partitioned_no_pk_2023_us",
+				"public.sales_hierarchy_2023_q1_us",
+				"public.has_pk_already",
 				"public.Test_caseSensitive",
-				"test.t_low_most",
+				"public.no_pk_nullable",
 				"test.test_mostcomm_status",
-				"test.t",
 				"public.t",
+				"test.t_low_most",
+				"test.t",
 				"public.users",
 				"public.tbl"
 			],
-			"ColocatedReasoning": "Recommended instance type with 4 vCPU and 16 GiB memory could fit 13 objects (6 tables/materialized views and 7 explicit/implicit indexes) with 1.25 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Rest 12 objects (2 tables/materialized views and 10 explicit/implicit indexes) with 13.05 MB size and throughput requirement of 0 reads/sec and 0 writes/sec need to be migrated as range partitioned tables. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.",
+			"ColocatedReasoning": "Recommended instance type with 4 vCPU and 16 GiB memory could fit 39 objects (18 tables/materialized views and 21 explicit/implicit indexes) with 0.00 MB size and throughput requirement of 0 reads/sec and 0 writes/sec as colocated. Rest 16 objects (3 tables/materialized views and 13 explicit/implicit indexes) with 0.73 MB size and throughput requirement of 0 reads/sec and 0 writes/sec need to be migrated as range partitioned tables. Non leaf partition tables/indexes and unsupported tables/indexes were not considered.",
 			"ShardedTables": [
+				"public.multiple_unique_options",
 				"public.test_most_freq",
 				"public.test_multi_col_idx"
 			],
@@ -306,44 +317,287 @@
 				"ColumnName": "val1",
 				"FrequencyOfNulls": "50%"
 			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL",
+			"Name": "Missing primary key for table when unique and not null columns exist",
+			"Description": "YugabyteDB's table storage is index-oriented. So, a table without a primary key is not viable in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "public.no_pk_table",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"PrimaryKeyColumnOptions": [
+					[
+						"public.no_pk_table.id",
+						"public.no_pk_table.name"
+					]
+				]
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL",
+			"Name": "Missing primary key for table when unique and not null columns exist",
+			"Description": "YugabyteDB's table storage is index-oriented. So, a table without a primary key is not viable in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "public.partitioned_multiple_unique",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"PrimaryKeyColumnOptions": [
+					[
+						"public.partitioned_multiple_unique.id",
+						"public.partitioned_multiple_unique.region",
+						"public.partitioned_multiple_unique.year",
+						"public.partitioned_multiple_unique.quarter"
+					],
+					[
+						"public.partitioned_multiple_unique.id",
+						"public.partitioned_multiple_unique.year",
+						"public.partitioned_multiple_unique.region",
+						"public.partitioned_multiple_unique.quarter"
+					]
+				]
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL",
+			"Name": "Missing primary key for table when unique and not null columns exist",
+			"Description": "YugabyteDB's table storage is index-oriented. So, a table without a primary key is not viable in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "public.partitioned_no_pk",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"PrimaryKeyColumnOptions": [
+					[
+						"public.partitioned_no_pk.id",
+						"public.partitioned_no_pk.region",
+						"public.partitioned_no_pk.year"
+					]
+				]
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL",
+			"Name": "Missing primary key for table when unique and not null columns exist",
+			"Description": "YugabyteDB's table storage is index-oriented. So, a table without a primary key is not viable in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "public.multiple_unique_options",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"PrimaryKeyColumnOptions": [
+					[
+						"public.multiple_unique_options.email"
+					],
+					[
+						"public.multiple_unique_options.id",
+						"public.multiple_unique_options.name"
+					],
+					[
+						"public.multiple_unique_options.phone",
+						"public.multiple_unique_options.name"
+					]
+				]
+			}
+		},
+		{
+			"Category": "performance_optimizations",
+			"CategoryDescription": "Recommendations to source schema or queries to optimize performance on YugabyteDB.",
+			"Type": "MISSING_PRIMARY_KEY_WHEN_UNIQUE_NOT_NULL",
+			"Name": "Missing primary key for table when unique and not null columns exist",
+			"Description": "YugabyteDB's table storage is index-oriented. So, a table without a primary key is not viable in YugabyteDB. If you don't specify a primary key, YugabyteDB will use the internal ybrowid column as PRIMARY KEY and the table will be sharded on ybrowid HASH. However, if there are candidate primary keys (unique + NOT NULL), it is recommended to define them as a Primary Key to avoid secondary index structures.",
+			"Impact": "LEVEL_1",
+			"ObjectType": "TABLE",
+			"ObjectName": "public.sales_hierarchy",
+			"SqlStatement": "",
+			"DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+			"MinimumVersionsFixedIn": null,
+			"Details": {
+				"PrimaryKeyColumnOptions": [
+					[
+						"public.sales_hierarchy.id",
+						"public.sales_hierarchy.region",
+						"public.sales_hierarchy.year",
+						"public.sales_hierarchy.quarter"
+					]
+				]
+			}
 		}
 	],
 	"TableIndexStats": [
 		{
 			"SchemaName": "public",
-			"ObjectName": "t",
-			"RowCount": 20000,
-			"ColumnCount": 2,
+			"ObjectName": "no_pk_table",
+			"RowCount": 100,
+			"ColumnCount": 3,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
 			"IsIndex": false,
 			"ObjectType": "table",
 			"ParentTableName": null,
-			"SizeInBytes": 655360
+			"SizeInBytes": 8192
 		},
 		{
 			"SchemaName": "public",
-			"ObjectName": "idx_name1",
-			"RowCount": null,
+			"ObjectName": "no_pk_nullable",
+			"RowCount": 100,
+			"ColumnCount": 3,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "partitioned_no_pk_2023_us",
+			"RowCount": 100,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "multiple_unique_options",
+			"RowCount": 100,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "test_multi_col_idx",
+			"RowCount": 10000,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 524288
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "partitioned_no_unique_2023_us",
+			"RowCount": 50,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "partitioned_multiple_unique_2023_us",
+			"RowCount": 40,
+			"ColumnCount": 5,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "tbl",
+			"RowCount": 1000,
 			"ColumnCount": 1,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.users",
-			"SizeInBytes": 16384
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 40960
 		},
 		{
 			"SchemaName": "public",
-			"ObjectName": "test_most_freq",
-			"RowCount": 20000,
+			"ObjectName": "sales_hierarchy_no_unique_2023_q1_us",
+			"RowCount": 30,
+			"ColumnCount": 5,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "users",
+			"RowCount": 1000,
+			"ColumnCount": 3,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 40960
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "t",
+			"RowCount": 500,
 			"ColumnCount": 2,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
 			"IsIndex": false,
 			"ObjectType": "table",
 			"ParentTableName": null,
-			"SizeInBytes": 786432
+			"SizeInBytes": 24576
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "Test_caseSensitive",
+			"RowCount": 100,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "sales_hierarchy_2023_q1_us",
+			"RowCount": 50,
+			"ColumnCount": 5,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
 		},
 		{
 			"SchemaName": "public",
@@ -359,32 +613,8 @@
 		},
 		{
 			"SchemaName": "public",
-			"ObjectName": "test_multi_col_idx",
-			"RowCount": 200004,
-			"ColumnCount": 4,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": false,
-			"ObjectType": "table",
-			"ParentTableName": null,
-			"SizeInBytes": 5636096
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "users",
-			"RowCount": 20000,
-			"ColumnCount": 3,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": false,
-			"ObjectType": "table",
-			"ParentTableName": null,
-			"SizeInBytes": 655360
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "Test_caseSensitive",
-			"RowCount": 200,
+			"ObjectName": "test_most_freq",
+			"RowCount": 100,
 			"ColumnCount": 2,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
@@ -394,10 +624,34 @@
 			"SizeInBytes": 8192
 		},
 		{
-			"SchemaName": "test",
-			"ObjectName": "t_low_most",
-			"RowCount": 200,
-			"ColumnCount": 2,
+			"SchemaName": "public",
+			"ObjectName": "child_partition_skipped",
+			"RowCount": 60,
+			"ColumnCount": 3,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "sales_with_mid_pk_2024_asia",
+			"RowCount": 60,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": false,
+			"ObjectType": "table",
+			"ParentTableName": null,
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "has_pk_already",
+			"RowCount": 75,
+			"ColumnCount": 3,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
 			"IsIndex": false,
@@ -408,265 +662,37 @@
 		{
 			"SchemaName": "test",
 			"ObjectName": "t",
-			"RowCount": 4,
+			"RowCount": 500,
 			"ColumnCount": 3,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
 			"IsIndex": false,
 			"ObjectType": "table",
 			"ParentTableName": null,
-			"SizeInBytes": 8192
+			"SizeInBytes": 24576
 		},
 		{
-			"SchemaName": "public",
-			"ObjectName": "idx_test_case_sensitive",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.Test_caseSensitive",
-			"SizeInBytes": 16384
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idxtt",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.t",
-			"SizeInBytes": 90112
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_low_card",
-			"SizeInBytes": 16384
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "tbl",
-			"RowCount": 2000,
-			"ColumnCount": 1,
+			"SchemaName": "test",
+			"ObjectName": "t_low_most",
+			"RowCount": 500,
+			"ColumnCount": 2,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
 			"IsIndex": false,
 			"ObjectType": "table",
 			"ParentTableName": null,
-			"SizeInBytes": 40960
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_try",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.tbl",
-			"SizeInBytes": 16384
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "indx34",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_most_freq",
-			"SizeInBytes": 245760
+			"SizeInBytes": 24576
 		},
 		{
 			"SchemaName": "test",
 			"ObjectName": "test_mostcomm_status",
-			"RowCount": 200,
+			"RowCount": 100,
 			"ColumnCount": 2,
 			"ReadsPerSecond": 0,
 			"WritesPerSecond": 0,
 			"IsIndex": false,
 			"ObjectType": "table",
 			"ParentTableName": null,
-			"SizeInBytes": 8192
-		},
-		{
-			"SchemaName": "test",
-			"ObjectName": "idx_normal",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "test.test_mostcomm_status",
-			"SizeInBytes": 16384
-		},
-		{
-			"SchemaName": "test",
-			"ObjectName": "idx_partial_high",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "test.test_mostcomm_status",
-			"SizeInBytes": 16384
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "indx1",
-			"RowCount": null,
-			"ColumnCount": 2,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_most_freq",
-			"SizeInBytes": 335872
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "indx",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_most_freq",
-			"SizeInBytes": 16384
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_test_multi_val",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_multi_col_idx",
-			"SizeInBytes": 704512
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_test_multi_id2",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_multi_col_idx",
-			"SizeInBytes": 712704
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_test_multi_id1_id2",
-			"RowCount": null,
-			"ColumnCount": 2,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_multi_col_idx",
-			"SizeInBytes": 745472
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_test_multi_id1",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_multi_col_idx",
-			"SizeInBytes": 745472
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_test_multi_id",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_multi_col_idx",
-			"SizeInBytes": 2260992
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_muli_col_key_first_col1",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_multi_col_idx",
-			"SizeInBytes": 745472
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_muli_col_key_first_col",
-			"RowCount": null,
-			"ColumnCount": 2,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.test_multi_col_idx",
-			"SizeInBytes": 761856
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idx_name",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.users",
-			"SizeInBytes": 90112
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "users_pkey",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "primary key",
-			"ParentTableName": "public.users",
-			"SizeInBytes": 245760
-		},
-		{
-			"SchemaName": "public",
-			"ObjectName": "idxtt1",
-			"RowCount": null,
-			"ColumnCount": 1,
-			"ReadsPerSecond": 0,
-			"WritesPerSecond": 0,
-			"IsIndex": true,
-			"ObjectType": "index",
-			"ParentTableName": "public.t",
 			"SizeInBytes": 8192
 		},
 		{
@@ -703,6 +729,414 @@
 			"IsIndex": true,
 			"ObjectType": "index",
 			"ParentTableName": "test.t_low_most",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "test",
+			"ObjectName": "idx_normal",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "test.test_mostcomm_status",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "test",
+			"ObjectName": "idx_partial_high",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "test.test_mostcomm_status",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_try",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.tbl",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "no_pk_table_id_name_key",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.no_pk_table",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_test_case_sensitive",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.Test_caseSensitive",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idxtt1",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.t",
+			"SizeInBytes": 8192
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idxtt",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.t",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_low_card",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "partitioned_multiple_unique_2023_us_id_year_region_quarter_key",
+			"RowCount": null,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.partitioned_multiple_unique_2023_us",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "partitioned_multiple_unique_2023_us_id_region_year_quarter_key",
+			"RowCount": null,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.partitioned_multiple_unique_2023_us",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "indx34",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_most_freq",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "indx1",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_most_freq",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "indx",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_most_freq",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_test_multi_val",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_multi_col_idx",
+			"SizeInBytes": 90112
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_test_multi_id2",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_multi_col_idx",
+			"SizeInBytes": 90112
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_test_multi_id1_id2",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_multi_col_idx",
+			"SizeInBytes": 90112
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_test_multi_id1",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_multi_col_idx",
+			"SizeInBytes": 90112
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_test_multi_id",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_multi_col_idx",
+			"SizeInBytes": 245760
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_muli_col_key_first_col1",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_multi_col_idx",
+			"SizeInBytes": 90112
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_muli_col_key_first_col",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.test_multi_col_idx",
+			"SizeInBytes": 90112
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_name1",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.users",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "idx_name",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.users",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "users_pkey",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "primary key",
+			"ParentTableName": "public.users",
+			"SizeInBytes": 40960
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "no_pk_nullable_id_name_key",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.no_pk_nullable",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "has_pk_already_name_key",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.has_pk_already",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "has_pk_already_pkey",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "primary key",
+			"ParentTableName": "public.has_pk_already",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "child_partition_skipped_id_region_key",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.child_partition_skipped",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "partitioned_no_pk_2023_us_id_region_year_key",
+			"RowCount": null,
+			"ColumnCount": 3,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.partitioned_no_pk_2023_us",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "sales_hierarchy_2023_q1_us_id_region_year_quarter_key",
+			"RowCount": null,
+			"ColumnCount": 4,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.sales_hierarchy_2023_q1_us",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "multiple_unique_options_phone_name_key",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.multiple_unique_options",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "multiple_unique_options_email_key",
+			"RowCount": null,
+			"ColumnCount": 1,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.multiple_unique_options",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "multiple_unique_options_id_name_key",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.multiple_unique_options",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "sales_with_mid_pk_2024_asia_pkey",
+			"RowCount": null,
+			"ColumnCount": 2,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "primary key",
+			"ParentTableName": "public.sales_with_mid_pk_2024_asia",
+			"SizeInBytes": 16384
+		},
+		{
+			"SchemaName": "public",
+			"ObjectName": "sales_with_mid_pk_2024_asia_id_sale_date_region_key",
+			"RowCount": null,
+			"ColumnCount": 3,
+			"ReadsPerSecond": 0,
+			"WritesPerSecond": 0,
+			"IsIndex": true,
+			"ObjectType": "index",
+			"ParentTableName": "public.sales_with_mid_pk_2024_asia",
 			"SizeInBytes": 16384
 		}
 	],

--- a/yb-voyager/src/query/queryissue/parser_issue_detector.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector.go
@@ -127,11 +127,7 @@ func (tm *TableMetadata) GetAllPartitionColumnsInHierarchy() []string {
 	}
 
 	// Convert map back to slice
-	result := make([]string, 0, len(allColumns))
-	for col := range allColumns {
-		result = append(result, col)
-	}
-	return result
+	return lo.Keys(allColumns)
 }
 
 // HasAnyRelatedTablePrimaryKey checks if this table or any of its descendants has a primary key
@@ -530,6 +526,7 @@ func (p *ParserIssueDetector) buildPartitionHierarchies() {
 				// CREATE TABLE ... PARTITION OF produces unqualified names (e.g., "sales") because
 				// PostgreSQL doesn't include schema info in parse tree, while ALTER TABLE ... ATTACH PARTITION
 				// produces qualified names (e.g., "public.sales") when schema is explicitly specified.
+				// TODO: Use sqlname for proper naming handling for qualified and unqualified names.
 				if parentTM.TableName == tm.PartitionedFrom || parentTM.GetObjectName() == tm.PartitionedFrom {
 					parentTM.Partitions = append(parentTM.Partitions, tm)
 					break

--- a/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
+++ b/yb-voyager/src/query/queryissue/parser_issue_detector_test.go
@@ -2515,6 +2515,16 @@ func TestPKRec_CommonRunner(t *testing.T) {
 			},
 			expected: []QueryIssue{NewMissingPrimaryKeyWhenUniqueNotNullIssue("TABLE", "public.sales", [][]string{{"public.sales.id", "public.sales.region", "public.sales.year"}})},
 		},
+		{
+			name: "PKREC: Root partitioned table with UNIQUE constraint including all partition columns - should not get recommendation",
+			ddls: []string{
+				`CREATE TABLE public.sales_with_mid_pk (id integer NOT NULL, sale_date date NOT NULL, region text NOT NULL, amount numeric, UNIQUE(id, sale_date, region)) PARTITION BY RANGE (sale_date);`,
+				`CREATE TABLE public.sales_with_mid_pk_2024 PARTITION OF public.sales_with_mid_pk FOR VALUES FROM ('2024-01-01') TO ('2025-01-01') PARTITION BY LIST (region);`,
+				`CREATE TABLE public.sales_with_mid_pk_2024_asia PARTITION OF public.sales_with_mid_pk_2024 FOR VALUES IN ('Asia');`,
+				`ALTER TABLE public.sales_with_mid_pk_2024 ADD CONSTRAINT sales_with_mid_pk_2024_pk PRIMARY KEY (id, region);`,
+			},
+			expected: nil,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
### Describe the changes in this pull request
This PR refactors the Primary Key (PK) creation recommendation logic to properly handle partitioned tables instead of skipping them entirely. Implements PostgreSQL's specific rules for PK inheritance in partitioned tables.

**Partitioned Table Handling**

- **Root tables only:** Only root partitioned tables get PK recommendations (child partitions inherit from root)

- **Partition column requirement:** PK suggestions must include all partition columns from the entire hierarchy

- **Child partition skipping:** Mid-level and leaf partition tables are skipped to avoid inheritance conflicts

- **PK Down the hierarchy:** If a child table already has PK defined on it, we don't give PK suggestions for the root table either since it cannot be created.


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
