### PR TITLE
Modified QUEUE_SEGMENT_MAX_BYTES to 10MB

### DIFF
--- a/migtests/tests/resumption/live-migration/fall-forward-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fall-forward-resumption-test/scenario.yaml.template
@@ -4,6 +4,7 @@ run_id: run
 
 env:
   LOG_LEVEL: info
+  QUEUE_SEGMENT_MAX_BYTES: 10485760
 
 export_dir: ./export-dir
 artifacts_dir: ./artifacts

--- a/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
@@ -4,6 +4,7 @@ run_id: run
 
 env:
   LOG_LEVEL: info
+  QUEUE_SEGMENT_MAX_BYTES: 10485760
 
 export_dir: ./export-dir
 artifacts_dir: ./artifacts

--- a/migtests/tests/resumption/live-migration/forward-migration/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/forward-migration/scenario.yaml.template
@@ -4,6 +4,7 @@ run_id: run
 
 env:
   LOG_LEVEL: info
+  QUEUE_SEGMENT_MAX_BYTES: 10485760
 
 export_dir: ./export-dir
 artifacts_dir: ./artifacts


### PR DESCRIPTION
### Describe the changes in this pull request
Modified QUEUE_SEGMENT_MAX_BYTES for all live migration resumption tests to 10MB

### Describe if there are any user-facing changes
N/A

### How was this pull request tested?
Through the following Jenkins Runs:
- https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/test-voyager-live-migration-resumption/88/
- https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/test-voyager-live-migration-resumption/89/
- https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/test-voyager-live-migration-resumption/91/
- https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/test-voyager-live-migration-resumption/92/

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No

### Does your PR have changes to on-disk structures that can cause upgrade issues? 
No

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
