### PR TITLE
Strip HTML anchor tags from YB-Aeon control plane payloads to prevent WAF 403 rejections

### DIFF
--- a/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/oracle/assessment-report-test/expectedAssessmentReport.json
@@ -1310,7 +1310,7 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "ColocatedShardedNotes",

--- a/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild1AssessmentReport.json
+++ b/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild1AssessmentReport.json
@@ -603,7 +603,7 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "ColocatedShardedNotes",

--- a/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild2AssessmentReport.json
+++ b/migtests/tests/oracle/bulk-assessment-test/expected_reports/expectedChild2AssessmentReport.json
@@ -747,7 +747,7 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "ColocatedShardedNotes",

--- a/migtests/tests/pg/adventureworks/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/adventureworks/expected_files/expectedAssessmentReport.json
@@ -4366,11 +4366,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-perf-optimization-test/expectedAssessmentReport.json
@@ -1519,11 +1519,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/assessment-report-test-uqc/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test-uqc/expectedAssessmentReport.json
@@ -340,11 +340,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/assessment-report-test-with-tdb/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test-with-tdb/expectedAssessmentReport.json
@@ -4305,7 +4305,7 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
@@ -4313,7 +4313,7 @@
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/assessment-report-test/expectedAssessmentReport.json
@@ -4193,11 +4193,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "GeneralNotes",

