### PR TITLE
Marked 2026.3.2 as a breaking release 

### DIFF
--- a/yb-voyager/src/utils/version.go
+++ b/yb-voyager/src/utils/version.go
@@ -20,7 +20,7 @@ const (
 	YB_VOYAGER_VERSION = "0rc1.2026.3.2"
 
 	// This constant must be updated after every breaking change.
-	PREVIOUS_BREAKING_CHANGE_VERSION = "2026.2.1"
+	PREVIOUS_BREAKING_CHANGE_VERSION = "2026.3.2"
 
 	// @Refer: https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/
 	GIT_COMMIT_HASH = "$Format:%H$"


### PR DESCRIPTION
### Describe the changes in this pull request
Cherry-pick: Mark 2026.3.2 as breaking release and update CDC savepoint fix versions

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
