### PR TITLE
Refactor: Rename USE_YB_LOGICAL_REPLICATION_CONNECTOR to USE_YB_GRPC_CONNECTOR and reverse logic

### DIFF
--- a/.github/workflows/pg-13-migtests.yml
+++ b/.github/workflows/pg-13-migtests.yml
@@ -211,7 +211,7 @@ jobs:
       - name: "TEST: pg-basic-non-public-live-migration-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-run-test.sh pg/basic-non-public-live-test
 
       - name: "TEST: pg-basic-non-public-live-migration-test"
@@ -221,7 +221,7 @@ jobs:
       - name: "TEST: pg-basic-public-fall-forward-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/basic-public-live-test
 
       - name: "TEST: pg-basic-public-fall-forward-test"
@@ -231,7 +231,7 @@ jobs:
       - name: "TEST: pg-datatypes-fall-forward-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/datatypes
 
       - name: "TEST: pg-datatypes-fall-forward-test"
@@ -244,7 +244,7 @@ jobs:
       - name: "TEST: pg-datatypes-fall-back-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallb-run-test.sh pg/datatypes
 
       - name: "TEST: pg-datatypes-fall-back-test"
@@ -255,7 +255,7 @@ jobs:
       - name: "TEST: pg-live-migration-multiple-schemas (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           EXPORT_TABLE_LIST="ext_test,tt,audit,recipients,session_log,schema2.ext_test,schema2.tt,schema2.audit,schema2.recipients,schema2.session_log" migtests/scripts/live-migration-run-test.sh  pg/multiple-schemas
 
       - name: "TEST: pg-live-migration-multiple-schemas"
@@ -265,7 +265,7 @@ jobs:
       - name: "TEST: pg-unique-key-conflicts-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/unique-key-conflicts-test
 
       - name: "TEST: pg-unique-key-conflicts-test"
@@ -275,7 +275,7 @@ jobs:
       - name: "TEST: pg-live-migration-partitions-fall-forward (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/partitions
 
       - name: "TEST: pg-live-migration-partitions-fall-forward"

--- a/.github/workflows/pg-17-migtests.yml
+++ b/.github/workflows/pg-17-migtests.yml
@@ -243,7 +243,7 @@ jobs:
       - name: "TEST: pg-basic-non-public-live-migration-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-run-test.sh pg/basic-non-public-live-test --run-via-config-file
 
       - name: "TEST: pg-basic-non-public-live-migration-test"
@@ -253,7 +253,7 @@ jobs:
       - name: "TEST: pg-basic-public-fall-forward-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/basic-public-live-test --run-via-config-file
 
       - name: "TEST: pg-basic-public-fall-forward-test"
@@ -263,7 +263,7 @@ jobs:
       - name: "TEST: pg-datatypes-fall-forward-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/datatypes --run-via-config-file
 
       - name: "TEST: pg-datatypes-fall-forward-test"
@@ -276,7 +276,7 @@ jobs:
       - name: "TEST: pg-datatypes-fall-back-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallb-run-test.sh pg/datatypes --run-via-config-file
 
       - name: "TEST: pg-datatypes-fall-back-test"
@@ -287,7 +287,7 @@ jobs:
       - name: "TEST: pg-live-migration-multiple-schemas (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           EXPORT_TABLE_LIST="ext_test,tt,audit,recipients,session_log,schema2.ext_test,schema2.tt,schema2.audit,schema2.recipients,schema2.session_log" migtests/scripts/live-migration-run-test.sh  pg/multiple-schemas --run-via-config-file
 
       - name: "TEST: pg-live-migration-multiple-schemas"
@@ -297,7 +297,7 @@ jobs:
       - name: "TEST: pg-unique-key-conflicts-test (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/unique-key-conflicts-test --run-via-config-file
 
       - name: "TEST: pg-unique-key-conflicts-test"
@@ -307,7 +307,7 @@ jobs:
       - name: "TEST: pg-live-migration-partitions-fall-forward (2.20/2.25/2024.1 with gRPC)"
         if: ${{ !cancelled() && matrix.test_group == 'live-migration' && (matrix.yb_version == '2.20.10.0-b29' || matrix.yb_version == '2.25.2.0-b359' || matrix.yb_version == '2024.1.6.1-b2') }}
         run: |
-          export USE_YB_LOGICAL_REPLICATION_CONNECTOR=false
+          export USE_YB_GRPC_CONNECTOR=true
           migtests/scripts/live-migration-fallf-run-test.sh pg/partitions --run-via-config-file
 
       - name: "TEST: pg-live-migration-partitions-fall-forward"

--- a/migtests/scripts/config-templates/live-migration-with-fall-back.yaml
+++ b/migtests/scripts/config-templates/live-migration-with-fall-back.yaml
@@ -86,7 +86,7 @@ finalize-schema-post-data-import:
 
 initiate-cutover-to-target:
   prepare-for-fall-back: true
-  use-yb-grpc-connector: {% if USE_YB_LOGICAL_REPLICATION_CONNECTOR is defined and USE_YB_LOGICAL_REPLICATION_CONNECTOR == "true" %}false{% else %}true{% endif %}
+  use-yb-grpc-connector: {% if USE_YB_GRPC_CONNECTOR is defined and USE_YB_GRPC_CONNECTOR == "true" %}true{% else %}false{% endif %}
 
 export-data-from-target:
   disable-pb: true

