### PR TITLE
Added normalisation for target_db_version for callhome automation script

### DIFF
--- a/.github/workflows/pg-13-migtests.yml
+++ b/.github/workflows/pg-13-migtests.yml
@@ -80,9 +80,6 @@ jobs:
           sudo apt install -y libpq-dev
           sudo apt install python3-psycopg2
 
-      - name: Install Flask
-        run: pip install Flask
-
       - name: Run installer script to setup voyager
         run: |
           cd installer_scripts
@@ -133,12 +130,6 @@ jobs:
           docker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' yugabytedb)
           echo "$docker_ip	yb-cluster-test" | sudo tee -a /etc/hosts
           psql "postgresql://yugabyte@yb-cluster-test:5433/yugabyte" -c "SELECT version();"
-
-      - name: "TEST: Callhome Datatypes Tests"
-        run: ./migtests/scripts/callhome/run-callhome-test.sh pg/datatypes
-
-      - name: "TEST: Callhome Assessment Report Tests"
-        run: ./migtests/scripts/callhome/run-callhome-test.sh pg/assessment-report-test --assess-only
 
       - name: "TEST: pg-table-list-flags-test (table-list and exclude-table-list)"
         if: ${{ !cancelled() && matrix.test_group == 'offline' }}

--- a/.github/workflows/pg-17-migtests.yml
+++ b/.github/workflows/pg-17-migtests.yml
@@ -80,9 +80,6 @@ jobs:
           sudo apt install -y libpq-dev
           sudo apt install python3-psycopg2
 
-      - name: Install Flask
-        run: pip install Flask
-
       - name: Run installer script to setup voyager
         run: |
           cd installer_scripts
@@ -133,12 +130,6 @@ jobs:
           docker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' yugabytedb)
           echo "$docker_ip	yb-cluster-test" | sudo tee -a /etc/hosts
           psql "postgresql://yugabyte@yb-cluster-test:5433/yugabyte" -c "SELECT version();"
-
-      - name: "TEST: Callhome Datatypes Tests"
-        run: ./migtests/scripts/callhome/run-callhome-test.sh pg/datatypes
-
-      - name: "TEST: Callhome Assessment Report Tests"
-        run: ./migtests/scripts/callhome/run-callhome-test.sh pg/assessment-report-test --assess-only
 
       - name: "TEST: PG sample schemas (sakila)"
         if: ${{ !cancelled() && matrix.test_group == 'offline' }}

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -5,7 +5,7 @@
     "MigrationComplexityExplanation": "Found 32 Level 2 issue(s) and 22 Level 3 issue(s), resulting in HIGH migration complexity",
     "SchemaSummary": {
         "Description": "Objects that will be created on the target YugabyteDB.",
-        "DbName": "pg_assessment_report",
+        "DbName": "pg_assessment_report_test_assess",
         "SchemaNames": [
             "public",
             "schema2",


### PR DESCRIPTION
### Describe the changes in this pull request
Added normalisation for target_db_version for callhome automation script

### Describe if there are any user-facing changes
N/A

### How was this pull request tested?
Using GH actions and Jenkins on following YB versions
- [2025.1.1.1-b1](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/6395/)
- [2024.2.4.0-b89](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/6397/)
- [2024.1.6.1-b2](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-testing-pipeline/6399/)

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    | No |
| Name registry json                                        | No |
| Data File Descriptor Json                                 | No |
| Export Snapshot Status Json                               | No |
| Import Data State                                         | No |
| Export Status Json                                        | No |
| Data .sql files of tables                                 | No |
| Export and import data queue                              | No |
| Schema Dump                                               | No |
| AssessmentDB                                              | No |
| Sizing DB                                                 | No |
| Migration Assessment Report Json                          | No |
| Callhome Json                                             | No |
| YugabyteD Tables                                          | No |
| TargetDB Metadata Tables                                  | No |
