### PR TITLE
Fix: import data file failing to skip empty data file 

### DIFF
--- a/yb-voyager/cmd/importDataFileTaskImporter.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter.go
@@ -199,6 +199,10 @@ func (fti *FileTaskImporter) importBatch(batch *Batch) {
 	var isPartialBatchIngestionPossibleOnError bool
 
 	if batch.RecordCount == 0 {
+		err = batch.MarkInProgress()
+		if err != nil {
+			utils.ErrExit("marking empty batch as in progress: %q: %s", batch.FilePath, err)
+		}
 		// an empty batch is possible in case there are errors while reading and procesing rows in the file
 		// and the errors are handled by the error handler.
 		log.Infof("Skipping empty batch: %s", spew.Sdump(batch))

--- a/yb-voyager/cmd/importDataFileTaskImporter.go
+++ b/yb-voyager/cmd/importDataFileTaskImporter.go
@@ -199,13 +199,13 @@ func (fti *FileTaskImporter) importBatch(batch *Batch) {
 	var isPartialBatchIngestionPossibleOnError bool
 
 	if batch.RecordCount == 0 {
+		// an empty batch is possible in case there are errors while reading and procesing rows in the file
+		// and the errors are handled by the error handler.
+		log.Infof("Skipping empty batch: %s", spew.Sdump(batch))
 		err = batch.MarkInProgress()
 		if err != nil {
 			utils.ErrExit("marking empty batch as in progress: %q: %s", batch.FilePath, err)
 		}
-		// an empty batch is possible in case there are errors while reading and procesing rows in the file
-		// and the errors are handled by the error handler.
-		log.Infof("Skipping empty batch: %s", spew.Sdump(batch))
 		err = batch.MarkDone()
 		if err != nil {
 			utils.ErrExit("marking empty batch as done: %q: %s", batch.FilePath, err)

--- a/yb-voyager/cmd/importDataFile_test.go
+++ b/yb-voyager/cmd/importDataFile_test.go
@@ -809,3 +809,75 @@ func TestImportDataFile_GeneratedAlwaysAsIdentity(t *testing.T) {
 	// Verify the identity column is still GENERATED ALWAYS
 	assertIdentityColumnIsAlways(t, ybConn, "public", "identity_file_test", "id")
 }
+
+func TestImportDataFile_EmptyFile(t *testing.T) {
+	exportDir = testutils.CreateTempExportDir()
+	defer testutils.RemoveTempExportDir(exportDir)
+
+	setupYugabyteTestDb(t)
+
+	createTableSQL := `CREATE TABLE public.empty_file_test (id INTEGER PRIMARY KEY, name TEXT);`
+	testYugabyteDBTarget.TestContainer.ExecuteSqls(createTableSQL)
+	t.Cleanup(func() {
+		testYugabyteDBTarget.TestContainer.ExecuteSqls("DROP TABLE IF EXISTS public.empty_file_test;")
+	})
+
+	dataFilePath := filepath.Join("/tmp", "abc1.csv")
+	f, err := os.Create(dataFilePath)
+	testutils.FatalIfError(t, err, "Failed to create CSV file")
+	defer os.Remove(dataFilePath)
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	w.Write([]string{"id", "name"})
+	w.Flush()
+
+	dataFilePath2 := filepath.Join("/tmp", "abc2.csv")
+	f2, err := os.Create(dataFilePath2)
+	testutils.FatalIfError(t, err, "Failed to create CSV file")
+	defer os.Remove(dataFilePath2)
+	defer f2.Close()
+
+	w2 := csv.NewWriter(f2)
+	w2.Write([]string{"id", "name"})
+	w2.Write([]string{"1", "abc"})
+	w2.Write([]string{"2", "def"})
+	w2.Write([]string{"3", "ghi"})
+	w2.Flush()
+
+	dataFilePath3 := filepath.Join("/tmp", "abc3.csv")
+	f3, err := os.Create(dataFilePath3)
+	testutils.FatalIfError(t, err, "Failed to create CSV file")
+	defer os.Remove(dataFilePath3)
+	defer f3.Close()
+
+	w3 := csv.NewWriter(f3)
+	w3.Write([]string{"id", "name"})
+	w3.Write([]string{"4", "abc"})
+	w3.Write([]string{"5", "def"})
+	w3.Write([]string{"6", "ghi"})
+	w3.Flush()
+
+	importDataFileCmdArgs := []string{
+		"--export-dir", exportDir,
+		"--disable-pb", "true",
+		"--target-db-schema", "public",
+		"--data-dir", "/tmp",
+		"--file-table-map", "abc*.csv:public.empty_file_test",
+		"--format", "CSV",
+		"--has-header", "true",
+		"--yes",
+	}
+
+	err = testutils.NewVoyagerCommandRunner(testYugabyteDBTarget.TestContainer, "import data file", importDataFileCmdArgs, nil, false).Run()
+	testutils.FatalIfError(t, err, "import data file failed")
+
+	ybConn, err := testYugabyteDBTarget.TestContainer.GetConnection()
+	testutils.FatalIfError(t, err, "connecting to YugabyteDB")
+	defer ybConn.Close()
+	// Verify row count
+	var rowCount int
+	err = ybConn.QueryRow("SELECT COUNT(*) FROM public.empty_file_test").Scan(&rowCount)
+	testutils.FatalIfError(t, err, "failed to query row count")
+	assert.Equal(t, 6, rowCount, "expected 6 rows imported")
+}

--- a/yb-voyager/cmd/importDataRandomFileBatchProducer_test.go
+++ b/yb-voyager/cmd/importDataRandomFileBatchProducer_test.go
@@ -726,6 +726,61 @@ func TestRandomBatchProducer_StashAndContinue(t *testing.T) {
 	assert.True(t, producer.Done(), "Done() should be true after producer finishes")
 }
 
+func TestRandomBatchProducer_StashAndContinue_LastBatchHasAllErrors(t *testing.T) {
+	// Set max batch size in bytes to a small value to trigger the row-too-large error
+	maxBatchSizeBytes := int64(15) // deliberately small to trigger error
+	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(1000, maxBatchSizeBytes)
+	require.NoError(t, err)
+
+	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir))
+	require.NoError(t, err)
+
+	if ldataDir != "" {
+		defer os.RemoveAll(fmt.Sprintf("%s/", ldataDir))
+	}
+	if lexportDir != "" {
+		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
+	}
+
+	// The second row will be too large for the batch size
+	fileContents := `id,val
+1, "hello"
+2, "this row is too long and should trigger an error because it exceeds the max batch size"`
+	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
+	require.NoError(t, err)
+
+	// Create RandomBatchProducer
+	producer, err := NewRandomFileBatchProducer(task, state, false, scErrorHandler, progressReporter, createTestSemaphore())
+	require.NoError(t, err)
+	defer producer.Close()
+
+	// Wait for batch to become available
+	available := waitForBatchAvailable(producer, 5*time.Second)
+	require.True(t, available, "Batch should become available within timeout")
+
+	// Get the batch - should contain only the first row (second row is skipped due to error)
+	batch, err := producer.NextBatch()
+	require.NoError(t, err, "NextBatch() should not return error with stash-and-continue policy")
+	require.NotNil(t, batch, "Batch should not be nil")
+	assert.Equal(t, int64(1), batch.RecordCount, "Batch should contain 1 record (second row skipped due to error)")
+
+	batch2, err := producer.NextBatch()
+	require.NoError(t, err, "NextBatch() should not return error with stash-and-continue policy")
+	require.NotNil(t, batch2, "Batch should not be nil")
+	assert.Equal(t, int64(0), batch2.RecordCount, "Batch should contain 0 records (second row skipped due to error)")
+
+	// Verify error file contains the error for the second row
+	assertProcessingErrorBatchFileContains(t, lexportDir, task,
+		batch.Number, 1, 91,
+		"larger than max batch size",
+		"ROW: 2, \"this row is too long and should trigger an error because it exceeds the max batch size\"")
+
+	// Verify producer eventually completes
+	_ = waitForProducerDone(producer, 5*time.Second)
+	assert.True(t, producer.Done(), "Done() should be true after producer finishes")
+
+}
+
 // ================================ Resumption Tests ================================
 
 // delayedSequentialFileBatchProducer wraps SequentialFileBatchProducer and adds a delay in NextBatch()


### PR DESCRIPTION
### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
