### PR TITLE
Validate read-replica-endpoints belong to the same primary cluster

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -272,6 +272,9 @@ func assessMigration() (err error) {
 			return goerrors.Errorf("failed to check if source schema exist: %q", source.Schema)
 		}
 
+		// Fetch source info early (includes system identifier needed for replica cluster validation)
+		fetchSourceInfo()
+
 		// Handle replica discovery and validation (PostgreSQL only)
 		replicaDiscoveryInfo, err := migassessment.HandleReplicaDiscoveryAndValidation(&source, sourceReadReplicaEndpoints, primaryOnly)
 		if err != nil {
@@ -292,8 +295,6 @@ func assessMigration() (err error) {
 				return fmt.Errorf("permission check failed: %w", err)
 			}
 		}
-
-		fetchSourceInfo()
 	}
 
 	startEvent := createMigrationAssessmentStartedEvent()

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -1908,6 +1908,9 @@ type ReplicaEndpoint struct {
 // ErrNotAReplica indicates that an endpoint is connectable but not a replica (pg_is_in_recovery = false)
 var ErrNotAReplica = errors.New("endpoint is not a replica (pg_is_in_recovery() = false)")
 
+// ErrDifferentCluster indicates that a replica belongs to a different PostgreSQL cluster (system identifier mismatch)
+var ErrDifferentCluster = errors.New("replica belongs to a different cluster")
+
 // DiscoverReplicas queries pg_stat_replication on the primary to discover physical streaming replicas
 func (pg *PostgreSQL) DiscoverReplicas() ([]ReplicaInfo, error) {
 	query := `
@@ -2059,4 +2062,51 @@ func (pg *PostgreSQL) GetReplicaConnectionUri(host string, port int) string {
 		RawQuery: generateSSLQueryStringIfNotExists(pg.source),
 	}
 	return sourceUrl.String()
+}
+
+// GetSystemIdentifierFromEndpoint connects to a remote endpoint and retrieves its system identifier.
+// This is used to verify that a replica belongs to the same PostgreSQL cluster as the primary.
+// Uses a 5-second timeout for the connection.
+func (pg *PostgreSQL) GetSystemIdentifierFromEndpoint(connectionUri string) (int64, error) {
+	replicaDB, err := sql.Open("pgx", connectionUri)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open connection: %w", err)
+	}
+	defer replicaDB.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Query system identifier (connection will be established on first query)
+	var systemIdentifier int64
+	query := "SELECT system_identifier FROM pg_control_system()"
+	err = replicaDB.QueryRowContext(ctx, query).Scan(&systemIdentifier)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query system identifier: %w", err)
+	}
+
+	return systemIdentifier, nil
+}
+
+// ValidateReplicaBelongsToCluster verifies that a replica endpoint belongs to the same PostgreSQL cluster
+// as the primary by comparing their system identifiers.
+// Returns ErrDifferentCluster if the system identifiers don't match.
+func (pg *PostgreSQL) ValidateReplicaBelongsToCluster(endpoint ReplicaEndpoint, primarySystemIdentifier int64) error {
+	if primarySystemIdentifier == 0 {
+		// System identifier not available from primary, skip validation
+		log.Infof("Primary system identifier not available, skipping cluster membership validation for %s", endpoint.Name)
+		return nil
+	}
+
+	replicaSystemIdentifier, err := pg.GetSystemIdentifierFromEndpoint(endpoint.ConnectionUri)
+	if err != nil {
+		return fmt.Errorf("failed to get replica system identifier: %w", err)
+	}
+
+	if replicaSystemIdentifier != primarySystemIdentifier {
+		return fmt.Errorf("%s has system identifier %d, expected %d (primary): %w",
+			endpoint.Name, replicaSystemIdentifier, primarySystemIdentifier, ErrDifferentCluster)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Describe the changes in this pull request

Added cluster membership validation for user-provided replica endpoints to ensure they belong to the same PostgreSQL cluster as the primary.

**Problem**: The `--source-read-replica-endpoints` flag previously accepted any endpoint without verifying cluster membership, leading to:
- Silent incorrect results (data collected from wrong cluster)
- Assessment failures when PostgreSQL versions differ between clusters
- Misleading IOPS and workload metrics

**Solution**: Implemented validation using PostgreSQL's system identifier to verify replicas belong to the same cluster as the primary.

**Validation only applies to user-provided replicas** via `--source-read-replica-endpoints` flag. Auto-discovered replicas (via `pg_stat_replication`) skip this check.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

<img width="3330" height="766" alt="image" src="https://github.com/user-attachments/assets/990ed3d1-3fc6-4919-aed9-7fce8958b69a" />

<img width="3278" height="858" alt="image" src="https://github.com/user-attachments/assets/6fd52731-36af-41c6-b901-18c856efea46" />

<img width="3454" height="1552" alt="image" src="https://github.com/user-attachments/assets/b9f2f7d2-4705-4b90-a030-1f2f0fb0290e" />

**Yes - Error messages**: Users will now see clear validation errors when providing replicas from a different cluster:

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

No

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
