### PR TITLE
Improve import data resumption UX and fix progress bar overwriting signal message

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -79,6 +79,15 @@ var skipNodeHealthChecks utils.BoolStr
 var skipDiskUsageHealthChecks utils.BoolStr
 var progressReporter *ImportDataProgressReporter
 var callhomeMetricsCollector *callhome.ImportDataMetricsCollector
+
+// ShutdownImportProgressBars stops the mpb progress container so that its
+// rendering goroutine no longer writes to stdout. Must be called before
+// printing any final messages on signal receipt to avoid the bars overwriting them.
+func ShutdownImportProgressBars() {
+	if progressReporter != nil {
+		progressReporter.Shutdown()
+	}
+}
 var importTableList []sqlname.NameTuple
 
 // Error policy
@@ -1077,12 +1086,17 @@ func importData(importFileTasks []*ImportFileTask, errorPolicy importdata.ErrorP
 		utils.ErrExit("Failed to prepare target DB for import: %s", err)
 	}
 
-	utils.PrintAndLogf("\nimport of data in %q database started", tconf.DBName)
 	state := NewImportDataState(exportDir)
 
 	err = clearMigrationStateForImportDataStartClean(state, importFileTasks, errorHandler)
 	if err != nil {
 		utils.ErrExit("Failed to clean MigrationStatusRecord for import data start clean: %s", err)
+	}
+
+	if state.HasExistingState() {
+		utils.PrintAndLogf("\nResuming import of data in %q database", tconf.DBName)
+	} else {
+		utils.PrintAndLogf("\nimport of data in %q database started", tconf.DBName)
 	}
 
 	if msr.SourceDBConf != nil {

--- a/yb-voyager/cmd/importDataFileTaskImporter.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter.go
@@ -99,6 +99,8 @@ type FileTaskImporter struct {
 
 	errorHandler             importdata.ImportDataErrorHandler
 	callhomeMetricsCollector *callhome.ImportDataMetricsCollector
+
+	resumeInfoShown bool
 }
 
 func NewFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchProducer FileBatchProducer, workerPool *pool.Pool,
@@ -108,6 +110,18 @@ func NewFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchProd
 	progressReporter.ImportFileStarted(task, totalProgressAmount)
 	currentProgressAmount := getImportedProgressAmount(task, state)
 	progressReporter.AddProgressAmount(task, currentProgressAmount)
+
+	resumeInfoShown := false
+	if currentProgressAmount > 0 {
+		var resumeMsg string
+		if reportProgressInBytes {
+			resumeMsg = "Resuming"
+		} else {
+			resumeMsg = fmt.Sprintf("Resuming: %d rows imported", currentProgressAmount)
+		}
+		progressReporter.AddResumeInformation(task, resumeMsg)
+		resumeInfoShown = true
+	}
 
 	fti := &FileTaskImporter{
 		state:                     state,
@@ -122,6 +136,7 @@ func NewFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchProd
 		currentProgressAmount:     currentProgressAmount,
 		errorHandler:              errorHandler,
 		callhomeMetricsCollector:  callhomeMetricsCollector,
+		resumeInfoShown:           resumeInfoShown,
 	}
 	state.RegisterFileTaskImporter(fti)
 	return fti, nil
@@ -270,6 +285,11 @@ func (fti *FileTaskImporter) importBatch(batch *Batch) {
 }
 
 func (fti *FileTaskImporter) updateProgressForCompletedBatch(batch *Batch) {
+	if fti.resumeInfoShown {
+		fti.progressReporter.RemoveResumeInformation(fti.task)
+		fti.resumeInfoShown = false
+	}
+
 	// Update basic progress update for progress bar and control plane.
 	var progressAmount int64
 	if reportProgressInBytes {

--- a/yb-voyager/cmd/importDataProgressReporter.go
+++ b/yb-voyager/cmd/importDataProgressReporter.go
@@ -46,6 +46,10 @@ func NewImportDataProgressReporter(disablePb bool) *ImportDataProgressReporter {
 	return pr
 }
 
+func (pr *ImportDataProgressReporter) Shutdown() {
+	pr.progress.Shutdown()
+}
+
 // Custom prepend decorator
 // This decorator is used to prepend the table name to the progress bar
 // It is also used to display the resume message to the user

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -83,6 +83,19 @@ func (e ErrTaskNotFound) Error() string {
 	return fmt.Sprintf("task importer with id %d not registered", e.taskID)
 }
 
+func (s *ImportDataState) HasExistingState() bool {
+	entries, err := os.ReadDir(s.stateDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "table::") {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *ImportDataState) PrepareForFileImport(filePath string, tableNameTup sqlname.NameTuple) error {
 	fileStateDir := s.getFileStateDir(filePath, tableNameTup)
 	log.Infof("Creating %q.", fileStateDir)

--- a/yb-voyager/main.go
+++ b/yb-voyager/main.go
@@ -54,9 +54,11 @@ func registerSignalHandlers() {
 		sig := <-sigs
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
+			cmd.ShutdownImportProgressBars()
 			utils.PrintAndLogf("\nReceived signal %s. Exiting...", sig)
 			cmd.ProcessShutdownRequested = true
 		case syscall.SIGUSR2:
+			cmd.ShutdownImportProgressBars()
 			utils.PrintAndLogf("\nReceived signal to terminate due to end migration command. Exiting...")
 			cmd.ProcessShutdownRequested = true
 		case syscall.SIGUSR1:


### PR DESCRIPTION
### Describe the changes in this pull request
Fixes: 

- https://yugabyte.atlassian.net/browse/DB-20611?atlOrigin=eyJpIjoiZjY2NzdkNWEzNjE2NDE0ZTk0ZDg3Y2FiODNhNDlmZGEiLCJwIjoiaiJ9
- https://yugabyte.atlassian.net/browse/DB-20222?atlOrigin=eyJpIjoiOWM2ZThmYzQxZGMxNDc5N2I2MjIyMzJlMzczMjUzMDYiLCJwIjoiaiJ9

This PR improves the user experience during import data resumption and fixes a visual bug where the progress bar overwrites the Ctrl+C signal message.

**Resumption banner:** When resuming an interrupted import, the top-level message now reads `"Resuming import of data in <db> database"` instead of the generic `"import of data in <db> database started"`. Detection is done by checking for existing import state (`table::*` directories in the state dir) after any `--start-clean` cleanup has been applied, via a new `HasExistingState()` method on `ImportDataState`.

**Per-table resume indicator:** On resumption, each table's progress bar shows a prepended message like `(Resuming: 96000000 rows imported)` indicating how many rows were already imported. This clears automatically after the first new batch completes, providing a transient visual cue that the import is picking up where it left off. For byte-based progress (import data file), a simpler `(Resuming)` label is shown.

**Signal message fix:** The `mpb` progress bar library runs a rendering goroutine that was racing with the signal handler — after Ctrl+C, mpb would render one more frame and overwrite the `"Received signal interrupt. Exiting..."` message. The fix calls `mpb.Progress.Shutdown()` **before** printing the signal message, stopping the renderer first. This follows the same pattern used by the export data `ProgressTracker`.

### Describe if there are any user-facing changes

1. On resumption, users now see `"Resuming import of data in <db> database"` instead of `"import of data in <db> database started"`.
2. Each table's progress bar temporarily shows `(Resuming: N rows imported)` until the first new batch completes.
3. The Ctrl+C exit message (`"Received signal interrupt. Exiting..."`) is no longer overwritten by a stale progress bar render.

### How was this pull request tested?

- Existing unit tests (`TestFileTaskImporter*`, `TestSequentialFileBatch*`, `TestRandomBatch*`) pass.
- Manual testing: ran `yb-voyager import data`, interrupted with Ctrl+C, verified the signal message is visible and not overwritten. Re-ran and confirmed the "Resuming" banner and per-table resume indicator appear correctly and clear after first batch.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. The `HasExistingState()` method is read-only and does not modify any on-disk structures.