### PR TITLE
Fix/validate flags before password

### DIFF
--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -202,6 +202,26 @@ func validateExportFlags(cmd *cobra.Command, exporterRole string) error {
 		}
 	}
 
+	// Add validation for mandatory flags before asking for password
+	if exporterRole == SOURCE_DB_EXPORTER_ROLE {
+		err := validateSourceDBHost()
+		if err != nil {
+			return err
+		}
+		err = validateSourceDBUser()
+		if err != nil {
+			return err
+		}
+		err = validateSourceDBName()
+		if err != nil {
+			return err
+		}
+		err = validateSourceDBPort()
+		if err != nil {
+			return err
+		}
+	}
+
 	switch exporterRole {
 	case SOURCE_DB_EXPORTER_ROLE:
 		getAndStoreSourceDBPasswordInSourceConf(cmd)
@@ -220,6 +240,38 @@ func validateExportFlags(cmd *cobra.Command, exporterRole string) error {
 		if source.TNSAlias != "" {
 			return goerrors.Errorf("--oracle-tns-alias flag is only valid for 'oracle' db type")
 		}
+	}
+	return nil
+}
+
+func validateSourceDBHost() error {
+	if source.DBType == ORACLE || source.DBType == YUGABYTEDB || source.DBType == POSTGRESQL || source.DBType == MYSQL {
+		if source.Host == "" {
+			return goerrors.Errorf("required flag \"source-db-host\" not set")
+		}
+	}
+	return nil
+}
+
+func validateSourceDBUser() error {
+	if source.User == "" {
+		return goerrors.Errorf("required flag \"source-db-user\" not set")
+	}
+	return nil
+}
+
+func validateSourceDBName() error {
+	if source.DBType == POSTGRESQL || source.DBType == MYSQL || source.DBType == YUGABYTEDB {
+		if source.DBName == "" {
+			return goerrors.Errorf("required flag \"source-db-name\" not set")
+		}
+	}
+	return nil
+}
+
+func validateSourceDBPort() error {
+	if source.Port == 0 {
+		return goerrors.Errorf("required flag \"source-db-port\" not set")
 	}
 	return nil
 }


### PR DESCRIPTION
### Describe the changes in this pull request
Fixed a user experience issue where `yb-voyager` would prompt for the source database password before validating that all mandatory connection flags (like host, user, port) were provided. This often led to a confusing flow where the user enters a password only to immediately receive an error about a missing flag.

The fix involves modifying `validateExportFlags` in `cmd/export.go` to explicitly validate `source-db-host`, `source-db-user`, `source-db-name`, and `source-db-port` **before** the password retrieval logic (`getAndStoreSourceDBPasswordInSourceConf`).

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Yes. The command-line behavior has improved. If a user runs an export command with missing mandatory flags (e.g., omitting `--source-db-user`), the tool will now immediately exit with a specific error message (e.g., `Required flag "source-db-user" not set`) instead of first pausing to ask for a password.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manual verification was performed:
1. Ran `yb-voyager export schema --export-dir temp_repro --source-db-type postgresql` (intentionally missing other flags).
2. **Before Fix**: The tool prompted: `Password to connect to source-db ...`
3. **After Fix**: The tool immediately outputted: `Error validating export schema flags: required flag "source-db-user" not set`.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No.

### Does your PR have changes to on-disk structures that can cause upgrade issues? 
No.


### After Fix
<img width="1093" height="314" alt="Screenshot 2026-01-13 at 12 45 03 AM" src="https://github.com/user-attachments/assets/a5a84783-6873-42f9-aeda-b411584ebd21" />
