### PR TITLE
Add current parallel connections to callhome data for import-data

### DIFF
--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -368,6 +368,7 @@ func packAndSendImportDataFilePayload(status string, errorMsg error) {
 	if callhomeMetricsCollector != nil {
 		dataMetrics.SnapshotTotalRows = callhomeMetricsCollector.GetSnapshotTotalRows()
 		dataMetrics.SnapshotTotalBytes = callhomeMetricsCollector.GetSnapshotTotalBytes()
+		dataMetrics.CurrentParallelConnections = callhomeMetricsCollector.GetCurrentParallelConnections()
 	}
 
 	// Get migration-related metrics from existing logic

--- a/yb-voyager/src/adaptiveparallelism/adaptive_parallelism_test.go
+++ b/yb-voyager/src/adaptiveparallelism/adaptive_parallelism_test.go
@@ -160,7 +160,7 @@ func TestIncreaseParallelism(t *testing.T) {
 		tserverRootMemSoftLimit2:   3286263299,
 	}
 
-	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool())
+	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool(), nil)
 	assert.NoErrorf(t, err, "failed to fetch cluster metrics and update parallelism")
 	assert.Equal(t, 4, yb.GetNumConnectionsInPool())
 }
@@ -175,7 +175,7 @@ func TestDecreaseParallelismBasedOnCpu(t *testing.T) {
 		cpuUsageSys2:  0.1,
 	}
 
-	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool())
+	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool(), nil)
 	assert.NoErrorf(t, err, "failed to fetch cluster metrics and update parallelism")
 	assert.Equal(t, 2, yb.GetNumConnectionsInPool())
 }
@@ -200,7 +200,7 @@ func TestDecreaseInParallelismBecauseOfLowAvailableMemory(t *testing.T) {
 		tserverRootMemSoftLimit2:   3286263299,
 	}
 
-	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool())
+	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool(), nil)
 	assert.NoErrorf(t, err, "failed to fetch cluster metrics and update parallelism")
 	assert.Equal(t, 2, yb.GetNumConnectionsInPool())
 }
@@ -225,7 +225,7 @@ func TestDecreaseInParallelismBecauseofTserverRootMemoryConsumptionSoftLimitBrea
 		tserverRootMemSoftLimit2:   3286263299,
 	}
 
-	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool())
+	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool(), nil)
 	assert.NoErrorf(t, err, "failed to fetch cluster metrics and update parallelism")
 	assert.Equal(t, 2, yb.GetNumConnectionsInPool())
 }
@@ -250,7 +250,7 @@ func TestIncreaseInParallelismBeyondMax(t *testing.T) {
 		tserverRootMemSoftLimit2:   3286263299,
 	}
 
-	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool())
+	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool(), nil)
 	assert.NoErrorf(t, err, "failed to fetch cluster metrics and update parallelism")
 	// assert no change in size because it would go beyond max size
 	assert.Equal(t, 6, yb.GetNumConnectionsInPool())
@@ -266,7 +266,7 @@ func TestDecreaseInParallelismBelowMin(t *testing.T) {
 		cpuUsageSys2:  0.1,
 	}
 
