### PR TITLE
Add TODO to remove stale-session-cleanup workaround once Voyager bug is fixed

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -93,6 +93,12 @@ run_ysql() {
 	PGPASSWORD="${TARGET_DB_ADMIN_PASSWORD}" psql -P pager=off -h ${TARGET_DB_HOST} -p ${TARGET_DB_PORT} -U ${TARGET_DB_ADMIN_USER} -d ${db_name} -c "${sql}"
 }
 
+# TODO: Remove this helper (and all its call-sites) once the underlying
+# Voyager bug is fixed: https://yugabyte.atlassian.net/browse/DB-14314
+# target-side disconnect() does not close the sql.DB handle, leaving
+# stale sessions that block DROP DATABASE.
+# Once that is fixed, a plain `DROP DATABASE IF EXISTS "<name>";` should
+# suffice and this workaround can be removed.
 ysql_terminate_and_drop_database() {
 	local target_db_to_drop=$1
 	run_ysql yugabyte "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${target_db_to_drop}' AND pid != pg_backend_pid();" || true


### PR DESCRIPTION
## Summary
- Adds a TODO comment above the `ysql_terminate_and_drop_database` helper in `migtests/scripts/functions.sh` noting that this helper (and all its call-sites) is a test-side workaround and should be removed once the underlying Voyager bug is fixed (target-side `disconnect()` not closing the `sql.DB` handle, leaving stale sessions that block `DROP DATABASE`).
- Follow-up to #3503.

## Test plan
- [x] Comment-only change, no behavior impact.

Made with [Cursor](https://cursor.com)