### PR TITLE
Fix: increased the object mapper limits to  500MB to be able to read …

### DIFF
--- a/debezium-server-voyager/debezium-server-voyagerexporter/195pom.xml
+++ b/debezium-server-voyager/debezium-server-voyagerexporter/195pom.xml
@@ -96,6 +96,12 @@
             <artifactId>json</artifactId>
             <version>20180130</version>
         </dependency>
+        <!-- jackson-core version 2.15.2 is used to support StreamReadConstraints while compiling but debezium core 1.9.5 uses jackson 2.13.1 which does not support StreamReadConstraints-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.15.2</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
+++ b/debezium-server-voyager/debezium-server-voyagerexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
@@ -6,6 +6,7 @@
 package io.debezium.server.ybexporter;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -46,14 +47,17 @@ public class QueueSegment {
     private ObjectWriter ow;
     private ExportStatus es;
     private String exporterRole;
+    private boolean ybGRPCConnectorEnabled;
+    private Integer ObjectMapperMaxStringLength;
     // (schemaName, tableName) -> (operation -> count)
     private Map<Pair<String, String>, Map<String, Long>> eventCountDeltaPerTable;
 
-    public QueueSegment(String datadirStr, long segmentNo, String filePath) {
+    public QueueSegment(String datadirStr, long segmentNo, String filePath, boolean ybGRPCConnectorEnabled, String exporterRole, Integer ObjectMapperMaxStringLength) {
         this.segmentNo = segmentNo;
         this.filePath = filePath;
-        final Config config = ConfigProvider.getConfig();
-        exporterRole = config.getValue("debezium.sink.ybexporter.exporter.role", String.class);
+        this.exporterRole = exporterRole;
+        this.ybGRPCConnectorEnabled = ybGRPCConnectorEnabled;
+        this.ObjectMapperMaxStringLength = ObjectMapperMaxStringLength;
         es = ExportStatus.getInstance(datadirStr);
         ow = new ObjectMapper().writer();
         try {
@@ -165,7 +169,7 @@ public class QueueSegment {
     }
 
     public long getSequenceNumberOfLastRecord() {
-        ObjectMapper mapper = new ObjectMapper(new JsonFactory());
+        ObjectMapper mapper = createObjectMapper();
         long vsn = -1;
         String last = null, line;
         BufferedReader input;
@@ -185,6 +189,17 @@ public class QueueSegment {
             throw new RuntimeException(e);
         }
         return vsn;
+    }
+    private ObjectMapper createObjectMapper() {
+        if (exporterRole.equals("target_db_exporter_fb") || exporterRole.equals("target_db_exporter_ff")) {
+            if (ybGRPCConnectorEnabled) {
+                //In case of gRPC connector, debezium is at 1.9.5 version and uses jackson 2.13.1 which does not support StreamReadConstraints
+                // So, we use the default ObjectMapper - should not cause issues for large strings in that path as this guardrail is introduced in 2.15 https://github.com/FasterXML/jackson-core/issues/1001
+                return new ObjectMapper(new JsonFactory());
+            }
+        }
+        //for any connector which uses 2.5.2 or higher uses jackson 2.15.2 which supports StreamReadConstraints
+        return new ObjectMapper(JsonFactory.builder().streamReadConstraints(StreamReadConstraints.builder().maxStringLength(ObjectMapperMaxStringLength).build()).build());
     }
 
     public boolean isClosed() {

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -246,6 +246,7 @@ debezium.source.hstore.handling.mode=map
 debezium.source.decimal.handling.mode=precise
 debezium.source.converters=postgres_source_converter
 debezium.source.postgres_source_converter.type=io.debezium.server.ybexporter.PostgresToYbValueConverter
+debezium.source.grpc.connector.enabled=true
 `
 
 var yugabyteLogicalReplicationSrcConfigTemplate = `
@@ -259,6 +260,7 @@ debezium.source.hstore.handling.mode=map
 debezium.source.decimal.handling.mode=string
 debezium.source.converters=postgres_source_converter
 debezium.source.postgres_source_converter.type=io.debezium.server.ybexporter.PostgresToYbValueConverter
+debezium.source.grpc.connector.enabled=false
 `
 
 var yugabyteLogicalReplicationSlotNameTemplate = `


### PR DESCRIPTION
…large size events on resumption (#3258)

In the debezium exporter, while resuming, we were reading the event to get the last VSN and in case of event larger than 20MB, we hit an error `string length (200000000) exceeds the maximum length (20000000)` with ObjectMapper. So increased the reader limits to 500MB now.

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
