### PR TITLE
Fix assess-migration for no-source-connectivity

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -235,16 +235,15 @@ func assessMigration() (err error) {
 	migassessment.SourceDBType = source.DBType
 	migassessment.IntervalForCapturingIops = intervalForCapturingIOPS
 
-	if source.Password == "" {
-		source.Password, err = askPassword("source DB", source.User, "SOURCE_DB_PASSWORD")
-		if err != nil {
-			return fmt.Errorf("failed to get source DB password for assessing migration: %w", err)
-		}
-	}
-
 	var validatedReplicaEndpoints []srcdb.ReplicaEndpoint
 
 	if assessmentMetadataDirFlag == "" { // only in case of source connectivity
+		if source.Password == "" {
+			source.Password, err = askPassword("source DB", source.User, "SOURCE_DB_PASSWORD")
+			if err != nil {
+				return fmt.Errorf("failed to get source DB password for assessing migration: %w", err)
+			}
+		}
 		err := source.DB().Connect()
 		if err != nil {
 			return fmt.Errorf("failed to connect source db for assessing migration: %w", err)


### PR DESCRIPTION
The password prompt was unconditionally triggered before checking whether source DB connectivity was needed. When running with --assessment-metadata-dir (offline assessment without source DB), this caused a spurious password prompt. Move the prompt inside the source-connectivity block so it only fires when a DB connection is actually required.

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small control-flow change that only affects when `askPassword` is invoked during `assess-migration`, with no impact on assessment logic when source connectivity is required.
> 
> **Overview**
> Fixes `assess-migration` runs that use `--assessment-metadata-dir` (offline/no source connectivity) by **only prompting for the source DB password when a live source DB connection is actually needed**.
> 
> This prevents an unnecessary password prompt while keeping the existing connection-path behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38a338df7ac0117e35a83c1f8d1a9705a1bed442. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->