### PR TITLE
Fix: large-sized row for BYTEA type column during streaming (#3255)

### DIFF
--- a/yb-voyager/cmd/live_migration_integration_test.go
+++ b/yb-voyager/cmd/live_migration_integration_test.go
@@ -1359,3 +1359,102 @@ END $$;`,
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
 }
+
+func TestLiveMigrationWithBytesColumn(t *testing.T) {
+	liveMigrationTest := NewLiveMigrationTest(t, &TestConfig{
+		SourceDB: ContainerConfig{
+			Type:    "postgresql",
+			ForLive: true,
+		},
+		TargetDB: ContainerConfig{
+			Type: "yugabytedb",
+		},
+		SchemaNames: []string{"test_schema"},
+		SchemaSQL: []string{
+			`CREATE SCHEMA IF NOT EXISTS test_schema;
+			CREATE TABLE test_schema.large_test (
+				id SERIAL PRIMARY KEY,
+				created_at TIMESTAMP DEFAULT now(),
+				metadata TEXT,
+				payload BYTEA -- This will hold our 5MB
+			);
+			
+			CREATE OR REPLACE FUNCTION generate_large_rows(num_rows INT, size_mb INT)
+RETURNS VOID AS $$
+DECLARE
+    byte_size INT := size_mb * 1024 * 1024;
+BEGIN
+    INSERT INTO test_schema.large_test (metadata, payload)
+    SELECT 
+        'Test row ' || i,
+        decode(repeat('00', byte_size), 'hex') -- Generates a zero-filled byte array
+    FROM generate_series(1, num_rows) AS i;
+END;
+$$ LANGUAGE plpgsql;`,
+		},
+		SourceSetupSchemaSQL: []string{
+			`ALTER TABLE test_schema.large_test REPLICA IDENTITY FULL;`,
+			`-- Force Postgres to NOT compress the data 
+			-- This ensures the row stays ~5MB and doesn't shrink if the data is repetitive.
+			ALTER TABLE test_schema.large_test ALTER COLUMN payload SET STORAGE EXTERNAL;`,
+		},
+		InitialDataSQL: []string{
+			`SELECT generate_large_rows(5, 5);`,
+		},
+		SourceDeltaSQL: []string{
+			`SELECT generate_large_rows(10, 10);`,
+		},
+		CleanupSQL: []string{
+			`DROP SCHEMA IF EXISTS test_schema CASCADE;`,
+		},
+	})
+
+	// defer liveMigrationTest.Cleanup()
+
+	err := liveMigrationTest.SetupContainers(context.Background())
+	testutils.FatalIfError(t, err, "failed to setup containers")
+
+	err = liveMigrationTest.SetupSchema()
+	testutils.FatalIfError(t, err, "failed to setup schema")
+
+	err = liveMigrationTest.StartExportData(true, nil)
+	testutils.FatalIfError(t, err, "failed to start export data")
+
+	err = liveMigrationTest.StartImportData(true, nil)
+	testutils.FatalIfError(t, err, "failed to start import data")
+
+	time.Sleep(5 * time.Second)
+
+	err = liveMigrationTest.WaitForSnapshotComplete(map[string]int64{
+		`test_schema."large_test"`: 5,
+	}, 80)
+	testutils.FatalIfError(t, err, "failed to wait for snapshot complete")
+
+	err = liveMigrationTest.ValidateDataConsistency([]string{`test_schema."large_test"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
+
+	err = liveMigrationTest.ExecuteSourceDelta()
+	testutils.FatalIfError(t, err, "failed to execute source delta")
+
+	err = liveMigrationTest.WaitForForwardStreamingComplete(map[string]ChangesCount{
+		`test_schema."large_test"`: {
+			Inserts: 10,
+			Updates: 0,
+			Deletes: 0,
+		},
+	}, 120, 5)
+	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+
+	err = liveMigrationTest.ValidateRowCount([]string{`test_schema."large_test"`})
+	testutils.FatalIfError(t, err, "failed to validate row count")
+
+	err = liveMigrationTest.ValidateDataConsistency([]string{`test_schema."large_test"`}, "id")
+	testutils.FatalIfError(t, err, "failed to verify data consistency")
+
+	err = liveMigrationTest.InitiateCutoverToTarget(false, nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover to target")
+
+	err = liveMigrationTest.WaitForCutoverComplete(50)
+	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
+
+}

--- a/yb-voyager/cmd/live_migration_testing_framework.go
+++ b/yb-voyager/cmd/live_migration_testing_framework.go
@@ -486,7 +486,7 @@ func (lm *LiveMigrationTest) ExecuteOnTarget(sqlStatements ...string) error {
 // ValidateDataConsistency compares data between source and target
 func (lm *LiveMigrationTest) ValidateDataConsistency(tables []string, orderBy string) error {
 	fmt.Printf("Validating data consistency\n")
-	lm.WithSourceTargetConn(func(source, target *sql.DB) error {
+	return lm.WithSourceTargetConn(func(source, target *sql.DB) error {
 		for _, table := range tables {
 			if err := testutils.CompareTableData(lm.ctx, source, target, table, orderBy); err != nil {
 				return goerrors.Errorf("table data mismatch for %s: %w", table, err)
@@ -495,8 +495,19 @@ func (lm *LiveMigrationTest) ValidateDataConsistency(tables []string, orderBy st
 		}
 		return nil
 	})
+}
 
-	return nil
+func (lm *LiveMigrationTest) ValidateRowCount(tables []string) error {
+	fmt.Printf("Validating row count\n")
+	return lm.WithSourceTargetConn(func(source, target *sql.DB) error {
+		for _, table := range tables {
+			if err := testutils.CompareRowCount(lm.ctx, source, target, table); err != nil {
+				return goerrors.Errorf("row count mismatch for %s: %w", table, err)
+			}
+			fmt.Printf("Row count validated for %s\n", table)
+		}
+		return nil
+	})
 }
 
 // WithSourceConn provides source database connection to callback

--- a/yb-voyager/src/tgtdb/suites/yugabytedbSuite.go
+++ b/yb-voyager/src/tgtdb/suites/yugabytedbSuite.go
@@ -163,15 +163,15 @@ var YBValueConverterSuite = map[string]ConverterFn{
 			return columnValue, goerrors.Errorf("decoding base64 string: %v", err)
 		}
 		//convert bytes to hex string e.g. `[]byte{0x00, 0x00, 0x00, 0x00}` -> `\\x00000000`
-		hexString := ""
+		var hexString strings.Builder
 		for _, b := range decodedBytes {
-			hexString += fmt.Sprintf("%02x", b)
+			hexString.WriteString(fmt.Sprintf("%02x", b))
 		}
 		hexValue := ""
 		if formatIfRequired {
-			hexValue = fmt.Sprintf("'\\x%s'", hexString) // in insert statement no need of escaping the backslash and add quotes
+			hexValue = fmt.Sprintf("'\\x%s'", hexString.String()) // in insert statement no need of escaping the backslash and add quotes
 		} else {
-			hexValue = fmt.Sprintf("\\x%s", hexString) // in data file need to escape the backslash
+			hexValue = fmt.Sprintf("\\x%s", hexString.String()) // in data file need to escape the backslash
 		}
 		return string(hexValue), nil
 	},


### PR DESCRIPTION
Fixed value converter for BYTES to use string builder instead of string concatenation to improve performance while converting Added tests unit and integration

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
