### PR TITLE
Exclude migration test files(SQL or PLPGSQL) from language statistics on github repo homepage

### DIFF
--- a/migtests/tests/pg/mgi/expected_files/expected_failed.sql
+++ b/migtests/tests/pg/mgi/expected_files/expected_failed.sql
@@ -15,7 +15,7 @@ ERROR: ALTER TABLE CLUSTER not supported yet (SQLSTATE 0A000)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/mgi/export-dir/schema/tables/table.sql
 */
 ALTER TABLE mgd.all_label CLUSTER ON all_label_pkey;
-test-text
+
 /*
 ERROR: ALTER TABLE CLUSTER not supported yet (SQLSTATE 0A000)
 File :/home/ubuntu/yb-voyager/migtests/tests/pg/mgi/export-dir/schema/tables/table.sql


### PR DESCRIPTION
### Describe the changes in this pull request
To fix below info on repo homepage with plpgsql as highest contribution
<img width="413" height="176" alt="image" src="https://github.com/user-attachments/assets/5d6e8303-fd26-46a7-b8ea-6150e3ca4d3f" />


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
