### PR TITLE
Updated the PK recommendation link in the migtests

### DIFF
--- a/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
@@ -185,7 +185,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.no_pk_table",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -206,7 +206,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.partitioned_multiple_unique",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -235,7 +235,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.partitioned_no_pk",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -257,7 +257,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.multiple_unique_options",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -285,7 +285,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.sales_hierarchy",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -308,7 +308,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.unique_index_composite",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -329,7 +329,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.partitioned_unique_index",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -351,7 +351,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.mix_constraint_index_same",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -372,7 +372,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.unique_index_multiple",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -399,7 +399,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.mix_constraint_index",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -426,7 +426,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "public.unique_index_simple",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [

--- a/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
@@ -14120,7 +14120,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p53_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -14140,7 +14140,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p43_not_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -14160,7 +14160,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p49_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -14180,7 +14180,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p49_not_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -14200,7 +14200,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p43_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -14220,7 +14220,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p53_not_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -14240,7 +14240,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p51_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [
@@ -14260,7 +14260,7 @@
             "ObjectType": "TABLE",
             "ObjectName": "rnacen.xref_p51_not_deleted_old",
             "SqlStatement": "",
-            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-when-unique-not-null",
+            "DocsLink": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist",
             "MinimumVersionsFixedIn": null,
             "Details": {
                 "PrimaryKeyColumnOptions": [


### PR DESCRIPTION
### Describe the changes in this pull request
Updated the PK recommendation link to https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#missing-primary-key-for-table-when-unique-and-not-null-columns-exist 
in the migtests expected files.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
None
### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
GH Actions
### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
None
### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
