### PR TITLE
Fix CMD syntax in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get update && apt-get install -y curl perl make libdbi-perl locales && \
     rm -rf /root/go /root/.cache /tmp/go && \
     apt-get clean
 COPY --from=0 $HOME/go/bin/dlv /usr/local/bin
-CMD [“yb-voyager”]
+CMD ["yb-voyager"]


### PR DESCRIPTION
The Dockerfile has a syntax error on quotes.

```bash
$ docker pull yugabytedb/yb-voyager:2026.2.1
2026.2.1: Pulling from yugabytedb/yb-voyager
Digest: sha256:ed43e7e3514e546ae4211a83c38e6d7601d907ac9e50d0d06943799247034bbb
Status: Image is up to date for yugabytedb/yb-voyager:2026.2.1
docker.io/yugabytedb/yb-voyager:2026.2.1

$ docker run --rm -it yugabytedb/yb-voyager:2026.2.1
/bin/sh: 1: [“yb-voyager”]: not found
```