### PR TITLE
Use mktemp in normalize_json helpers to fix /tmp race in migtests

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -1173,8 +1173,12 @@ move_tables() {
 normalize_json() {
     local input_file="$1"
     local output_file="$2"
-    local temp_file="/tmp/temp_file.json"
-	local temp_file2="/tmp/temp_file2.json"
+    # Use mktemp: hardcoded /tmp paths race across parallel nightly tests,
+    # causing jq-open errors and cross-test payload contamination in diffs.
+    local temp_file
+    temp_file=$(mktemp)
+    local temp_file2
+    temp_file2=$(mktemp)
 
     # Normalize JSON with jq; use --sort-keys to avoid the need to keep the same sequence of keys in expected vs actual json
     jq --sort-keys 'walk(
@@ -1227,6 +1231,7 @@ normalize_json() {
 
     # Move cleaned file to output
     mv "$temp_file2" "$output_file"
+    rm -f "$temp_file"
 }
 
 
@@ -1482,7 +1487,10 @@ generate_voyager_config() {
 normalize_callhome_json() {
     local input_file="$1"
     local output_file="$2"
-    local temp_file="/tmp/temp_file.json"
+    # Use mktemp: hardcoded /tmp paths race across parallel nightly tests,
+    # causing jq-open errors and cross-test payload contamination in diffs.
+    local temp_file
+    temp_file=$(mktemp)
 
     # Normalize JSON with jq; use --sort-keys to avoid the need to keep the same sequence of keys in expected vs actual json
     jq --sort-keys 'walk(


### PR DESCRIPTION
### Describe the changes in this pull request

`normalize_json` and `normalize_callhome_json` in `migtests/scripts/functions.sh`
wrote jq intermediate output to hardcoded `/tmp/temp_file.json` and
`/tmp/temp_file2.json`. When multiple nightly pipelines run in parallel,
these shared paths race between the `jq > tmp` and subsequent `mv` / `sed -i`
steps, producing two observed failure signatures:

1. `pg/assessment-report-test`: `jq: error: Could not open file /tmp/temp_file.json`
   — a parallel run removed the file between write and read.
2. `pg/datatypes` export-schema callhome diff — the "expected" normalized
   file was overwritten mid-flight with another test's payload, generating a
   valid-looking but completely wrong diff.

Replacing the hardcoded paths with `$(mktemp)` makes each invocation unique
and eliminates the race. Internal-only change to the two helpers; external
contract and surrounding logic are untouched.

### Describe if there are any user-facing changes

No user-facing changes.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

Made with [Cursor](https://cursor.com)