### PR TITLE
Use ysql_terminate_and_drop_database in import-data-file test runner

### DIFF
--- a/migtests/tests/import-file/run-import-file-test
+++ b/migtests/tests/import-file/run-import-file-test
@@ -46,7 +46,7 @@ main() {
 	pushd ${TEST_DIR}
 
 	step "Create target database."
-	run_ysql yugabyte "DROP DATABASE IF EXISTS ${TARGET_DB_NAME};"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	run_ysql yugabyte "CREATE DATABASE ${TARGET_DB_NAME}"
 
 	step "Unzip the data file."
@@ -403,7 +403,7 @@ main() {
 
 	step "Clean up"
 	rm -rf "${EXPORT_DIR}"
-	run_ysql yugabyte "DROP DATABASE IF EXISTS ${TARGET_DB_NAME};"
+	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 
 	step "Remove the credentials file for GCS default authentications"
 	rm -rf ~/.config/gcloud/application_default_credentials.json


### PR DESCRIPTION
### Describe the changes in this pull request

`migtests/tests/import-file/run-import-file-test` still uses the raw
`run_ysql "DROP DATABASE IF EXISTS ${TARGET_DB_NAME};"` pattern at both the
pre-test create step and the final cleanup step. #3503 introduced the
`ysql_terminate_and_drop_database` helper and converted the standard
orchestration scripts (`run-test.sh`, `run-schema-migration.sh`,
`live-migration-*.sh`, etc.) to use it, but this bespoke per-test runner
was missed. As a result, the cleanup step still occasionally fails with:

```
ERROR:  database "testdb" is being accessed by other users
DETAIL:  There is 1 other session using the database.
```

This PR converts both call-sites in `run-import-file-test` to
`ysql_terminate_and_drop_database`, matching the pattern now used by the
rest of the suite. No other tests are touched — the remaining
non-converted call-sites (the 3 `init-db` / `init-target-db` scripts under
`migtests/tests/resumption/`) are pre-test init and don't hit the
stale-session path, so they're intentionally left alone.

### Describe if there are any user-facing changes

No user-facing changes.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

Made with [Cursor](https://cursor.com)