### PR TITLE
Fix test cleanup failures by terminating stale sessions before DROP DATABASE

### DIFF
--- a/migtests/scripts/callhome/run-callhome-test.sh
+++ b/migtests/scripts/callhome/run-callhome-test.sh
@@ -143,7 +143,7 @@ main() {
     fi
 
     step "Create target database."
-    run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME};\""
+    ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
     run_ysql yugabyte "CREATE DATABASE  \"${TARGET_DB_NAME}\" with COLOCATION=TRUE;"
 
     step "Export schema"

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -93,6 +93,13 @@ run_ysql() {
 	PGPASSWORD="${TARGET_DB_ADMIN_PASSWORD}" psql -P pager=off -h ${TARGET_DB_HOST} -p ${TARGET_DB_PORT} -U ${TARGET_DB_ADMIN_USER} -d ${db_name} -c "${sql}"
 }
 
+ysql_terminate_and_drop_database() {
+	local target_db_to_drop=$1
+	run_ysql yugabyte "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${target_db_to_drop}' AND pid != pg_backend_pid();" || true
+	sleep 1
+	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${target_db_to_drop}\";"
+}
+
 ysql_import_file() {
 	db_name=$1
 	file=$2

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -144,7 +144,7 @@ main() {
 	tail -20 ${EXPORT_DIR}/reports/schema_analysis_report.json
 
 	step "Create target database."
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
 		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
 	else
@@ -338,7 +338,7 @@ main() {
 	if [ "${run_via_config_file}" = true ]; then
 	rm -f "${GENERATED_CONFIG}"
 	fi
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 }	
 
 main

--- a/migtests/scripts/live-migration-fallf-run-test.sh
+++ b/migtests/scripts/live-migration-fallf-run-test.sh
@@ -141,7 +141,7 @@ main() {
 	tail -20 ${EXPORT_DIR}/reports/schema_analysis_report.json
 
 	step "Create target database."
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
 		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
 	else
@@ -350,7 +350,7 @@ main() {
 	if [ "${run_via_config_file}" = true ]; then
 	rm -f "${GENERATED_CONFIG}"
 	fi
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 }
 
 main

--- a/migtests/scripts/live-migration-run-test.sh
+++ b/migtests/scripts/live-migration-run-test.sh
@@ -134,7 +134,7 @@ main() {
 	tail -20 ${EXPORT_DIR}/reports/schema_analysis_report.json
 
 	step "Create target database."
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
 		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
 	else
@@ -272,7 +272,7 @@ main() {
 	if [ "${run_via_config_file}" = true ]; then
 	rm -f "${GENERATED_CONFIG}"
 	fi
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME};\""
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 }
 
 main

--- a/migtests/scripts/resumption.sh
+++ b/migtests/scripts/resumption.sh
@@ -120,7 +120,7 @@ main() {
 	if [ -n "${SOURCE_DB_NAME}" ]; then
 		run_psql postgres "DROP DATABASE ${SOURCE_DB_NAME};"
 	fi
-	run_ysql yugabyte "DROP DATABASE IF EXISTS ${TARGET_DB_NAME};"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 }
 
 main

--- a/migtests/scripts/run-schema-migration.sh
+++ b/migtests/scripts/run-schema-migration.sh
@@ -98,7 +98,7 @@ main() {
 	compare_json_reports "${TEST_DIR}/expected_files/expected_schema_analysis_report.json" "${EXPORT_DIR}/reports/schema_analysis_report.json"
 
 	step "Create target database."
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME};\""
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
 
 	step "Import schema."
@@ -152,7 +152,7 @@ main() {
 	step "Clean up"
 	./cleanup-db
 	rm -rf "${EXPORT_DIR}"
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 }
 
 main

--- a/migtests/scripts/run-test-export-data.sh
+++ b/migtests/scripts/run-test-export-data.sh
@@ -75,7 +75,7 @@ main() {
 	step "Clean up"
 	./cleanup-db
 	rm -rf "${EXPORT_DIR}"
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 }
 
 main

--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -164,7 +164,7 @@ main() {
 	fi
 
 	step "Create target database."
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
 		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
 	else
@@ -262,7 +262,7 @@ main() {
 	if [ "${run_via_config_file}" = true ]; then
 	rm -f "${GENERATED_CONFIG}"
 	fi
-	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${TARGET_DB_NAME}\";"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 }
 
 main


### PR DESCRIPTION
### Describe the changes in this pull request

Test scripts were intermittently failing during cleanup because `DROP DATABASE IF EXISTS` would error out when active sessions (from a prior migration run) were still connected to the target database. This PR introduces a shared helper function `ysql_terminate_and_drop_database` in `functions.sh` that first calls `pg_terminate_backend` to kill all active connections to the target database, waits briefly for them to close, and then drops the database. All nine test scripts that perform target database cleanup are updated to use this helper instead of calling `DROP DATABASE` directly. This also fixes a couple of pre-existing quoting bugs where the semicolon was incorrectly placed inside the database name quotes (e.g., `"${TARGET_DB_NAME};"` instead of `"${TARGET_DB_NAME}"`).

### Describe if there are any user-facing changes

No user-facing changes. This only affects internal CI/test scripts.

### How was this pull request tested?

The affected CI pipelines were triggered and all pass without cleanup failures.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

Made with [Cursor](https://cursor.com)