### PR TITLE
Add partition iteration resumption test for --use-partition-root=false

### DIFF
--- a/migtests/scripts/event-generator/generator.py
+++ b/migtests/scripts/event-generator/generator.py
@@ -67,6 +67,9 @@ WAIT_DURATION_SECONDS = GEN["wait_duration_seconds"]
 # Index events flag
 ENABLE_INDEX_CREATE_DROP = GEN.get("enable_index_create_drop", False)
 INDEX_EVENTS_INTERVAL = GEN.get("index_events_interval", 5)
+
+# Column overrides for partition-aware value generation
+COLUMN_OVERRIDES = GEN.get("column_overrides", {})
 # ---------------------------------
 
 # Deterministic seeds from YAML
@@ -151,7 +154,7 @@ try:
             if operation == "INSERT":
                 # Generate random data and execute INSERT statement
                 columns = ", ".join(table_schemas[table_name]["columns"].keys())
-                values_holder = {"values_list": build_insert_values(table_schemas, table_name, INSERT_ROWS)}
+                values_holder = {"values_list": build_insert_values(table_schemas, table_name, INSERT_ROWS, COLUMN_OVERRIDES)}
 
                 # Prepare callbacks for retryable execution
                 def run_once():
@@ -159,7 +162,7 @@ try:
                     cursor.execute(query_to_run)
 
                 def rebuild():
-                    values_holder["values_list"] = build_insert_values(table_schemas, table_name, INSERT_ROWS)
+                    values_holder["values_list"] = build_insert_values(table_schemas, table_name, INSERT_ROWS, COLUMN_OVERRIDES)
 
                 success = execute_with_retry(run_once, rebuild, conn.rollback, max_retries=INSERT_MAX_RETRIES)
                 if success:
@@ -167,25 +170,29 @@ try:
                     pass
             
             elif operation == "UPDATE":
+                primary_key = table_schemas[table_name]["primary_key"]
+                if not primary_key:
+                    print(f"Skipping UPDATE on '{table_name}': no primary key found")
+                    continue
+
+                pk_set = set(primary_key) if isinstance(primary_key, list) else {primary_key}
+
                 for _ in range(UPDATE_MAX_RETRIES):
                     columns = table_schemas[table_name]["columns"]
-                    primary_key = table_schemas[table_name]["primary_key"]
 
-                    if len(columns) == 1:
-                        break  # Skip the entire update operation for tables with only one column
-                
-                    updateable_columns = [col for col in columns if col != primary_key]
+                    if len(columns) <= len(pk_set):
+                        break
+
+                    updateable_columns = [col for col in columns if col not in pk_set]
 
                     if not updateable_columns:
                         print(f"No updateable columns found for table {table_name}. Retrying...")
                         continue
 
                     num_columns_to_update = random.randint(1, len(updateable_columns))
-
-                    # Randomly choose the columns to update
                     columns_to_update = random.sample(updateable_columns, num_columns_to_update)
 
