### PR TITLE
Update AGENTS.md with dev environment gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,5 @@ yes | bash installer_scripts/install-yb-voyager -v
 - The `-l` (local build) flag requires `rsync` to be installed on the system.
 - Lock files (`.lck`) in the export directory can block re-runs; remove them if a previous `yb-voyager` process was killed.
 - Set `YB_VOYAGER_SEND_DIAGNOSTICS=0` to disable telemetry during development/testing.
+- After a full build (`install-yb-voyager -l`), run `source /home/ubuntu/.yb-voyager.rc` to set Maven/Debezium env vars for the current shell.
+- The default PostgreSQL `pg_hba.conf` uses `peer` auth. For `yb-voyager` to connect via TCP (127.0.0.1), add `host all all 127.0.0.1/32 md5` and reload: `sudo pg_ctlcluster 17 main reload`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Describe the changes in this pull request

Updates `AGENTS.md` with two additional development environment gotchas discovered during cloud agent setup:
- After a full build (`install-yb-voyager -l`), `source /home/ubuntu/.yb-voyager.rc` is needed to set Maven/Debezium env vars for the current shell.
- The default PostgreSQL `pg_hba.conf` uses `peer` auth; TCP connections from `yb-voyager` require adding `host all all 127.0.0.1/32 md5` and reloading.

### Describe if there are any user-facing changes

No user-facing changes. This only affects the developer/agent experience documentation.

### How was this pull request tested?

Full development environment setup was validated:
- Built `yb-voyager` from source (`install-yb-voyager -l -p`)
- Ran lint: `go vet ./...` and `staticcheck -tags unit ./...` — both clean
- Ran unit tests: `go test -tags unit ./...` — all passed
- Completed a full offline migration (PostgreSQL → YugabyteDB) with 5 rows

Evidence:
[migration_demo.log](https://cursor.com/agents/bc-62a87088-6fc3-43b5-a739-585ee630e5a4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmigration_demo.log)
[lint_and_tests.log](https://cursor.com/agents/bc-62a87088-6fc3-43b5-a739-585ee630e5a4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flint_and_tests.log)

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62a87088-6fc3-43b5-a739-585ee630e5a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62a87088-6fc3-43b5-a739-585ee630e5a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

