### PR TITLE
resumptions based on time (4 hours default)

### DIFF
--- a/migtests/scripts/resumption.py
+++ b/migtests/scripts/resumption.py
@@ -48,7 +48,8 @@ target_db_schema = ''
 target_db_name = ''
 data_dir = ''
 varying_flags = {}
-max_resumption_time = 14400 # 4 hours
+max_resumption_time = 5400 # 1.5 hours
+
 def parse_arguments():
     parser = argparse.ArgumentParser(description="YB Voyager Resumption Test")
     parser.add_argument('config_file', metavar='config.yaml', type=str, 


### PR DESCRIPTION
### Describe the changes in this pull request
Changing the offline migration resumption script to be based on time instead of attempts. Kept 4 hours of resumption by default.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
