### PR TITLE
feat(analyze-schema): implement version-aware extension reporting

### DIFF
--- a/yb-voyager/src/query/queryissue/extensions_test.go
+++ b/yb-voyager/src/query/queryissue/extensions_test.go
@@ -1,0 +1,57 @@
+package queryissue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/ybversion"
+)
+
+func TestExtensionsVersionSupport(t *testing.T) {
+	parserIssueDetector := NewParserIssueDetector()
+
+	testCases := []struct {
+		name            string
+		extension       string
+		version         *ybversion.YBVersion
+		shouldHaveIssue bool
+	}{
+		// Vector (should be supported everywhere now)
+		{"vector_2024_1", "vector", ybversion.V2024_1_0_0, false},
+		{"vector_2_25", "vector", ybversion.V2_25_0_0, false},
+
+		// pg_partman (added in 2024.2 and 2.25)
+		{"pg_partman_2024_1", "pg_partman", ybversion.V2024_1_0_0, true},
+		{"pg_partman_2024_2", "pg_partman", ybversion.V2024_2_0_0, false},
+		{"pg_partman_2_20", "pg_partman", ybversion.V2_23_0_0, true}, // Using V2_23 as proxy for < 2.25
+		{"pg_partman_2_25", "pg_partman", ybversion.V2_25_0_0, false},
+
+		// anon (added in 2024.2 and 2.25.1)
+		{"anon_2024_2", "anon", ybversion.V2024_2_0_0, false},
+		{"anon_2_25_0", "anon", ybversion.V2_25_0_0, true},
+		{"anon_2_25_1", "anon", ybversion.V2_25_1_0, false},
+
+		// timetravel (removed in 2.25+, 2025.1+)
+		{"timetravel_2024_2", "timetravel", ybversion.V2024_2_0_0, false},
+		{"timetravel_2_25", "timetravel", ybversion.V2_25_0_0, true},
+		{"timetravel_2025_1", "timetravel", ybversion.V2025_1_0_0, true},
+
+		// Unknown extension
+		{"unknown_ext", "my_cool_ext", ybversion.V2025_1_0_0, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := "CREATE EXTENSION " + tc.extension + ";"
+			issues, err := parserIssueDetector.GetDDLIssues(stmt, tc.version)
+			assert.NoError(t, err)
+
+			if tc.shouldHaveIssue {
+				assert.NotEmpty(t, issues, "Expected issue for %s on %s", tc.extension, tc.version)
+				assert.Equal(t, UNSUPPORTED_EXTENSION, issues[0].Issue.Type)
+			} else {
+				assert.Empty(t, issues, "Expected NO issue for %s on %s", tc.extension, tc.version)
+			}
+		})
+	}
+}

--- a/yb-voyager/src/query/queryissue/helpers.go
+++ b/yb-voyager/src/query/queryissue/helpers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/ybversion"
 )
 
 // Refer: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
