### PR TITLE
Added string patterns to detect non retryable errrors produced by pgx driver

### DIFF
--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -329,10 +329,30 @@ const SYNTAX_ERROR = "syntax error at"
 const RPC_MSG_LIMIT_ERROR = "Sending too long RPC message"
 const INVALID_INPUT_SYNTAX_ERROR = "invalid input syntax"
 
+// pgx driver error patterns
+// Mismatched param and argument count - produced by pgx's ExtendedQueryBuilder
+const MISMATCHED_PARAM_ARGUMENT_COUNT_ERROR = "mismatched param and argument count"
+
+// Failed to encode args[N] - pgx wraps encoding failures with fmt.Errorf
+const FAILED_TO_ENCODE_ARGS_ERROR = "failed to encode args"
+
+// Unable to encode - many pgx/pgtype errors include this text
+const UNABLE_TO_ENCODE_ERROR = "unable to encode"
+
+// Cannot find encode plan - specific phrase from pgx/pgtype
+const CANNOT_FIND_ENCODE_PLAN_ERROR = "cannot find encode plan"
+
 var NonRetryCopyErrors = []string{
+	// Existing patterns
 	INVALID_INPUT_SYNTAX_ERROR,
 	VIOLATES_UNIQUE_CONSTRAINT_ERROR,
 	SYNTAX_ERROR,
+
+	// pgx driver error patterns
+	MISMATCHED_PARAM_ARGUMENT_COUNT_ERROR,
+	FAILED_TO_ENCODE_ARGS_ERROR,
+	UNABLE_TO_ENCODE_ERROR,
+	CANNOT_FIND_ENCODE_PLAN_ERROR,
 }
 
 // IsPgErrorCodeNonRetryable checks if an error is a data integrity or constraint violation or syntax error


### PR DESCRIPTION
### Describe the changes in this pull request
Added a few string patterns in the functions `IsNonRetryableCopyErrorerror` to detect non-retryable pgx driver errrors.

Fixes this: https://yugabyte.atlassian.net/browse/DB-18205?atlOrigin=eyJpIjoiMjA3YTkzZTBhMzI3NGQ2YmI2ODM2YmEyN2RkYWY5YWYiLCJwIjoiaiJ9

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Yeah we wont retry now if these errors occur

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
GH actions

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  No |
| Name registry json                                        |  No |
| Data File Descriptor Json                                 |  No |
| Export Snapshot Status Json                               |  No |
| Import Data State                                         |  No |
| Export Status Json                                        |  No |
| Data .sql files of tables                                 |  No |
| Export and import data queue                              |  No |
| Schema Dump                                               |  No |
| AssessmentDB                                              |  No |
| Sizing DB                                                 |  No |
| Migration Assessment Report Json                          |  No |
| Callhome Json                                             |  No |
| YugabyteD Tables                                          |  No |
| TargetDB Metadata Tables                                  |  No |
