### PR TITLE
Implement compare-performance command structure

### DIFF
--- a/yb-voyager/cmd/comparePerformanceCommand.go
+++ b/yb-voyager/cmd/comparePerformanceCommand.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/migassessment"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+)
+
+var comparePerformanceCmd = &cobra.Command{
+	Use:   "compare-performance",
+	Short: "Compare query performance between source PostgreSQL and target YugabyteDB",
+	Long: `Compare query performance between source PostgreSQL and target YugabyteDB using pg_stat_statements data.
+
+This command analyzes pg_stat_statements data collected during assess-migration from the source database
+and compares it with current pg_stat_statements data from the target YugabyteDB database.
+
+Prerequisites:
+  - assess-migration command must have been run with PGSS data collection
+  - Source workload should have been executed on both source and target databases
+  - pg_stat_statements extension must be enabled on the target YugabyteDB database`,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		validatePrerequisites()
+	},
+
+	Run: comparePerformanceHandler,
+}
+
+func comparePerformanceHandler(cmd *cobra.Command, args []string) {
+	utils.PrintAndLog("Starting performance comparison...")
+
+	err := collectTargetPgssData()
+	if err != nil {
+		utils.ErrExit("Target PGSS collection failed: %v", err)
+	}
+
+	err = performAnalysisAndGenerateReport()
+	if err != nil {
+		utils.ErrExit("Performance analysis failed: %v", err)
+	}
+
+	utils.PrintAndLog("Performance comparison completed successfully!")
+}
+
+// collectTargetPgssData collects current PGSS data from target database (STUB)
+func collectTargetPgssData() error {
+	// TODO: Implement target PGSS data collection
+	// This should:
+	// 1. Connect to target YugabyteDB database
+	// 2. Query pg_stat_statements view
+	// 3. Handle multi-node cluster data aggregation
+	// 4. Return PGSS data as pgss.QueryStats slice
+
+	return nil
+}
+
+// performAnalysisAndGenerateReport performs performance analysis and generates reports (STUB)
+func performAnalysisAndGenerateReport() error {
+	// TODO: Implement performance analysis and report generation
+	// This should:
+	// 1. Match queries between source and target
+	// 2. Calculate performance metrics (slowdown ratios, impact)
+	// 3. Generate HTML and JSON reports with multiple views
+	// 4. Save reports to output directory
+
+	return nil
+}
+
+func validatePrerequisites() {
+	utils.PrintAndLog("Validating prerequisites...")
+
+	// Check 1: Assessment database exists and is accessible
+	utils.PrintAndLog("Checking assessment database...")
+	assessmentDBPath := migassessment.GetSourceMetadataDBFilePath()
+	if _, err := os.Stat(assessmentDBPath); os.IsNotExist(err) {
+		utils.ErrExit("Assessment database not found. Please run 'assess-migration' command first.")
+	}
+
+	adb, err := migassessment.NewAssessmentDB("")
+	if err != nil {
+		utils.ErrExit("Failed to open assessment database: %v", err)
+	}
+
+	// Check 2: Source PGSS data exists in assessment DB
+	utils.PrintAndLog("Checking source pg_stat_statements data...")
+	hasData, err := adb.HasPgssData()
+	if err != nil {
+		utils.ErrExit("Failed to verify pg_stat_statements data in assessment database: %v", err)
+	}
+	if !hasData {
+		utils.ErrExit("No pg_stat_statements data found in assessment database. Please ensure pg_stat_statements extension was enabled during assess-migration and workload was executed on source database.")
+	}
+
+	// Check 3: Target database is reachable
+	utils.PrintAndLog("Checking target database connection...")
+	tdb := tgtdb.NewTargetDB(&tconf)
+	err = tdb.Init()
+	if err != nil {
+		utils.ErrExit("Failed to initialize target database: %v", err)
+	}
+	defer tdb.Finalize()
+
+	// Check 4: pg_stat_statements extension is enabled on target database
+	utils.PrintAndLog("Checking pg_stat_statements extension on target database...")
+	_, err = tdb.Query("SELECT 1 FROM pg_stat_statements LIMIT 1")
+	if err != nil {
+		utils.ErrExit("pg_stat_statements extension is not available on target database: %v\n"+
+			"Please ensure the extension is installed and enabled.", err)
+	}
+
+	utils.PrintAndLog("Prerequisites validated successfully for performance comparison\n")
+}
+
+func init() {
+	// Register the command with root
+	rootCmd.AddCommand(comparePerformanceCmd)
+
+	registerCommonGlobalFlags(comparePerformanceCmd)
+	registerTargetDBConnFlags(comparePerformanceCmd)
+}

--- a/yb-voyager/cmd/comparePerformanceCommand.go
+++ b/yb-voyager/cmd/comparePerformanceCommand.go
@@ -39,6 +39,8 @@ Prerequisites:
   - Source workload should have been executed on both source and target databases
   - pg_stat_statements extension must be enabled on the target YugabyteDB database`,
 
+	Hidden: true, // Hide command until fully implemented
+
 	PreRun: func(cmd *cobra.Command, args []string) {
 		validatePrerequisites()
 	},

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -543,3 +543,16 @@ func (adb *AssessmentDB) LoadPgssFromDB() ([]pgss.QueryStats, error) {
 
 	return entries, nil
 }
+
+// HasPgssData checks if any pg_stat_statements data exists in the assessment database
+func (adb *AssessmentDB) HasPgssData() (bool, error) {
+	query := fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", DB_QUERIES_SUMMARY)
+	rows, err := adb.Query(query)
+	if err != nil {
+		return false, fmt.Errorf("failed to check for PGSS data: %w", err)
+	}
+	defer rows.Close()
+
+	// If we can read at least one row, data exists
+	return rows.Next(), nil
+}


### PR DESCRIPTION
### Describe the changes in this pull request
- adds a new command `compare-performance` to yb-voyager CLI
- added prerequisites check before start the comparison
- added TODOs/codestubs for things to be implemented in later PRs; this mostly focussing on putting the structure in place.


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
This new command will not be visible to users(hidden for now)

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
TODO

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