--- a/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.json
+++ b/migtests/tests/pg/basic-assessment-report-test/expectedAssessmentReport.json
@@ -391,11 +391,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/mgi/expected_files/expectedAssessmentReport.json
@@ -16893,11 +16893,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/omnibus/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/omnibus/expected_files/expectedAssessmentReport.json
@@ -5649,11 +5649,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/osm/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/osm/expected_files/expectedAssessmentReport.json
@@ -258,11 +258,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/pgtbrus/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/pgtbrus/expected_files/expectedAssessmentReport.json
@@ -191,11 +191,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/rna/expected_files/expectedAssessmentReport.json
@@ -37759,11 +37759,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/sakila/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/sakila/expected_files/expectedAssessmentReport.json
@@ -1262,11 +1262,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/sample-is/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/sample-is/expected_files/expectedAssessmentReport.json
@@ -313,11 +313,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/migtests/tests/pg/stackexchange/expected_files/expectedAssessmentReport.json
+++ b/migtests/tests/pg/stackexchange/expected_files/expectedAssessmentReport.json
@@ -1828,11 +1828,11 @@
     "Notes": [
         {
             "Type": "GeneralNotes",
-            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes (https://docs.yugabyte.com/preview/releases/ybdb-releases/) for detailed information and usage guidelines."
+            "Text": "Some features listed in this report may be supported under a preview flag in the specified target-db-version of YugabyteDB. Please refer to the official release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ ) for detailed information and usage guidelines."
         },
         {
             "Type": "GeneralNotes",
-            "Text": "Limitations in assessment (https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations)"
+            "Text": "Limitations in assessment ( https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#assessment-and-schema-analysis-limitations )"
         },
         {
             "Type": "SizingNotes",

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1312,38 +1312,38 @@ func (ni NoteInfo) MarshalJSON() ([]byte, error) {
 		Text string   `json:"Text"`
 	}{
 		Type: ni.Type,
-		Text: stripHTMLTags(ni.Text),
+		Text: stripAnchorTags(ni.Text),
 	})
 }
 
-// stripHTMLTags removes <a> tags but preserves both link text and URL
-func stripHTMLTags(htmlText string) string {
+// stripAnchorTags converts HTML <a> tags to plain text "text (URL)" format,
+// preserving both the link text and the URL. If the link text equals the URL,
+// only the URL is kept to avoid duplication.
+// Note: This only handles <a> tags. Other HTML tags (e.g., <br>, <div>) are left as-is.
+func stripAnchorTags(htmlText string) string {
 	if htmlText == "" {
 		return ""
 	}
 
-	// Extract href and text from <a> tags: <a href="URL">text</a> → "text (URL)"
 	linkPattern := regexp.MustCompile(`<a[^>]*href=["']([^"']*)["'][^>]*>(.*?)</a>`)
 	result := linkPattern.ReplaceAllStringFunc(htmlText, func(match string) string {
 		submatch := linkPattern.FindStringSubmatch(match)
 		if len(submatch) >= 3 {
 			url := submatch[1]
 			text := submatch[2]
-			// If text is the same as URL, just return the URL
 			if text == url {
 				return url
 			}
-			// Otherwise return "text (URL)"
-			return text + " (" + url + ")"
+			return text + " ( " + url + " )"
 		}
 		return match
 	})
 
-	// Clean up whitespace
 	result = strings.TrimSpace(result)
 
 	return result
 }
+
 
 // ======================================================================
 type BulkAssessmentReport struct {

--- a/yb-voyager/cmd/common_test.go
+++ b/yb-voyager/cmd/common_test.go
@@ -401,7 +401,7 @@ func TestAssessmentReportJson(t *testing.T) {
 
 }
 
-func TestStripHTMLTags(t *testing.T) {
+func TestStripAnchorTags(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -425,12 +425,12 @@ func TestStripHTMLTags(t *testing.T) {
 		{
 			name:     "Leading and trailing whitespace",
 			input:    "   <a href=\"https://example.com\">Example</a>   ",
-			expected: "Example (https://example.com)",
+			expected: "Example ( https://example.com )",
 		},
 		{
 			name:     "Basic link processing",
 			input:    "<a href=\"https://example.com\">Example</a>",
-			expected: "Example (https://example.com)",
+			expected: "Example ( https://example.com )",
 		},
 		{
 			name:     "Link with text same as URL",
@@ -440,12 +440,12 @@ func TestStripHTMLTags(t *testing.T) {
 		{
 			name:     "Link with attributes and single quotes",
 			input:    "<a href='https://docs.yugabyte.com' target=\"_blank\" class=\"link\">YugabyteDB Docs</a>",
-			expected: "YugabyteDB Docs (https://docs.yugabyte.com)",
+			expected: "YugabyteDB Docs ( https://docs.yugabyte.com )",
 		},
 		{
 			name:     "Multiple links",
 			input:    "<a href=\"https://example1.com\">Link1</a> and <a href=\"https://example2.com\">Link2</a>",
-			expected: "Link1 (https://example1.com) and Link2 (https://example2.com)",
+			expected: "Link1 ( https://example1.com ) and Link2 ( https://example2.com )",
 		},
 		{
 			name:     "Various HTML tags preserved",
@@ -455,17 +455,22 @@ func TestStripHTMLTags(t *testing.T) {
 		{
 			name:     "Mixed content with links and diverse tags",
 			input:    "<div><a href=\"https://example.com\">Link</a> and <span>span text</span><img src=\"image.jpg\" alt=\"image\"/></div>",
-			expected: "<div>Link (https://example.com) and <span>span text</span><img src=\"image.jpg\" alt=\"image\"/></div>",
+			expected: "<div>Link ( https://example.com ) and <span>span text</span><img src=\"image.jpg\" alt=\"image\"/></div>",
 		},
 		{
 			name:     "Link with special characters in URL",
 			input:    "<a href=\"https://example.com/path?param=value&other=123\">Special URL</a>",
-			expected: "Special URL (https://example.com/path?param=value&other=123)",
+			expected: "Special URL ( https://example.com/path?param=value&other=123 )",
 		},
 		{
 			name:     "Link with special characters in text",
 			input:    "<a href=\"https://example.com\">Text with &amp; symbols &lt;tags&gt;</a>",
-			expected: "Text with &amp; symbols &lt;tags&gt; (https://example.com)",
+			expected: "Text with &amp; symbols &lt;tags&gt; ( https://example.com )",
+		},
+		{
+			name:     "URL with trailing slash preserved",
+			input:    `<a href="https://docs.yugabyte.com/preview/releases/ybdb-releases/">release notes</a>`,
+			expected: "release notes ( https://docs.yugabyte.com/preview/releases/ybdb-releases/ )",
 		},
 		{
 			name:     "Malformed HTML - missing closing tag",
@@ -476,7 +481,7 @@ func TestStripHTMLTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := stripHTMLTags(tt.input)
+			result := stripAnchorTags(tt.input)
 			assert.Equal(t, tt.expected, result,
 				"Test: %s\nInput: %q\nExpected: %q\nActual: %q",
 				tt.name, tt.input, tt.expected, result)

--- a/yb-voyager/cmd/ybaeon_event_builder.go
+++ b/yb-voyager/cmd/ybaeon_event_builder.go
@@ -93,13 +93,14 @@ func createMigrationAssessmentCompletedEventForYBAeon() *cp.MigrationAssessmentC
 
 	// Classify notes into categories (same as yugabyted)
 	for _, note := range assessmentReport.Notes {
+		sanitizedText := stripAnchorTags(note.Text)
 		switch note.Type {
 		case GeneralNotes:
-			payload.GeneralNotes = append(payload.GeneralNotes, note.Text)
+			payload.GeneralNotes = append(payload.GeneralNotes, sanitizedText)
 		case ColocatedShardedNotes:
-			payload.ColocatedShardedNotes = append(payload.ColocatedShardedNotes, note.Text)
+			payload.ColocatedShardedNotes = append(payload.ColocatedShardedNotes, sanitizedText)
 		case SizingNotes:
-			payload.SizingNotes = append(payload.SizingNotes, note.Text)
+			payload.SizingNotes = append(payload.SizingNotes, sanitizedText)
 		}
 	}
 


### PR DESCRIPTION
… WAF 403 rejections (#3387)

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