-	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool())
+	err := fetchClusterMetricsAndUpdateParallelism(yb, MIN_PARALLELISM, yb.GetNumMaxConnectionsInPool(), nil)
 	assert.NoErrorf(t, err, "failed to fetch cluster metrics and update parallelism")
 	// assert no change in size because it would go below min size
 	assert.Equal(t, 1, yb.GetNumConnectionsInPool())

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -298,6 +298,8 @@ type ImportDataPhasePayload struct {
 }
 
 type ImportDataMetrics struct {
+	CurrentParallelConnections int `json:"current_parallel_connections"`
+
 	// for the entire migration, across command runs. would be sensitive to start-clean.
 	MigrationSnapshotTotalRows        int64 `json:"migration_snapshot_total_rows"`
 	MigrationSnapshotLargestTableRows int64 `json:"migration_snapshot_largest_table_rows"`
@@ -339,6 +341,8 @@ type ImportDataFilePhasePayload struct {
 }
 
 type ImportDataFileMetrics struct {
+	CurrentParallelConnections int `json:"current_parallel_connections"`
+
 	// for the entire migration, across command runs. would be sensitive to start-clean.
 	MigrationSnapshotTotalBytes        int64 `json:"migration_snapshot_total_bytes"`
 	MigrationSnapshotLargestTableBytes int64 `json:"migration_snapshot_largest_table_bytes"`

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -275,8 +275,9 @@ Version History:
 1.0: Added fields for BatchSize, OnPrimaryKeyConflictAction, EnableYBAdaptiveParallelism, AdaptiveParallelismMax
 1.1: Added YBClusterMetrics field, and corresponding struct - YBClusterMetrics, NodeMetric
 1.2: Split out the data metrics into a separate struct - ImportDataMetrics
+1.3: Added CurrentParallelConnections field to ImportDataMetrics
 */
-var IMPORT_DATA_CALLHOME_PAYLOAD_VERSION = "1.2"
+var IMPORT_DATA_CALLHOME_PAYLOAD_VERSION = "1.3"
 
 type ImportDataPhasePayload struct {
 	PayloadVersion              string            `json:"payload_version"`

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -293,6 +293,7 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate ImportDataMetrics Struct Definition",
 			actualType: reflect.TypeOf(ImportDataMetrics{}),
 			expectedType: struct {
+				CurrentParallelConnections        int   `json:"current_parallel_connections"`
 				MigrationSnapshotTotalRows        int64 `json:"migration_snapshot_total_rows"`
 				MigrationSnapshotLargestTableRows int64 `json:"migration_snapshot_largest_table_rows"`
 				MigrationCdcTotalImportedEvents   int64 `json:"migration_cdc_total_imported_events"`
@@ -305,6 +306,7 @@ func TestCallhomeStructs(t *testing.T) {
 			name:       "Validate ImportDataFileMetrics Struct Definition",
 			actualType: reflect.TypeOf(ImportDataFileMetrics{}),
 			expectedType: struct {
+				CurrentParallelConnections         int   `json:"current_parallel_connections"`
 				MigrationSnapshotTotalBytes        int64 `json:"migration_snapshot_total_bytes"`
 				MigrationSnapshotLargestTableBytes int64 `json:"migration_snapshot_largest_table_bytes"`
 				SnapshotTotalRows                  int64 `json:"snapshot_total_rows"`


### PR DESCRIPTION
### Describe the changes in this pull request
Updated Payload: 
```
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
migration_uuid     | 17f37988-cdff-4eb1-928c-2f3a2501033e
phase_start_time   | 2025-09-18 05:19:18.499045+00
collected_at       | 2025-09-18 05:21:19.629645+00
source_db_details  |
target_db_details  | {"host": "", "db_version": "15.12-YB-2.27.0.0-b0", "node_count": 1, "total_cores": 0, "db_system_identifier": "ffa61054-a2fe-45ed-bda6-18397872384f"}
yb_voyager_version | main
migration_phase    | import-data
phase_payload      | {"error": "", "phase": "SNAPSHOT", "batch_size": 1, "start_clean": true, "data_metrics": {"snapshot_total_rows": 2, "snapshot_total_bytes": 22, "cdc_events_import_rate_3min": 0, "current_parallel_connections": 4, "migration_snapshot_total_rows": 2, "migration_cdc_total_imported_events": 0, "migration_snapshot_largest_table_rows": 2}, "enable_upsert": false, "parallel_jobs": 3, "payload_version": "1.2", "control_plane_type": "yugabyted", "yb_cluster_metrics": {"nodes": [{"uuid": "704132eac2b548a88befc295a5d893ab", "error": "", "status": "OK", "memory_free": 0, "memory_total": 17179869184, "total_cpu_pct": 91.61670000000001, "memory_available": 0, "tserver_mem_soft_limit_pct": 6.814982255172909}], "timestamp": "2025-09-18T05:21:20.140772Z", "avg_cpu_pct": 91.61670000000001, "max_cpu_pct": 91.61670000000001}, "error_policy_snapshot": "abort", "adaptive_parallelism_max": 6, "enable_yb_adaptive_parallelism": true, "on_primary_key_conflict_action": "ERROR"}
migration_type     | offline
time_taken_sec     | 122
status             | IN-PROGRESS
host_ip            | 100.76.18.48
-[ RECORD 18 ]-----+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
migration_uuid     | 17f37988-cdff-4eb1-928c-2f3a2501033e
phase_start_time   | 2025-09-18 05:19:18.499045+00
collected_at       | 2025-09-18 05:21:33.061482+00
source_db_details  |
target_db_details  | {"host": "", "db_version": "15.12-YB-2.27.0.0-b0", "node_count": 1, "total_cores": 0, "db_system_identifier": "ffa61054-a2fe-45ed-bda6-18397872384f"}
yb_voyager_version | main
migration_phase    | import-data
phase_payload      | {"error": "", "phase": "SNAPSHOT", "batch_size": 1, "start_clean": true, "data_metrics": {"snapshot_total_rows": 3, "snapshot_total_bytes": 33, "cdc_events_import_rate_3min": 0, "current_parallel_connections": 3, "migration_snapshot_total_rows": 3, "migration_cdc_total_imported_events": 0, "migration_snapshot_largest_table_rows": 3}, "enable_upsert": false, "parallel_jobs": 3, "payload_version": "1.2", "control_plane_type": "yugabyted", "yb_cluster_metrics": {"nodes": [{"uuid": "704132eac2b548a88befc295a5d893ab", "error": "", "status": "OK", "memory_free": 0, "memory_total": 17179869184, "total_cpu_pct": 28.6, "memory_available": 0, "tserver_mem_soft_limit_pct": 6.825219378865274}], "timestamp": "2025-09-18T05:21:33.564829Z", "avg_cpu_pct": 28.6, "max_cpu_pct": 28.6}, "error_policy_snapshot": "abort", "adaptive_parallelism_max": 6, "enable_yb_adaptive_parallelism": true, "on_primary_key_conflict_action": "ERROR"}
migration_type     | offline
time_taken_sec     | 135
status             | EXIT
host_ip            | 100.76.18.48
```

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually tested

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
Yes, updated the payload version for import data. 

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
