### PR TITLE
[DB-18385]: Assess Migration command fails for queries with same queryid in pgss

### DIFF
--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -157,8 +157,7 @@ func InitAssessmentDB() error {
 			mean_exec_time		REAL,
 			min_exec_time		REAL,
 			max_exec_time		REAL,
-			stddev_exec_time	REAL,
-			PRIMARY KEY (queryid, query));`, DB_QUERIES_SUMMARY),
+			stddev_exec_time	REAL);`, DB_QUERIES_SUMMARY),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			redundant_schema_name TEXT,
 			redundant_table_name TEXT,

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -455,7 +455,7 @@ func (adb *AssessmentDB) LoadPgssCSVIntoTable(filePath string) error {
 	return nil
 }
 
-func (adb *AssessmentDB) InsertPgssEntries(entries []pgss.PgStatStatements) error {
+func (adb *AssessmentDB) InsertPgssEntries(entries []*pgss.PgStatStatements) error {
 	if len(entries) == 0 {
 		return nil
 	}

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -158,7 +158,7 @@ func InitAssessmentDB() error {
 			min_exec_time		REAL,
 			max_exec_time		REAL,
 			stddev_exec_time	REAL,
-			PRIMARY KEY (queryid));`, DB_QUERIES_SUMMARY),
+			PRIMARY KEY (queryid, query));`, DB_QUERIES_SUMMARY),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			redundant_schema_name TEXT,
 			redundant_table_name TEXT,

--- a/yb-voyager/src/migassessment/assessmentDB_test.go
+++ b/yb-voyager/src/migassessment/assessmentDB_test.go
@@ -85,7 +85,7 @@ func TestInitAssessmentDB(t *testing.T) {
 			"size_in_bytes":     {Type: "INTEGER"},
 		},
 		DB_QUERIES_SUMMARY: {
-			"queryid":          {Type: "BIGINT", PrimaryKey: 1},
+			"queryid":          {Type: "BIGINT"},
 			"query":            {Type: "TEXT"},
 			"calls":            {Type: "BIGINT"},
 			"rows":             {Type: "BIGINT"},

--- a/yb-voyager/src/pgss/parser.go
+++ b/yb-voyager/src/pgss/parser.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ParseFromCSV parses a CSV file and returns normalized PgStatStatements entries
-func ParseFromCSV(csvPath string) ([]PgStatStatements, error) {
+func ParseFromCSV(csvPath string) ([]*PgStatStatements, error) {
 	file, err := os.Open(csvPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open PGSS CSV file %s: %w", csvPath, err)
@@ -40,7 +40,7 @@ func ParseFromCSV(csvPath string) ([]PgStatStatements, error) {
 		return nil, fmt.Errorf("failed to read CSV headers: %w", err)
 	}
 
-	var entries []PgStatStatements
+	var entries []*PgStatStatements
 	lineNumber := 1 // Header is line 0
 	for {
 		record, err := reader.Read()
@@ -58,12 +58,13 @@ func ParseFromCSV(csvPath string) ([]PgStatStatements, error) {
 		}
 
 		// Entry is valid if parsing succeeded
-		entries = append(entries, *entry)
+		entries = append(entries, entry)
 		lineNumber++
 	}
 
 	log.Infof("PGSS CSV parsing completed with %d entries", len(entries))
-	return entries, nil
+	// since there is a possibility of same queryid for different entries(due to userid difference), we need to merge them
+	return MergePgStatStatements(entries), nil
 }
 
 // parseCSVRecord converts a single CSV record to PgStatStatements struct

--- a/yb-voyager/src/pgss/parser.go
+++ b/yb-voyager/src/pgss/parser.go
@@ -63,8 +63,8 @@ func ParseFromCSV(csvPath string) ([]*PgStatStatements, error) {
 	}
 
 	log.Infof("PGSS CSV parsing completed with %d entries", len(entries))
-	// since there is a possibility of same queryid for different entries(due to userid difference), we need to merge them
-	return MergePgStatStatements(entries), nil
+	// since there is a possibility of same query text for different entries(due to userid difference), we need to merge them
+	return MergePgStatStatementsBasedOnQuery(entries), nil
 }
 
 // parseCSVRecord converts a single CSV record to PgStatStatements struct

--- a/yb-voyager/src/pgss/pgss.go
+++ b/yb-voyager/src/pgss/pgss.go
@@ -17,6 +17,8 @@ package pgss
 
 import (
 	"math"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // PgStatStatements represents a pg_stat_statements entry
@@ -91,10 +93,10 @@ func (p *PgStatStatements) Merge(second *PgStatStatements) {
 
 // ================================ Merge PgStatStatements =================================
 
-// MergePgStatStatements merges the stats for the entries with the same query
+// MergePgStatStatements merges the stats for the entries with the same query text
 func MergePgStatStatements(entries []*PgStatStatements) []*PgStatStatements {
+	log.Infof("merging pg_stat_statements entries")
 	queryMap := make(map[string]*PgStatStatements)
-
 	for _, entry := range entries {
 		if _, ok := queryMap[entry.Query]; !ok {
 			queryMap[entry.Query] = entry
@@ -107,5 +109,8 @@ func MergePgStatStatements(entries []*PgStatStatements) []*PgStatStatements {
 	for _, entry := range queryMap {
 		mergedEntries = append(mergedEntries, entry)
 	}
+
+	log.Infof("entries before merge: %d", len(entries))
+	log.Infof("entries after merge: %d", len(mergedEntries))
 	return mergedEntries
 }

--- a/yb-voyager/src/pgss/pgss.go
+++ b/yb-voyager/src/pgss/pgss.go
@@ -42,6 +42,8 @@ type PgStatStatements struct {
 
 // Merge merges the stats for the entries with the same query
 func (p *PgStatStatements) Merge(second *PgStatStatements) {
+	log.Infof("structs before merge:\nfirst: %+v, second: %+v", p, second)
+
 	first := *p // shallow copy is ok as no pointers in the struct
 
 	// queryid and query are expected to be same for the entries to be merged
@@ -62,6 +64,8 @@ func (p *PgStatStatements) Merge(second *PgStatStatements) {
 	// 	first.Calls, first.TotalExecTime, first.StddevExecTime,
 	// 	second.Calls, second.TotalExecTime, second.StddevExecTime,
 	// )
+
+	log.Infof("struct after merge: %+v", p)
 }
 
 // By ChatGPT:

--- a/yb-voyager/src/pgss/pgss.go
+++ b/yb-voyager/src/pgss/pgss.go
@@ -97,8 +97,8 @@ func (p *PgStatStatements) Merge(second *PgStatStatements) {
 
 // ================================ Merge PgStatStatements =================================
 
-// MergePgStatStatements merges the stats for the entries with the same query text
-func MergePgStatStatements(entries []*PgStatStatements) []*PgStatStatements {
+// MergePgStatStatementsBasedOnQuery merges the stats for the entries with the same query text
+func MergePgStatStatementsBasedOnQuery(entries []*PgStatStatements) []*PgStatStatements {
 	log.Infof("merging pg_stat_statements entries")
 	queryMap := make(map[string]*PgStatStatements)
 	for _, entry := range entries {

--- a/yb-voyager/src/pgss/pgss_test.go
+++ b/yb-voyager/src/pgss/pgss_test.go
@@ -411,7 +411,7 @@ func TestMergePgStatStatements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MergePgStatStatements(tt.input)
+			result := MergePgStatStatementsBasedOnQuery(tt.input)
 
 			// Since the function returns entries in map iteration order which is not deterministic,
 			// we need to sort both result and expected for comparison

--- a/yb-voyager/src/pgss/pgss_test.go
+++ b/yb-voyager/src/pgss/pgss_test.go
@@ -85,6 +85,23 @@ func TestParseFromCSVFormats(t *testing.T) {
 				assert.Len(t, entries, 0, "Should have expected number of entries")
 			},
 		},
+		{
+			name: "Same queries resulting in merging of entries",
+			csvData: `queryid,query,calls,rows,total_exec_time,mean_exec_time,min_exec_time,max_exec_time,stddev_exec_time
+123,"SELECT * FROM users",100,1000,1500.5,15.005,5.2,25.8,3.5
+123,"SELECT * FROM users",50,500,750.0,15.0,10.0,20.0,2.1`,
+			expectedLen: 1,
+			validate: func(t *testing.T, entries []*PgStatStatements) {
+				assert.Len(t, entries, 1, "Should have expected number of entries")
+				assert.Equal(t, int64(150), entries[0].Calls, "Calls should match")
+				assert.Equal(t, int64(1500), entries[0].Rows, "Rows should match")
+				assert.Equal(t, 2250.5, entries[0].TotalExecTime, "TotalExecTime should match")
+				assert.Equal(t, 15.003333333333334, entries[0].MeanExecTime, "MeanExecTime should match")
+				assert.Equal(t, 5.2, entries[0].MinExecTime, "MinExecTime should match")
+				assert.Equal(t, 25.8, entries[0].MaxExecTime, "MaxExecTime should match")
+				assert.Equal(t, 3.5, entries[0].StddevExecTime, "StddevExecTime should match")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/yb-voyager/src/pgss/pgss_test.go
+++ b/yb-voyager/src/pgss/pgss_test.go
@@ -30,7 +30,7 @@ func TestParseFromCSVFormats(t *testing.T) {
 		name        string
 		csvData     string
 		expectedLen int
-		validate    func(t *testing.T, entries []PgStatStatements)
+		validate    func(t *testing.T, entries []*PgStatStatements)
 	}{
 		{
 			name: "PostgreSQL 11-12 format (9 columns without exec)",
@@ -38,7 +38,7 @@ func TestParseFromCSVFormats(t *testing.T) {
 123,"SELECT * FROM users",100,1000,1500.5,15.005,5.2,25.8,3.5
 456,"SELECT id FROM products",50,500,750.0,15.0,10.0,20.0,2.1`,
 			expectedLen: 2,
-			validate: func(t *testing.T, entries []PgStatStatements) {
+			validate: func(t *testing.T, entries []*PgStatStatements) {
 				entry1 := entries[0]
 				assert.Equal(t, int64(123), entry1.QueryID, "Entry1 QueryID should match")
 				assert.Equal(t, "SELECT * FROM users", entry1.Query, "Entry1 Query should match")
@@ -52,7 +52,7 @@ func TestParseFromCSVFormats(t *testing.T) {
 789,"SELECT count(*) FROM orders",200,1,50.0,0.25,0.1,0.5,0.05
 321,"UPDATE users SET last_login = NOW()",75,75,150.0,2.0,1.0,5.0,0.8`,
 			expectedLen: 2,
-			validate: func(t *testing.T, entries []PgStatStatements) {
+			validate: func(t *testing.T, entries []*PgStatStatements) {
 				entry1 := entries[0]
 				assert.Equal(t, int64(789), entry1.QueryID, "Entry1 QueryID should match")
 				assert.Equal(t, "SELECT count(*) FROM orders", entry1.Query, "Entry1 Query should match")
@@ -66,7 +66,7 @@ func TestParseFromCSVFormats(t *testing.T) {
 999,"SELECT pg_stat_reset()",5,5,1.5,0.3,0.1,0.8,0.2,100,10,5,2,0,0,0,0,0,0,0.1,0.05,3,1,512
 1001,"CREATE INDEX CONCURRENTLY idx_test ON table_test (column)",1,0,30000.0,30000.0,30000.0,30000.0,0.0,5000,2000,1000,500,100,50,25,10,500,250,1500.0,800.0,1000,200,102400`,
 			expectedLen: 2,
-			validate: func(t *testing.T, entries []PgStatStatements) {
+			validate: func(t *testing.T, entries []*PgStatStatements) {
 				entry1 := entries[0]
 				assert.Equal(t, int64(999), entry1.QueryID, "Entry1 QueryID should match")
 				assert.Equal(t, "SELECT pg_stat_reset()", entry1.Query, "Entry1 Query should match")
@@ -81,7 +81,7 @@ func TestParseFromCSVFormats(t *testing.T) {
 			name:        "Only header",
 			csvData:     `queryid,query,calls,rows,total_exec_time,mean_exec_time,min_exec_time,max_exec_time,stddev_exec_time`,
 			expectedLen: 0,
-			validate: func(t *testing.T, entries []PgStatStatements) {
+			validate: func(t *testing.T, entries []*PgStatStatements) {
 				assert.Len(t, entries, 0, "Should have expected number of entries")
 			},
 		},

--- a/yb-voyager/src/pgss/pgss_test.go
+++ b/yb-voyager/src/pgss/pgss_test.go
@@ -417,7 +417,9 @@ func TestMergePgStatStatements(t *testing.T) {
 				assert.Equal(t, expected.MeanExecTime, actual.MeanExecTime, "MeanExecTime should match for entry %d", i)
 				assert.Equal(t, expected.MinExecTime, actual.MinExecTime, "MinExecTime should match for entry %d", i)
 				assert.Equal(t, expected.MaxExecTime, actual.MaxExecTime, "MaxExecTime should match for entry %d", i)
-				assert.Equal(t, expected.StddevExecTime, actual.StddevExecTime, "StddevExecTime should match for entry %d", i)
+
+				// TODO: merge logic is disable for stddev_exec_time right now
+				// assert.Equal(t, expected.StddevExecTime, actual.StddevExecTime, "StddevExecTime should match for entry %d", i)
 			}
 		})
 	}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1999,7 +1999,7 @@ func (yb *TargetYugabyteDB) CollectPgStatStatements() ([]*pgss.PgStatStatements,
 		rows.Close()
 	}
 
-	mergedEntries := pgss.MergePgStatStatements(entries)
+	mergedEntries := pgss.MergePgStatStatementsBasedOnQuery(entries)
 	return mergedEntries, nil
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request
We decided to go with this logic:
- Merge source PGSS entries queries with same query text (same we do for YB cluster)
- Remove primary key from table in assessmentDB (same as before this feature)
- There will be two entries in report if there is even a slight difference in the query text. Basically no decision makings base done higher calls/rows etc.. In worst there will be two similar looking entries trying to match with same on target.

Create a [ticket](https://github.com/yugabyte/yb-voyager/issues/3087) for handling the cases properly later.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
