### PR TITLE
Fix colocated prompt during import-schema

### DIFF
--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -352,7 +352,7 @@ func isYBDatabaseIsColocated(conn *pgx.Conn) bool {
 func assessmentRecommendedColocatedTables() (bool, error) {
 	reportPath := GetJsonAssessmentReportPath()
 	if !utils.FileOrFolderExists(reportPath) {
-		return false, fmt.Errorf("assessment report not found at %s", reportPath)
+		return false, goerrors.Errorf("assessment report not found at %s", reportPath)
 	}
 	report, err := ParseJSONToAssessmentReport(reportPath)
 	if err != nil {


### PR DESCRIPTION
### Describe the changes in this pull request
Refine the colocated database warning prompt in import schema to only appear when the migration assessment has actually recommended colocated tables. Previously, the prompt was shown whenever the target DB was non-colocated and assessment recommendations had been applied -- even if all tables were recommended as sharded. With the shift toward an all-sharded strategy, the old prompt was misleading for the majority of cases.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
Before / After
Before (always shown when target DB is non-colocated and assessment was applied):
`Warning: Target DB 'testcursor' is a non-colocated database, colocated tables can't be created in a non-colocated database. Use a colocated database if your schema contains colocated tables. Do you still want to continue? [Y/N]:`

After (only shown when assessment recommends colocated tables + target DB is non-colocated):
`Warning: Target DB 'testcursor' is a non-colocated database. The migration assessment has recommended colocated tables, which require a colocated database. Do you still want to continue without colocation? [Y/N]:`

When assessment recommends all-sharded (no colocated tables), the prompt is skipped entirely.

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No

### Does your PR have changes to on-disk structures that can cause upgrade issues? 
No

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `import-schema` execution path and changes when/if the user is prompted, including downgrading some assessment/report errors to warnings which could let imports proceed without the previous safeguard.
> 
> **Overview**
> **Refines the colocated database warning during `import-schema`.** The non-colocated target DB prompt is now shown only when migration assessment is marked done/applied *and* the assessment JSON report contains a non-empty colocated-tables recommendation.
> 
> The colocated check/prompt logic is refactored into helper functions and failures to read/parse the assessment report now log a warning rather than aborting the import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df5a8392b17380498b64e063b4266b84691c4fac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->