-                    set_clause, params = build_update_values(table_schemas, table_name, columns_to_update)
+                    set_clause, params = build_update_values(table_schemas, table_name, columns_to_update, COLUMN_OVERRIDES)
                     where_clause, sampling_params = build_sampling_condition(
                         db_flavor=DB_FLAVOR,
                         table_name=table_name,
@@ -199,12 +206,17 @@ try:
                     try:
                         cursor.execute(query_to_run, full_params)
                         conn.commit()
-                        break  # Break out of the loop if the update is successful
+                        break
                     except Exception as e:
+                        print(f"UPDATE failed on '{table_name}': {e}")
                         conn.rollback()
 
             elif operation == "DELETE":
                 primary_key = table_schemas[table_name]["primary_key"]
+                if not primary_key:
+                    print(f"Skipping DELETE on '{table_name}': no primary key found")
+                    continue
+
                 where_clause, sampling_params = build_sampling_condition(
                     db_flavor=DB_FLAVOR,
                     table_name=table_name,

--- a/migtests/scripts/event-generator/utils.py
+++ b/migtests/scripts/event-generator/utils.py
@@ -52,6 +52,7 @@ CONFIG_SCHEMA: Dict[str, Dict[str, Any]] = {
         "update_max_retries": int,
         "enable_index_create_drop": bool,
         "index_events_interval": int,
+        "column_overrides": dict,
     },
 }
 
@@ -73,7 +74,7 @@ def load_yaml_file(path: str) -> Dict[str, Any]:
 
 def validate_section(section: Dict[str, Any], schema: Dict[str, Any], section_name: str) -> None:
     # Optional fields that don't need to be present (for backward compatibility)
-    optional_fields = {"enable_index_create_drop","index_events_interval"}
+    optional_fields = {"enable_index_create_drop","index_events_interval","column_overrides"}
     
     for key, expected_type in schema.items():
         if key not in section:
@@ -167,6 +168,60 @@ def get_estimated_row_count(
 
 def set_faker_seed(seed: int) -> None:
     _fake.seed_instance(seed)
+
+
+# ----- Column override helpers -----
+
+def generate_override_value(override_spec: Dict[str, Any]) -> Any:
+    """Generate a value based on a column_overrides spec entry.
+
+    Supported override types:
+      - choice: pick randomly from a list of values
+      - timestamp_range: random timestamp between min and max (ISO format strings)
+      - date_range: random date between min and max (YYYY-MM-DD strings)
+      - int_range: random integer between min and max
+    """
+    from datetime import datetime, timedelta, date as date_type
+
+    override_type = override_spec.get("type")
+
+    if override_type == "choice":
+        return random.choice(override_spec["values"])
+
+    elif override_type == "timestamp_range":
+        min_ts = datetime.fromisoformat(override_spec["min"])
+        max_ts = datetime.fromisoformat(override_spec["max"])
+        delta = (max_ts - min_ts).total_seconds()
+        random_seconds = random.uniform(0, delta)
+        result = min_ts + timedelta(seconds=random_seconds)
+        return result.strftime("%Y-%m-%d %H:%M:%S")
+
+    elif override_type == "date_range":
+        min_d = date_type.fromisoformat(override_spec["min"])
+        max_d = date_type.fromisoformat(override_spec["max"])
+        delta_days = (max_d - min_d).days
+        random_days = random.randint(0, delta_days)
+        result = min_d + timedelta(days=random_days)
+        return result.isoformat()
+
+    elif override_type == "int_range":
+        return random.randint(override_spec["min"], override_spec["max"])
+
+    else:
+        raise ValueError(f"Unknown column_overrides type: {override_type}")
+
+
+def get_column_override(
+    column_overrides: Dict[str, Any],
+    table_name: str,
+    column_name: str,
+) -> Optional[Dict[str, Any]]:
+    """Look up an override spec for a given table.column, or None."""
+    table_overrides = column_overrides.get(table_name)
+    if not table_overrides:
+        return None
+    return table_overrides.get(column_name)
+
 
 # ----- Schema discovery/introspection -----
 
@@ -338,23 +393,56 @@ def _find_primary_key(
     cursor: Any,
     table_name: str,
     schema_name: Optional[str],
-) -> Optional[str]:
-    """Return the name of the primary key column or None if not found."""
+) -> Optional[List[str]]:
+    """Return the primary key column(s) as a list, or None if not found.
+
+    For partitioned tables where the root has no PK, falls back to querying
+    the first child partition's PK.
+    """
     regclass = _qualify_regclass(table_name, schema_name)
-    cursor.execute(
-        """
-            SELECT a.attname
-            FROM pg_index i
-            JOIN pg_class c ON c.oid = i.indrelid
-            JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey)
-            WHERE c.oid = %s::regclass
-              AND i.indisprimary
-            ORDER BY a.attnum
-        """,
-        (regclass,),
-    )
-    result = cursor.fetchone()
-    return result[0] if result else None
+    pk_query = """
+        SELECT a.attname
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indrelid
+        JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey)
+        WHERE c.oid = %s::regclass
+          AND i.indisprimary
+        ORDER BY a.attnum
+    """
+    cursor.execute(pk_query, (regclass,))
+    rows = cursor.fetchall()
+    if rows:
+        return [r[0] for r in rows]
+
+    # Root partitioned tables often have no PK; walk down through children
+    # until we find a leaf partition that has a PK (handles multilevel partitioning).
+    children_query = """
+        SELECT c.relname
+        FROM pg_inherits i
+        JOIN pg_class c ON c.oid = i.inhrelid
+        JOIN pg_class p ON p.oid = i.inhparent
+        JOIN pg_namespace n ON n.oid = p.relnamespace
+        WHERE p.relname = %s AND n.nspname = %s
+        ORDER BY c.relname
+        LIMIT 1
+    """
+    current = table_name
+    visited = set()
+    while current not in visited:
+        visited.add(current)
+        cursor.execute(children_query, (current, schema_name or 'public'))
+        child = cursor.fetchone()
+        if not child:
+            break
+        child_regclass = _qualify_regclass(child[0], schema_name)
+        cursor.execute(pk_query, (child_regclass,))
+        rows = cursor.fetchall()
+        if rows:
+            pk_cols = [r[0] for r in rows]
+            print(f"PK for '{table_name}' resolved from child '{child[0]}': {pk_cols}")
+            return pk_cols
+        current = child[0]
+    return None
 
 
 def _build_enum_values(
@@ -693,13 +781,18 @@ def build_insert_values(
     table_schemas: Dict[str, Dict[str, Any]],
     table_name: str,
     number_of_rows_to_insert: int,
+    column_overrides: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Build VALUES list like (v1, v2), (v1, v2) for INSERT ... VALUES ..."""
     rows = []
     for _ in range(number_of_rows_to_insert):
         values = []
         for column_name, data_type in table_schemas[table_name]["columns"].items():
-            if "bit" in data_type.lower():
+            override_spec = get_column_override(column_overrides or {}, table_name, column_name)
+            if override_spec:
+                value = generate_override_value(override_spec)
+                values.append(f"'{value}'" if value is not None else "NULL")
+            elif "bit" in data_type.lower():
                 values.append(build_bit_cast_expr(table_schemas, table_name, column_name))
             elif data_type != "USER-DEFINED" and data_type != "ARRAY":
                 values.append(f"'{generate_random_data(data_type, table_name, None, None)}'")
@@ -718,6 +811,7 @@ def build_update_values(
     table_schemas: Dict[str, Dict[str, Any]],
     table_name: str,
     columns_to_update: List[str],
+    column_overrides: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, List[Any]]:
     """Build a SET clause and params for UPDATE with type-aware handling.
 
@@ -731,7 +825,15 @@ def build_update_values(
 
     for col in columns_to_update:
         data_type = columns[col]
-        if "bit" in data_type.lower():
+        override_spec = get_column_override(column_overrides or {}, table_name, col)
+        if override_spec:
+            value = generate_override_value(override_spec)
+            if value is None:
+                set_parts.append(f"{col} = NULL")
+            else:
+                set_parts.append(f"{col} = %s")
+                params.append(value)
+        elif "bit" in data_type.lower():
             expr = build_bit_cast_expr(table_schemas, table_name, col)
             set_parts.append(f"{col} = {expr}")
         else:
@@ -786,7 +888,7 @@ DEFAULT_ROW_ESTIMATE = 1000
 def build_sampling_condition(
     db_flavor: str,
     table_name: str,
-    primary_key: str,
+    primary_key: "str | List[str]",
     target_row_count: int,
     estimated_row_count: Optional[int],
 ) -> Tuple[str, List[Any]]:
@@ -794,25 +896,39 @@ def build_sampling_condition(
     Build a WHERE condition fragment and parameters for sampling rows
     for UPDATE/DELETE operations.
 
+    primary_key can be a single column name (str) or a list of column names.
+    For composite PKs, uses row-value syntax: (col1, col2) IN (SELECT col1, col2 ...).
+
     For PostgreSQL, this uses TABLESAMPLE SYSTEM_ROWS(target_row_count).
     For YugabyteDB, it uses a probabilistic filter WHERE random() < p,
     where p is derived from target_row_count and an estimated row count.
     """
+    if isinstance(primary_key, str):
+        pk_cols = [primary_key]
+    else:
+        pk_cols = primary_key
+
+    if len(pk_cols) == 1:
+        pk_select = pk_cols[0]
+        pk_where = pk_cols[0]
+    else:
+        pk_select = ", ".join(pk_cols)
+        pk_where = f"({pk_select})"
+
     if db_flavor == "POSTGRES":
         where_clause = (
-            f"{primary_key} IN ("
-            f"SELECT {primary_key} FROM {table_name} TABLESAMPLE SYSTEM_ROWS(%s))"
+            f"{pk_where} IN ("
+            f"SELECT {pk_select} FROM {table_name} TABLESAMPLE SYSTEM_ROWS(%s))"
         )
         return where_clause, [target_row_count]
 
     # YugabyteDB path: derive p from estimated row count
     est = estimated_row_count if estimated_row_count and estimated_row_count > 0 else DEFAULT_ROW_ESTIMATE
 
-    # Derive sampling probability p from desired rows and estimated row count.
     p = min(1.0, float(target_row_count) / float(est))
 
     where_clause = (
-        f"{primary_key} IN ("
-        f"SELECT {primary_key} FROM {table_name} WHERE random() < %s)"
+        f"{pk_where} IN ("
+        f"SELECT {pk_select} FROM {table_name} WHERE random() < %s)"
     )
     return where_clause, [p]

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -363,9 +363,9 @@ def kill(proc: subprocess.Popen | None, timeout_sec: int = 10) -> None:
             return
         proc.kill()
         wait_process(proc, timeout_sec)
-        log(f"kill: killed {proc.pid}")
+        print(f"kill: killed {proc.pid}")
     except Exception:
-        log(f"kill: failed to kill {proc.pid}")
+        print(f"kill: failed to kill {proc.pid}")
         pass
 
 

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, Callable, Optional, List
 import os
-import re
 import signal
 import time
 import threading
@@ -364,9 +363,9 @@ def kill(proc: subprocess.Popen | None, timeout_sec: int = 10) -> None:
             return
         proc.kill()
         wait_process(proc, timeout_sec)
-        print(f"kill: killed {proc.pid}")
+        log(f"kill: killed {proc.pid}")
     except Exception:
-        print(f"kill: failed to kill {proc.pid}")
+        log(f"kill: failed to kill {proc.pid}")
         pass
 
 
@@ -588,25 +587,11 @@ def _return_segment_files(directory: str) -> list[str]:
         key=lambda n: int(n.split(".")[1]),
     )
 
-def _return_first_last_vsn(filepath: str) -> tuple[int | None, int | None]:
-    """Return (first_vsn, last_vsn) from a segment file, ignoring blank lines and the EOF marker."""
-    first = None
-    last_line = None
-    with open(filepath, "r") as f:
-        for line in f:
-            line = line.strip()
-            if not line or line == r"\.":
-                continue
-            if first is None:
-                first = json.loads(line)["vsn"]
-            last_line = line
-    last = json.loads(last_line)["vsn"] if last_line is not None else None
-    return first, last
 
 def _return_total_segments_in_metadb(export_dir: str) -> int:
     meta_db = os.path.join(export_dir, "metainfo", "meta.db")
     proc = subprocess.run(
-        ["sqlite3", meta_db, "select max(segment_no)+1 as number_of_segments from queue_segment_meta;"],
+        ["sqlite3", meta_db, "select coalesce(max(segment_no)+1, 0) as number_of_segments from queue_segment_meta;"],
         capture_output=True, text=True, check=True,
     )
     return int(proc.stdout.strip())

--- a/migtests/scripts/live-migration-resumption/segment_hash_validation.sql
+++ b/migtests/scripts/live-migration-resumption/segment_hash_validation.sql
@@ -170,10 +170,11 @@ DECLARE
     tbl RECORD;
 BEGIN
     FOR tbl IN
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema = p_schema_name
-          AND table_type   = 'BASE TABLE'
+        SELECT c.relname AS table_name
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname   = p_schema_name
+          AND c.relkind   = 'r'  -- ordinary tables only, skip partitioned parents ('p')
     LOOP
         PERFORM public.compute_table_segment_hashes(
             p_side,

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/init.sql
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/init.sql
@@ -79,22 +79,6 @@ ALTER TABLE public.events_202606 ADD PRIMARY KEY (id);
 CREATE TABLE public.events_default PARTITION OF public.events DEFAULT;
 ALTER TABLE public.events_default ADD PRIMARY KEY (id);
 
--- REPLICA IDENTITY FULL on root + all children for CDC without PK on root
-ALTER TABLE public.events REPLICA IDENTITY FULL;
-DO $$
-DECLARE
-    child TEXT;
-BEGIN
-    FOR child IN
-        SELECT c.relname FROM pg_inherits i
-        JOIN pg_class c ON c.oid = i.inhrelid
-        JOIN pg_class p ON p.oid = i.inhparent
-        JOIN pg_namespace n ON n.oid = p.relnamespace
-        WHERE p.relname = 'events' AND n.nspname = 'public'
-    LOOP
-        EXECUTE format('ALTER TABLE public.%I REPLICA IDENTITY FULL', child);
-    END LOOP;
-END $$;
 
 -- 4 indexes: 52 RANGE partitions × (1 table + 4 indexes) = 260 + 15 (LIST/HASH/roots) = 275
 -- 275 + 220 system = 495 tablets, safely under YB 530 limit
@@ -133,13 +117,6 @@ ALTER TABLE public.sales_tokyo   ADD PRIMARY KEY (id, region);
 ALTER TABLE public.sales_berlin  ADD PRIMARY KEY (id, region);
 ALTER TABLE public.sales_default ADD PRIMARY KEY (id, region);
 
-ALTER TABLE public.sales_region REPLICA IDENTITY FULL;
-ALTER TABLE public.sales_london  REPLICA IDENTITY FULL;
-ALTER TABLE public.sales_sydney  REPLICA IDENTITY FULL;
-ALTER TABLE public.sales_boston   REPLICA IDENTITY FULL;
-ALTER TABLE public.sales_tokyo   REPLICA IDENTITY FULL;
-ALTER TABLE public.sales_berlin  REPLICA IDENTITY FULL;
-ALTER TABLE public.sales_default REPLICA IDENTITY FULL;
 
 
 -- ===================== HASH PARTITIONED TABLE =====================
@@ -168,12 +145,6 @@ ALTER TABLE public.emp_2 ADD PRIMARY KEY (emp_id);
 ALTER TABLE public.emp_3 ADD PRIMARY KEY (emp_id);
 ALTER TABLE public.emp_4 ADD PRIMARY KEY (emp_id);
 
-ALTER TABLE public.emp REPLICA IDENTITY FULL;
-ALTER TABLE public.emp_0 REPLICA IDENTITY FULL;
-ALTER TABLE public.emp_1 REPLICA IDENTITY FULL;
-ALTER TABLE public.emp_2 REPLICA IDENTITY FULL;
-ALTER TABLE public.emp_3 REPLICA IDENTITY FULL;
-ALTER TABLE public.emp_4 REPLICA IDENTITY FULL;
 
 
 -- ===================== MULTILEVEL (SUB)PARTITIONED TABLE =====================
@@ -248,25 +219,3 @@ ALTER TABLE public.orders_2026_shipped   ADD PRIMARY KEY (order_id, order_date, 
 ALTER TABLE public.orders_2026_delivered ADD PRIMARY KEY (order_id, order_date, status);
 ALTER TABLE public.orders_2026_default   ADD PRIMARY KEY (order_id, order_date, status);
 
--- REPLICA IDENTITY FULL on root, intermediate, and leaf partitions
-ALTER TABLE public.orders REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2023 REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2024 REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2025 REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2026 REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2023_pending   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2023_shipped   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2023_delivered REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2023_default   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2024_pending   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2024_shipped   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2024_delivered REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2024_default   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2025_pending   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2025_shipped   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2025_delivered REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2025_default   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2026_pending   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2026_shipped   REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2026_delivered REPLICA IDENTITY FULL;
-ALTER TABLE public.orders_2026_default   REPLICA IDENTITY FULL;

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/init.sql
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/init.sql
@@ -1,0 +1,272 @@
+-- Partition iteration test schema
+-- Tests --use-partition-root=false with CDC routing to child partitions.
+-- Three partition types: RANGE (50 partitions), LIST, HASH, plus multilevel.
+-- RANGE table mirrors production pattern: no PK on root, PKs on children,
+-- shared sequence, 31 columns including JSONB.
+
+-- ===================== RANGE PARTITIONED TABLE =====================
+-- 50 monthly partitions (Jan 2022 – Feb 2026) + empty Jun 2026 = 51 total.
+-- No DEFAULT partition (matches production pattern).
+-- Indexes kept minimal to stay under YB tablet limit.
+
+DROP TABLE IF EXISTS public.events CASCADE;
+DROP SEQUENCE IF EXISTS public.events_id_seq CASCADE;
+
+CREATE SEQUENCE public.events_id_seq;
+
+CREATE TABLE public.events (
+    id              BIGINT       NOT NULL DEFAULT nextval('events_id_seq'::regclass),
+    ref_id          BIGINT,
+    ref_type        VARCHAR(255),
+    recipient_id    BIGINT,
+    destination     VARCHAR(255),
+    channel         VARCHAR(255),
+    event_key       VARCHAR(255),
+    body            TEXT,
+    created_at      TIMESTAMP    NOT NULL,
+    updated_at      TIMESTAMP    NOT NULL,
+    handler         VARCHAR(255),
+    is_silent       BOOLEAN,
+    agent_id        BIGINT,
+    candidate_id    BIGINT,
+    is_automated    BOOLEAN,
+    origin_id       BIGINT,
+    metadata        JSONB        DEFAULT '{}'::jsonb,
+    external_id     VARCHAR,
+    event_type      VARCHAR,
+    dispatched_at   TIMESTAMP,
+    read_at         TIMESTAMP,
+    acted_at        TIMESTAMP,
+    errored_at      TIMESTAMP,
+    push_token      TEXT,
+    platform        VARCHAR,
+    received_at     TIMESTAMP,
+    attachment_url  TEXT,
+    origin_address  TEXT,
+    subject         TEXT,
+    recipient_type  VARCHAR,
+    fallback_domain VARCHAR
+) PARTITION BY RANGE (created_at);
+
+ALTER SEQUENCE public.events_id_seq OWNED BY public.events.id;
+
+-- Generate 50 monthly partitions: Jan 2022 through Feb 2026
+DO $$
+DECLARE
+    start_date DATE := '2022-01-01';
+    end_date   DATE;
+    part_name  TEXT;
+BEGIN
+    FOR i IN 0..49 LOOP
+        end_date := start_date + INTERVAL '1 month';
+        part_name := 'events_' || to_char(start_date, 'YYYYMM');
+        EXECUTE format(
+            'CREATE TABLE public.%I PARTITION OF public.events
+                FOR VALUES FROM (%L) TO (%L)',
+            part_name, start_date::TIMESTAMP, end_date::TIMESTAMP
+        );
+        EXECUTE format('ALTER TABLE public.%I ADD PRIMARY KEY (id)', part_name);
+        start_date := end_date;
+    END LOOP;
+END $$;
+
+-- TC18: Empty partition — validates Voyager handles partitions with zero rows
+CREATE TABLE public.events_202606 PARTITION OF public.events
+    FOR VALUES FROM ('2026-06-01 00:00:00') TO ('2026-07-01 00:00:00');
+ALTER TABLE public.events_202606 ADD PRIMARY KEY (id);
+
+-- TC38: DEFAULT partition — catches rows outside all defined ranges
+CREATE TABLE public.events_default PARTITION OF public.events DEFAULT;
+ALTER TABLE public.events_default ADD PRIMARY KEY (id);
+
+-- REPLICA IDENTITY FULL on root + all children for CDC without PK on root
+ALTER TABLE public.events REPLICA IDENTITY FULL;
+DO $$
+DECLARE
+    child TEXT;
+BEGIN
+    FOR child IN
+        SELECT c.relname FROM pg_inherits i
+        JOIN pg_class c ON c.oid = i.inhrelid
+        JOIN pg_class p ON p.oid = i.inhparent
+        JOIN pg_namespace n ON n.oid = p.relnamespace
+        WHERE p.relname = 'events' AND n.nspname = 'public'
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I REPLICA IDENTITY FULL', child);
+    END LOOP;
+END $$;
+
+-- 4 indexes: 52 RANGE partitions × (1 table + 4 indexes) = 260 + 15 (LIST/HASH/roots) = 275
+-- 275 + 220 system = 495 tablets, safely under YB 530 limit
+CREATE INDEX idx_events_event_key ON public.events (event_key);
+CREATE INDEX idx_events_updated_at ON public.events (updated_at);
+CREATE INDEX idx_events_candidate_id ON public.events (candidate_id);
+CREATE INDEX idx_events_created_at_ref_id_partial ON public.events (created_at, ref_id)
+    WHERE event_key = 'running_late' AND handler = 'OrderHandler' AND ref_type = 'OrderDelivery';
+
+
+-- ===================== LIST PARTITIONED TABLE =====================
+-- Partitioned by region (LIST). No PK on root, PK on children only.
+-- Tests CDC routing for LIST partitions with --use-partition-root=false.
+
+DROP TABLE IF EXISTS public.sales_region CASCADE;
+
+CREATE TABLE public.sales_region (
+    id       SERIAL,
+    amount   INT,
+    branch   TEXT,
+    region   TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb
+) PARTITION BY LIST (region);
+
+CREATE TABLE public.sales_london  PARTITION OF public.sales_region FOR VALUES IN ('London');
+CREATE TABLE public.sales_sydney  PARTITION OF public.sales_region FOR VALUES IN ('Sydney');
+CREATE TABLE public.sales_boston   PARTITION OF public.sales_region FOR VALUES IN ('Boston');
+CREATE TABLE public.sales_tokyo   PARTITION OF public.sales_region FOR VALUES IN ('Tokyo');
+CREATE TABLE public.sales_berlin  PARTITION OF public.sales_region FOR VALUES IN ('Berlin');
+CREATE TABLE public.sales_default PARTITION OF public.sales_region DEFAULT;
+
+ALTER TABLE public.sales_london  ADD PRIMARY KEY (id, region);
+ALTER TABLE public.sales_sydney  ADD PRIMARY KEY (id, region);
+ALTER TABLE public.sales_boston   ADD PRIMARY KEY (id, region);
+ALTER TABLE public.sales_tokyo   ADD PRIMARY KEY (id, region);
+ALTER TABLE public.sales_berlin  ADD PRIMARY KEY (id, region);
+ALTER TABLE public.sales_default ADD PRIMARY KEY (id, region);
+
+ALTER TABLE public.sales_region REPLICA IDENTITY FULL;
+ALTER TABLE public.sales_london  REPLICA IDENTITY FULL;
+ALTER TABLE public.sales_sydney  REPLICA IDENTITY FULL;
+ALTER TABLE public.sales_boston   REPLICA IDENTITY FULL;
+ALTER TABLE public.sales_tokyo   REPLICA IDENTITY FULL;
+ALTER TABLE public.sales_berlin  REPLICA IDENTITY FULL;
+ALTER TABLE public.sales_default REPLICA IDENTITY FULL;
+
+
+-- ===================== HASH PARTITIONED TABLE =====================
+-- Partitioned by HASH on emp_id. No PK on root, PK on children only.
+-- Tests CDC routing for HASH partitions with --use-partition-root=false.
+
+DROP TABLE IF EXISTS public.emp CASCADE;
+
+CREATE TABLE public.emp (
+    emp_id    SERIAL,
+    emp_name  TEXT,
+    dep_code  INT,
+    salary    NUMERIC(10,2),
+    metadata  JSONB DEFAULT '{}'::jsonb
+) PARTITION BY HASH (emp_id);
+
+CREATE TABLE public.emp_0 PARTITION OF public.emp FOR VALUES WITH (MODULUS 5, REMAINDER 0);
+CREATE TABLE public.emp_1 PARTITION OF public.emp FOR VALUES WITH (MODULUS 5, REMAINDER 1);
+CREATE TABLE public.emp_2 PARTITION OF public.emp FOR VALUES WITH (MODULUS 5, REMAINDER 2);
+CREATE TABLE public.emp_3 PARTITION OF public.emp FOR VALUES WITH (MODULUS 5, REMAINDER 3);
+CREATE TABLE public.emp_4 PARTITION OF public.emp FOR VALUES WITH (MODULUS 5, REMAINDER 4);
+
+ALTER TABLE public.emp_0 ADD PRIMARY KEY (emp_id);
+ALTER TABLE public.emp_1 ADD PRIMARY KEY (emp_id);
+ALTER TABLE public.emp_2 ADD PRIMARY KEY (emp_id);
+ALTER TABLE public.emp_3 ADD PRIMARY KEY (emp_id);
+ALTER TABLE public.emp_4 ADD PRIMARY KEY (emp_id);
+
+ALTER TABLE public.emp REPLICA IDENTITY FULL;
+ALTER TABLE public.emp_0 REPLICA IDENTITY FULL;
+ALTER TABLE public.emp_1 REPLICA IDENTITY FULL;
+ALTER TABLE public.emp_2 REPLICA IDENTITY FULL;
+ALTER TABLE public.emp_3 REPLICA IDENTITY FULL;
+ALTER TABLE public.emp_4 REPLICA IDENTITY FULL;
+
+
+-- ===================== MULTILEVEL (SUB)PARTITIONED TABLE =====================
+-- RANGE (by order_date) → LIST (by status) sub-partitioning.
+-- No PK on root/intermediate, PK on leaf children only.
+-- Tests CDC routing through two levels of partition hierarchy.
+
+DROP TABLE IF EXISTS public.orders CASCADE;
+
+CREATE TABLE public.orders (
+    order_id    SERIAL,
+    customer_id BIGINT,
+    order_date  DATE NOT NULL,
+    status      TEXT NOT NULL,
+    amount      NUMERIC(10,2),
+    metadata    JSONB DEFAULT '{}'::jsonb
+) PARTITION BY RANGE (order_date);
+
+-- Level 1: RANGE by year (widened to 2023-2026 for better random data coverage)
+CREATE TABLE public.orders_2023 PARTITION OF public.orders
+    FOR VALUES FROM ('2023-01-01') TO ('2024-01-01')
+    PARTITION BY LIST (status);
+
+CREATE TABLE public.orders_2024 PARTITION OF public.orders
+    FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')
+    PARTITION BY LIST (status);
+
+CREATE TABLE public.orders_2025 PARTITION OF public.orders
+    FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')
+    PARTITION BY LIST (status);
+
+CREATE TABLE public.orders_2026 PARTITION OF public.orders
+    FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')
+    PARTITION BY LIST (status);
+
+-- Level 2: LIST by status under each year
+CREATE TABLE public.orders_2023_pending   PARTITION OF public.orders_2023 FOR VALUES IN ('pending');
+CREATE TABLE public.orders_2023_shipped   PARTITION OF public.orders_2023 FOR VALUES IN ('shipped');
+CREATE TABLE public.orders_2023_delivered PARTITION OF public.orders_2023 FOR VALUES IN ('delivered');
+CREATE TABLE public.orders_2023_default   PARTITION OF public.orders_2023 DEFAULT;
+
+CREATE TABLE public.orders_2024_pending   PARTITION OF public.orders_2024 FOR VALUES IN ('pending');
+CREATE TABLE public.orders_2024_shipped   PARTITION OF public.orders_2024 FOR VALUES IN ('shipped');
+CREATE TABLE public.orders_2024_delivered PARTITION OF public.orders_2024 FOR VALUES IN ('delivered');
+CREATE TABLE public.orders_2024_default   PARTITION OF public.orders_2024 DEFAULT;
+
+CREATE TABLE public.orders_2025_pending   PARTITION OF public.orders_2025 FOR VALUES IN ('pending');
+CREATE TABLE public.orders_2025_shipped   PARTITION OF public.orders_2025 FOR VALUES IN ('shipped');
+CREATE TABLE public.orders_2025_delivered PARTITION OF public.orders_2025 FOR VALUES IN ('delivered');
+CREATE TABLE public.orders_2025_default   PARTITION OF public.orders_2025 DEFAULT;
+
+CREATE TABLE public.orders_2026_pending   PARTITION OF public.orders_2026 FOR VALUES IN ('pending');
+CREATE TABLE public.orders_2026_shipped   PARTITION OF public.orders_2026 FOR VALUES IN ('shipped');
+CREATE TABLE public.orders_2026_delivered PARTITION OF public.orders_2026 FOR VALUES IN ('delivered');
+CREATE TABLE public.orders_2026_default   PARTITION OF public.orders_2026 DEFAULT;
+
+-- PK on leaf partitions only
+ALTER TABLE public.orders_2023_pending   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2023_shipped   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2023_delivered ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2023_default   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2024_pending   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2024_shipped   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2024_delivered ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2024_default   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2025_pending   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2025_shipped   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2025_delivered ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2025_default   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2026_pending   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2026_shipped   ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2026_delivered ADD PRIMARY KEY (order_id, order_date, status);
+ALTER TABLE public.orders_2026_default   ADD PRIMARY KEY (order_id, order_date, status);
+
+-- REPLICA IDENTITY FULL on root, intermediate, and leaf partitions
+ALTER TABLE public.orders REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2023 REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2024 REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2025 REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2026 REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2023_pending   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2023_shipped   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2023_delivered REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2023_default   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2024_pending   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2024_shipped   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2024_delivered REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2024_default   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2025_pending   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2025_shipped   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2025_delivered REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2025_default   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2026_pending   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2026_shipped   REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2026_delivered REPLICA IDENTITY FULL;
+ALTER TABLE public.orders_2026_default   REPLICA IDENTITY FULL;

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -1,0 +1,385 @@
+name: partition-iteration-test
+
+num_iterations: 20
+
+env:
+  LOG_LEVEL: info
+  QUEUE_SEGMENT_MAX_BYTES: 10485760
+
+export_dir: ./export-dir
+artifacts_dir: ./artifacts
+
+source:
+  type: postgresql
+  host: 127.0.0.1
+  port: 5432
+  database: test_db
+  user: ybvoyager
+  password: Test@123#$%^&*()!
+  schema: public
+  admin:
+    user: postgres
+    password: postgres
+
+target:
+  type: yugabytedb
+  host: ${TARGET_DB_HOST}
+  port: ${TARGET_DB_PORT}
+  database: test_db
+  user: ${TARGET_DB_USER}
+  password: ${TARGET_DB_PASSWORD}
+  admin:
+    user: ${TARGET_DB_ADMIN_USER}
+    password: ${TARGET_DB_ADMIN_PASSWORD}
+
+# Forward (source) event generator: random INSERT/UPDATE/DELETE on all 3 tables.
+generator_source:
+  config_inline:
+    connection:
+      host: 127.0.0.1
+      port: 5432
+      database: test_db
+      user: postgres
+      password: postgres
+
+    generator:
+      schema_name: public
+      manual_table_list: []
+      exclude_table_list: [cutover_table]
+      num_iterations: -1
+      wait_after_operations: 1000
+      wait_duration_seconds: 1
+      table_weights: {events: 5, sales_region: 3, emp: 2, orders: 3}
+      operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
+      random_seed: 12345
+      faker_seed: 12345
+      insert_rows: 4
+      update_rows: 2
+      delete_rows: 1
+      insert_max_retries: 50
+      update_max_retries: 3
+      column_overrides:
+        events:
+          created_at:
+            type: timestamp_range
+            min: "2022-01-01 00:00:00"
+            max: "2026-02-28 23:59:59"
+          updated_at:
+            type: timestamp_range
+            min: "2022-01-01 00:00:00"
+            max: "2026-02-28 23:59:59"
+        sales_region:
+          region:
+            type: choice
+            values: ["London", "Sydney", "Boston", "Tokyo", "Berlin"]
+        orders:
+          order_date:
+            type: date_range
+            min: "2023-01-01"
+            max: "2026-12-31"
+          status:
+            type: choice
+            values: ["pending", "shipped", "delivered"]
+
+# Fallback (target) event generator: random traffic on target during fallback.
+generator_target:
+  config_inline:
+    connection:
+      host: ${TARGET_DB_HOST}
+      port: ${TARGET_DB_PORT}
+      database: test_db
+      user: ${TARGET_DB_USER}
+      password: ${TARGET_DB_PASSWORD}
+
+    generator:
+      schema_name: public
+      manual_table_list: []
+      exclude_table_list: [cutover_table]
+      num_iterations: -1
+      wait_after_operations: 5000
+      wait_duration_seconds: 1
+      table_weights: {events: 5, sales_region: 3, emp: 2, orders: 3}
+      operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
+      random_seed: 67890
+      faker_seed: 67890
+      insert_rows: 6
+      update_rows: 4
+      delete_rows: 2
+      insert_max_retries: 50
+      update_max_retries: 3
+      column_overrides:
+        events:
+          created_at:
+            type: timestamp_range
+            min: "2022-01-01 00:00:00"
+            max: "2026-02-28 23:59:59"
+          updated_at:
+            type: timestamp_range
+            min: "2022-01-01 00:00:00"
+            max: "2026-02-28 23:59:59"
+        sales_region:
+          region:
+            type: choice
+            values: ["London", "Sydney", "Boston", "Tokyo", "Berlin"]
+        orders:
+          order_date:
+            type: date_range
+            min: "2023-01-01"
+            max: "2026-12-31"
+          status:
+            type: choice
+            values: ["pending", "shipped", "delivered"]
+
+voyager:
+  import_data:
+    flags:
+      use-partition-root: "false"
+  import_to_source:
+    flags:
+      use-partition-root: "false"
+  cutover_to_target:
+    flags:
+      prepare-for-fall-back: true
+  cutover_to_source:
+    flags:
+      restart-data-migration-source-target: true
+
+stages:
+  - name: create_source_and_target_dbs
+    action: reset_databases
+    targets: [source, target]
+
+  - name: create_source_schema
+    action: run_sql
+    sql_path: ./init.sql
+    use_admin: true
+
+  - name: create_cutover_table
+    action: create_cutover_table
+    target: [source]
+
+  - name: grant_source_permissions
+    action: grant_source_permissions
+    is_live_migration_fall_back: 1
+
+  - name: export_schema_from_source
+    action: voyager_export_schema
+
+  - name: import_schema_on_target
+    action: voyager_import_schema
+
+  - name: loop_start
+    action: loop_start
+
+  - name: stop_prev_iteration_fallback_exporter
+    action: voyager_stop_command
+    command: export_from_target
+    graceful_timeout_sec: 60
+
+  - name: stop_prev_iteration_fallback_importer
+    action: voyager_stop_command
+    command: import_to_source
+    graceful_timeout_sec: 60
+
+  - name: start_exporter
+    action: voyager_export_start
+
+  - name: start_importer
+    action: voyager_import_start
+
+  # Deterministic edge-case DML (boundary values, TOAST, cross-partition, LIST, HASH)
+  - name: run_source_dml
+    action: run_sql
+    target: source
+    sql_path: ./source_dml.sql
+    use_admin: true
+
+  # Random DML via event generator (runs continuously until stopped)
+  - name: start_event_generator
+    action: generator_start
+    generator_key: generator_source
+
+  - name: start_import_resumptions
+    action: start_resumptions
+    resumption:
+      import_data:
+        max_restarts: 50
+        min_interrupt_seconds: 20
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 20
+        max_restart_wait_seconds: 60
+
+  - name: wait_exporter_streaming
+    action: wait_for
+    condition: exporter_in_streaming_phase
+    timeout_sec: 600
+
+  - name: start_archiver
+    action: voyager_archive_changes_start
+
+  - name: start_export_resumptions
+    action: start_resumptions
+    resumption:
+      export_data:
+        max_restarts: 50
+        min_interrupt_seconds: 20
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 20
+        max_restart_wait_seconds: 60
+
+  - name: soak_with_resumptions
+    action: sleep
+    seconds: 400
+
+  - name: stop_event_generator
+    action: generator_stop
+    generator_key: generator_source
+    graceful_timeout_sec: 30
+
+  - name: insert_backlog_marker
+    action: run_sql
+    target: source
+    sql_path: ../common-sql/insert_marker.sql
+
+  - name: wait_backlog_zero
+    action: wait_for
+    condition: remaining_events_eq_0
+    timeout_sec: 2400
+
+  - name: stop_export_resumptions
+    action: voyager_stop_resumptions
+    command: export_data
+    timeout_sec: 60
+
+  - name: stop_import_resumptions
+    action: voyager_stop_resumptions
+    command: import_data
+    timeout_sec: 60
+
+  - name: wait_for_archiver
+    action: sleep
+    seconds: 180
+
+  - name: validate_archive_changes
+    action: validate_archive_changes
+
+  - name: cutover_to_target
+    action: cutover_to_target
+
+  - name: wait_cutover_to_target_completed
+    action: wait_for
+    condition: cutover_to_target_status_completed
+    timeout_sec: 1800
+
+  - name: stop_forward_exporter_for_fallback
+    action: voyager_stop_command
+    command: export_data
+    graceful_timeout_sec: 60
+
+  - name: stop_forward_importer_for_fallback
+    action: voyager_stop_command
+    command: import_data
+    graceful_timeout_sec: 60
+
+  - name: start_fallback_exporter_from_target
+    action: voyager_export_from_target_start
+
+  - name: start_fallback_importer_to_source
+    action: voyager_import_to_source_start
+
+  # Deterministic edge-case DML on target (fallback direction)
+  - name: run_target_dml
+    action: run_sql
+    target: target
+    sql_path: ./target_dml.sql
+    use_admin: true
+
+  # Random DML on target during fallback
+  - name: start_target_event_generator
+    action: generator_start
+    generator_key: generator_target
+
+  - name: start_fallback_resumptions
+    action: start_resumptions
+    resumption:
+      export_from_target:
+        max_restarts: 50
+        min_interrupt_seconds: 20
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 20
+        max_restart_wait_seconds: 60
+
+  - name: start_import_to_source_resumptions
+    action: start_resumptions
+    resumption:
+      import_to_source:
+        max_restarts: 50
+        min_interrupt_seconds: 20
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 20
+        max_restart_wait_seconds: 60
+
+  - name: soak_fallback_with_resumptions
+    action: sleep
+    seconds: 400
+
+  - name: stop_target_event_generator
+    action: generator_stop
+    generator_key: generator_target
+    graceful_timeout_sec: 60
+
+  - name: sleep
+    action: sleep
+    seconds: 10
+
+  - name: insert_backlog_marker_on_target
+    action: run_sql
+    target: target
+    sql_path: ../common-sql/insert_marker.sql
+
+  - name: wait_backlog_zero_after_fallback
+    action: wait_for
+    condition: remaining_events_eq_0
+    timeout_sec: 6000
+
+  - name: stop_fallback_export_resumptions
+    action: voyager_stop_resumptions
+    command: export_from_target
+    timeout_sec: 60
+
+  - name: stop_fallback_import_resumptions
+    action: voyager_stop_resumptions
+    command: import_to_source
+    timeout_sec: 60
+
+  - name: wait_for_archiver
+    action: sleep
+    seconds: 180
+
+  - name: validate_archive_changes
+    action: validate_archive_changes
+
+  - name: cutover_to_source
+    action: cutover_to_source
+
+  - name: wait_cutover_to_source_completed
+    action: wait_for
+    condition: cutover_to_source_status_completed
+    timeout_sec: 1800
+
+  - name: wait_for_archiver
+    action: sleep
+    seconds: 240
+
+  - name: validate_archive_changes
+    action: validate_archive_changes
+    check_post_cutover_to_source: True
+
+  - name: row_count_validations
+    action: row_count_validations
+
+  - name: row_hash_validations
+    action: row_hash_validations
+
+  - name: loop_end
+    action: loop_end

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -1,10 +1,10 @@
 name: partition-iteration-test
 
-num_iterations: 10
+num_iterations: 20
 
 env:
   LOG_LEVEL: info
-  QUEUE_SEGMENT_MAX_BYTES: 1048576
+  QUEUE_SEGMENT_MAX_BYTES: 10485760
 
 export_dir: ./export-dir
 artifacts_dir: ./artifacts
@@ -229,7 +229,7 @@ stages:
 
   - name: soak_with_resumptions
     action: sleep
-    seconds: 120
+    seconds: 400
 
   - name: stop_event_generator
     action: generator_stop
@@ -244,7 +244,7 @@ stages:
   - name: wait_backlog_zero
     action: wait_for
     condition: remaining_events_eq_0
-    timeout_sec: 1200
+    timeout_sec: 2400
 
   - name: stop_export_resumptions
     action: voyager_stop_resumptions
@@ -258,7 +258,7 @@ stages:
 
   - name: wait_for_archiver
     action: sleep
-    seconds: 80
+    seconds: 180
 
   - name: validate_archive_changes
     action: validate_archive_changes
@@ -269,7 +269,7 @@ stages:
   - name: wait_cutover_to_target_completed
     action: wait_for
     condition: cutover_to_target_status_completed
-    timeout_sec: 900
+    timeout_sec: 1800
 
   - name: stop_forward_exporter_for_fallback
     action: voyager_stop_command
@@ -321,7 +321,7 @@ stages:
 
   - name: soak_fallback_with_resumptions
     action: sleep
-    seconds: 120
+    seconds: 400
 
   - name: stop_target_event_generator
     action: generator_stop
@@ -330,7 +330,7 @@ stages:
 
   - name: sleep
     action: sleep
-    seconds: 30
+    seconds: 10
 
   - name: insert_backlog_marker_on_target
     action: run_sql
@@ -354,7 +354,7 @@ stages:
 
   - name: wait_for_archiver
     action: sleep
-    seconds: 80
+    seconds: 180
 
   - name: validate_archive_changes
     action: validate_archive_changes
@@ -365,11 +365,11 @@ stages:
   - name: wait_cutover_to_source_completed
     action: wait_for
     condition: cutover_to_source_status_completed
-    timeout_sec: 900
+    timeout_sec: 1800
 
   - name: wait_for_archiver
     action: sleep
-    seconds: 80
+    seconds: 240
 
   - name: validate_archive_changes
     action: validate_archive_changes

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -44,6 +44,7 @@ generator_source:
 
     generator:
       schema_name: public
+      manual_table_list: []
       exclude_table_list: [cutover_table]
       num_iterations: -1
       wait_after_operations: 1000
@@ -92,6 +93,7 @@ generator_target:
 
     generator:
       schema_name: public
+      manual_table_list: []
       exclude_table_list: [cutover_table]
       num_iterations: -1
       wait_after_operations: 5000

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -44,7 +44,6 @@ generator_source:
 
     generator:
       schema_name: public
-      manual_table_list: []
       exclude_table_list: [cutover_table]
       num_iterations: -1
       wait_after_operations: 1000
@@ -93,7 +92,6 @@ generator_target:
 
     generator:
       schema_name: public
-      manual_table_list: []
       exclude_table_list: [cutover_table]
       num_iterations: -1
       wait_after_operations: 5000

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -1,10 +1,10 @@
 name: partition-iteration-test
 
-num_iterations: 20
+num_iterations: 10
 
 env:
   LOG_LEVEL: info
-  QUEUE_SEGMENT_MAX_BYTES: 10485760
+  QUEUE_SEGMENT_MAX_BYTES: 1048576
 
 export_dir: ./export-dir
 artifacts_dir: ./artifacts
@@ -229,7 +229,7 @@ stages:
 
   - name: soak_with_resumptions
     action: sleep
-    seconds: 400
+    seconds: 120
 
   - name: stop_event_generator
     action: generator_stop
@@ -244,7 +244,7 @@ stages:
   - name: wait_backlog_zero
     action: wait_for
     condition: remaining_events_eq_0
-    timeout_sec: 2400
+    timeout_sec: 1200
 
   - name: stop_export_resumptions
     action: voyager_stop_resumptions
@@ -258,7 +258,7 @@ stages:
 
   - name: wait_for_archiver
     action: sleep
-    seconds: 180
+    seconds: 80
 
   - name: validate_archive_changes
     action: validate_archive_changes
@@ -269,7 +269,7 @@ stages:
   - name: wait_cutover_to_target_completed
     action: wait_for
     condition: cutover_to_target_status_completed
-    timeout_sec: 1800
+    timeout_sec: 900
 
   - name: stop_forward_exporter_for_fallback
     action: voyager_stop_command
@@ -321,7 +321,7 @@ stages:
 
   - name: soak_fallback_with_resumptions
     action: sleep
-    seconds: 400
+    seconds: 120
 
   - name: stop_target_event_generator
     action: generator_stop
@@ -330,7 +330,7 @@ stages:
 
   - name: sleep
     action: sleep
-    seconds: 10
+    seconds: 30
 
   - name: insert_backlog_marker_on_target
     action: run_sql
@@ -354,7 +354,7 @@ stages:
 
   - name: wait_for_archiver
     action: sleep
-    seconds: 180
+    seconds: 80
 
   - name: validate_archive_changes
     action: validate_archive_changes
@@ -365,11 +365,11 @@ stages:
   - name: wait_cutover_to_source_completed
     action: wait_for
     condition: cutover_to_source_status_completed
-    timeout_sec: 1800
+    timeout_sec: 900
 
   - name: wait_for_archiver
     action: sleep
-    seconds: 240
+    seconds: 80
 
   - name: validate_archive_changes
     action: validate_archive_changes

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/source_dml.sql
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/source_dml.sql
@@ -1,0 +1,130 @@
+-- Deterministic edge-case DML for partition iteration test.
+-- Runs ONCE per iteration as a separate step before the event generator.
+-- The event generator handles bulk random INSERT/UPDATE/DELETE traffic.
+-- This script covers specific edge cases that random traffic may not hit.
+
+DO $$
+DECLARE
+    row_id BIGINT;
+    i      INT;
+BEGIN
+    -- ===================== RANGE TABLE: edge cases =====================
+
+    -- TC19: Boundary values — rows at exact partition boundaries
+    -- RANGE uses inclusive lower, exclusive upper: [start, end)
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (nextval('events_id_seq'), 99901, 'OrderDelivery', 99901, 'boundary@test.com', 'email', 'delivered', 'Exact start of Jan 2022', '2022-01-01 00:00:00', '2022-01-01 00:00:01', 'OrderHandler', 'customer'),
+        (nextval('events_id_seq'), 99902, 'OrderPickup', 99902, 'boundary@test.com', 'sms', 'picked_up', 'Last moment of Jan 2022', '2022-01-31 23:59:59', '2022-01-31 23:59:59', 'UserHandler', 'agent'),
+        (nextval('events_id_seq'), 99903, 'UserAlert', 99903, 'boundary@test.com', 'push', 'reminder', 'Exact start of Feb 2026', '2026-02-01 00:00:00', '2026-02-01 00:00:01', 'PromoHandler', 'customer'),
+        (nextval('events_id_seq'), 99904, 'PromoOffer', 99904, 'boundary@test.com', 'in_app', 'promo_sent', 'Last moment of Feb 2026', '2026-02-28 23:59:59', '2026-02-28 23:59:59', 'OrderHandler', 'agent');
+
+    -- TC38: DEFAULT partition — rows with timestamps outside all defined ranges
+    -- Dec 2021 (before first partition Jan 2022) and Aug 2026 (after last defined range)
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (nextval('events_id_seq'), 99906, 'OrderDelivery', 99906, 'default@test.com', 'email', 'delivered', 'Lands in DEFAULT (Dec 2021)', '2021-12-15 10:00:00', '2021-12-15 10:00:01', 'OrderHandler', 'customer'),
+        (nextval('events_id_seq'), 99907, 'UserAlert', 99907, 'default@test.com', 'push', 'reminder', 'Lands in DEFAULT (Aug 2026)', '2026-08-20 14:30:00', '2026-08-20 14:30:01', 'PromoHandler', 'agent');
+
+    -- TC42: Large JSONB (>8KB triggers TOAST storage in PG)
+    -- Validates that CDC replicates TOAST'd columns correctly via REPLICA IDENTITY FULL
+    row_id := nextval('events_id_seq');
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, metadata, recipient_type)
+    VALUES (
+        row_id, 99908, 'OrderDelivery', 99908, 'toast@test.com', 'email', 'delivered',
+        'TOAST test row',
+        '2024-06-15 12:00:00', '2024-06-15 12:00:01', 'OrderHandler',
+        jsonb_build_object(
+            'large_field', repeat('x', 10000),
+            'nested', jsonb_build_object('a', repeat('y', 5000), 'b', repeat('z', 5000))
+        ),
+        'customer'
+    );
+
+    -- TC43: Rapid UPDATEs on same row — 10 consecutive updates without pause
+    -- Validates CDC handles multiple events for same PK without losing final state
+    FOR i IN 1..10 LOOP
+        UPDATE public.events
+           SET metadata = jsonb_build_object('rapid_update', i, 'ts', now(), 'payload', repeat('u', 500)),
+               updated_at = '2024-06-15 12:00:01'::TIMESTAMP + (i || ' seconds')::INTERVAL
+         WHERE id = row_id;
+    END LOOP;
+
+    -- TC17: Cross-partition UPDATE — INSERT into Jun 2024, then UPDATE created_at to Jul 2024
+    -- PG internally does DELETE from events_202406 + INSERT into events_202407
+    -- CDC must replicate this as a DELETE+INSERT pair on the correct child partitions
+    row_id := nextval('events_id_seq');
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (row_id, 99909, 'OrderPickup', 99909, 'crosspart@test.com', 'sms', 'picked_up', 'Will move partitions', '2024-06-10 08:00:00', '2024-06-10 08:00:01', 'UserHandler', 'agent');
+
+    UPDATE public.events SET created_at = '2024-07-10 08:00:00', updated_at = '2024-07-10 08:00:01' WHERE id = row_id;
+
+    -- ===================== LIST TABLE: edge cases =====================
+
+    -- Insert into each LIST partition + DEFAULT
+    INSERT INTO public.sales_region (amount, branch, region, metadata) VALUES
+        (1000, 'Main St', 'London', '{"type": "retail"}'::jsonb),
+        (2000, 'Harbor Rd', 'Sydney', '{"type": "wholesale"}'::jsonb),
+        (3000, 'Beacon St', 'Boston', '{"type": "retail"}'::jsonb),
+        (4000, 'Shibuya', 'Tokyo', '{"type": "flagship"}'::jsonb),
+        (5000, 'Unter den Linden', 'Berlin', '{"type": "outlet"}'::jsonb),
+        (6000, 'Unknown Blvd', 'Mumbai', '{"type": "new_market"}'::jsonb);  -- lands in DEFAULT
+
+    -- UPDATE on LIST partition
+    UPDATE public.sales_region SET amount = amount + 500, metadata = metadata || '{"updated": true}'::jsonb
+    WHERE region = 'London';
+
+    -- TC17-LIST: Cross-partition UPDATE — INSERT into London, then UPDATE region to Sydney
+    -- PG internally does DELETE from sales_london + INSERT into sales_sydney
+    -- CDC must replicate this as a DELETE+INSERT pair on the correct child partitions
+    INSERT INTO public.sales_region (id, amount, branch, region, metadata)
+    VALUES (88001, 7777, 'Will Move', 'London', '{"will_move": true}'::jsonb);
+
+    UPDATE public.sales_region SET region = 'Sydney', metadata = metadata || '{"region_change": true}'::jsonb
+    WHERE id = 88001 AND region = 'London';
+
+    -- DELETE from LIST partition
+    DELETE FROM public.sales_region WHERE region = 'Berlin';
+
+    -- ===================== HASH TABLE: edge cases =====================
+
+    -- Insert rows that will distribute across HASH partitions
+    INSERT INTO public.emp (emp_name, dep_code, salary, metadata) VALUES
+        ('Alice', 101, 85000.50, '{"level": "senior"}'::jsonb),
+        ('Bob', 102, 72000.00, '{"level": "mid"}'::jsonb),
+        ('Charlie', 103, 95000.75, '{"level": "lead"}'::jsonb),
+        ('Diana', 101, 68000.00, '{"level": "junior"}'::jsonb),
+        ('Eve', 104, 110000.00, '{"level": "principal"}'::jsonb);
+
+    -- UPDATE on HASH partition
+    UPDATE public.emp SET salary = salary * 1.10, metadata = metadata || '{"raise": true}'::jsonb
+    WHERE emp_name = 'Alice';
+
+    -- DELETE from HASH partition
+    DELETE FROM public.emp WHERE emp_name = 'Diana';
+
+    -- ===================== MULTILEVEL TABLE: edge cases =====================
+
+    -- Insert into each sub-partition (year × status combinations)
+    INSERT INTO public.orders (customer_id, order_date, status, amount, metadata) VALUES
+        (1001, '2024-03-15', 'pending',   150.00, '{"source": "web"}'::jsonb),
+        (1002, '2024-06-20', 'shipped',   275.50, '{"source": "app"}'::jsonb),
+        (1003, '2024-09-10', 'delivered', 420.00, '{"source": "web"}'::jsonb),
+        (1004, '2024-12-25', 'cancelled', 99.99,  '{"source": "phone"}'::jsonb),   -- lands in orders_2024_default
+        (1005, '2025-02-14', 'pending',   310.00, '{"source": "app"}'::jsonb),
+        (1006, '2025-07-04', 'shipped',   185.75, '{"source": "web"}'::jsonb),
+        (1007, '2025-11-28', 'delivered', 550.00, '{"source": "app"}'::jsonb),
+        (1008, '2025-08-15', 'refunded',  60.00,  '{"source": "web"}'::jsonb);    -- lands in orders_2025_default
+
+    -- Cross sub-partition UPDATE: change status (moves between LIST sub-partitions within same year)
+    UPDATE public.orders SET status = 'shipped', metadata = metadata || '{"status_change": true}'::jsonb
+    WHERE customer_id = 1001 AND order_date = '2024-03-15' AND status = 'pending';
+
+    -- Cross top-level partition UPDATE: change order_date year (moves between RANGE partitions)
+    UPDATE public.orders SET order_date = '2025-03-15', metadata = metadata || '{"year_change": true}'::jsonb
+    WHERE customer_id = 1003 AND order_date = '2024-09-10' AND status = 'delivered';
+
+    -- DELETE from multilevel sub-partition
+    DELETE FROM public.orders WHERE customer_id = 1004 AND order_date = '2024-12-25' AND status = 'cancelled';
+
+END $$;

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/source_dml.sql
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/source_dml.sql
@@ -59,6 +59,37 @@ BEGIN
 
     UPDATE public.events SET created_at = '2024-07-10 08:00:00', updated_at = '2024-07-10 08:00:01' WHERE id = row_id;
 
+    -- ===================== RANGE TABLE: Unicode / special characters =====================
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (nextval('events_id_seq'), 77001, 'OrderDelivery', 77001, 'unicode@test.com', 'email', 'delivered',
+         E'Emojis: \xF0\x9F\x9A\x80\xF0\x9F\x8E\x89 CJK: \u4F60\u597D\u4E16\u754C RTL: \u0645\u0631\u062D\u0628\u0627 Newline:\nTab:\t',
+         '2024-08-15 10:00:00', '2024-08-15 10:00:01', 'OrderHandler', 'customer');
+
+    -- ===================== RANGE TABLE: empty string vs NULL =====================
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (nextval('events_id_seq'), 77002, 'UserAlert', 77002, '', 'sms', 'reminder',
+         NULL, '2024-09-10 10:00:00', '2024-09-10 10:00:01', 'PromoHandler', 'agent'),
+        (nextval('events_id_seq'), 77003, 'UserAlert', 77003, NULL, 'push', 'reminder',
+         '', '2024-09-10 11:00:00', '2024-09-10 11:00:01', 'PromoHandler', 'customer');
+
+    -- ===================== RANGE TABLE: DELETE + re-INSERT same PK =====================
+    row_id := nextval('events_id_seq');
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (row_id, 77004, 'OrderPickup', 77004, 'tombstone@test.com', 'sms', 'picked_up', 'Original row', '2024-10-05 08:00:00', '2024-10-05 08:00:01', 'UserHandler', 'agent');
+
+    DELETE FROM public.events WHERE id = row_id;
+
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (row_id, 77005, 'PromoOffer', 77005, 'resurrected@test.com', 'in_app', 'promo_sent', 'Resurrected row', '2024-10-05 09:00:00', '2024-10-05 09:00:01', 'OrderHandler', 'customer');
+
+    -- TC18: First CDC event into empty partition (events_202606)
+    -- This partition has zero rows at snapshot time; validates CDC handles first-ever insert
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (nextval('events_id_seq'), 99910, 'OrderDelivery', 99910, 'empty-part@test.com', 'email', 'delivered',
+            'First row in empty Jun 2026 partition via CDC', '2026-06-15 10:00:00', '2026-06-15 10:00:01', 'OrderHandler', 'customer');
+
     -- ===================== LIST TABLE: edge cases =====================
 
     -- Insert into each LIST partition + DEFAULT
@@ -77,11 +108,12 @@ BEGIN
     -- TC17-LIST: Cross-partition UPDATE — INSERT into London, then UPDATE region to Sydney
     -- PG internally does DELETE from sales_london + INSERT into sales_sydney
     -- CDC must replicate this as a DELETE+INSERT pair on the correct child partitions
-    INSERT INTO public.sales_region (id, amount, branch, region, metadata)
-    VALUES (88001, 7777, 'Will Move', 'London', '{"will_move": true}'::jsonb);
+    INSERT INTO public.sales_region (amount, branch, region, metadata)
+    VALUES (7777, 'Will Move', 'London', '{"will_move": true}'::jsonb)
+    RETURNING id INTO row_id;
 
     UPDATE public.sales_region SET region = 'Sydney', metadata = metadata || '{"region_change": true}'::jsonb
-    WHERE id = 88001 AND region = 'London';
+    WHERE id = row_id AND region = 'London';
 
     -- DELETE from LIST partition
     DELETE FROM public.sales_region WHERE region = 'Berlin';

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/target_dml.sql
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/target_dml.sql
@@ -1,6 +1,6 @@
 -- Deterministic edge-case DML for fallback (target → source).
--- Runs ONCE per iteration as a separate step before the target event generator.
--- Uses high IDs to avoid PK conflicts with source DML rows.
+-- Runs ONCE per iteration on the YB target.
+-- All IDs are sequence-generated to avoid conflicts across iterations.
 
 DO $$
 DECLARE
@@ -10,18 +10,27 @@ BEGIN
     -- ===================== RANGE TABLE: edge cases =====================
 
     -- Boundary values on target side
+    row_id := nextval('events_id_seq');
     INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
     VALUES
-        (900001, 80001, 'OrderDelivery', 80001, 'tgt@test.com', 'email', 'delivered', 'Target boundary start', '2022-01-01 00:00:00', '2022-01-01 00:00:01', 'OrderHandler', 'customer'),
-        (900002, 80002, 'UserAlert', 80002, 'tgt@test.com', 'push', 'reminder', 'Target boundary end', '2026-02-28 23:59:59', '2026-02-28 23:59:59', 'PromoHandler', 'agent');
+        (row_id, 80001, 'OrderDelivery', 80001, 'tgt@test.com', 'email', 'delivered', 'Target boundary start', '2022-01-01 00:00:00', '2022-01-01 00:00:01', 'OrderHandler', 'customer');
+
+    row_id := nextval('events_id_seq');
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (row_id, 80002, 'UserAlert', 80002, 'tgt@test.com', 'push', 'reminder', 'Target boundary end', '2026-02-28 23:59:59', '2026-02-28 23:59:59', 'PromoHandler', 'agent');
 
     -- DEFAULT partition insert from target
+    row_id := nextval('events_id_seq');
     INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
-    VALUES (900003, 80003, 'OrderPickup', 80003, 'tgt@test.com', 'sms', 'picked_up', 'Target DEFAULT row', '2021-11-01 10:00:00', '2021-11-01 10:00:01', 'UserHandler', 'customer');
+    VALUES (row_id, 80003, 'OrderPickup', 80003, 'tgt@test.com', 'sms', 'picked_up', 'Target DEFAULT row', '2021-11-01 10:00:00', '2021-11-01 10:00:01', 'UserHandler', 'customer');
+
+    DELETE FROM public.events WHERE id = row_id;
 
     -- Large JSONB (TOAST) from target
+    row_id := nextval('events_id_seq');
     INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, metadata, recipient_type)
-    VALUES (900004, 80004, 'OrderDelivery', 80004, 'tgt-toast@test.com', 'email', 'delivered', 'Target TOAST test',
+    VALUES (row_id, 80004, 'OrderDelivery', 80004, 'tgt-toast@test.com', 'email', 'delivered', 'Target TOAST test',
         '2024-05-15 12:00:00', '2024-05-15 12:00:01', 'OrderHandler',
         jsonb_build_object('large_field', repeat('t', 10000), 'nested', jsonb_build_object('a', repeat('v', 5000))),
         'customer');
@@ -31,67 +40,106 @@ BEGIN
         UPDATE public.events
            SET metadata = jsonb_build_object('target_rapid', i, 'ts', now()),
                updated_at = '2024-05-15 12:00:01'::TIMESTAMP + (i || ' seconds')::INTERVAL
-         WHERE id = 900004;
+         WHERE id = row_id;
     END LOOP;
 
-    -- Cross-partition UPDATE on target
+    -- Unicode / special characters from target
     INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
-    VALUES (900005, 80005, 'OrderPickup', 80005, 'tgt-cross@test.com', 'sms', 'picked_up', 'Will move partitions on target', '2024-04-10 08:00:00', '2024-04-10 08:00:01', 'UserHandler', 'agent');
+    VALUES
+        (nextval('events_id_seq'), 80010, 'OrderDelivery', 80010, 'tgt-unicode@test.com', 'email', 'delivered',
+         E'Emojis: \xF0\x9F\x9A\x80\xF0\x9F\x8E\x89 CJK: \u4F60\u597D\u4E16\u754C RTL: \u0645\u0631\u062D\u0628\u0627 Newline:\nTab:\t',
+         '2024-07-15 10:00:00', '2024-07-15 10:00:01', 'OrderHandler', 'customer');
 
-    UPDATE public.events SET created_at = '2024-05-10 08:00:00', updated_at = '2024-05-10 08:00:01' WHERE id = 900005;
+    -- Empty string vs NULL from target
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (nextval('events_id_seq'), 80011, 'UserAlert', 80011, '', 'sms', 'reminder',
+         NULL, '2024-08-10 10:00:00', '2024-08-10 10:00:01', 'PromoHandler', 'agent');
 
-    -- DELETE from target RANGE
-    DELETE FROM public.events WHERE id = 900003;
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (nextval('events_id_seq'), 80012, 'UserAlert', 80012, NULL, 'push', 'reminder',
+         '', '2024-08-10 11:00:00', '2024-08-10 11:00:01', 'PromoHandler', 'customer');
+
+    -- DELETE + re-INSERT same PK from target
+    row_id := nextval('events_id_seq');
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (row_id, 80013, 'OrderPickup', 80013, 'tgt-tombstone@test.com', 'sms', 'picked_up', 'Target original', '2024-09-05 08:00:00', '2024-09-05 08:00:01', 'UserHandler', 'agent');
+
+    DELETE FROM public.events WHERE id = row_id;
+
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (row_id, 80014, 'PromoOffer', 80014, 'tgt-resurrected@test.com', 'in_app', 'promo_sent', 'Target resurrected', '2024-09-05 09:00:00', '2024-09-05 09:00:01', 'OrderHandler', 'customer');
+
+    -- Cross-partition UPDATE on target (RANGE: move from Apr 2024 to May 2024)
+    row_id := nextval('events_id_seq');
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (row_id, 80005, 'OrderPickup', 80005, 'tgt-cross@test.com', 'sms', 'picked_up', 'Will move partitions on target', '2024-04-10 08:00:00', '2024-04-10 08:00:01', 'UserHandler', 'agent');
+
+    UPDATE public.events SET created_at = '2024-05-10 08:00:00', updated_at = '2024-05-10 08:00:01' WHERE id = row_id;
 
     -- ===================== LIST TABLE: edge cases =====================
 
-    INSERT INTO public.sales_region (id, amount, branch, region, metadata) VALUES
-        (90001, 7000, 'Target Branch', 'Sydney', '{"target": true}'::jsonb),
-        (90002, 8000, 'Target Branch 2', 'Tokyo', '{"target": true}'::jsonb),
-        (90003, 9000, 'Target Default', 'Paris', '{"target": true}'::jsonb);  -- DEFAULT
+    INSERT INTO public.sales_region (amount, branch, region, metadata)
+    VALUES (7000, 'Target Branch', 'Sydney', '{"target": true}'::jsonb)
+    RETURNING id INTO row_id;
 
     UPDATE public.sales_region SET amount = 9999, metadata = metadata || '{"tgt_updated": true}'::jsonb
-    WHERE id = 90001 AND region = 'Sydney';
+    WHERE id = row_id AND region = 'Sydney';
 
-    -- TC17-LIST (target): Cross-partition UPDATE — INSERT into Boston, then UPDATE region to Tokyo
-    -- PG internally does DELETE from sales_boston + INSERT into sales_tokyo
-    -- CDC must replicate this as a DELETE+INSERT pair on the correct child partitions
-    INSERT INTO public.sales_region (id, amount, branch, region, metadata)
-    VALUES (88101, 6666, 'Target Will Move', 'Boston', '{"tgt_will_move": true}'::jsonb);
+    INSERT INTO public.sales_region (amount, branch, region, metadata)
+    VALUES (8000, 'Target Branch 2', 'Tokyo', '{"target": true}'::jsonb);
+
+    INSERT INTO public.sales_region (amount, branch, region, metadata)
+    VALUES (9000, 'Target Default', 'Paris', '{"target": true}'::jsonb);
+
+    -- TC17-LIST (target): Cross-partition UPDATE (region is PK column on YB)
+    INSERT INTO public.sales_region (amount, branch, region, metadata)
+    VALUES (6666, 'Target Will Move', 'Boston', '{"tgt_will_move": true}'::jsonb)
+    RETURNING id INTO row_id;
 
     UPDATE public.sales_region SET region = 'Tokyo', metadata = metadata || '{"tgt_region_change": true}'::jsonb
-    WHERE id = 88101 AND region = 'Boston';
-
-    DELETE FROM public.sales_region WHERE id = 90002 AND region = 'Tokyo';
+    WHERE id = row_id AND region = 'Boston';
 
     -- ===================== HASH TABLE: edge cases =====================
 
-    INSERT INTO public.emp (emp_id, emp_name, dep_code, salary, metadata) VALUES
-        (90001, 'TargetEmp1', 201, 55000.00, '{"target": true}'::jsonb),
-        (90002, 'TargetEmp2', 202, 65000.00, '{"target": true}'::jsonb),
-        (90003, 'TargetEmp3', 203, 75000.00, '{"target": true}'::jsonb);
+    INSERT INTO public.emp (emp_name, dep_code, salary, metadata)
+    VALUES ('TargetEmp1', 201, 55000.00, '{"target": true}'::jsonb)
+    RETURNING emp_id INTO row_id;
+
+    INSERT INTO public.emp (emp_name, dep_code, salary, metadata)
+    VALUES ('TargetEmp2', 202, 65000.00, '{"target": true}'::jsonb);
+
+    INSERT INTO public.emp (emp_name, dep_code, salary, metadata)
+    VALUES ('TargetEmp3', 203, 75000.00, '{"target": true}'::jsonb);
 
     UPDATE public.emp SET salary = 70000.00, metadata = metadata || '{"tgt_raise": true}'::jsonb
-    WHERE emp_id = 90001;
+    WHERE emp_id = row_id;
 
-    DELETE FROM public.emp WHERE emp_id = 90003;
+    DELETE FROM public.emp WHERE emp_id = row_id;
 
     -- ===================== MULTILEVEL TABLE: edge cases =====================
 
-    INSERT INTO public.orders (customer_id, order_date, status, amount, metadata) VALUES
-        (9001, '2024-04-10', 'pending',   200.00, '{"target": true}'::jsonb),
-        (9002, '2024-08-20', 'shipped',   350.00, '{"target": true}'::jsonb),
-        (9003, '2025-03-05', 'delivered', 475.00, '{"target": true}'::jsonb),
-        (9004, '2025-06-15', 'returned',  120.00, '{"target": true}'::jsonb);  -- DEFAULT sub-partition
+    INSERT INTO public.orders (customer_id, order_date, status, amount, metadata)
+    VALUES (990001, '2024-04-10', 'pending', 200.00, '{"target": true}'::jsonb);
 
-    -- Cross sub-partition UPDATE on target (status change)
+    INSERT INTO public.orders (customer_id, order_date, status, amount, metadata)
+    VALUES (990002, '2024-08-20', 'shipped', 350.00, '{"target": true}'::jsonb);
+
+    INSERT INTO public.orders (customer_id, order_date, status, amount, metadata)
+    VALUES (990003, '2025-03-05', 'delivered', 475.00, '{"target": true}'::jsonb);
+
+    INSERT INTO public.orders (customer_id, order_date, status, amount, metadata)
+    VALUES (990004, '2025-06-15', 'returned', 120.00, '{"target": true}'::jsonb);
+
+    -- Cross sub-partition UPDATE on target (status change: pending → delivered)
     UPDATE public.orders SET status = 'delivered', metadata = metadata || '{"tgt_status_change": true}'::jsonb
-    WHERE customer_id = 9001 AND order_date = '2024-04-10' AND status = 'pending';
+    WHERE customer_id = 990001 AND order_date = '2024-04-10' AND status = 'pending';
 
-    -- Cross top-level UPDATE on target (year change)
+    -- Cross top-level UPDATE on target (year change: 2024 → 2025)
     UPDATE public.orders SET order_date = '2025-08-20', metadata = metadata || '{"tgt_year_change": true}'::jsonb
-    WHERE customer_id = 9002 AND order_date = '2024-08-20' AND status = 'shipped';
+    WHERE customer_id = 990002 AND order_date = '2024-08-20' AND status = 'shipped';
 
-    DELETE FROM public.orders WHERE customer_id = 9004 AND order_date = '2025-06-15' AND status = 'returned';
+    DELETE FROM public.orders WHERE customer_id = 990004 AND order_date = '2025-06-15' AND status = 'returned';
 
 END $$;

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/target_dml.sql
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/target_dml.sql
@@ -1,0 +1,97 @@
+-- Deterministic edge-case DML for fallback (target → source).
+-- Runs ONCE per iteration as a separate step before the target event generator.
+-- Uses high IDs to avoid PK conflicts with source DML rows.
+
+DO $$
+DECLARE
+    row_id BIGINT;
+    i      INT;
+BEGIN
+    -- ===================== RANGE TABLE: edge cases =====================
+
+    -- Boundary values on target side
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES
+        (900001, 80001, 'OrderDelivery', 80001, 'tgt@test.com', 'email', 'delivered', 'Target boundary start', '2022-01-01 00:00:00', '2022-01-01 00:00:01', 'OrderHandler', 'customer'),
+        (900002, 80002, 'UserAlert', 80002, 'tgt@test.com', 'push', 'reminder', 'Target boundary end', '2026-02-28 23:59:59', '2026-02-28 23:59:59', 'PromoHandler', 'agent');
+
+    -- DEFAULT partition insert from target
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (900003, 80003, 'OrderPickup', 80003, 'tgt@test.com', 'sms', 'picked_up', 'Target DEFAULT row', '2021-11-01 10:00:00', '2021-11-01 10:00:01', 'UserHandler', 'customer');
+
+    -- Large JSONB (TOAST) from target
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, metadata, recipient_type)
+    VALUES (900004, 80004, 'OrderDelivery', 80004, 'tgt-toast@test.com', 'email', 'delivered', 'Target TOAST test',
+        '2024-05-15 12:00:00', '2024-05-15 12:00:01', 'OrderHandler',
+        jsonb_build_object('large_field', repeat('t', 10000), 'nested', jsonb_build_object('a', repeat('v', 5000))),
+        'customer');
+
+    -- Rapid UPDATEs on target
+    FOR i IN 1..10 LOOP
+        UPDATE public.events
+           SET metadata = jsonb_build_object('target_rapid', i, 'ts', now()),
+               updated_at = '2024-05-15 12:00:01'::TIMESTAMP + (i || ' seconds')::INTERVAL
+         WHERE id = 900004;
+    END LOOP;
+
+    -- Cross-partition UPDATE on target
+    INSERT INTO public.events (id, ref_id, ref_type, recipient_id, destination, channel, event_key, body, created_at, updated_at, handler, recipient_type)
+    VALUES (900005, 80005, 'OrderPickup', 80005, 'tgt-cross@test.com', 'sms', 'picked_up', 'Will move partitions on target', '2024-04-10 08:00:00', '2024-04-10 08:00:01', 'UserHandler', 'agent');
+
+    UPDATE public.events SET created_at = '2024-05-10 08:00:00', updated_at = '2024-05-10 08:00:01' WHERE id = 900005;
+
+    -- DELETE from target RANGE
+    DELETE FROM public.events WHERE id = 900003;
+
+    -- ===================== LIST TABLE: edge cases =====================
+
+    INSERT INTO public.sales_region (id, amount, branch, region, metadata) VALUES
+        (90001, 7000, 'Target Branch', 'Sydney', '{"target": true}'::jsonb),
+        (90002, 8000, 'Target Branch 2', 'Tokyo', '{"target": true}'::jsonb),
+        (90003, 9000, 'Target Default', 'Paris', '{"target": true}'::jsonb);  -- DEFAULT
+
+    UPDATE public.sales_region SET amount = 9999, metadata = metadata || '{"tgt_updated": true}'::jsonb
+    WHERE id = 90001 AND region = 'Sydney';
+
+    -- TC17-LIST (target): Cross-partition UPDATE — INSERT into Boston, then UPDATE region to Tokyo
+    -- PG internally does DELETE from sales_boston + INSERT into sales_tokyo
+    -- CDC must replicate this as a DELETE+INSERT pair on the correct child partitions
+    INSERT INTO public.sales_region (id, amount, branch, region, metadata)
+    VALUES (88101, 6666, 'Target Will Move', 'Boston', '{"tgt_will_move": true}'::jsonb);
+
+    UPDATE public.sales_region SET region = 'Tokyo', metadata = metadata || '{"tgt_region_change": true}'::jsonb
+    WHERE id = 88101 AND region = 'Boston';
+
+    DELETE FROM public.sales_region WHERE id = 90002 AND region = 'Tokyo';
+
+    -- ===================== HASH TABLE: edge cases =====================
+
+    INSERT INTO public.emp (emp_id, emp_name, dep_code, salary, metadata) VALUES
+        (90001, 'TargetEmp1', 201, 55000.00, '{"target": true}'::jsonb),
+        (90002, 'TargetEmp2', 202, 65000.00, '{"target": true}'::jsonb),
+        (90003, 'TargetEmp3', 203, 75000.00, '{"target": true}'::jsonb);
+
+    UPDATE public.emp SET salary = 70000.00, metadata = metadata || '{"tgt_raise": true}'::jsonb
+    WHERE emp_id = 90001;
+
+    DELETE FROM public.emp WHERE emp_id = 90003;
+
+    -- ===================== MULTILEVEL TABLE: edge cases =====================
+
+    INSERT INTO public.orders (customer_id, order_date, status, amount, metadata) VALUES
+        (9001, '2024-04-10', 'pending',   200.00, '{"target": true}'::jsonb),
+        (9002, '2024-08-20', 'shipped',   350.00, '{"target": true}'::jsonb),
+        (9003, '2025-03-05', 'delivered', 475.00, '{"target": true}'::jsonb),
+        (9004, '2025-06-15', 'returned',  120.00, '{"target": true}'::jsonb);  -- DEFAULT sub-partition
+
+    -- Cross sub-partition UPDATE on target (status change)
+    UPDATE public.orders SET status = 'delivered', metadata = metadata || '{"tgt_status_change": true}'::jsonb
+    WHERE customer_id = 9001 AND order_date = '2024-04-10' AND status = 'pending';
+
+    -- Cross top-level UPDATE on target (year change)
+    UPDATE public.orders SET order_date = '2025-08-20', metadata = metadata || '{"tgt_year_change": true}'::jsonb
+    WHERE customer_id = 9002 AND order_date = '2024-08-20' AND status = 'shipped';
+
+    DELETE FROM public.orders WHERE customer_id = 9004 AND order_date = '2025-06-15' AND status = 'returned';
+
+END $$;


### PR DESCRIPTION
### Describe the changes in this pull request


Jenkins run : https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/test-voyager-live-migration-resumption/381/


Adds a long-running partition iteration resumption test that validates live migration with `--use-partition-root=false` for partitioned tables where the root has no primary key but child partitions do (mirrors the Instacart production schema pattern - DB-21087).

The test exercises:
- RANGE-partitioned table (by timestamp) with 5 monthly partitions, 30+ columns including JSONB and sequences
- Forward migration: snapshot + CDC streaming with process kill/restart cycles
- Fallback migration: export-from-target + import-to-source with resumptions
- Cutover to target and cutover to source with restart
- Row count and row hash validation after each iteration
- 20 iterations in CI pipeline (3 locally) with 400s soak periods

Also fixes `segment_hash_validation.sql` to skip partitioned parent tables (`relkind='p'`) that lack primary keys, which previously caused hash validation to fail.

### Describe if there are any user-facing changes

No user-facing changes. This is a test-only addition.

### How was this pull request tested?

- Ran 3 full iterations locally on EC2 (PG source → YugabyteDB target) with all stages passing:
  - Forward: export + import + CDC + resumptions + cutover to target
  - Fallback: export-from-target + import-to-source + resumptions + cutover to source
  - Row count validations: PASS
  - Row hash validations: PASS
- Pipeline template configured for 20 iterations with matching timings from the existing iteration test PR (#3482)

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.


Made with [Cursor](https://cursor.com)