### PR TITLE
Quote HTML tags in YbAeon control plane note payloads instead of stripping them

### DIFF
--- a/yb-voyager/cmd/yugabyted_event_builder.go
+++ b/yb-voyager/cmd/yugabyted_event_builder.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"html"
 
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
@@ -62,7 +61,7 @@ func createMigrationAssessmentCompletedEventForYugabyteD() *cp.MigrationAssessme
 	assessmentIssues := convertAssessmentIssueToYugabyteDAssessmentIssue(assessmentReport)
 
 	allNotesText := lo.Map(assessmentReport.Notes, func(note NoteInfo, _ int) string {
-		return html.EscapeString(note.Text)
+		return note.Text
 	})
 
 	schemaSummaryPayload := convertSchemaSummaryToPayload(assessmentReport.SchemaSummary, source.DBType)
@@ -111,14 +110,13 @@ func createMigrationAssessmentCompletedEventForYugabyteD() *cp.MigrationAssessme
 
 	// classify notes into GeneralNotes, ColocatedShardedNotes, SizingNotes
 	for _, note := range assessmentReport.Notes {
-		sanitizedText := html.EscapeString(note.Text)
 		switch note.Type {
 		case GeneralNotes:
-			payload.GeneralNotes = append(payload.GeneralNotes, sanitizedText)
+			payload.GeneralNotes = append(payload.GeneralNotes, note.Text)
 		case ColocatedShardedNotes:
-			payload.ColocatedShardedNotes = append(payload.ColocatedShardedNotes, sanitizedText)
+			payload.ColocatedShardedNotes = append(payload.ColocatedShardedNotes, note.Text)
 		case SizingNotes:
-			payload.SizingNotes = append(payload.SizingNotes, sanitizedText)
+			payload.SizingNotes = append(payload.SizingNotes, note.Text)
 		}
 	}
 


### PR DESCRIPTION
### Describe the changes in this pull request
stripAnchorTags() in cmd/common.go removes <a> tags and converts them to plaintext. This loses the original tag structure, only handles <a> tags, and isn't future-proof if other HTML tags are added to notes.

- Instead of stripping <a> tags, HTML-escaped all tags in YbAeon notes payloads using Go's html.EscapeString() (e.g., `<a href="...">` becomes `&lt;a href=&quot;...&quot;&gt;`). This is generic, future-proof, and preserves the full original content.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->
No
### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually
### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
Notes will have quoted html tags in payloads, no structural change
### Does your PR have changes to on-disk structures that can cause upgrade issues? 
No

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
