### PR TITLE
Source schema name in target

### DIFF
--- a/yb-voyager/cmd/exportSchemaOptimizationReport.go
+++ b/yb-voyager/cmd/exportSchemaOptimizationReport.go
@@ -285,7 +285,7 @@ func NewPKHashShardingChange(applied bool, modifiedTables []string) *PKHashShard
 }
 
 func (p *PKHashShardingChange) Exist() bool {
-	return true
+	return len(p.ModifiedTables) > 0
 }
 
 func (p *PKHashShardingChange) Summary() string {
@@ -320,7 +320,7 @@ func NewPKOnTimestampRangeShardingChange(applied bool, modifiedTables []string) 
 }
 
 func (p *PKOnTimestampRangeShardingChange) Exist() bool {
-	return true
+	return len(p.ModifiedTables) > 0
 }
 
 func (p *PKOnTimestampRangeShardingChange) Summary() string {
@@ -331,10 +331,11 @@ type UKRangeSplittingChange struct {
 	Title                   string            `json:"title"`
 	Description             string            `json:"description"`
 	HyperLinksInDescription map[string]string `json:"hyper_links_in_description"`
+	ModifiedUKTables        []string          `json:"modified_uk_tables"`
 	IsApplied               bool              `json:"is_applied"`
 }
 
-func NewUKRangeSplittingChange(applied bool) *UKRangeSplittingChange {
+func NewUKRangeSplittingChange(applied bool, modifiedUKTables []string) *UKRangeSplittingChange {
 	title := "Unique Key Constraints to be range-sharded - Applied"
 	description := "All the unique key constraints were configured to be range-sharded in YugabyteDB."
 	if !applied {
@@ -343,9 +344,10 @@ func NewUKRangeSplittingChange(applied bool) *UKRangeSplittingChange {
 	}
 	description += "The range-sharded indexes helps in giving the flexibility to execute range-based queries, and avoids potential hotspot that comes with hash-sharded indexes such as index on high percentage of NULLs. Refer to sharding strategy in documentation for more information."
 	return &UKRangeSplittingChange{
-		Title:       title,
-		Description: description,
-		IsApplied:   applied,
+		Title:            title,
+		Description:      description,
+		ModifiedUKTables: modifiedUKTables,
+		IsApplied:        applied,
 		HyperLinksInDescription: map[string]string{
 			"documentation":                     "https://docs.yugabyte.com/preview/architecture/docdb-sharding/sharding/",
 			"index on high percentage of NULLs": "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/postgresql/#index-on-column-with-a-high-percentage-of-null-values",
@@ -354,7 +356,7 @@ func NewUKRangeSplittingChange(applied bool) *UKRangeSplittingChange {
 }
 
 func (p *UKRangeSplittingChange) Exist() bool {
-	return p != nil
+	return len(p.ModifiedUKTables) > 0
 }
 
 func (u *UKRangeSplittingChange) Summary() string {
@@ -495,15 +497,22 @@ func generatePerformanceOptimizationReport(indexTransformer *sqltransformer.Inde
 	schemaOptimizationReport.SecondaryIndexToRangeChange = buildSecondaryIndexToRangeChange(indexTransformer)
 
 	var shardingChangesApplied bool
-	pkTablesOnTimestampOrDate, pkTablesWithHashSharded := []string{}, []string{}
+	pkTablesOnTimestampOrDate, pkTablesWithHashSharded, ukTablesWithRangeSharded := []string{}, []string{}, []string{}
 	if tableTransformer != nil {
 		shardingChangesApplied = tableTransformer.AppliedHashOrRangeShardingStrategyToConstraints
 		pkTablesOnTimestampOrDate = tableTransformer.PKTablesOnTimestampWithRangeSharded
 		pkTablesWithHashSharded = tableTransformer.PKTablesWithHashSharded
+		ukTablesWithRangeSharded = tableTransformer.UKTablesWithRangeSharded
 	}
-	schemaOptimizationReport.PKHashShardingChange = NewPKHashShardingChange(shardingChangesApplied, pkTablesWithHashSharded)
-	schemaOptimizationReport.PKOnTimestampRangeShardingChange = NewPKOnTimestampRangeShardingChange(shardingChangesApplied, pkTablesOnTimestampOrDate)
-	schemaOptimizationReport.UKRangeShardingChange = NewUKRangeSplittingChange(shardingChangesApplied)
+	if len(pkTablesWithHashSharded) > 0 {
+		schemaOptimizationReport.PKHashShardingChange = NewPKHashShardingChange(shardingChangesApplied, pkTablesWithHashSharded)
+	}
+	if len(pkTablesOnTimestampOrDate) > 0 {
+		schemaOptimizationReport.PKOnTimestampRangeShardingChange = NewPKOnTimestampRangeShardingChange(shardingChangesApplied, pkTablesOnTimestampOrDate)
+	}
+	if len(ukTablesWithRangeSharded) > 0 {
+		schemaOptimizationReport.UKRangeShardingChange = NewUKRangeSplittingChange(shardingChangesApplied, ukTablesWithRangeSharded)
+	}
 
 	if schemaOptimizationReport.HasOptimizations() {
 		file, err := os.Create(htmlReportFilePath)

--- a/yb-voyager/cmd/templates/schema_optimization_report.template
+++ b/yb-voyager/cmd/templates/schema_optimization_report.template
@@ -514,6 +514,31 @@
                      {{.UKRangeShardingChange.Title}}
                   </h3>
                <pre>{{ replaceLinks .UKRangeShardingChange.Description .UKRangeShardingChange.HyperLinksInDescription}}</pre>
+               {{ if and (.UKRangeShardingChange.IsApplied) (.UKRangeShardingChange.ModifiedUKTables) }}
+                  <details>
+                     <summary>Details</summary>
+                     <table>
+                        <thead>
+                           <tr>
+                              <th class="centered-cell">Tables</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <tr>
+                              <td>
+                                 <div class="scrollable-div no-wrap-list">
+                                    <ul>
+                                       {{range $idx, $table := .UKRangeShardingChange.ModifiedUKTables }}
+                                          <li>{{ $table }}</li>
+                                       {{end}}
+                                    </ul>
+                                 </div>
+                              </td>
+                           </tr>
+                        </tbody>
+                     </table>
+                  </details>
+               {{ end }}
             </div>
             {{ end }}
 

--- a/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
+++ b/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
@@ -175,6 +175,7 @@ type TableFileTransformer struct {
 	skipPerformanceOptimizations                    bool
 	PKTablesOnTimestampWithRangeSharded             []string
 	PKTablesWithHashSharded                         []string
+	UKTablesWithRangeSharded                        []string
 	AppliedHashOrRangeShardingStrategyToConstraints bool
 
 	//Colocation recommendation related information - currently this change is done outside of this transformer but whenever we merge it will be easier for consumers of transformer t o rely on same informaiton
@@ -218,7 +219,7 @@ func (t *TableFileTransformer) Transform(file string) (string, error) {
 	}
 
 	if t.shouldConfigureShardingStrategyForConstraints() {
-		parseTree.Stmts, t.PKTablesOnTimestampWithRangeSharded, t.PKTablesWithHashSharded, err = transformer.AddShardingStrategyForConstraints(parseTree.Stmts)
+		parseTree.Stmts, t.PKTablesOnTimestampWithRangeSharded, t.PKTablesWithHashSharded, t.UKTablesWithRangeSharded, err = transformer.AddShardingStrategyForConstraints(parseTree.Stmts)
 		if err != nil {
 			return "", fmt.Errorf("failed to add hash splitting on for pk constraints: %w", err)
 		}

--- a/yb-voyager/src/query/sqltransformer/transformer.go
+++ b/yb-voyager/src/query/sqltransformer/transformer.go
@@ -240,7 +240,7 @@ order of statements after transformation:
 6. Other statements
 */
 
-func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStmt) ([]*pg_query.RawStmt, []string, []string, error) {
+func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStmt) ([]*pg_query.RawStmt, []string, []string, []string, error) {
 	log.Infof("adding hash splitting on for pk constraints to the schema")
 	selectSetStatements := make([]*pg_query.RawStmt, 0)
 	createAndAlterTableWithPK := make([]*pg_query.RawStmt, 0)
@@ -250,10 +250,11 @@ func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStm
 
 	pkTablesOnTimestampOrDate := make([]string, 0)
 	pkTablesWithHashSharding := make([]string, 0)
+	ukTables := make([]string, 0)
 
 	tablesMap, err := getTablesMap(stmts)
 	if err != nil {
-		return nil, nil, nil, goerrors.Errorf("failed to get tables to column on range types: %v", err)
+		return nil, nil, nil, nil, goerrors.Errorf("failed to get tables to column on range types: %v", err)
 	}
 
 	for _, stmt := range stmts {
@@ -263,7 +264,7 @@ func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStm
 		}
 		ddlObject, err := queryparser.ProcessDDL(&pg_query.ParseResult{Stmts: []*pg_query.RawStmt{stmt}})
 		if err != nil {
-			return nil, nil, nil, goerrors.Errorf("failed to process ddl: %v", err)
+			return nil, nil, nil, nil, goerrors.Errorf("failed to process ddl: %v", err)
 		}
 		switch ddlObject.(type) {
 		case *queryparser.Table:
@@ -277,7 +278,7 @@ func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStm
 			}
 			isPKOnRangeDatatype, err := t.checkIfPrimaryKeyOnRangeDatatype(pkConstraint.Columns, table)
 			if err != nil {
-				return nil, nil, nil, goerrors.Errorf("failed to check if primary key on range datatype: %v", err)
+				return nil, nil, nil, nil, goerrors.Errorf("failed to check if primary key on range datatype: %v", err)
 			}
 			if isPKOnRangeDatatype {
 				pkTablesOnTimestampOrDate = append(pkTablesOnTimestampOrDate, tableName)
@@ -292,11 +293,11 @@ func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStm
 			case queryparser.PRIMARY_CONSTR_TYPE:
 				table, ok := tablesMap[alterTable.GetObjectName()]
 				if !ok {
-					return nil, nil, nil, goerrors.Errorf("table %s not found in tables map", alterTable.GetObjectName())
+					return nil, nil, nil, nil, goerrors.Errorf("table %s not found in tables map", alterTable.GetObjectName())
 				}
 				isPKOnRangeDatatype, err := t.checkIfPrimaryKeyOnRangeDatatype(alterTable.ConstraintColumns, table)
 				if err != nil {
-					return nil, nil, nil, goerrors.Errorf("failed to check if primary key on range datatype: %v", err)
+					return nil, nil, nil, nil, goerrors.Errorf("failed to check if primary key on range datatype: %v", err)
 				}
 				if isPKOnRangeDatatype {
 					pkTablesOnTimestampOrDate = append(pkTablesOnTimestampOrDate, alterTable.GetObjectName())
@@ -306,6 +307,7 @@ func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStm
 					createAndAlterTableWithPK = append(createAndAlterTableWithPK, stmt)
 				}
 			case queryparser.UNIQUE_CONSTR_TYPE:
+				ukTables = append(ukTables, alterTable.GetObjectName())
 				AlterTableUKConstraints = append(AlterTableUKConstraints, stmt)
 			default:
 				otherStatements = append(otherStatements, stmt)
@@ -317,11 +319,11 @@ func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStm
 
 	hashSplittingSessionVariableOnParseTree, err := queryparser.Parse(HASH_SPLITTING_SESSION_VARIABLE_ON)
 	if err != nil {
-		return nil, nil, nil, goerrors.Errorf("failed to parse hash splitting session variable on: %v", err)
+		return nil, nil, nil, nil, goerrors.Errorf("failed to parse hash splitting session variable on: %v", err)
 	}
 	hashSplittingSessionVariableOffParseTree, err := queryparser.Parse(HASH_SPLITTING_SESSION_VARIABLE_OFF)
 	if err != nil {
-		return nil, nil, nil, goerrors.Errorf("failed to parse hash splitting session variable off: %v", err)
+		return nil, nil, nil, nil, goerrors.Errorf("failed to parse hash splitting session variable off: %v", err)
 	}
 
 	//TODO: see how we can add comments in between statements to make the table.sql more readable
@@ -334,7 +336,7 @@ func (t *Transformer) AddShardingStrategyForConstraints(stmts []*pg_query.RawStm
 	modifiedStmts = append(modifiedStmts, AlterTableUKConstraints...)
 	modifiedStmts = append(modifiedStmts, otherStatements...)
 
-	return modifiedStmts, pkTablesOnTimestampOrDate, pkTablesWithHashSharding, nil
+	return modifiedStmts, pkTablesOnTimestampOrDate, pkTablesWithHashSharding, ukTables, nil
 
 }
 

--- a/yb-voyager/src/query/sqltransformer/transformer_test.go
+++ b/yb-voyager/src/query/sqltransformer/transformer_test.go
@@ -709,7 +709,7 @@ func TestHashSplittingChanges(t *testing.T) {
 
 		transformer := NewTransformer()
 
-		transformedStmts, _, _, err := transformer.AddShardingStrategyForConstraints(parseTree.Stmts)
+		transformedStmts, _, _, _, err := transformer.AddShardingStrategyForConstraints(parseTree.Stmts)
 		if testCase.errExpected {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), testCase.errExpectedMsg)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Correctly hide schema optimization report sections when no applicable objects exist.

Previously, sections for PK hash, timestamp PK range, and UK range sharding appeared even when empty, leading to a misleading report. This fix ensures these sections are only displayed when there are actual objects to report, and also provides details for UK range splitting similar to PK sections.

---
<p><a href="https://cursor.com/agents/bc-e5b5ae96-3d07-4738-8ae8-aad16a3f1700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5b5ae96-3d07-4738-8ae8-aad16a3f1700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->