### PR TITLE
Add segment-cleanup command with delete policy

### DIFF
--- a/yb-voyager/cmd/import_data_snapshot_and_changes_snapshot_failures_test.go
+++ b/yb-voyager/cmd/import_data_snapshot_and_changes_snapshot_failures_test.go
@@ -43,8 +43,8 @@ import (
 //  4. Resume `import data` without failpoint and verify target matches source.
 //
 // Injection point:
-// - `src/tgtdb/yugabytedb.go` in transactional COPY path, right before txn commit:
-//   failpoint `importBatchCommitError`.
+//   - `src/tgtdb/yugabytedb.go` in transactional COPY path, right before txn commit:
+//     failpoint `importBatchCommitError`.
 func TestImportSnapshotCommitFailureAndResume(t *testing.T) {
 	ctx := context.Background()
 	tableName := "test_schema_import_snap_fail.snapshot_import_test"
@@ -95,7 +95,6 @@ func TestImportSnapshotCommitFailureAndResume(t *testing.T) {
 	// --- Phase 1: Start export and import concurrently ---
 	err = lm.StartExportData(true, nil)
 	require.NoError(t, err, "failed to start export")
-
 
 	const (
 		batchSizeRows      = 2
@@ -230,7 +229,6 @@ func TestImportSnapshotTransformFailureAndResume(t *testing.T) {
 	// --- Phase 1: Start export and import concurrently ---
 	err = lm.StartExportData(true, nil)
 	require.NoError(t, err, "failed to start export")
-
 
 	failpointEnv := testutils.GetFailpointEnvVar(
 		// Skip the first 20 per-row transform calls (let them succeed), then inject

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -355,6 +355,7 @@ var exportDirInitialisedCheckNeededList = []string{
 	"yb-voyager get data-migration-report",
 	"yb-voyager compare-performance",
 	"yb-voyager archive changes",
+	"yb-voyager segment-cleanup",
 	"yb-voyager end migration",
 	"yb-voyager initiate cutover to source",
 	"yb-voyager initiate cutover to source-replica",

--- a/yb-voyager/cmd/segmentCleanupCommand.go
+++ b/yb-voyager/cmd/segmentCleanupCommand.go
@@ -1,0 +1,95 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/segmentcleanup"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+)
+
+var (
+	cleanupPolicy               string
+	cleanupUtilizationThreshold int
+)
+
+var segmentCleanupCmd = &cobra.Command{
+	Use:   "segment-cleanup",
+	Short: "Clean up processed CDC event queue segments",
+	Long: fmt.Sprintf(`Manage the lifecycle of processed CDC event segments during live migration.
+
+Supported policies (--policy):
+  delete  (default) — delete processed segments once fs utilization exceeds the threshold.
+  retain  — keep all segments on disk; emit warnings if the threshold is exceeded.
+
+Policies: %s`, strings.Join(segmentcleanup.ValidPolicyNames, ", ")),
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		validateSegmentCleanupFlags()
+	},
+
+	Run: segmentCleanupCommandFn,
+}
+
+func segmentCleanupCommandFn(cmd *cobra.Command, args []string) {
+	msr, err := metaDB.GetMigrationStatusRecord()
+	if err != nil {
+		utils.ErrExit("error getting migration status record: %v", err)
+	}
+	if msr == nil {
+		utils.ErrExit("migration status record not found; ensure export has been initiated before running segment-cleanup")
+	}
+	if !msr.ExportDataSourceDebeziumStarted {
+		utils.ErrExit("the streaming phase of export data has not started yet — this command can only be run after streaming begins")
+	}
+
+	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		record.ArchivingEnabled = true
+	})
+
+	cfg := segmentcleanup.Config{
+		Policy:                 cleanupPolicy,
+		ExportDir:              exportDir,
+		FSUtilizationThreshold: cleanupUtilizationThreshold,
+	}
+
+	cleaner := segmentcleanup.NewSegmentCleaner(cfg, metaDB)
+	if err := cleaner.Run(); err != nil {
+		utils.ErrExit("segment cleanup failed: %v", err)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(segmentCleanupCmd)
+	registerCommonGlobalFlags(segmentCleanupCmd)
+
+	segmentCleanupCmd.Flags().StringVar(&cleanupPolicy, "policy", segmentcleanup.PolicyDelete,
+		fmt.Sprintf("cleanup policy for processed segments (%s)", strings.Join(segmentcleanup.ValidPolicyNames, ", ")))
+
+	segmentCleanupCmd.Flags().IntVar(&cleanupUtilizationThreshold, "fs-utilization-threshold", 70,
+		"disk utilization percentage above which cleanup actions are triggered")
+}
+
+func validateSegmentCleanupFlags() {
+	if !segmentcleanup.IsValidPolicy(cleanupPolicy) {
+		utils.ErrExit("invalid --policy %q: must be one of %s", cleanupPolicy, strings.Join(segmentcleanup.ValidPolicyNames, ", "))
+	}
+}

--- a/yb-voyager/src/metadb/metadataDB.go
+++ b/yb-voyager/src/metadb/metadataDB.go
@@ -513,6 +513,19 @@ func (m *MetaDB) GetSegmentsToBeArchived(importCount int) ([]utils.Segment, erro
 	return segmentsToBeArchived, nil
 }
 
+// GetProcessedSegments returns segments that all required importers have finished
+// processing and that have not yet been deleted, regardless of archive status.
+func (m *MetaDB) GetProcessedSegments(importCount int) ([]utils.Segment, error) {
+	predicate := fmt.Sprintf(`((exporter_role == 'source_db_exporter' AND (imported_by_target_db_importer + imported_by_source_replica_db_importer + imported_by_source_db_importer = %d)) OR
+	(exporter_role LIKE 'target_db_exporter%%' AND (imported_by_target_db_importer + imported_by_source_replica_db_importer + imported_by_source_db_importer = 1)))
+	AND deleted = 0`, importCount)
+	segments, err := m.querySegments(predicate)
+	if err != nil {
+		return nil, goerrors.Errorf("fetch processed segments: %v", err)
+	}
+	return segments, nil
+}
+
 func (m *MetaDB) GetSegmentsToBeDeleted() ([]utils.Segment, error) {
 	// sample query: SELECT segment_no, file_path FROM queue_segment_meta WHERE archived = 1 AND deleted = 0 ORDER BY segment_no;
 	predicate := "archived = 1 AND deleted = 0"
@@ -584,6 +597,15 @@ func (m *MetaDB) MarkSegmentDeleted(segmentNum int) error {
 	err := m.updateSegment(segmentNum, queryParams)
 	if err != nil {
 		return goerrors.Errorf("mark segment deleted in metaDB for segment %d: %v", segmentNum, err)
+	}
+	return nil
+}
+
+func (m *MetaDB) MarkSegmentDeletedAndArchived(segmentNum int) error {
+	queryParams := "archived = 1, deleted = 1"
+	err := m.updateSegment(segmentNum, queryParams)
+	if err != nil {
+		return goerrors.Errorf("mark segment deleted and archived in metaDB for segment %d: %v", segmentNum, err)
 	}
 	return nil
 }

--- a/yb-voyager/src/segmentcleanup/cleanup.go
+++ b/yb-voyager/src/segmentcleanup/cleanup.go
@@ -1,0 +1,182 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package segmentcleanup
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	goerrors "github.com/go-errors/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+)
+
+const (
+	PolicyDelete = "delete"
+	PolicyRetain = "retain"
+)
+
+var ValidPolicyNames = []string{PolicyDelete, PolicyRetain}
+
+func IsValidPolicy(policy string) bool {
+	for _, v := range ValidPolicyNames {
+		if policy == v {
+			return true
+		}
+	}
+	return false
+}
+
+type Config struct {
+	Policy                 string
+	ExportDir              string
+	FSUtilizationThreshold int
+}
+
+type SegmentCleaner struct {
+	config Config
+	metaDB *metadb.MetaDB
+	stop   bool
+}
+
+func NewSegmentCleaner(cfg Config, metaDB *metadb.MetaDB) *SegmentCleaner {
+	return &SegmentCleaner{
+		config: cfg,
+		metaDB: metaDB,
+	}
+}
+
+// SignalStop tells the cleaner to drain remaining work and exit.
+func (sc *SegmentCleaner) SignalStop() {
+	sc.stop = true
+}
+
+func (sc *SegmentCleaner) Run() error {
+	switch sc.config.Policy {
+	case PolicyDelete:
+		return sc.runDeletePolicy()
+	case PolicyRetain:
+		return sc.runRetainPolicy()
+	default:
+		return goerrors.Errorf("unsupported cleanup policy: %s", sc.config.Policy)
+	}
+}
+
+func (sc *SegmentCleaner) getImportCount() (int, error) {
+	msr, err := sc.metaDB.GetMigrationStatusRecord()
+	if err != nil {
+		return 0, goerrors.Errorf("get migration status record: %v", err)
+	}
+	if msr == nil {
+		return 0, goerrors.Errorf("migration status record not found")
+	}
+	if msr.FallForwardEnabled {
+		return 2, nil
+	}
+	return 1, nil
+}
+
+func (sc *SegmentCleaner) isFSUtilizationExceeded() bool {
+	if sc.stop {
+		return true
+	}
+	fsUtil, err := utils.GetFSUtilizationPercentage(sc.config.ExportDir)
+	if err != nil {
+		utils.ErrExit("failed to get fs utilization: %v", err)
+	}
+	return fsUtil > sc.config.FSUtilizationThreshold
+}
+
+// --- delete policy ---
+
+func (sc *SegmentCleaner) runDeletePolicy() error {
+	utils.PrintAndLogf("segment cleanup running with policy=delete, fs-utilization-threshold=%d%%\n",
+		sc.config.FSUtilizationThreshold)
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		if !sc.isFSUtilizationExceeded() {
+			continue
+		}
+
+		importCount, err := sc.getImportCount()
+		if err != nil {
+			return fmt.Errorf("get import count: %w", err)
+		}
+
+		segments, err := sc.metaDB.GetProcessedSegments(importCount)
+		if err != nil {
+			return goerrors.Errorf("get processed segments: %v", err)
+		}
+
+		if sc.stop && len(segments) == 0 {
+			log.Infof("all processed segments deleted, cleanup complete")
+			return nil
+		}
+
+		for _, seg := range segments {
+			if err := sc.deleteSegment(seg); err != nil {
+				return goerrors.Errorf("delete segment %s: %v", seg.FilePath, err)
+			}
+			if !sc.isFSUtilizationExceeded() {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (sc *SegmentCleaner) deleteSegment(seg utils.Segment) error {
+	if utils.FileOrFolderExists(seg.FilePath) {
+		if err := os.Remove(seg.FilePath); err != nil {
+			return goerrors.Errorf("remove segment file %s: %v", seg.FilePath, err)
+		}
+	}
+	if err := sc.metaDB.MarkSegmentDeletedAndArchived(seg.Num); err != nil {
+		return goerrors.Errorf("mark segment %d as deleted and archived: %v", seg.Num, err)
+	}
+	utils.PrintAndLogf("segment file %s deleted", seg.FilePath)
+	return nil
+}
+
+// --- retain policy ---
+
+func (sc *SegmentCleaner) runRetainPolicy() error {
+	utils.PrintAndLogf("segment cleanup running with policy=retain — processed segments will not be deleted\n")
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		if sc.stop {
+			log.Infof("retain policy: stop signal received, exiting")
+			return nil
+		}
+		fsUtil, err := utils.GetFSUtilizationPercentage(sc.config.ExportDir)
+		if err != nil {
+			return goerrors.Errorf("get fs utilization: %v", err)
+		}
+		if fsUtil > sc.config.FSUtilizationThreshold {
+			utils.PrintAndLogf("WARNING: fs utilization at %d%% (threshold %d%%) — segments are being retained per policy\n",
+				fsUtil, sc.config.FSUtilizationThreshold)
+		}
+	}
+	return nil
+}
+


### PR DESCRIPTION
Introduce a new `yb-voyager segment-cleanup` command that manages the lifecycle of processed CDC event queue segments. The delete policy (default) removes segment files from disk once all importers have marked them as processed and fs utilization exceeds the configured threshold.

The implementation decouples the delete path from the existing archive pipeline by adding a new `GetProcessedSegments` query that checks importer completion directly, and `MarkSegmentDeletedAndArchived` that atomically updates both flags in a single metaDB operation.|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new long-running command that can delete on-disk CDC segment files and updates MetaDB flags, so mistakes in processed-segment selection or threshold logic could cause data loss or premature cleanup during live migrations.
> 
> **Overview**
> Adds a new `yb-voyager segment-cleanup` command that can run during live migration streaming to manage processed CDC queue segment files, with `delete` (default) removing processed segments when disk utilization exceeds a configurable threshold and `retain` only warning.
> 
> Extends `metadb.MetaDB` with `GetProcessedSegments` (processed regardless of archive status) and `MarkSegmentDeletedAndArchived` (single update setting both flags), which the cleaner uses to decouple deletion from the existing archive pipeline. Also wires the command into `root.go`’s export-dir initialization checks and makes a small failpoint test adjustment (comment formatting and bumping a snapshot transform test `--batch-size` to `100`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbafbdf22ba7c0e468984350f2730a61de3ba9f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->