### PR TITLE
Add Docker/testcontainers documentation to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,12 @@ yes | bash installer_scripts/install-yb-voyager -v
 ### Docker (for testcontainers)
 
 Docker is installed with the fuse-overlayfs storage driver and iptables-legacy (required for DinD in Cloud Agent VMs). Before running integration tests, ensure the Docker daemon is running:
+Verify with `docker info`. If not started, use this to start docker: 
 ```
 sudo dockerd &>/tmp/dockerd.log &
 sleep 3
 sudo chmod 666 /var/run/docker.sock
 ```
-Verify with `docker info`. The daemon must be started each session — it does not auto-start.
 
 ### Running local databases
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ YugabyteDB Voyager (`yb-voyager`) is a database migration CLI tool (Go) with a D
 - **PostgreSQL client 17** — provides `pg_dump`/`pg_restore`.
 - **YugabyteDB** — installed at `/opt/yugabyte-2025.2.1.0`. The target database for migrations.
 - **PostgreSQL 17 server** — local source database for development/testing.
+- **Docker 28.5.2** — required for integration tests that use testcontainers.
 
 ### Building from source
 
@@ -34,7 +35,18 @@ yes | bash installer_scripts/install-yb-voyager -v
 
 - Unit tests use the `unit` build tag: `go test -tags unit ./...` (from `yb-voyager/` directory).
 - Integration tests use tags like `issues_integration` and require Docker + testcontainers.
+- Other integration test tags: `integration` (srcdb/tgtdb/pgss tests), `integration_voyager_command` (cmd-level tests), `integration_live_migration`, `failpoint_*`.
 - Lint: `go vet ./...` and `staticcheck -tags unit ./...` (from `yb-voyager/`).
+
+### Docker (for testcontainers)
+
+Docker is installed with the fuse-overlayfs storage driver and iptables-legacy (required for DinD in Cloud Agent VMs). Before running integration tests, ensure the Docker daemon is running:
+```
+sudo dockerd &>/tmp/dockerd.log &
+sleep 3
+sudo chmod 666 /var/run/docker.sock
+```
+Verify with `docker info`. The daemon must be started each session — it does not auto-start.
 
 ### Running local databases
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Docker and testcontainers documentation to `AGENTS.md` for Cloud Agent environments.

### Changes
- Added **Docker 28.5.2** as a key environment requirement
- Added Docker startup instructions for Cloud Agent VMs (fuse-overlayfs storage driver, iptables-legacy workaround)
- Documented additional integration test build tags (`integration`, `integration_voyager_command`, `integration_live_migration`, `failpoint_*`)

### Verification

Docker was installed and verified working with testcontainers by running the `pgss` integration test suite, which spins up PostgreSQL containers for versions 11–17:

```
--- PASS: TestPgStatStatementsRequiredColumns (66.94s)
    --- PASS: TestPgStatStatementsRequiredColumns/PostgreSQL_11 (9.77s)
    --- PASS: TestPgStatStatementsRequiredColumns/PostgreSQL_12 (9.78s)
    --- PASS: TestPgStatStatementsRequiredColumns/PostgreSQL_13 (9.69s)
    --- PASS: TestPgStatStatementsRequiredColumns/PostgreSQL_14 (9.75s)
    --- PASS: TestPgStatStatementsRequiredColumns/PostgreSQL_15 (9.69s)
    --- PASS: TestPgStatStatementsRequiredColumns/PostgreSQL_16 (9.07s)
    --- PASS: TestPgStatStatementsRequiredColumns/PostgreSQL_17 (9.20s)
PASS
```

Full test log: [testcontainers_pgss_test.log](https://cursor.com/agents/bc-7c356e22-8875-4c08-8fd3-4113c49e76f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftestcontainers_pgss_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c356e22-8875-4c08-8fd3-4113c49e76f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c356e22-8875-4c08-8fd3-4113c49e76f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

