### PR TITLE
Add iteration testing framework for live migration resumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ debezium-server-voyager/**/target/
 *.iml
 
 **/dummy_name_registry.json
+
+# resumption test artifacts (logs, metainfo, validation output)
+migtests/tests/resumption/**/artifacts/
+migtests/scripts/event-generator/event-generator-manual*.yaml
+migtests/scripts/event-generator/event-generator-iterations*.yaml

--- a/migtests/scripts/event-generator/generator.py
+++ b/migtests/scripts/event-generator/generator.py
@@ -137,6 +137,8 @@ if ENABLE_INDEX_CREATE_DROP:
 
 iteration_iter = itertools.count(1) if NUM_ITERATIONS == -1 else range(1, NUM_ITERATIONS + 1)
 
+stats = {"INSERT": 0, "UPDATE": 0, "DELETE": 0, "errors": 0, "insert_rows": 0, "update_rows": 0, "delete_rows": 0}
+
 try:
     for i in iteration_iter:
         # Choose a random table
@@ -163,8 +165,8 @@ try:
 
                 success = execute_with_retry(run_once, rebuild, conn.rollback, max_retries=INSERT_MAX_RETRIES)
                 if success:
-                    # Placeholder: hook for future stats reporting (e.g., counting successful INSERT batches)
-                    pass
+                    stats["INSERT"] += 1
+                    stats["insert_rows"] += INSERT_ROWS
             
             elif operation == "UPDATE":
                 for _ in range(UPDATE_MAX_RETRIES):
@@ -199,7 +201,9 @@ try:
                     try:
                         cursor.execute(query_to_run, full_params)
                         conn.commit()
-                        break  # Break out of the loop if the update is successful
+                        stats["UPDATE"] += 1
+                        stats["update_rows"] += UPDATE_ROWS
+                        break
                     except Exception as e:
                         conn.rollback()
 
@@ -214,7 +218,8 @@ try:
                 )
                 query_to_run = f"DELETE FROM {table_name} WHERE {where_clause}"
                 cursor.execute(query_to_run, sampling_params)
-
+                stats["DELETE"] += 1
+                stats["delete_rows"] += DELETE_ROWS
                 conn.commit()
 
             if WAIT_AFTER_OPERATIONS and i % WAIT_AFTER_OPERATIONS == 0 and i != 0:
@@ -228,25 +233,28 @@ try:
             conn.commit()
 
         except psycopg2.Error as e:
+            stats["errors"] += 1
             print(f"An error occurred: {e}")
             if "current transaction is aborted" in str(e):
                 print("Transaction aborted. Commands ignored until the end of the transaction block.")
-            # Rollback the transaction to avoid leaving it in an inconsistent state
             conn.rollback()
 
 except KeyboardInterrupt:
     print("Received KeyboardInterrupt. Stopping generator...")
 finally:
-    # Stop index operations thread if it's running
     if ENABLE_INDEX_CREATE_DROP and stop_index_thread is not None and index_thread is not None:
         print("Stopping index operations thread...")
         stop_index_thread.set()
         index_thread.join(timeout=5)
     
-    # Commit changes outside the loop for UPDATE and DELETE operations
     try:
         conn.commit()
     finally:
-        # Close the connection
         conn.close()
+        total_ops = stats["INSERT"] + stats["UPDATE"] + stats["DELETE"]
+        print(f"EVENT_GEN_SUMMARY: total_ops={total_ops} "
+              f"INSERT={stats['INSERT']}({stats['insert_rows']} rows) "
+              f"UPDATE={stats['UPDATE']}({stats['update_rows']} rows) "
+              f"DELETE={stats['DELETE']}({stats['delete_rows']} rows) "
+              f"errors={stats['errors']}")
         print("Program Complete")

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -3,8 +3,8 @@
 set -e
 set -m
 
-if [ $# -gt 2 ]; then
-    echo "Usage: $0 TEST_NAME [--run-via-config-file]"
+if [ $# -gt 3 ]; then
+    echo "Usage: $0 TEST_NAME [--run-via-config-file] [--with-iterations]"
     exit 1
 fi
 
@@ -22,17 +22,25 @@ export QUEUE_SEGMENT_MAX_BYTES=400
 export PYTHONPATH="${REPO_ROOT}/migtests/lib"
 
 run_via_config_file=false
+with_iterations=false
 
-# Parse optional second argument
-if [ $# -eq 2 ]; then
-    if [ "$2" = "--run-via-config-file" ]; then
-        run_via_config_file=true
-    else
-        echo "Unknown option: $2"
-        echo "Usage: $0 TEST_NAME [--run-via-config-file]"
-        exit 1
-    fi
-fi
+# Parse optional arguments
+shift
+for arg in "$@"; do
+    case "$arg" in
+        --run-via-config-file)
+            run_via_config_file=true
+            ;;
+        --with-iterations)
+            with_iterations=true
+            ;;
+        *)
+            echo "Unknown option: $arg"
+            echo "Usage: $0 TEST_NAME [--run-via-config-file] [--with-iterations]"
+            exit 1
+            ;;
+    esac
+done
 
 # Order of env.sh import matters.
 if [ -f "${TEST_DIR}/live_env.sh" ]; then