@@ -204,8 +205,94 @@ var SupportedExtensionsOnYB = []string{
 	"hypopg", "insert_username", "intagg", "intarray", "isn", "lo", "ltree", "moddatetime",
 	"orafce", "pageinspect", "pg_buffercache", "pg_cron", "pg_freespacemap", "pg_hint_plan", "pg_prewarm", "pg_stat_monitor",
 	"pg_stat_statements", "pg_trgm", "pg_visibility", "pgaudit", "pgcrypto", "pgrowlocks", "pgstattuple", "plpgsql",
-	"postgres_fdw", "refint", "seg", "sslinfo", "tablefunc", "tcn", "timetravel", "tsm_system_rows",
-	"tsm_system_time", "unaccent", "uuid-ossp", "yb_pg_metrics", "yb_test_extension",
+	"postgres_fdw", "refint", "seg", "sslinfo", "tablefunc", "tcn", "tsm_system_rows",
+	"tsm_system_time", "unaccent", "uuid-ossp", "yb_pg_metrics", "yb_test_extension", "vector",
+}
+
+var extensionsFixedInVersions = map[string]map[string]string{
+	"timetravel": {
+		ybversion.SERIES_2_14:   "2.14.0.0",
+		ybversion.SERIES_2_18:   "2.18.0.0",
+		ybversion.SERIES_2_20:   "2.20.0.0",
+		ybversion.SERIES_2_21:   "2.21.0.0",
+		ybversion.SERIES_2_23:   "2.23.0.0",
+		ybversion.SERIES_2024_1: "2024.1.0.0",
+		ybversion.SERIES_2024_2: "2024.2.0.0",
+	},
+	"pg_partman": {
+		ybversion.SERIES_2024_2: "2024.2.0.0",
+		ybversion.SERIES_2_25:   "2.25.0.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"pg_walinspect": {
+		ybversion.SERIES_2_25:   "2.25.0.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"old_snapshot": {
+		ybversion.SERIES_2_25:   "2.25.0.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"pgtap": {
+		ybversion.SERIES_2024_2: "2024.2.0.0",
+		ybversion.SERIES_2_25:   "2.25.0.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"yb_ycql_utils": {
+		ybversion.SERIES_2024_1: "2024.1.0.0",
+		ybversion.SERIES_2024_2: "2024.2.0.0",
+		ybversion.SERIES_2_25:   "2.25.0.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"pg_surgery": {
+		ybversion.SERIES_2_25:   "2.25.0.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"yb_xcluster_ddl_replication": {
+		ybversion.SERIES_2024_2: "2024.2.0.0",
+		ybversion.SERIES_2_25:   "2.25.0.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"anon": {
+		ybversion.SERIES_2024_2: "2024.2.0.0",
+		ybversion.SERIES_2_25:   "2.25.1.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"dummy_seclabel": {
+		ybversion.SERIES_2024_2: "2024.2.0.0",
+		ybversion.SERIES_2_25:   "2.25.1.0",
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"documentdb": {
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2_25:   "2.25.2.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"documentdb_core": {
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2_25:   "2.25.2.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"documentdb_distributed": {
+		ybversion.SERIES_2025_1: "2025.1.0.0",
+		ybversion.SERIES_2_25:   "2.25.2.0",
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+	"pg_parquet": {
+		ybversion.SERIES_2025_2: "2025.2.0.0",
+	},
+}
+
+func GetExtensionFixedVersions(extensionName string) map[string]string {
+	return extensionsFixedInVersions[extensionName]
 }
 
 func AppendObjectNameToIssueName(issueName string, objectName string) string {

--- a/yb-voyager/src/query/queryissue/issues_ddl.go
+++ b/yb-voyager/src/query/queryissue/issues_ddl.go
@@ -2048,5 +2048,13 @@ var extensionsIssue = issue.Issue{
 
 func NewExtensionsIssue(objectType string, objectName string, sqlStatement string) QueryIssue {
 	issue := extensionsIssue
+	fixedVersions := GetExtensionFixedVersions(objectName)
+	if len(fixedVersions) > 0 {
+		issue.MinimumVersionsFixedIn = make(map[string]*ybversion.YBVersion)
+		for series, verStr := range fixedVersions {
+			ver, _ := ybversion.NewYBVersion(verStr)
+			issue.MinimumVersionsFixedIn[series] = ver
+		}
+	}
 	return newQueryIssue(issue, objectType, objectName, sqlStatement, map[string]interface{}{}, map[string]interface{}{})
 }


### PR DESCRIPTION
- Enhanced  to report extension support based on the specified target YugabyteDB version.
- Added a version support matrix for extensions like , , , and .
- Updated [NewExtensionsIssue](yb-voyager/yb-voyager/src/query/queryissue/issues_ddl.go) to dynamically populate , allowing Voyager to filter false positives for supported versions.
- Handled the removal of the  extension for PG15-based YugabyteDB versions (2.25+).
- Added a new unit test suite [New Test Cases](yb-voyager/yb-voyager/src/query/queryissue/extensions_test.go) to verify version-specific support across multiple YugabyteDB series.

### Describe the changes in this pull request

This pull request enhances the **analyze-schema / assessment phase** to detect unsupported PostgreSQL extensions **based on the specified target YugabyteDB version**, instead of relying on a static extension list.

Previously, YB Voyager used a fixed list of supported extensions, which caused **false positives** when extensions were newly supported in recent YugabyteDB releases.

**Key changes:**

- **Base Support Added**
  - Added `vector` to the `SupportedExtensionsOnYB` list in `helpers.go`.

- **Version Support Matrix**
  - Introduced a mapping of extensions to their **minimum supported YugabyteDB versions** in `helpers.go`.
  - The data is extracted from the validation logic already present in the `migtests` suite, ensuring consistency.

- **Dynamic Issue Metadata**
  - Updated `NewExtensionsIssue` in `issues_ddl.go` to populate the `MinimumVersionsFixedIn` field.
  - This enables Voyager’s existing filtering logic to automatically suppress “unsupported extension” warnings when the specified target version supports the extension.

- **Deprecation Handling**
  - Implemented version-aware logic for `timetravel`, marking it unsupported **only for PG15-based versions** (2.25+, 2025.1+), while preserving support for older versions.

---

### Describe if there are any user-facing changes

- **Reports**
  - `schema_analysis_report.json` and assessment reports will no longer flag extensions such as `vector`, `pg_partman`, or `anon` as unsupported when the provided `--target-db-version` supports them.

- **Command Line**
  - No changes to existing flags.

- **Configuration**
  - No changes.

- **Installation**
  - No changes.

---

### How was this pull request tested?

- **New Unit Tests**
  - Added a comprehensive test suite in  
    `yb-voyager/src/query/queryissue/extensions_test.go`
  - Covers extension support and unsupported scenarios across multiple YugabyteDB version series:
    - `2.25`
    - `2024.1`
    - `2024.2`
    - `2025.1`

- **Manual Verification**
  - Ran `analyze-schema` with different `--target-db-version` values to verify:
    - `vector` is correctly detected as supported where applicable.
    - Version-specific extensions are flagged only when unsupported for the chosen target version.

---

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

---

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes schema assessment output by dynamically suppressing/flagging `UNSUPPORTED_EXTENSION` issues based on target YugabyteDB version; incorrect version mappings could hide real incompatibilities or reintroduce false positives.
> 
> **Overview**
> Makes `UNSUPPORTED_EXTENSION` reporting **version-aware** by attaching per-extension `MinimumVersionsFixedIn` data to `NewExtensionsIssue`, derived from a new extension→YB-series minimum-version matrix.
> 
> Updates the static supported extension list to include `vector`, and adds unit tests covering version-specific support/removal scenarios (e.g., `pg_partman`, `anon`, `timetravel`) plus unknown-extension behavior across multiple YugabyteDB versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 461c29c648e9bec5248f19138697cf10dd29f7fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->