### PR TITLE
Removed pg_stat_statements_reset() from the assessment tests

### DIFF
--- a/migtests/tests/pg/assessment-report-test-uqc/unsupported_query_constructs.sql
+++ b/migtests/tests/pg/assessment-report-test-uqc/unsupported_query_constructs.sql
@@ -1,7 +1,6 @@
 -- Unsupported Query Constructs 
 DROP EXTENSION IF EXISTS pg_stat_statements;
 CREATE EXTENSION pg_stat_statements;
-SELECT pg_stat_statements_reset();
 SELECT * FROM pg_stat_statements;
 
 

--- a/migtests/tests/pg/assessment-report-test/unsupported_query_constructs.sql
+++ b/migtests/tests/pg/assessment-report-test/unsupported_query_constructs.sql
@@ -4,8 +4,6 @@ drop extension if exists pg_stat_statements;
 
 create extension pg_stat_statements;
 
-SELECT pg_stat_statements_reset();
-
 SELECT * FROM pg_stat_statements;
 
 -- System Columns 

--- a/migtests/tests/pg/basic-assessment-report-test/pg_basic_assessment_report_test.sql
+++ b/migtests/tests/pg/basic-assessment-report-test/pg_basic_assessment_report_test.sql
@@ -80,8 +80,6 @@ drop extension if exists pg_stat_statements;
 
 create extension pg_stat_statements;
 
-SELECT pg_stat_statements_reset();
-
 SELECT * FROM pg_stat_statements;
 
 SELECT ctid, tableoid, xmin, xmax, cmin, cmax


### PR DESCRIPTION
### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes that can cause upgrade issues? 
| Component        | Breaking changes? |
| :----------------------------------------------: | :-----------: |
| MetaDB                                                    |  Yes/No |
| Name registry json                                        |  Yes/No |
| Data File Descriptor Json                                 |  Yes/No |
| Export Snapshot Status Json                               |  Yes/No |
| Import Data State                                         |  Yes/No |
| Export Status Json                                        |  Yes/No |
| Data .sql files of tables                                 |  Yes/No |
| Export and import data queue                              |  Yes/No |
| Schema Dump                                               |  Yes/No |
| AssessmentDB                                              |  Yes/No |
| Sizing DB                                                 |  Yes/No |
| Migration Assessment Report Json                          |  Yes/No |
| Callhome Json                                             |  Yes/No |
| YugabyteD Tables                                          |  Yes/No |
| TargetDB Metadata Tables                                  |  Yes/No |
