### PR TITLE
Update CDC savepoint fix versions: bump 2025.1.3.0 to 2025.1.4.0 and 2025.2.1.0 to 2025.2.2.0

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -314,8 +314,8 @@ func startNextIterationImportDataToTarget() {
 
 var ybCDCSavepointAndReadCommittedFixedVersions = map[string]*ybversion.YBVersion{
 	ybversion.SERIES_2024_2: ybversion.V2024_2_8_0,
-	ybversion.SERIES_2025_1: ybversion.V2025_1_3_0,
-	ybversion.SERIES_2025_2: ybversion.V2025_2_1_0,
+	ybversion.SERIES_2025_1: ybversion.V2025_1_4_0,
+	ybversion.SERIES_2025_2: ybversion.V2025_2_2_0,
 }
 
 // isCDCSavepointFixedInTargetDBVersion returns whether the CDC savepoint rollback

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -161,13 +161,13 @@ func TestIsCDCSavepointFixedInTargetDBVersion(t *testing.T) {
 		{name: "2024.2 series exactly at fix", dbVersionStr: "11.2-YB-2024.2.8.0-b85", expectedFixed: true, expectedFixVersion: "2024.2.8.0"},
 		{name: "2024.2 series above fix", dbVersionStr: "11.2-YB-2024.2.9.0-b1", expectedFixed: true, expectedFixVersion: "2024.2.8.0"},
 
-		{name: "2025.1 series below fix", dbVersionStr: "11.2-YB-2025.1.2.0-b1", expectedFixed: false, expectedFixVersion: "2025.1.3.0"},
-		{name: "2025.1 series exactly at fix", dbVersionStr: "11.2-YB-2025.1.3.0-b42", expectedFixed: true, expectedFixVersion: "2025.1.3.0"},
-		{name: "2025.1 series above fix", dbVersionStr: "11.2-YB-2025.1.4.0-b1", expectedFixed: true, expectedFixVersion: "2025.1.3.0"},
+		{name: "2025.1 series below fix", dbVersionStr: "11.2-YB-2025.1.3.0-b1", expectedFixed: false, expectedFixVersion: "2025.1.4.0"},
+		{name: "2025.1 series exactly at fix", dbVersionStr: "11.2-YB-2025.1.4.0-b42", expectedFixed: true, expectedFixVersion: "2025.1.4.0"},
+		{name: "2025.1 series above fix", dbVersionStr: "11.2-YB-2025.1.5.0-b1", expectedFixed: true, expectedFixVersion: "2025.1.4.0"},
 
-		{name: "2025.2 series below fix", dbVersionStr: "11.2-YB-2025.2.0.0-b1", expectedFixed: false, expectedFixVersion: "2025.2.1.0"},
-		{name: "2025.2 series exactly at fix", dbVersionStr: "11.2-YB-2025.2.1.0-b10", expectedFixed: true, expectedFixVersion: "2025.2.1.0"},
-		{name: "2025.2 series above fix", dbVersionStr: "11.2-YB-2025.2.2.0-b1", expectedFixed: true, expectedFixVersion: "2025.2.1.0"},
+		{name: "2025.2 series below fix", dbVersionStr: "11.2-YB-2025.2.1.0-b1", expectedFixed: false, expectedFixVersion: "2025.2.2.0"},
+		{name: "2025.2 series exactly at fix", dbVersionStr: "11.2-YB-2025.2.2.0-b10", expectedFixed: true, expectedFixVersion: "2025.2.2.0"},
+		{name: "2025.2 series above fix", dbVersionStr: "11.2-YB-2025.2.3.0-b1", expectedFixed: true, expectedFixVersion: "2025.2.2.0"},
 
 		{name: "2024.1 series has no fix entry", dbVersionStr: "11.2-YB-2024.1.5.0-b1", expectedFixed: false, expectedFixVersion: ""},
 	}

--- a/yb-voyager/src/query/queryissue/issues_dml.go
+++ b/yb-voyager/src/query/queryissue/issues_dml.go
@@ -403,8 +403,8 @@ var savepointUsageIssue = issue.Issue{
 	DocsLink:    "https://docs.yugabyte.com/preview/yugabyte-voyager/known-issues/#savepoint-usage-in-transactions",
 	MinimumVersionsFixedIn: map[string]*ybversion.YBVersion{
 		ybversion.SERIES_2024_2: ybversion.V2024_2_8_0,
-		ybversion.SERIES_2025_1: ybversion.V2025_1_3_0,
-		ybversion.SERIES_2025_2: ybversion.V2025_2_1_0,
+		ybversion.SERIES_2025_1: ybversion.V2025_1_4_0,
+		ybversion.SERIES_2025_2: ybversion.V2025_2_2_0,
 	},
 }
 

--- a/yb-voyager/src/ybversion/constants.go
+++ b/yb-voyager/src/ybversion/constants.go
@@ -44,9 +44,9 @@ var V2024_2_3_1 *YBVersion
 var V2024_2_4_0 *YBVersion
 var V2024_2_8_0 *YBVersion
 var V2025_1_0_0 *YBVersion
-var V2025_1_3_0 *YBVersion
+var V2025_1_4_0 *YBVersion
 var V2025_2_0_0 *YBVersion
-var V2025_2_1_0 *YBVersion
+var V2025_2_2_0 *YBVersion
 var V2_23_0_0 *YBVersion
 var V2025_1_1_1 *YBVersion
 var V2_25_0_0 *YBVersion
@@ -125,9 +125,9 @@ func init() {
 		panic("could not create version 2025.1.0.0")
 	}
 
-	V2025_1_3_0, err = NewYBVersion("2025.1.3.0")
+	V2025_1_4_0, err = NewYBVersion("2025.1.4.0")
 	if err != nil {
-		panic("could not create version 2025.1.3.0")
+		panic("could not create version 2025.1.4.0")
 	}
 
 	V2025_2_0_0, err = NewYBVersion("2025.2.0.0")
@@ -135,9 +135,9 @@ func init() {
 		panic("could not create version 2025.2.0.0")
 	}
 
-	V2025_2_1_0, err = NewYBVersion("2025.2.1.0")
+	V2025_2_2_0, err = NewYBVersion("2025.2.2.0")
 	if err != nil {
-		panic("could not create version 2025.2.1.0")
+		panic("could not create version 2025.2.2.0")
 	}
 
 	// Whenever latest_stable version is updated in yb-versions.json, it will be reflected here as well.


### PR DESCRIPTION
### Describe the changes in this pull request
Update CDC savepoint fix versions: bump 2025.1.3.0 to 2025.1.4.0 and 2025.2.1.0 to 2025.2.2.0 

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