@@ -260,8 +268,14 @@ main() {
 	step "Resetting the trap command"
 	trap - SIGINT SIGTERM EXIT SIGSEGV SIGHUP
 
-	step "Initiating cutover to source"
-	yb-voyager initiate cutover to source --export-dir ${EXPORT_DIR} --yes
+	if [ "${with_iterations}" = true ]; then
+		step "Initiating cutover to source with restart flag (iteration mode)"
+		yb-voyager initiate cutover to source --export-dir ${EXPORT_DIR} \
+			--restart-data-migration-source-target true --yes
+	else
+		step "Initiating cutover to source"
+		yb-voyager initiate cutover to source --export-dir ${EXPORT_DIR} --yes
+	fi
 
 	for ((i = 0; i < 15; i++)); do
 		if [ "$(yb-voyager cutover status --export-dir "${EXPORT_DIR}" | grep "target → source" | grep -v "source-replica" | awk -F'|' '{print $2}' | tr -d '[:blank:]')"  != "COMPLETED" ]; then
@@ -278,6 +292,47 @@ main() {
         break
     fi
 	done
+
+	if [ "${with_iterations}" = true ]; then
+		step "Verifying iteration-1 directory was created"
+		ITERATION_DIR="${EXPORT_DIR}/live-data-migration-iterations/live-data-migration-iteration-1/export-dir"
+		if [ -d "${ITERATION_DIR}" ]; then
+			echo "Iteration-1 directory created successfully: ${ITERATION_DIR}"
+		else
+			echo "ERROR: Iteration-1 directory not found!"
+			exit 1
+		fi
+
+		step "Waiting for iteration-1 exporter to reach streaming phase"
+		wait_for_string_in_file "${ITERATION_DIR}/logs/yb-voyager-export-data-from-source.log" "streaming changes to a local queue file"
+
+		step "Inserting events to source for iteration-1"
+		run_sql_file source_delta.sql
+
+		wait_for_exporter_event "source"
+
+		step "Initiating cutover to target for iteration-1 (no fallback)"
+		yb-voyager initiate cutover to target \
+			--export-dir ${EXPORT_DIR} \
+			--prepare-for-fall-back false \
+			--yes
+
+		for ((i = 0; i < 20; i++)); do
+		ITER_EXPORT_DIR="${EXPORT_DIR}/live-data-migration-iterations/live-data-migration-iteration-1/export-dir"
+		if [ "$(yb-voyager cutover status --export-dir "${ITER_EXPORT_DIR}" | grep "cutover to target status" | cut -d ':'  -f 2 | tr -d '[:blank:]')" != "COMPLETED" ]; then
+			echo "Waiting for iteration-1 cutover to target to be COMPLETED..."
+			sleep 20
+			if [ "$i" -eq 19 ]; then
+				tail_log_file "yb-voyager-export-data-from-source.log"
+				tail_log_file "yb-voyager-import-data-to-target.log"
+				exit 1
+			fi
+		else
+			echo "Iteration-1 cutover to target COMPLETED"
+			break
+		fi
+		done
+	fi
 
 	run_ysql ${TARGET_DB_NAME} "\di"
 	run_ysql ${TARGET_DB_NAME} "\dft" 
@@ -296,36 +351,37 @@ main() {
 		} 
 	fi
 
-	step "Run get data-migration-report"
-	get_data_migration_report
+	if [ "${with_iterations}" = false ]; then
+		step "Run get data-migration-report"
+		get_data_migration_report
 
-	# Choose expected report file based on connector type
-	if [ "${USE_YB_GRPC_CONNECTOR}" = true ]; then
-		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallb.json"
-		echo "Using gRPC connector expected report"
-	else
-		expected_file="${TEST_DIR}/data-migration-report-live-migration-fallb-logical-connector.json"
-		echo "Using logical replication connector expected report"
-	fi
-	actual_file="${EXPORT_DIR}/reports/data-migration-report.json"
-
-	step "Verify data-migration-report report"
-	verify_report ${expected_file} ${actual_file}
-
-	step "Run performance comparison."
-	if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
-		compare_performance || {
-			cat_log_file "yb-voyager-compare-performance.log"
-		}
-
-		step "Validate Performance Reports"
-		# Checking if the performance comparison reports were created
-		if [ -f "${EXPORT_DIR}/reports/performance_comparison_report.html" ] && [ -f "${EXPORT_DIR}/reports/performance_comparison_report.json" ]; then
-			echo "Performance comparison reports created successfully."
+		# Choose expected report file based on connector type
+		if [ "${USE_YB_GRPC_CONNECTOR}" = true ]; then
+			expected_file="${TEST_DIR}/data-migration-report-live-migration-fallb.json"
+			echo "Using gRPC connector expected report"
 		else
-			echo "Error: Performance comparison reports were not created successfully."
-			cat_log_file "yb-voyager-compare-performance.log"
-			exit 1
+			expected_file="${TEST_DIR}/data-migration-report-live-migration-fallb-logical-connector.json"
+			echo "Using logical replication connector expected report"
+		fi
+		actual_file="${EXPORT_DIR}/reports/data-migration-report.json"
+
+		step "Verify data-migration-report report"
+		verify_report ${expected_file} ${actual_file}
+
+		step "Run performance comparison."
+		if [ "${SOURCE_DB_TYPE}" = "postgresql" ]; then
+			compare_performance || {
+				cat_log_file "yb-voyager-compare-performance.log"
+			}
+
+			step "Validate Performance Reports"
+			if [ -f "${EXPORT_DIR}/reports/performance_comparison_report.html" ] && [ -f "${EXPORT_DIR}/reports/performance_comparison_report.json" ]; then
+				echo "Performance comparison reports created successfully."
+			else
+				echo "Error: Performance comparison reports were not created successfully."
+				cat_log_file "yb-voyager-compare-performance.log"
+				exit 1
+			fi
 		fi
 	fi
 

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -13,15 +13,43 @@ from datetime import datetime
 import json
 import sys
 import yaml
+import re
+import sqlite3
 
 
 # -------------------------
 # Config / Context helpers
 # -------------------------
 
+def _expand_env_in_value(val: Any) -> Any:
+    """Recursively expand ${VAR:-default} and ${VAR} patterns in strings,
+    with type coercion for numeric values."""
+    if isinstance(val, str):
+        def _replace(m):
+            var_name = m.group(1)
+            default = m.group(2)
+            return os.environ.get(var_name, default if default is not None else "")
+        expanded = re.sub(r'\$\{([^}:]+)(?::-(.*?))?\}', _replace, val)
+        if expanded != val:
+            try:
+                return int(expanded)
+            except ValueError:
+                try:
+                    return float(expanded)
+                except ValueError:
+                    pass
+        return expanded
+    elif isinstance(val, dict):
+        return {k: _expand_env_in_value(v) for k, v in val.items()}
+    elif isinstance(val, list):
+        return [_expand_env_in_value(item) for item in val]
+    return val
+
+
 def load_config(path: str) -> Dict[str, Any]:
     with open(path, "r") as f:
-        return yaml.safe_load(f)
+        raw = yaml.safe_load(f)
+    return _expand_env_in_value(raw)
 
 
 def merge_env(base: Dict[str, str], override: Dict[str, str] | None) -> Dict[str, str]:
@@ -203,14 +231,23 @@ def get_cutover_status(export_dir: str, mode: str = "target") -> str:
 def backlog_marker_present(export_dir: str) -> bool:
     """
     Return True when the latest queue segment contains the marker insert for cutover_table.
-    Looks for "cutover_table" and the literal "Last event before cutover" in the last non-empty line.
+    Checks both the base export-dir and the latest iteration export-dir (after iterations,
+    the active queue moves to the iteration-specific directory).
     """
+    if _check_backlog_marker_in_dir(export_dir):
+        return True
+    iter_dir = latest_iteration_export_dir(export_dir)
+    if iter_dir != export_dir:
+        return _check_backlog_marker_in_dir(iter_dir)
+    return False
+
+
+def _check_backlog_marker_in_dir(export_dir: str) -> bool:
     queue_dir = os.path.join(export_dir, "data", "queue")
     try:
         names = [n for n in os.listdir(queue_dir) if n.startswith("segment.") and n.endswith(".ndjson")]
         if not names:
             return False
-        # segment.N.ndjson -> pick max N
         latest = max(names, key=lambda n: int(n.split(".")[1]))
         path = os.path.join(queue_dir, latest)
         if os.path.getsize(path) == 0:
@@ -224,6 +261,81 @@ def backlog_marker_present(export_dir: str) -> bool:
         return last is not None and ("cutover_table" in last) and ("Last event before cutover" in last)
     except OSError:
         return False
+
+
+def latest_iteration_export_dir(base_export_dir: str) -> str:
+    """Return the export-dir of the latest iteration, or base_export_dir if no iterations exist."""
+    iterations_dir = os.path.join(base_export_dir, "live-data-migration-iterations")
+    if not os.path.isdir(iterations_dir):
+        return base_export_dir
+    dirs = [d for d in os.listdir(iterations_dir) if d.startswith("live-data-migration-iteration-")]
+    if not dirs:
+        return base_export_dir
+    latest = max(dirs, key=lambda d: int(d.split("-")[-1]))
+    return os.path.join(iterations_dir, latest, "export-dir")
+
+
+def iteration_exporter_streaming(base_export_dir: str) -> bool:
+    """Check if the iteration exporter is in streaming phase.
+    For changes-only exports, also check export_status.json for STREAMING mode."""
+    iter_dir = latest_iteration_export_dir(base_export_dir)
+    if exporter_streaming(iter_dir):
+        return True
+    status_file = os.path.join(iter_dir, "data", "export_status.json")
+    try:
+        if os.path.isfile(status_file):
+            with open(status_file, "r") as f:
+                status = json.load(f)
+            return status.get("mode", "").upper() == "STREAMING"
+    except (OSError, json.JSONDecodeError):
+        pass
+    return False
+
+
+def backlog_marker_imported(ctx, target_role: str = "target") -> bool:
+    """Check if the backlog marker row exists in the destination database's cutover_table."""
+    try:
+        db_cfg = ctx.cfg[target_role]
+        conn = psycopg2.connect(
+            host=str(db_cfg["host"]),
+            port=int(db_cfg["port"]),
+            dbname=str(db_cfg["database"]),
+            user=str(db_cfg.get("admin", {}).get("user", db_cfg["user"])),
+            password=str(db_cfg.get("admin", {}).get("password", db_cfg["password"])),
+        )
+        conn.autocommit = True
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM public.cutover_table WHERE status = 'Last event before cutover'")
+        count = cur.fetchone()[0]
+        cur.close()
+        conn.close()
+        return count > 0
+    except Exception as e:
+        log(f"backlog_marker_imported check failed: {e}")
+        return False
+
+
+def get_iteration_number_from_metadb(base_export_dir: str) -> int:
+    """Read the current iteration number from meta.db."""
+    meta_db = os.path.join(base_export_dir, "metainfo", "meta.db")
+    if not os.path.isfile(meta_db):
+        return 0
+    try:
+        conn = sqlite3.connect(meta_db)
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM migration_status_record WHERE key = 'iteration_number'")
+        row = cur.fetchone()
+        conn.close()
+        return int(row[0]) if row else 0
+    except Exception:
+        return 0
+
+
+def assert_iteration_number(base_export_dir: str, expected: int) -> None:
+    actual = get_iteration_number_from_metadb(base_export_dir)
+    if actual != expected:
+        raise AssertionError(f"Expected iteration number {expected}, got {actual}")
+    log(f"Iteration number assertion passed: {actual}")
 
 
 # -------------------------
@@ -409,8 +521,11 @@ def export_schema(cfg: Dict[str, Any], env: Dict[str, str]) -> None:
     run_checked(cmd, env, description="export_schema")
 
 
-def initiate_cutover(cfg: Dict[str, Any], env: Dict[str, str], direction: str) -> None:
+def initiate_cutover(cfg: Dict[str, Any], env: Dict[str, str], direction: str, *, flag_overrides: Dict[str, Any] | None = None) -> None:
     voyager_flags = _get_voyager_flags(cfg, f"cutover_to_{direction}")
+    if flag_overrides is not None:
+        voyager_flags = dict(voyager_flags)
+        voyager_flags.update(flag_overrides)
     base = {"export-dir": cfg["export_dir"],}
     merged = _merge_flags(base, voyager_flags)
     cmd = ["yb-voyager", "initiate", "cutover", "to", direction, "--yes"] + to_kv_flags(merged)
@@ -421,9 +536,12 @@ def build_export_data_cmd(cfg: Dict[str, Any]) -> list[str]:
     voyager_flags = _get_voyager_flags(cfg, "export_data")
     base = _base_common_flags(cfg)
     base.update(_source_conn_flags(cfg))
-    # Live migration default
-    base["export-type"] = "snapshot-and-changes"
-    # data command defaults
+    export_dir = base.get("export-dir", "")
+    iterations_dir = os.path.join(export_dir, "live-data-migration-iterations")
+    if os.path.isdir(iterations_dir):
+        base["export-type"] = "changes-only"
+    else:
+        base["export-type"] = "snapshot-and-changes"
     base["disable-pb"] = True
     merged = _merge_flags(base, voyager_flags)
     return ["yb-voyager", "export", "data", "--yes"] + to_kv_flags(merged)
@@ -439,6 +557,110 @@ def build_import_data_cmd(cfg: Dict[str, Any]) -> list[str]:
     base["disable-pb"] = True
     merged = _merge_flags(base, voyager_flags)
     return ["yb-voyager", "import", "data", "--yes"] + to_kv_flags(merged)
+
+
+def build_finalize_schema_cmd(cfg: Dict[str, Any]) -> list[str]:
+    """Build yb-voyager finalize-schema-post-data-import command."""
+    voyager_flags = _get_voyager_flags(cfg, "finalize_schema")
+    base = _base_common_flags(cfg)
+    base.update(_target_conn_flags(cfg))
+    merged = _merge_flags(base, voyager_flags)
+    return ["yb-voyager", "finalize-schema-post-data-import", "--yes"] + to_kv_flags(merged)
+
+
+def build_end_migration_cmd(cfg: Dict[str, Any]) -> list[str]:
+    """Build yb-voyager end migration command."""
+    voyager_flags = _get_voyager_flags(cfg, "end_migration")
+    base = _base_common_flags(cfg)
+    backup_dir = os.path.join(cfg["export_dir"], "backup-dir")
+    os.makedirs(backup_dir, exist_ok=True)
+    base["backup-dir"] = backup_dir
+    base["backup-schema-files"] = True
+    base["backup-data-files"] = True
+    base["backup-log-files"] = True
+    base["save-migration-reports"] = True
+    merged = _merge_flags(base, voyager_flags)
+    return ["yb-voyager", "end", "migration", "--yes"] + to_kv_flags(merged)
+
+
+def end_migration(cfg: Dict[str, Any], env: Dict[str, str]) -> None:
+    src = cfg.get("source", {})
+    tgt = cfg.get("target", {})
+    run_env = dict(env)
+    if src.get("password"):
+        run_env["SOURCE_DB_PASSWORD"] = str(src["password"])
+    if tgt.get("password"):
+        run_env["TARGET_DB_PASSWORD"] = str(tgt["password"])
+    src_rep = cfg.get("source_replica", {})
+    if src_rep.get("password"):
+        run_env["SOURCE_REPLICA_DB_PASSWORD"] = str(src_rep["password"])
+    cmd = build_end_migration_cmd(cfg)
+    run_checked(cmd, run_env, description="end_migration")
+
+
+def build_get_data_migration_report_cmd(cfg: Dict[str, Any]) -> list[str]:
+    """Build yb-voyager get data-migration-report command."""
+    base = _base_common_flags(cfg)
+    base["output-format"] = "json"
+    return ["yb-voyager", "get", "data-migration-report"] + to_kv_flags(base)
+
+
+def get_data_migration_report(cfg: Dict[str, Any], env: Dict[str, str], artifacts_dir: str) -> Dict[str, Any]:
+    """Run get data-migration-report and save the JSON output to artifacts."""
+    src = cfg.get("source", {})
+    tgt = cfg.get("target", {})
+    run_env = dict(env)
+    if src.get("password"):
+        run_env["SOURCE_DB_PASSWORD"] = str(src["password"])
+    if tgt.get("password"):
+        run_env["TARGET_DB_PASSWORD"] = str(tgt["password"])
+    src_rep = cfg.get("source_replica", {})
+    if src_rep.get("password"):
+        run_env["SOURCE_REPLICA_DB_PASSWORD"] = str(src_rep["password"])
+
+    cmd = build_get_data_migration_report_cmd(cfg)
+    run_checked(cmd, run_env, description="get_data_migration_report")
+
+    report_path = os.path.join(cfg["export_dir"], "reports", "data-migration-report.json")
+    report: Dict[str, Any] = {}
+    if os.path.isfile(report_path):
+        with open(report_path, "r") as f:
+            report = json.load(f)
+        dest = os.path.join(artifacts_dir, "data-migration-report.json")
+        os.makedirs(artifacts_dir, exist_ok=True)
+        shutil.copy2(report_path, dest)
+        log(f"data-migration-report saved to {dest}")
+    else:
+        log("WARNING: data-migration-report.json not found after command")
+    return report
+
+
+def validate_cutover_status(cfg: Dict[str, Any], artifacts_dir: str) -> Dict[str, str]:
+    """Capture full cutover status output and save to artifacts."""
+    export_dir = cfg["export_dir"]
+    cmd = ["yb-voyager", "cutover", "status", "--export-dir", export_dir]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    output = proc.stdout.strip()
+
+    os.makedirs(artifacts_dir, exist_ok=True)
+    dest = os.path.join(artifacts_dir, "cutover-status.txt")
+    with open(dest, "w") as f:
+        f.write(output + "\n")
+    log(f"cutover status saved to {dest}")
+
+    statuses: Dict[str, str] = {}
+    for line in output.splitlines():
+        stripped = line.strip()
+        for key in ("cutover to target status", "cutover to source status"):
+            if stripped.lower().startswith(key):
+                parts = stripped.split(":", 1)
+                if len(parts) == 2:
+                    statuses[key] = parts[1].strip()
+
+    for line in output.splitlines():
+        log(f"  cutover-status: {line.rstrip()}")
+
+    return statuses
 
 
 def build_export_from_target_cmd(cfg: Dict[str, Any]) -> list[str]:
@@ -481,6 +703,84 @@ def build_import_to_source_replica_cmd(cfg: Dict[str, Any]) -> list[str]:
 
     merged = _merge_flags(base, voyager_flags)
     return ["yb-voyager", "import", "data", "to", "source-replica", "--yes"] + to_kv_flags(merged)
+
+
+def _kill_all_voyager_for_export_dir(export_dir: str) -> None:
+    """Aggressively kill all yb-voyager and child Debezium processes using this export-dir."""
+
+    def _find_pids() -> list:
+        pids: list = []
+        for pattern in [f"yb-voyager.*{export_dir}", f"debezium.*{export_dir}"]:
+            try:
+                result = subprocess.run(
+                    ["pgrep", "-f", pattern],
+                    capture_output=True, text=True, timeout=10,
+                )
+                pids.extend(p.strip() for p in result.stdout.strip().split("\n") if p.strip())
+            except Exception:
+                pass
+        return list(dict.fromkeys(pids))
+
+    for sig in ["-TERM", "-9"]:
+        pids = _find_pids()
+        if pids:
+            log(f"  killing PIDs {pids} with {sig}")
+            subprocess.run(["kill", sig] + pids, capture_output=True, timeout=10)
+        time.sleep(2)
+
+    # Remove voyager lock files (.lck) that prevent restart
+    for search_dir in [export_dir, latest_iteration_export_dir(export_dir)]:
+        try:
+            for f in os.listdir(search_dir):
+                if f.endswith("Lockfile.lck"):
+                    lock_path = os.path.join(search_dir, f)
+                    os.remove(lock_path)
+                    log(f"  removed lock: {lock_path}")
+        except OSError:
+            pass
+
+    # Final check -- make sure nothing is left
+    pids = _find_pids()
+    if pids:
+        log(f"  WARNING: processes still alive: {pids}")
+        subprocess.run(["kill", "-9"] + pids, capture_output=True, timeout=5)
+        time.sleep(2)
+
+
+def takeover_auto_transitioned_processes(ctx: Context) -> None:
+    """Kill voyager's auto-transitioned export/import processes and start fresh ones
+    that the orchestrator controls (needed for resumption kill/restart cycles)."""
+    export_dir = ctx.cfg["export_dir"]
+    log("takeover: killing auto-transitioned voyager processes")
+    _kill_all_voyager_for_export_dir(export_dir)
+
+    log("takeover: starting fresh export_data")
+    ctx.processes["export_data"] = start_command_by_name("export_data", ctx)
+
+    log("takeover: starting fresh import_data")
+    ctx.processes["import_data"] = start_command_by_name("import_data", ctx)
+
+    log("takeover: fresh processes registered, waiting for streaming")
+    ok = poll_until(300, 5, lambda: iteration_exporter_streaming(export_dir))
+    if not ok:
+        raise TimeoutError("takeover: exporter did not reach streaming after restart")
+    log("takeover: exporter streaming, ready for resumptions")
+
+
+def takeover_fallback_processes(ctx: Context) -> None:
+    """Kill voyager's auto-transitioned fallback processes and start fresh ones."""
+    export_dir = ctx.cfg["export_dir"]
+    log("takeover_fallback: killing auto-transitioned voyager processes")
+    _kill_all_voyager_for_export_dir(export_dir)
+
+    log("takeover_fallback: starting fresh export_from_target")
+    ctx.processes["export_from_target"] = start_command_by_name("export_from_target", ctx)
+
+    log("takeover_fallback: starting fresh import_to_source")
+    ctx.processes["import_to_source"] = start_command_by_name("import_to_source", ctx)
+
+    log("takeover_fallback: fresh fallback processes registered")
+    time.sleep(5)
 
 
 def start_command_by_name(name: str, ctx: Context) -> subprocess.Popen:
@@ -526,28 +826,80 @@ def resolve_generator_config(gen_cfg: Dict[str, Any] | None, test_root: str | No
     return fallback_path
 
 
-def start_generator(final_cfg_path: str, env: Dict[str, str]) -> subprocess.Popen:
+def start_generator(final_cfg_path: str, env: Dict[str, str], artifacts_dir: str | None = None) -> subprocess.Popen:
     helper_dir = os.path.dirname(__file__)
     generator_dir = os.path.abspath(os.path.join(helper_dir, "..", "event-generator"))
     generator_main = os.path.join(generator_dir, "generator.py")
     log(f"starting generator with --config {final_cfg_path}")
-    return subprocess.Popen(
+
+    log_file = None
+    if artifacts_dir:
+        os.makedirs(artifacts_dir, exist_ok=True)
+        log_path = os.path.join(artifacts_dir, "event-generator.log")
+        log_file = open(log_path, "a")
+
+    proc = subprocess.Popen(
         [sys.executable, generator_main, "--config", final_cfg_path],
         env=env,
-        stdout=subprocess.DEVNULL,
+        stdout=log_file or subprocess.DEVNULL,
+        stderr=subprocess.STDOUT if log_file else subprocess.DEVNULL,
         text=True,
         cwd=generator_dir,
     )
+    proc._gen_log_file = log_file  # type: ignore[attr-defined]
+    return proc
 
 
 def start_generator_from_context(ctx: Context, config_key: str = "generator") -> subprocess.Popen:
     gen_cfg = ctx.cfg.get(config_key)
     final_cfg_path = resolve_generator_config(gen_cfg, ctx.test_root)
-    return start_generator(final_cfg_path, ctx.env)
+    artifacts_dir = ctx.cfg.get("artifacts_dir")
+    return start_generator(final_cfg_path, ctx.env, artifacts_dir)
 
 
-def stop_generator(proc: subprocess.Popen | None, graceful_timeout_sec: int) -> None:
+def stop_generator(proc: subprocess.Popen | None, graceful_timeout_sec: int) -> Dict[str, int]:
+    """Stop the generator and return parsed event stats (if available)."""
     kill(proc, timeout_sec=graceful_timeout_sec)
+    stats: Dict[str, int] = {}
+    if proc is None:
+        return stats
+    log_file = getattr(proc, "_gen_log_file", None)
+    if log_file:
+        try:
+            log_file.close()
+        except Exception:
+            pass
+        try:
+            log_path = log_file.name
+            stats = _parse_generator_summary(log_path)
+            if stats:
+                log(f"event-gen stats: {stats}")
+        except Exception as e:
+            log(f"warning: could not parse event-gen summary: {e}")
+    return stats
+
+
+def _parse_generator_summary(log_path: str) -> Dict[str, int]:
+    """Parse the last EVENT_GEN_SUMMARY line from the generator log."""
+    import re
+    stats: Dict[str, int] = {}
+    last_summary = ""
+    with open(log_path, "r") as f:
+        for line in f:
+            if "EVENT_GEN_SUMMARY:" in line:
+                last_summary = line
+    if not last_summary:
+        return stats
+    for key in ("total_ops", "errors"):
+        m = re.search(rf"{key}=(\d+)", last_summary)
+        if m:
+            stats[key] = int(m.group(1))
+    for key in ("INSERT", "UPDATE", "DELETE"):
+        m = re.search(rf"{key}=(\d+)\((\d+) rows\)", last_summary)
+        if m:
+            stats[f"{key}_ops"] = int(m.group(1))
+            stats[f"{key}_rows"] = int(m.group(2))
+    return stats
 
 
 # -------------------------
@@ -976,6 +1328,12 @@ def _reset_database(db_cfg: Dict[str, Any], *, admin_db_name: str, role: str) ->
     port = str(db_cfg["port"])
     admin_user = str(admin["user"])
 
+    terminate_cmd = [
+        "psql", "-h", host, "-p", port, "-U", admin_user,
+        "-d", admin_db_name, "-v", "ON_ERROR_STOP=1",
+        "-c", f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{dbname}' AND pid <> pg_backend_pid()",
+    ]
+
     drop_cmd = [
         "psql", "-h", host, "-p", port, "-U", admin_user,
         "-d", admin_db_name, "-v", "ON_ERROR_STOP=1",
@@ -987,6 +1345,12 @@ def _reset_database(db_cfg: Dict[str, Any], *, admin_db_name: str, role: str) ->
         "-d", admin_db_name, "-v", "ON_ERROR_STOP=1",
         "-c", f'CREATE DATABASE "{dbname}"',
     ]
+
+    log(f"[db-reset:{role}] terminating active connections to '{dbname}'")
+    try:
+        run_checked(terminate_cmd, env, description=f"reset_database:{role}:terminate")
+    except Exception:
+        pass
 
     log(f"[db-reset:{role}] dropping database '{dbname}'")
     run_checked(drop_cmd, env, description=f"reset_database:{role}:drop")
@@ -1168,6 +1532,7 @@ def run_segment_hash_validations(
     ctx: Context,
     left_side: str = "source",
     right_side: str = "target",
+    exclude_tables: List[str] | None = None,
 ) -> None:
     """End-to-end segment-hash validation: compute, compare, and persist artifacts.
 
@@ -1180,6 +1545,8 @@ def run_segment_hash_validations(
 
     # 2) Compare in-memory
     all_segments, mismatches = compare_segment_hashes(ctx, left_side, right_side)
+    if exclude_tables:
+        mismatches = [m for m in mismatches if m.get("table_name") not in exclude_tables]
 
     # 3) Persist artifacts
     base_dir = os.path.join(ctx.artifacts_dir, "validation", "hash_segments")
@@ -1210,11 +1577,20 @@ def run_row_count_validations(
     ctx: Context,
     left_role: str = "source",
     right_role: str = "target",
+    mode: str = "exact",
+    exclude_tables: List[str] | None = None,
 ) -> None:
-    """Compare row counts between two roles (default: source and target) using direct SQL."""
+    """Compare row counts between two roles using direct SQL.
+
+    mode:
+        "exact"  – left_count must equal right_count (default)
+        "gte"    – right_count must be >= left_count (no data loss from left)
+    """
     cfg = ctx.cfg
     schema = cfg["source"]["schema"]
     tables = list_source_tables(cfg)
+    if exclude_tables:
+        tables = [t for t in tables if t not in exclude_tables]
     out_dir = os.path.join(ctx.artifacts_dir, "validation", "row_counts")
     os.makedirs(out_dir, exist_ok=True)
     mismatches = []
@@ -1224,21 +1600,31 @@ def run_row_count_validations(
             left_count = _fetch_table_count(left_conn, schema, table)
             right_count = _fetch_table_count(right_conn, schema, table)
 
+            if mode == "gte":
+                ok = right_count >= left_count
+            else:
+                ok = left_count == right_count
+
             record = {
                 "table": table,
-                # Field names kept for backward-compatibility; values come from left/right roles.
                 "source_count": left_count,
                 "target_count": right_count,
-                "status": "success" if left_count == right_count else "mismatch",
+                "status": "success" if ok else "mismatch",
             }
 
-            # Write per-table result
             with open(os.path.join(out_dir, f"{table}.json"), "w") as f:
                 json.dump(record, f)
             if record["status"] == "mismatch":
                 mismatches.append(record)
 
-    # If any mismatches, write summary + raise error
+    log(f"row count validation: {len(tables)} tables checked, {len(mismatches)} mismatches")
+    for table in tables:
+        rec_path = os.path.join(out_dir, f"{table}.json")
+        if os.path.isfile(rec_path):
+            with open(rec_path) as f:
+                rec = json.load(f)
+                log(f"  {rec['table']:30s}  source={rec['source_count']:>8,}  target={rec['target_count']:>8,}  {rec['status']}")
+
     if mismatches:
         summary_path = os.path.join(out_dir, "row_count_mismatches.json")
         with open(summary_path, "w") as f:

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -66,7 +66,11 @@ def generator_start_action(stage: Dict[str, Any], ctx: Any) -> None:
 def generator_stop_action(stage: Dict[str, Any], ctx: Any) -> None:
     key = stage.get("generator_key", "generator")
     timeout = int(stage.get("graceful_timeout_sec", 60))
-    H.stop_generator(ctx.processes.pop(key, None), timeout)
+    stats = H.stop_generator(ctx.processes.pop(key, None), timeout)
+    if stats:
+        if not hasattr(ctx, "last_gen_stats"):
+            ctx.last_gen_stats = {}
+        ctx.last_gen_stats[key] = stats
 
 
 @action("voyager_export_start")
@@ -114,9 +118,21 @@ _WAIT_FOR_CONDITIONS: Dict[str, Dict[str, Any]] = {
         "interval": 5,
         "predicate": lambda ctx: H.exporter_streaming(ctx.cfg["export_dir"]),
     },
+    "iteration_exporter_in_streaming_phase": {
+        "interval": 5,
+        "predicate": lambda ctx: H.iteration_exporter_streaming(ctx.cfg["export_dir"]),
+    },
     "remaining_events_eq_0": {
         "interval": 5,
         "predicate": lambda ctx: H.backlog_marker_present(ctx.cfg["export_dir"]),
+    },
+    "marker_imported_on_target": {
+        "interval": 5,
+        "predicate": lambda ctx: H.backlog_marker_imported(ctx, "target"),
+    },
+    "marker_imported_on_source": {
+        "interval": 5,
+        "predicate": lambda ctx: H.backlog_marker_imported(ctx, "source"),
     },
     "cutover_to_target_status_completed": {
         "interval": 10,
@@ -151,26 +167,28 @@ def wait_for_action(stage: Dict[str, Any], ctx: Any) -> None:
 
 
 @action("cutover_to_target")
-def cutover_to_target_action(_stage, ctx: Any) -> None:
-    H.initiate_cutover(ctx.cfg, ctx.env, "target")
+def cutover_to_target_action(stage: Dict[str, Any], ctx: Any) -> None:
+    H.initiate_cutover(ctx.cfg, ctx.env, "target", flag_overrides=stage.get("flags"))
 
 
 @action("cutover_to_source")
-def cutover_to_source_action(_stage, ctx: Any) -> None:
-    H.initiate_cutover(ctx.cfg, ctx.env, "source")
+def cutover_to_source_action(stage: Dict[str, Any], ctx: Any) -> None:
+    H.initiate_cutover(ctx.cfg, ctx.env, "source", flag_overrides=stage.get("flags"))
 
 
 @action("cutover_to_source_replica")
-def cutover_to_source_replica_action(_stage, ctx: Any) -> None:
+def cutover_to_source_replica_action(stage: Dict[str, Any], ctx: Any) -> None:
     """Initiate cutover back to the source-replica database."""
-    H.initiate_cutover(ctx.cfg, ctx.env, "source-replica")
+    H.initiate_cutover(ctx.cfg, ctx.env, "source-replica", flag_overrides=stage.get("flags"))
 
 
 @action("row_count_validations")
 def row_count_validations_action(stage: Dict[str, Any], ctx: Any) -> None:
     left_role = stage.get("left_role", "source")
     right_role = stage.get("right_role", "target")
-    H.run_row_count_validations(ctx, left_role, right_role)
+    mode = stage.get("mode", "exact")
+    exclude_tables = stage.get("exclude_tables")
+    H.run_row_count_validations(ctx, left_role, right_role, mode=mode, exclude_tables=exclude_tables)
 
 
 @action("row_hash_validations")
@@ -182,10 +200,12 @@ def row_hash_validations_action(stage: Dict[str, Any], ctx: Any) -> None:
     left_role = stage.get("left_role", "source")
     right_role = stage.get("right_role", "target")
 
+    exclude_tables = stage.get("exclude_tables")
+
     for role in {left_role, right_role}:
         H.run_sql_file(ctx, sql_path, target=role, use_admin=False)
 
-    H.run_segment_hash_validations(ctx, left_role, right_role)
+    H.run_segment_hash_validations(ctx, left_role, right_role, exclude_tables=exclude_tables)
 
 
 @action("start_resumptions")
@@ -239,6 +259,192 @@ def grant_source_permissions_action(stage: Dict[str, Any], ctx: Any) -> None:
     """
     fallback = int(stage.get("is_live_migration_fall_back", 0))
     H.grant_postgres_live_migration_permissions(ctx, is_live_migration_fall_back=fallback)
+
+
+@action("voyager_finalize_schema_start")
+def finalize_schema_start_action(_stage, ctx: Any) -> None:
+    cmd = H.build_finalize_schema_cmd(ctx.cfg)
+    H.run_checked(cmd, ctx.env, description="finalize_schema")
+
+
+@action("voyager_end_migration")
+def end_migration_action(_stage, ctx: Any) -> None:
+    H.end_migration(ctx.cfg, ctx.env)
+
+
+@action("get_data_migration_report")
+def get_data_migration_report_action(_stage, ctx: Any) -> None:
+    """Run yb-voyager get data-migration-report and save output to artifacts."""
+    H.get_data_migration_report(ctx.cfg, ctx.env, ctx.artifacts_dir)
+
+
+@action("validate_cutover_status")
+def validate_cutover_status_action(_stage, ctx: Any) -> None:
+    """Capture and log full cutover status from yb-voyager."""
+    H.validate_cutover_status(ctx.cfg, ctx.artifacts_dir)
+
+
+@action("assert_iteration_number")
+def assert_iteration_number_action(stage: Dict[str, Any], ctx: Any) -> None:
+    expected = int(stage["expected"])
+    H.assert_iteration_number(ctx.cfg["export_dir"], expected)
+
+
+@action("takeover_auto_transitioned")
+def takeover_action(_stage, ctx: Any) -> None:
+    """Kill voyager's auto-transitioned processes and start fresh ones we control."""
+    H.takeover_auto_transitioned_processes(ctx)
+
+
+@action("takeover_fallback")
+def takeover_fallback_action(_stage, ctx: Any) -> None:
+    """Kill voyager's auto-transitioned fallback processes and start fresh ones."""
+    H.takeover_fallback_processes(ctx)
+
+
+def _count_injections(sub_stages: list) -> int:
+    total = 0
+    for s in sub_stages:
+        if s.get("action") == "start_resumptions":
+            for _, cfg in s.get("resumption", {}).items():
+                total += int(cfg.get("max_restarts", 0))
+    return total
+
+
+def _count_resumption_events(ctx: Any, event_type: str) -> int:
+    """Count resumption events of a given type from the ndjson log."""
+    import json as _json
+    path = os.path.join(ctx.cfg.get("artifacts_dir", ""), "resumption_events.ndjson")
+    if not os.path.isfile(path):
+        return 0
+    count = 0
+    with open(path, "r") as f:
+        for line in f:
+            try:
+                rec = _json.loads(line)
+                if rec.get("event") == event_type:
+                    count += 1
+            except Exception:
+                pass
+    return count
+
+
+def _append_ndjson(artifacts_dir: str, filename: str, record: dict) -> None:
+    """Append a JSON record to an ndjson file in the artifacts directory."""
+    import json as _json
+    os.makedirs(artifacts_dir, exist_ok=True)
+    path = os.path.join(artifacts_dir, filename)
+    with open(path, "a") as f:
+        f.write(_json.dumps(record) + "\n")
+
+
+@action("iteration_loop")
+def iteration_loop_action(stage: Dict[str, Any], ctx: Any) -> None:
+    """Repeat a block of sub-stages N times for iteration testing."""
+    count_key = stage.get("count_from_config")
+    count = int(ctx.cfg.get(count_key, 1)) if count_key else int(stage.get("count", 1))
+    subtract = int(stage.get("subtract", 0))
+    count = max(0, count - subtract)
+
+    sub_stages = stage.get("stages", [])
+    import time as _time
+    loop_start = _time.monotonic()
+    total_kills = 0
+    total_restarts = 0
+
+    for i in range(count):
+        iter_start = _time.monotonic()
+        total_elapsed = iter_start - loop_start
+        total_mins, total_secs = divmod(int(total_elapsed), 60)
+        total_hrs, total_mins = divmod(total_mins, 60)
+        H.log(f"\n{'='*60}")
+        H.log(f"  ITERATION {i+1} / {count}  |  injections: {_count_injections(sub_stages)}")
+        H.log(f"  elapsed: {total_hrs}h {total_mins}m {total_secs}s  |  kills so far: {total_kills}  |  restarts: {total_restarts}")
+        H.log(f"{'='*60}")
+
+        iter_kills_before = _count_resumption_events(ctx, "killed")
+        iter_restarts_before = _count_resumption_events(ctx, "restart_success")
+        if hasattr(ctx, "last_gen_stats"):
+            ctx.last_gen_stats.clear()
+
+        for sub in sub_stages:
+            if _stage_is_skipped(sub):
+                H.log(f"  [skip] {sub.get('name', '<unnamed>')}")
+                continue
+            sub_name = f"loop[{i+1}].{sub.get('name', '<unnamed>')}"
+            H.log_stage_start(sub_name)
+            start_ts = H._ts()
+            try:
+                get_action(sub["action"])(sub, ctx)
+                end_ts = H._ts()
+                H.append_stage_summary(ctx.cfg["artifacts_dir"], sub_name, start_ts, end_ts, status="OK")
+                H.log_stage_end(sub_name, status="OK")
+            except Exception as e:
+                end_ts = H._ts()
+                H.append_stage_summary(ctx.cfg["artifacts_dir"], sub_name, start_ts, end_ts, status="FAILED", error=str(e))
+                H.log_stage_end(sub_name, status=f"FAILED: {e}")
+                raise
+
+        elapsed = _time.monotonic() - iter_start
+        mins, secs = divmod(int(elapsed), 60)
+        iter_kills = _count_resumption_events(ctx, "killed") - iter_kills_before
+        iter_restarts = _count_resumption_events(ctx, "restart_success") - iter_restarts_before
+        total_kills += iter_kills
+        total_restarts += iter_restarts
+
+        gen_stats = getattr(ctx, "last_gen_stats", {})
+        gen_summary = ""
+        for key, st in gen_stats.items():
+            if st:
+                gen_summary += (f"  events: {st.get('total_ops', '?')} ops "
+                                f"(I={st.get('INSERT_ops', 0)} U={st.get('UPDATE_ops', 0)} D={st.get('DELETE_ops', 0)})")
+
+        iter_summary = {
+            "stage": f"iteration_summary[{i+1}]",
+            "iteration": i + 1,
+            "duration_sec": round(elapsed, 1),
+            "kills": iter_kills,
+            "restarts": iter_restarts,
+        }
+        if gen_stats:
+            for key, st in gen_stats.items():
+                iter_summary["event_gen"] = st
+        H.append_stage_summary(
+            ctx.cfg["artifacts_dir"],
+            iter_summary["stage"],
+            H._ts(), H._ts(),
+            status="OK",
+        )
+        _append_ndjson(ctx.cfg["artifacts_dir"], "iteration_metrics.ndjson", iter_summary)
+
+        H.log(f"  ITERATION {i+1} / {count} completed in {mins}m {secs}s  |  kills: {iter_kills}  restarts: {iter_restarts}{gen_summary}")
+
+    total_elapsed = _time.monotonic() - loop_start
+    hrs, rem = divmod(int(total_elapsed), 3600)
+    mins, secs = divmod(rem, 60)
+    run_summary = {
+        "stage": "iteration_loop_summary",
+        "total_iterations": count,
+        "total_duration_sec": round(total_elapsed, 1),
+        "total_kills": total_kills,
+        "total_restarts": total_restarts,
+    }
+    _append_ndjson(ctx.cfg["artifacts_dir"], "iteration_metrics.ndjson", run_summary)
+    H.log(f"\n{'='*60}")
+    H.log(f"  ALL {count} ITERATIONS COMPLETE  |  {hrs}h {mins}m {secs}s  |  kills: {total_kills}  restarts: {total_restarts}")
+    H.log(f"{'='*60}")
+
+
+def _stage_is_skipped(stage: Dict[str, Any]) -> bool:
+    enabled = stage.get("enabled")
+    if enabled is None:
+        return False
+    if isinstance(enabled, bool):
+        return not enabled
+    if isinstance(enabled, str):
+        expanded = os.path.expandvars(enabled)
+        return expanded.lower() in ("false", "0", "no", "")
+    return not bool(enabled)
 
 
 # -------------------------

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/cleanup-db
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/cleanup-db
@@ -1,0 +1,1 @@
+../basic-public-live-test/cleanup-db

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/init-db
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/init-db
@@ -1,0 +1,1 @@
+../basic-public-live-test/init-db

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/live-migration-events.json
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/live-migration-events.json
@@ -1,0 +1,1 @@
+../basic-public-live-test/live-migration-events.json

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/snapshot_data.sql
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/snapshot_data.sql
@@ -1,0 +1,1 @@
+../basic-public-live-test/snapshot_data.sql

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/snapshot_schema.sql
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/snapshot_schema.sql
@@ -1,0 +1,1 @@
+../basic-public-live-test/snapshot_schema.sql

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/source_delta.sql
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/source_delta.sql
@@ -1,0 +1,1 @@
+../basic-public-live-test/source_delta.sql

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/target_delta.sql
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/target_delta.sql
@@ -1,0 +1,1 @@
+../basic-public-live-test/target_delta.sql

--- a/migtests/tests/pg/basic-live-fallback-iterations-test/validate
+++ b/migtests/tests/pg/basic-live-fallback-iterations-test/validate
@@ -1,0 +1,1 @@
+../basic-public-live-test/validate

--- a/migtests/tests/resumption/live-migration/common-sql/delete_marker.sql
+++ b/migtests/tests/resumption/live-migration/common-sql/delete_marker.sql
@@ -1,0 +1,1 @@
+DELETE FROM public.cutover_table WHERE status = 'Last event before cutover';

--- a/migtests/tests/resumption/live-migration/common-sql/init.sql
+++ b/migtests/tests/resumption/live-migration/common-sql/init.sql
@@ -59,3 +59,32 @@ CREATE TABLE tsvector_table (
     title_tsv TSVECTOR,
     content_tsv TSVECTOR
 );
+
+DROP TABLE IF EXISTS public.empty_iteration_table;
+CREATE TABLE public.empty_iteration_table (
+    id SERIAL PRIMARY KEY,
+    val TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+DROP TABLE IF EXISTS public.identity_test;
+CREATE TABLE public.identity_test (
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    action TEXT NOT NULL,
+    detail TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+INSERT INTO public.identity_test (action, detail)
+SELECT 'seed_' || i, 'initial row ' || i FROM generate_series(1, 20) i;
+
+ALTER TABLE public.num_types REPLICA IDENTITY FULL;
+ALTER TABLE public.decimal_types REPLICA IDENTITY FULL;
+ALTER TABLE public.datatypes1 REPLICA IDENTITY FULL;
+ALTER TABLE public.datetime_type REPLICA IDENTITY FULL;
+ALTER TABLE public.datetime_type2 REPLICA IDENTITY FULL;
+ALTER TABLE public.datatypes2 REPLICA IDENTITY FULL;
+ALTER TABLE public.null_and_default REPLICA IDENTITY FULL;
+ALTER TABLE public.tsvector_table REPLICA IDENTITY FULL;
+ALTER TABLE public.empty_iteration_table REPLICA IDENTITY FULL;
+ALTER TABLE public.identity_test REPLICA IDENTITY FULL;

--- a/migtests/tests/resumption/live-migration/iteration-test/run-iteration-tests.sh
+++ b/migtests/tests/resumption/live-migration/iteration-test/run-iteration-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load environment variables
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    set -a
+    source "$SCRIPT_DIR/.env"
+    set +a
+fi
+
+ORCHESTRATOR="$SCRIPT_DIR/../../../../scripts/live-migration-resumption/orchestrator.py"
+SCENARIO="$SCRIPT_DIR/scenario.yaml"
+
+echo "=== Running iteration tests ==="
+echo "Orchestrator: $ORCHESTRATOR"
+echo "Scenario: $SCENARIO"
+echo ""
+
+stdbuf -oL python3 -u "$ORCHESTRATOR" "$SCENARIO"

--- a/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml
+++ b/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml
@@ -1,0 +1,378 @@
+name: iteration-test
+
+env:
+  LOG_LEVEL: info
+
+export_dir: ./export-dir
+artifacts_dir: ./artifacts
+
+source:
+  type: postgresql
+  host: "${SOURCE_DB_HOST:-127.0.0.1}"
+  port: 5432
+  database: "${SOURCE_DB_NAME:-test_db}"
+  user: ybvoyager
+  password: "${SOURCE_DB_PASSWORD:-password}"
+  schema: public
+  admin:
+    user: postgres
+    password: postgres
+
+target:
+  type: yugabytedb
+  host: "${TARGET_DB_HOST:-10.9.15.11}"
+  port: 5433
+  database: "${TARGET_DB_NAME:-test_db}"
+  user: ybvoyager
+  password: "${TARGET_DB_PASSWORD:-yugabyte}"
+  admin:
+    user: yugabyte
+    password: yugabyte
+
+generator_source:
+  config_inline:
+    connection:
+      host: "${SOURCE_DB_HOST:-127.0.0.1}"
+      port: 5432
+      database: "${SOURCE_DB_NAME:-test_db}"
+      user: postgres
+      password: postgres
+
+    generator:
+      schema_name: public
+      manual_table_list: []
+      exclude_table_list: [cutover_table, identity_test, tsvector_table]
+      num_iterations: -1
+      wait_after_operations: 1000
+      wait_duration_seconds: 1
+      table_weights: {}
+      operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
+      random_seed: 123
+      faker_seed: 123
+      insert_rows: 3
+      update_rows: 2
+      delete_rows: 1
+      insert_max_retries: 5
+      update_max_retries: 1
+
+generator_target:
+  config_inline:
+    connection:
+      host: "${TARGET_DB_HOST:-10.9.15.11}"
+      port: 5433
+      database: "${TARGET_DB_NAME:-test_db}"
+      user: ybvoyager
+      password: "${TARGET_DB_PASSWORD:-yugabyte}"
+
+    generator:
+      schema_name: public
+      manual_table_list: []
+      exclude_table_list: [cutover_table, identity_test, tsvector_table]
+      num_iterations: -1
+      wait_after_operations: 5000
+      wait_duration_seconds: 1
+      table_weights: {}
+      operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 2}
+      random_seed: 456
+      faker_seed: 456
+      insert_rows: 6
+      update_rows: 4
+      delete_rows: 1
+      insert_max_retries: 5
+      update_max_retries: 1
+
+voyager:
+  cutover_to_target:
+    flags:
+      prepare-for-fall-back: true
+  cutover_to_source:
+    flags:
+      restart-data-migration-source-target: true
+
+iteration_count: 50
+
+stages:
+  # ============================================================
+  # Phase 1: Setup
+  # ============================================================
+  - name: create_source_and_target_dbs
+    action: reset_databases
+    targets: [source, target]
+
+  - name: create_source_schema
+    action: run_sql
+    sql_path: ../common-sql/init.sql
+    use_admin: true
+
+  - name: create_cutover_table
+    action: create_cutover_table
+    target: [source]
+
+  - name: grant_source_permissions
+    action: grant_source_permissions
+    is_live_migration_fall_back: 1
+
+  - name: export_schema_from_source
+    action: voyager_export_schema
+
+  - name: import_schema_on_target
+    action: voyager_import_schema
+
+  # ============================================================
+  # Phase 2: Initial forward migration (with snapshot-phase resumption)
+  # ============================================================
+  - name: start_source_event_generator
+    action: generator_start
+    generator_key: generator_source
+
+  - name: load_snapshot_soak
+    action: sleep
+    seconds: 10
+
+  - name: start_exporter
+    action: voyager_export_start
+
+  - name: start_importer
+    action: voyager_import_start
+
+  # Snapshot-phase resumptions disabled for now — the exporter must complete
+  # its snapshot cleanly for the first cutover to succeed. Needs further
+  # investigation on how to safely resume during snapshot without breaking
+  # the cutover handshake.
+  # TODO: Re-enable once snapshot resumption is validated independently.
+
+  - name: wait_exporter_streaming
+    action: wait_for
+    condition: exporter_in_streaming_phase
+    timeout_sec: 600
+
+  - name: soak_forward_streaming
+    action: sleep
+    seconds: 30
+
+  - name: stop_source_event_generator
+    action: generator_stop
+    generator_key: generator_source
+    graceful_timeout_sec: 60
+
+  - name: insert_backlog_marker
+    action: run_sql
+    target: source
+    sql_path: ../common-sql/insert_marker.sql
+
+  - name: wait_backlog_drained_forward
+    action: wait_for
+    condition: remaining_events_eq_0
+    timeout_sec: 1200
+
+  # ============================================================
+  # Phase 3: Cutover to target
+  # ============================================================
+  - name: cutover_to_target
+    action: cutover_to_target
+
+  - name: wait_cutover_to_target_completed
+    action: wait_for
+    condition: cutover_to_target_status_completed
+    timeout_sec: 900
+
+  # ============================================================
+  # Phase 4: Fallback (target -> source)
+  # Voyager auto-transitions to fallback after cutover to target.
+  # No target generator — keeps source and target data identical
+  # so row count validation can do an exact match at the end.
+  # ============================================================
+  - name: soak_fallback_streaming
+    action: sleep
+    seconds: 30
+
+  # ============================================================
+  # Phase 5: Cutover to source with restart (starts iteration loop)
+  # ============================================================
+  - name: cutover_to_source_with_restart
+    action: cutover_to_source
+
+  - name: wait_cutover_to_source_completed
+    action: wait_for
+    condition: cutover_to_source_status_completed
+    timeout_sec: 900
+
+  # ============================================================
+  # Phase 6: Iteration loop (repeats for iteration_count - 1)
+  # Voyager auto-transitions processes across iterations
+  # ============================================================
+  - name: iteration_loop
+    action: iteration_loop
+    count_from_config: iteration_count
+    subtract: 1
+    stages:
+      # Voyager auto-transitions export/import after cutover-to-source-with-restart
+      # We must take over those processes so the resumer can kill/restart them
+
+      - name: wait_iteration_exporter_streaming
+        action: wait_for
+        condition: iteration_exporter_in_streaming_phase
+        timeout_sec: 600
+
+      - name: takeover_processes
+        action: takeover_auto_transitioned
+
+      - name: start_iteration_source_event_generator
+        action: generator_start
+        generator_key: generator_source
+
+      # 3 kill/restart cycles during forward streaming (export_data only)
+      - name: forward_resumptions
+        action: start_resumptions
+        resumption:
+          export_data:
+            max_restarts: 3
+            min_interrupt_seconds: 5
+            max_interrupt_seconds: 15
+            min_restart_wait_seconds: 5
+            max_restart_wait_seconds: 15
+
+      - name: soak_iteration_forward_with_resumptions
+        action: sleep
+        seconds: 60
+
+      - name: stop_forward_export_resumptions
+        action: voyager_stop_resumptions
+        command: export_data
+        timeout_sec: 60
+
+      - name: stop_iteration_source_event_generator
+        action: generator_stop
+        generator_key: generator_source
+        graceful_timeout_sec: 60
+
+      - name: drain_iteration_forward_events
+        action: sleep
+        seconds: 30
+
+      - name: iteration_cutover_to_target
+        action: cutover_to_target
+
+      - name: wait_iteration_cutover_to_target
+        action: wait_for
+        condition: cutover_to_target_status_completed
+        timeout_sec: 900
+
+      - name: takeover_fallback_processes
+        action: takeover_fallback
+
+      # 2 kill/restart cycles during fallback streaming (1 each)
+      - name: fallback_resumptions
+        action: start_resumptions
+        resumption:
+          export_from_target:
+            max_restarts: 1
+            min_interrupt_seconds: 5
+            max_interrupt_seconds: 15
+            min_restart_wait_seconds: 5
+            max_restart_wait_seconds: 15
+          import_to_source:
+            max_restarts: 1
+            min_interrupt_seconds: 5
+            max_interrupt_seconds: 15
+            min_restart_wait_seconds: 5
+            max_restart_wait_seconds: 15
+
+      - name: soak_iteration_fallback_with_resumptions
+        action: sleep
+        seconds: 45
+
+      - name: stop_fallback_export_resumptions
+        action: voyager_stop_resumptions
+        command: export_from_target
+        timeout_sec: 60
+
+      - name: stop_fallback_import_resumptions
+        action: voyager_stop_resumptions
+        command: import_to_source
+        timeout_sec: 60
+
+      - name: drain_iteration_fallback_events
+        action: sleep
+        seconds: 30
+
+      - name: iteration_cutover_to_source_with_restart
+        action: cutover_to_source
+
+      - name: wait_iteration_cutover_to_source
+        action: wait_for
+        condition: cutover_to_source_status_completed
+        timeout_sec: 900
+
+  # ============================================================
+  # Phase 7: Final drain + cutover (no new events, no takeover)
+  # The last iteration ended with cutover-to-source + restart,
+  # so voyager auto-transitioned into a new forward cycle.
+  # Let the auto-transitioned processes drain naturally, then
+  # insert a marker, wait for it on target, and cutover.
+  # ============================================================
+  - name: final_wait_exporter_streaming
+    action: wait_for
+    condition: iteration_exporter_in_streaming_phase
+    timeout_sec: 600
+
+  - name: final_insert_backlog_marker
+    action: run_sql
+    target: source
+    sql_path: ../common-sql/insert_marker.sql
+
+  - name: final_wait_backlog_drained
+    action: wait_for
+    condition: remaining_events_eq_0
+    timeout_sec: 3600
+
+  - name: final_wait_marker_on_target
+    action: wait_for
+    condition: marker_imported_on_target
+    timeout_sec: 1800
+
+  - name: final_delete_backlog_marker
+    action: run_sql
+    target: source
+    sql_path: ../common-sql/delete_marker.sql
+
+  - name: final_cutover_to_target
+    action: cutover_to_target
+    flags:
+      prepare-for-fall-back: false
+
+  - name: final_wait_cutover_to_target
+    action: wait_for
+    condition: cutover_to_target_status_completed
+    timeout_sec: 900
+
+  # ============================================================
+  # Phase 8: Validation, reporting, and cleanup
+  # At this point the forward pipeline has drained all source events
+  # to target. Source and target should be identical.
+  # ============================================================
+  - name: final_cutover_status_check
+    action: validate_cutover_status
+
+  - name: final_data_migration_report
+    action: get_data_migration_report
+
+  - name: final_row_count_validations
+    action: row_count_validations
+    exclude_tables: [cutover_table]
+
+  - name: final_row_hash_validations
+    action: row_hash_validations
+    exclude_tables: [cutover_table]
+
+  - name: cleanup_source
+    action: run_sql
+    sql_path: ../common-sql/cleanup.sql
+
+  - name: cleanup_target
+    action: run_sql
+    target: target
+    sql_path: ../common-sql/cleanup.sql
+
+  - name: final_end_migration
+    action: voyager_end_migration


### PR DESCRIPTION
Introduces a YAML-driven orchestrator for automated iteration testing of live migration with fall-back. The framework supports configurable forward/fallback cycling with event generation, process takeover, cutover management, and optional row count/hash validation.

Key changes:
- New Python orchestrator (orchestrator.py) with stage-based execution, iteration loops, resumption injection, and NDJSON metrics logging
- Enhanced helpers.py with process management (takeover, kill+restart), cutover status parsing, backlog marker draining, and validation helpers
- Event generator (generator.py) now emits structured summary on exit
- New iteration-test scenario.yaml defining the full test workflow
- Shell wrapper (run-iteration-tests.sh) and CI integration via live-migration-fallb-run-test.sh --with-iterations flag
- .gitignore updated to exclude test artifacts

Made-with: Cursor

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