--- a/migtests/scripts/config-templates/live-migration-with-fall-forward.yaml
+++ b/migtests/scripts/config-templates/live-migration-with-fall-forward.yaml
@@ -95,7 +95,7 @@ finalize-schema-post-data-import:
 
 initiate-cutover-to-target:
   prepare-for-fall-back: false
-  use-yb-grpc-connector: {% if USE_YB_LOGICAL_REPLICATION_CONNECTOR is defined and USE_YB_LOGICAL_REPLICATION_CONNECTOR == "true" %}false{% else %}true{% endif %}
+  use-yb-grpc-connector: {% if USE_YB_GRPC_CONNECTOR is defined and USE_YB_GRPC_CONNECTOR == "true" %}true{% else %}false{% endif %}
 
 export-data-from-target:
   disable-pb: true

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -657,7 +657,7 @@ get_expected_event_count() {
             return 0
             ;;
         "target")
-            if [ "${USE_YB_LOGICAL_REPLICATION_CONNECTOR}" = true ] \
+            if [ "${USE_YB_GRPC_CONNECTOR}" != true ] \
                && jq -e 'has("target_delta_events_logical_replication")' "$metadata_file" >/dev/null 2>&1; then
                 jq -r '.target_delta_events_logical_replication' "$metadata_file"
                 return 0
@@ -1385,7 +1385,7 @@ cutover_to_target() {
     "
 
     # Set grpc connector flag
-    if [ "${USE_YB_LOGICAL_REPLICATION_CONNECTOR}" = false ]; then
+    if [ "${USE_YB_GRPC_CONNECTOR}" = true ]; then
         args="${args} --use-yb-grpc-connector true"
     fi
 
@@ -1545,7 +1545,7 @@ compare_callhome_json_reports() {
 
 # Function to execute logical replication connector specific DMLs
 execute_logical_replication_target_delta() {
-	if [ "${USE_YB_LOGICAL_REPLICATION_CONNECTOR}" != true ]; then
+	if [ "${USE_YB_GRPC_CONNECTOR}" = true ]; then
 		echo "Skipping logical replication specific DMLs (gRPC connector)"
 		return 0
 	fi

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -300,12 +300,12 @@ main() {
 	get_data_migration_report
 
 	# Choose expected report file based on connector type
-	if [ "${USE_YB_LOGICAL_REPLICATION_CONNECTOR}" = true ]; then
-		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallb-logical-connector.json"
-		echo "Using logical replication connector expected report"
-	else
+	if [ "${USE_YB_GRPC_CONNECTOR}" = true ]; then
 		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallb.json"
 		echo "Using gRPC connector expected report"
+	else
+		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallb-logical-connector.json"
+		echo "Using logical replication connector expected report"
 	fi
 	actual_file="${EXPORT_DIR}/reports/data-migration-report.json"
 

--- a/migtests/scripts/live-migration-fallf-run-test.sh
+++ b/migtests/scripts/live-migration-fallf-run-test.sh
@@ -312,12 +312,12 @@ main() {
 	get_data_migration_report
 
 	# Choose expected report file based on connector type
-	if [ "${USE_YB_LOGICAL_REPLICATION_CONNECTOR}" = true ]; then
-		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallf-logical-connector.json"
-		echo "Using logical replication connector expected report"
-	else
+	if [ "${USE_YB_GRPC_CONNECTOR}" = true ]; then
 		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallf.json"
 		echo "Using gRPC connector expected report"
+	else
+		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallf-logical-connector.json"
+		echo "Using logical replication connector expected report"
 	fi
 	actual_file="${EXPORT_DIR}/reports/data-migration-report.json"
 

--- a/migtests/tests/pg/datatypes/validateAfterChanges
+++ b/migtests/tests/pg/datatypes/validateAfterChanges
@@ -6,9 +6,9 @@ import yb
 
 #=============================================================================
 
-def is_logical_replication_connector():
-    """Check if logical replication connector is being used"""
-    return os.environ.get('USE_YB_LOGICAL_REPLICATION_CONNECTOR', 'false').lower() == 'true'
+def is_grpc_connector():
+    """Check if gRPC connector is being used"""
+    return os.environ.get('USE_YB_GRPC_CONNECTOR', 'false').lower() == 'true'
 
 #=============================================================================
 # Base expected row counts (for gRPC connector)
@@ -160,7 +160,7 @@ def build_expected_values(ff_fb_enabled: bool):
     }
 
     # Override for logical replication
-    if is_logical_replication_connector():
+    if not is_grpc_connector():
         for table, replacement in LOGICAL_REPLICATION_ROW_OVERRIDES.items():
             expected["row_count"][table] = replacement
         expected["hstore_values"] = EXPECTED_HSTORE_VALUES_LOGICAL_FF_FB
@@ -171,7 +171,7 @@ def build_expected_values(ff_fb_enabled: bool):
 
 def run_migration_checks(db_type: str, expected, ff_fb_enabled: bool = False):
     """Run validation checks on the given db_type (yb, source, source_replica)"""
-    connector_type = "logical replication" if is_logical_replication_connector() else "gRPC"
+    connector_type = "gRPC" if is_grpc_connector() else "logical replication"
     msg = f"Running validation on {db_type}"
     if ff_fb_enabled:
         msg += f" with {connector_type} connector expectations"


### PR DESCRIPTION
### IMPORTANT: Need to modify the cron jobs after merging
### Describe the changes in this pull request
Refactor: Rename USE_YB_LOGICAL_REPLICATION_CONNECTOR to USE_YB_GRPC_CONNECTOR and reverse logic

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Jenkins

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No

### Does your PR have changes to on-disk structures that can cause upgrade issues? 
No

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
