### PR TITLE
Fix: nil pointer in case the table is not present in target for live migration

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -234,10 +234,10 @@ func checkTablesPresentInTarget(importFileTasks []*ImportFileTask) {
 		}
 	}
 	if len(tablesNotPresentInTarget) > 0 {
-		utils.PrintAndLogf("Following source tables are not present in the target database:\n%v", strings.Join(lo.Map(tablesNotPresentInTarget, func(t sqlname.NameTuple, _ int) string {
+		utils.PrintAndLogfInfo("\nFollowing source tables are not present in the target database:\n%v", strings.Join(lo.Map(tablesNotPresentInTarget, func(t sqlname.NameTuple, _ int) string {
 			return t.ForKey()
-		}), ","))
-		utils.ErrExit("Create these tables in the target database to continue with the import.")
+		}), ", "))
+		utils.ErrExit(utils.ErrorColor.Sprint("Create these tables in the target database to continue with the import."))
 	}
 }
 
@@ -614,10 +614,10 @@ func applyTableListFilter(importFileTasks []*ImportFileTask) []*ImportFileTask {
 		result = append(result, task)
 	}
 	if len(tablesNotPresentInTarget) > 0 {
-		utils.PrintAndLogf("Following source tables are not present in the target database:\n%v", strings.Join(lo.Map(tablesNotPresentInTarget, func(t sqlname.NameTuple, _ int) string {
+		utils.PrintAndLogfInfo("\nFollowing source tables are not present in the target database:\n%v", strings.Join(lo.Map(tablesNotPresentInTarget, func(t sqlname.NameTuple, _ int) string {
 			return t.ForKey()
 		}), ","))
-		utils.ErrExit("Create these tables in the target database or exclude the tables in table-list flags if you don't want to import them.")
+		utils.ErrExit(utils.ErrorColor.Sprint("Create these tables in the target database or exclude the tables in table-list flags if you don't want to import them."))
 	}
 	return result
 }


### PR DESCRIPTION
### Describe the changes in this pull request

If a table is not present in the target the import data command was failing with a nil pointer whenever we use the Nametuple functions, that are using the CurrentName. So adding a guardrails for checking if all tables are present or not.

Issue 
```
~ yb-voyager import data --export-dir ~/export-dir-tabl-list .... --start-clean t --truncate-tables t
Using export-dir: /Users/priyanshigupta/export-dir-tabl-list

migrationID: e1bf66bc-1259-4c42-89cb-060cf57433c6
Using 1-2 parallel jobs (adaptive)
yugabytedb version: 15.12-YB-2025.1.1.2-b0

import of data in "test2" database started
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x104cb1388]

goroutine 1 [running]:
github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname.NameTuple.ForUserQuery(...)
	/Users/priyanshigupta/Documents/voyager/yb-voyager/yb-voyager/src/utils/sqlname/nametuple.go:157
github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb.(*TargetYugabyteDB).GetNonEmptyTables(0x14000dd4dc0, {0x14000011788?, 0x105fe6e20?, 0x14000204d10?})
	/Users/priyanshigupta/Documents/voyager/yb-voyager/yb-voyager/src/tgtdb/yugabytedb.go:656 +0xf8
github.com/yugabyte/yb-voyager/yb-voyager/cmd.cleanImportState(0x14000995ef0, {0x1400011e1a0, 0x1, 0x1?})
	/Users/priyanshigupta/Documents/voyager/yb-voyager/yb-voyager/cmd/importData.go:1516 +0x70
github.com/yugabyte/yb-voyager/yb-voyager/cmd.importData({0x1400011e1a0, 0x1, 0x1}, {0x1059305f7, 0x5})
	/Users/priyanshigupta/Documents/voyager/yb-voyager/yb-voyager/cmd/importData.go:716 +0x920
github.com/yugabyte/yb-voyager/yb-voyager/cmd.importDataCommandFn(0x107210ca0?, {0x14000dbab00?, 0x4?, 0x
``` 

fix
```
migrationID: e1bf66bc-1259-4c42-89cb-060cf57433c6
Following source tables are not present in the target database:
public."user_table"
Create these tables in the target database to continue with the import.
```
### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
