### PR TITLE
Fix non-deterministic failure in TestImportSnapshotTransformFailureAndResume

### DIFF
--- a/yb-voyager/cmd/import_data_snapshot_and_changes_snapshot_failures_test.go
+++ b/yb-voyager/cmd/import_data_snapshot_and_changes_snapshot_failures_test.go
@@ -234,15 +234,15 @@ func TestImportSnapshotTransformFailureAndResume(t *testing.T) {
 
 	failpointEnv := testutils.GetFailpointEnvVar(
 		// Skip the first 20 per-row transform calls (let them succeed), then inject
-		// a transform error on the 21st row. This crashes the importer mid-batch-
-		// production, before any batch is committed to the target.
+		// a transform error on the 21st row. With batch-size=100, all 20 rows fit
+		// in the first batch which is never finalized, so zero rows reach the target.
 		"github.com/yugabyte/yb-voyager/yb-voyager/cmd/importSnapshotTransformError=20*off->return(true)",
 	)
 	failMarkerPath := filepath.Join(lm.GetExportDir(), "failpoints", "failpoint-import-snapshot-transform-error.log")
 
 	t.Log("Starting import with snapshot transform failpoint...")
 	err = lm.StartImportDataWithEnv(true, map[string]string{
-		"--batch-size":           "2",
+		"--batch-size":           "100",
 		"--parallel-jobs":        "1",
 		"--adaptive-parallelism": "disabled",
 	}, []string{


### PR DESCRIPTION
### Describe the changes in this pull request
**Fix non-deterministic failure in TestImportSnapshotTransformFailureAndResume**

- With batch-size=2 and the failpoint set to trigger on the 21st transform call, 9 complete batches (18 rows) were produced and submitted to the worker pool before the error fired. 
- Since batch production and import run concurrently, those batches could be committed before the process exited, causing the assertion for 0 target rows to fail non-deterministically. 
- Increase batch-size to 100 so all 20 successful transforms stay within the first (never-finalized) batch, guaranteeing 0 rows on target.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
