### PR TITLE
Import CDC UPDATE event in YB via child partitions in case of use-partition-root is false

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,13 +83,13 @@ jobs:
       run: |
         aws s3 cp s3://dev-itest-builds/2.31.0.0-b99961491/yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz .
         tar -xzf yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz
-        cd yugabyte-2.31.0.0
-        ./bin/yugabyted start --background=false --ui=false --callhome=false 
-        timeout 60s bash -c 'until psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT 1" > /dev/null 2>&1; do 
-          echo "YugabyteDB not ready yet, waiting 2 seconds..."
-          sleep 2
-        done'
-        echo "YugabyteDB is ready!"
+        cd yugabyte-2.31.0.0 && ./bin/yugabyted start
+
+        # timeout 60s bash -c 'until psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT 1" > /dev/null 2>&1; do 
+        #   echo "YugabyteDB not ready yet, waiting 2 seconds..."
+        #   sleep 2
+        # done'
+        # echo "YugabyteDB is ready!"
         psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT version();"
 
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,15 +81,10 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.RAHULB_S3_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.RAHULB_S3_SECRET_ACCESS_KEY }}
       run: |
-        aws s3 cp s3://dev-itest-builds/2.31.0.0-b99961491/yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz .
+        aws s3 cp s3://dev-itest-builds/2025.2.4.0-b99961587/yugabyte-2025.2.4.0-b99961587-centos-x86_64.tar.gz .
         tar -xzf yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz
         cd yugabyte-2.31.0.0 && ./bin/yugabyted start --advertise_address=127.0.0.1
 
-        # timeout 60s bash -c 'until psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT 1" > /dev/null 2>&1; do 
-        #   echo "YugabyteDB not ready yet, waiting 2 seconds..."
-        #   sleep 2
-        # done'
-        # echo "YugabyteDB is ready!"
         psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT version();"
 
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,6 +76,23 @@ jobs:
     - name: Set up gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
 
+    - name: Set up YugabyteDB with DB fix for UPDATE on child table 
+      env: 
+        AWS_ACCESS_KEY_ID: ${{ secrets.RAHULB_S3_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.RAHULB_S3_SECRET_ACCESS_KEY }}
+      run: |
+        aws s3 cp s3://dev-itest-builds/2.31.0.0-b99961491/yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz .
+        tar -xzf yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz
+        cd yugabyte-2.31.0.0
+        ./bin/yugabyted start --background=false --ui=false --callhome=false 
+        timeout 60s bash -c 'until psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT 1" > /dev/null 2>&1; do 
+          echo "YugabyteDB not ready yet, waiting 2 seconds..."
+          sleep 2
+        done'
+        echo "YugabyteDB is ready!"
+        psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT version();"
+
+
     # Note: Some voyager_command related go tests use a voyager binary to call voyager commands
     # Hence its important to ensure the voyager binary built is using the changes in the PR branch - `./install-yb-voyager --install-from-local-source`
     - name: Run Integration Tests (${{ matrix.test-tags }})

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,8 +82,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.RAHULB_S3_SECRET_ACCESS_KEY }}
       run: |
         aws s3 cp s3://dev-itest-builds/2025.2.4.0-b99961587/yugabyte-2025.2.4.0-b99961587-centos-x86_64.tar.gz .
-        tar -xzf yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz
-        cd yugabyte-2.31.0.0 && ./bin/yugabyted start --advertise_address=127.0.0.1
+        tar -xzf yugabyte-2025.2.4.0-b99961587-centos-x86_64.tar.gz
+        cd yugabyte-2025.2.4.0-b99961587 && ./bin/yugabyted start --advertise_address=127.0.0.1
 
         psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT version();"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         aws s3 cp s3://dev-itest-builds/2.31.0.0-b99961491/yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz .
         tar -xzf yugabyte-2.31.0.0-b99961491-centos-x86_64.tar.gz
-        cd yugabyte-2.31.0.0 && ./bin/yugabyted start
+        cd yugabyte-2.31.0.0 && ./bin/yugabyted start --advertise_address=127.0.0.1
 
         # timeout 60s bash -c 'until psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT 1" > /dev/null 2>&1; do 
         #   echo "YugabyteDB not ready yet, waiting 2 seconds..."

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         aws s3 cp s3://dev-itest-builds/2025.2.4.0-b99961587/yugabyte-2025.2.4.0-b99961587-centos-x86_64.tar.gz .
         tar -xzf yugabyte-2025.2.4.0-b99961587-centos-x86_64.tar.gz
-        cd yugabyte-2025.2.4.0-b99961587 && ./bin/yugabyted start --advertise_address=127.0.0.1
+        cd yugabyte-2025.2.4.0 && ./bin/yugabyted start --advertise_address=127.0.0.1
 
         psql "postgresql://yugabyte:@127.0.0.1:5433/yugabyte" -c "SELECT version();"
 

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -150,10 +150,10 @@ var cutoverToTargetCmd = &cobra.Command{
 
 			// Validate YugabyteDB version for logical connector
 			if !useYBgRPCConnector {
-				// err = validateYBVersionForLogicalConnector(msr.TargetDBConf)
-				// if err != nil {
-				// 	utils.ErrExit("%w", err)
-				// }
+				err = validateYBVersionForLogicalConnector(msr.TargetDBConf)
+				if err != nil {
+					utils.ErrExit("%w", err)
+				}
 			}
 			if useYBgRPCConnector {
 				utils.PrintAndLog("Using YB gRPC connector for export data from target")

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -150,10 +150,10 @@ var cutoverToTargetCmd = &cobra.Command{
 
 			// Validate YugabyteDB version for logical connector
 			if !useYBgRPCConnector {
-				err = validateYBVersionForLogicalConnector(msr.TargetDBConf)
-				if err != nil {
-					utils.ErrExit("%w", err)
-				}
+				// err = validateYBVersionForLogicalConnector(msr.TargetDBConf)
+				// if err != nil {
+				// 	utils.ErrExit("%w", err)
+				// }
 			}
 			if useYBgRPCConnector {
 				utils.PrintAndLog("Using YB gRPC connector for export data from target")

--- a/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
@@ -509,32 +509,33 @@ func TestLiveMigrationPartitionedTableWithChildPK(t *testing.T) {
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
 	// Perform cutover
-	err = lm.InitiateCutoverToTarget(true, nil)
+	err = lm.InitiateCutoverToTarget(false, nil)
 	testutils.FatalIfError(t, err, "failed to initiate cutover")
 
 	err = lm.WaitForCutoverComplete(0, 30)
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
-	err = lm.ExecuteTargetDelta()
-	testutils.FatalIfError(t, err, "failed to execute target delta")
+	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
+	// err = lm.ExecuteTargetDelta()
+	// testutils.FatalIfError(t, err, "failed to execute target delta")
 
-	err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
-		`"public"."orders"`: {
-			Inserts: 300,
-			Updates: 300,
-			Deletes: 50,
-		},
-	}, 60, 1)
-	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+	// err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
+	// 	`"public"."orders"`: {
+	// 		Inserts: 300,
+	// 		Updates: 300,
+	// 		Deletes: 50,
+	// 	},
+	// }, 60, 1)
+	// testutils.FatalIfError(t, err, "failed to wait for streaming complete")
 
-	err = lm.ValidateDataConsistency([]string{`"public"."orders"`}, "id")
-	testutils.FatalIfError(t, err, "failed to validate data consistency")
+	// err = lm.ValidateDataConsistency([]string{`"public"."orders"`}, "id")
+	// testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	err = lm.InitiateCutoverToSource(nil)
-	testutils.FatalIfError(t, err, "failed to initiate cutover to source")
+	// err = lm.InitiateCutoverToSource(nil)
+	// testutils.FatalIfError(t, err, "failed to initiate cutover to source")
 
-	err = lm.WaitForCutoverSourceComplete(0, 160)
-	testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
+	// err = lm.WaitForCutoverSourceComplete(0, 160)
+	// testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
 
 	err = lm.ValidateDataConsistency([]string{`"public"."orders"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -889,32 +890,33 @@ func TestLiveMigrationWithMultiLevelPartitioningWithChildTablesHasPK(t *testing.
 	err = lm.ValidateDataConsistency([]string{`"public"."customers"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	err = lm.InitiateCutoverToTarget(true, nil)
+	err = lm.InitiateCutoverToTarget(false, nil)
 	testutils.FatalIfError(t, err, "failed to initiate cutover to target")
 
 	err = lm.WaitForCutoverComplete(0, 30)
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
-	err = lm.ExecuteTargetDelta()
-	testutils.FatalIfError(t, err, "failed to execute target delta")
+	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
+	// err = lm.ExecuteTargetDelta()
+	// testutils.FatalIfError(t, err, "failed to execute target delta")
 
-	err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
-		`"public"."customers"`: {
-			Inserts: 800,
-			Updates: 400,
-			Deletes: 450,
-		},
-	}, 60, 1)
-	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+	// err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
+	// 	`"public"."customers"`: {
+	// 		Inserts: 800,
+	// 		Updates: 400,
+	// 		Deletes: 450,
+	// 	},
+	// }, 60, 1)
+	// testutils.FatalIfError(t, err, "failed to wait for streaming complete")
 
-	err = lm.ValidateDataConsistency([]string{`"public"."customers"`}, "id")
-	testutils.FatalIfError(t, err, "failed to validate data consistency")
+	// err = lm.ValidateDataConsistency([]string{`"public"."customers"`}, "id")
+	// testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	err = lm.InitiateCutoverToSource(nil)
-	testutils.FatalIfError(t, err, "failed to initiate cutover to source")
+	// err = lm.InitiateCutoverToSource(nil)
+	// testutils.FatalIfError(t, err, "failed to initiate cutover to source")
 
-	err = lm.WaitForCutoverSourceComplete(0, 160)
-	testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
+	// err = lm.WaitForCutoverSourceComplete(0, 160)
+	// testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
 
 	err = lm.ValidateDataConsistency([]string{`"public"."customers"`, `public.customers_other`, `public.customers_part11`, `public.customers_part21`, `public.customers_part12`, `public.customers_part22`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -1167,37 +1169,38 @@ func TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas(
 	err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	err = lm.InitiateCutoverToTarget(true, nil)
+	err = lm.InitiateCutoverToTarget(false, nil)
 	testutils.FatalIfError(t, err, "failed to initiate cutover to target")
 
 	err = lm.WaitForCutoverComplete(0, 30)
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
-	err = lm.ExecuteTargetDelta()
-	testutils.FatalIfError(t, err, "failed to execute target delta")
+	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
+	// err = lm.ExecuteTargetDelta()
+	// testutils.FatalIfError(t, err, "failed to execute target delta")
 
-	err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
-		`"TestSchemaCase"."orders"`: {
-			Inserts: 600,
-			Updates: 300,
-			Deletes: 350,
-		},
-		`"public"."customers"`: {
-			Inserts: 3,
-			Updates: 2,
-			Deletes: 2,
-		},
-	}, 60, 1)
-	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+	// err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
+	// 	`"TestSchemaCase"."orders"`: {
+	// 		Inserts: 600,
+	// 		Updates: 300,
+	// 		Deletes: 350,
+	// 	},
+	// 	`"public"."customers"`: {
+	// 		Inserts: 3,
+	// 		Updates: 2,
+	// 		Deletes: 2,
+	// 	},
+	// }, 60, 1)
+	// testutils.FatalIfError(t, err, "failed to wait for streaming complete")
 
-	err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`}, "id")
-	testutils.FatalIfError(t, err, "failed to validate data consistency")
+	// err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`}, "id")
+	// testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	err = lm.InitiateCutoverToSource(nil)
-	testutils.FatalIfError(t, err, "failed to initiate cutover to source")
+	// err = lm.InitiateCutoverToSource(nil)
+	// testutils.FatalIfError(t, err, "failed to initiate cutover to source")
 
-	err = lm.WaitForCutoverSourceComplete(0, 160)
-	testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
+	// err = lm.WaitForCutoverSourceComplete(0, 160)
+	// testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
 
 	err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`, `"test_schema"."Orders_US"`, `"test_schema"."Orders_EU"`, `"test_schema"."Orders_APAC"`,
 		`test_schema."Customers_Other"`, `test_schema."Customers_Part11"`, `"TestSchemaCase"."Customers_Part12"`, `"TestSchemaCase".customers_part22`, `public.customers_part21`}, "id")
@@ -1294,6 +1297,8 @@ func validatingPartitionConsistencyCheck(lm *LiveMigrationTest) {
 }
 
 func TestLiveMigrationWithIterationsOnPartitionedTableWithChildPK(t *testing.T) {
+	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
+	t.Skip("Skipping this test as it is not supported yet for now as it will error out at fallback phase with 2.31 YB")
 	t.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
 	t.Setenv("YB_EXTERNAL_PORT", "5433")
 	t.Setenv("YB_EXTERNAL_USER", "yugabyte")

--- a/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
@@ -20,6 +20,7 @@ package testlivemigration
 import (
 	"context"
 	"database/sql"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -459,6 +460,11 @@ func TestLiveMigrationPartitionedTableWithChildPK(t *testing.T) {
 
 	defer lm.Cleanup()
 
+	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	os.Setenv("YB_EXTERNAL_PORT", "5433")
+	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
 
@@ -635,6 +641,11 @@ func TestLiveMigrationPartitionedTableWithChildTablesHavingDifferentPK(t *testin
 	})
 
 	defer lm.Cleanup()
+
+	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	os.Setenv("YB_EXTERNAL_PORT", "5433")
+	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -844,6 +855,11 @@ func TestLiveMigrationWithMultiLevelPartitioningWithChildTablesHasPK(t *testing.
 
 	defer lm.Cleanup()
 
+	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	os.Setenv("YB_EXTERNAL_PORT", "5433")
+	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
 
@@ -947,6 +963,7 @@ Initially missing PKs (to trigger the primary-key guardrail in export data):
   - test_schema."Orders_EU"
   - test_schema."Customers_Other"
   - public.customers_part21
+
 Checking if export data fails with the Primary key guardrail error.
 If it fails, assert the error message contains the table names without a Primary key,
 and then create the PK on those tables and continue with the rest of the flow.
@@ -1106,6 +1123,11 @@ func TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas(
 	})
 
 	defer lm.Cleanup()
+
+	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	os.Setenv("YB_EXTERNAL_PORT", "5433")
+	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -1283,6 +1305,11 @@ func TestLiveMigrationWithIterationsOnPartitionedTableWithChildPK(t *testing.T) 
 	lm := getLiveMigrationTestBasicForPartitionedTableWithChildPK(t, "test_iterations_on_partitioned_table_with_child_pk")
 
 	defer lm.Cleanup()
+
+	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	os.Setenv("YB_EXTERNAL_PORT", "5433")
+	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")

--- a/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
@@ -509,33 +509,33 @@ func TestLiveMigrationPartitionedTableWithChildPK(t *testing.T) {
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
 	// Perform cutover
-	err = lm.InitiateCutoverToTarget(false, nil)
+	err = lm.InitiateCutoverToTarget(true, nil)
 	testutils.FatalIfError(t, err, "failed to initiate cutover")
 
 	err = lm.WaitForCutoverComplete(0, 30)
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
 	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
-	// err = lm.ExecuteTargetDelta()
-	// testutils.FatalIfError(t, err, "failed to execute target delta")
+	err = lm.ExecuteTargetDelta()
+	testutils.FatalIfError(t, err, "failed to execute target delta")
 
-	// err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
-	// 	`"public"."orders"`: {
-	// 		Inserts: 300,
-	// 		Updates: 300,
-	// 		Deletes: 50,
-	// 	},
-	// }, 60, 1)
-	// testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+	err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
+		`"public"."orders"`: {
+			Inserts: 300,
+			Updates: 300,
+			Deletes: 50,
+		},
+	}, 60, 1)
+	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
 
-	// err = lm.ValidateDataConsistency([]string{`"public"."orders"`}, "id")
-	// testutils.FatalIfError(t, err, "failed to validate data consistency")
+	err = lm.ValidateDataConsistency([]string{`"public"."orders"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	// err = lm.InitiateCutoverToSource(nil)
-	// testutils.FatalIfError(t, err, "failed to initiate cutover to source")
+	err = lm.InitiateCutoverToSource(nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover to source")
 
-	// err = lm.WaitForCutoverSourceComplete(0, 160)
-	// testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
+	err = lm.WaitForCutoverSourceComplete(0, 160)
+	testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
 
 	err = lm.ValidateDataConsistency([]string{`"public"."orders"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -890,33 +890,33 @@ func TestLiveMigrationWithMultiLevelPartitioningWithChildTablesHasPK(t *testing.
 	err = lm.ValidateDataConsistency([]string{`"public"."customers"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	err = lm.InitiateCutoverToTarget(false, nil)
+	err = lm.InitiateCutoverToTarget(true, nil)
 	testutils.FatalIfError(t, err, "failed to initiate cutover to target")
 
 	err = lm.WaitForCutoverComplete(0, 30)
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
 	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
-	// err = lm.ExecuteTargetDelta()
-	// testutils.FatalIfError(t, err, "failed to execute target delta")
+	err = lm.ExecuteTargetDelta()
+	testutils.FatalIfError(t, err, "failed to execute target delta")
 
-	// err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
-	// 	`"public"."customers"`: {
-	// 		Inserts: 800,
-	// 		Updates: 400,
-	// 		Deletes: 450,
-	// 	},
-	// }, 60, 1)
-	// testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+	err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
+		`"public"."customers"`: {
+			Inserts: 800,
+			Updates: 400,
+			Deletes: 450,
+		},
+	}, 60, 1)
+	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
 
-	// err = lm.ValidateDataConsistency([]string{`"public"."customers"`}, "id")
-	// testutils.FatalIfError(t, err, "failed to validate data consistency")
+	err = lm.ValidateDataConsistency([]string{`"public"."customers"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	// err = lm.InitiateCutoverToSource(nil)
-	// testutils.FatalIfError(t, err, "failed to initiate cutover to source")
+	err = lm.InitiateCutoverToSource(nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover to source")
 
-	// err = lm.WaitForCutoverSourceComplete(0, 160)
-	// testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
+	err = lm.WaitForCutoverSourceComplete(0, 160)
+	testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
 
 	err = lm.ValidateDataConsistency([]string{`"public"."customers"`, `public.customers_other`, `public.customers_part11`, `public.customers_part21`, `public.customers_part12`, `public.customers_part22`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -1176,31 +1176,31 @@ func TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas(
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
 	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
-	// err = lm.ExecuteTargetDelta()
-	// testutils.FatalIfError(t, err, "failed to execute target delta")
+	err = lm.ExecuteTargetDelta()
+	testutils.FatalIfError(t, err, "failed to execute target delta")
 
-	// err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
-	// 	`"TestSchemaCase"."orders"`: {
-	// 		Inserts: 600,
-	// 		Updates: 300,
-	// 		Deletes: 350,
-	// 	},
-	// 	`"public"."customers"`: {
-	// 		Inserts: 3,
-	// 		Updates: 2,
-	// 		Deletes: 2,
-	// 	},
-	// }, 60, 1)
-	// testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+	err = lm.WaitForFallbackStreamingComplete(map[string]ChangesCount{
+		`"TestSchemaCase"."orders"`: {
+			Inserts: 600,
+			Updates: 300,
+			Deletes: 350,
+		},
+		`"public"."customers"`: {
+			Inserts: 3,
+			Updates: 2,
+			Deletes: 2,
+		},
+	}, 60, 1)
+	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
 
-	// err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`}, "id")
-	// testutils.FatalIfError(t, err, "failed to validate data consistency")
+	err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	// err = lm.InitiateCutoverToSource(nil)
-	// testutils.FatalIfError(t, err, "failed to initiate cutover to source")
+	err = lm.InitiateCutoverToSource(nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover to source")
 
-	// err = lm.WaitForCutoverSourceComplete(0, 160)
-	// testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
+	err = lm.WaitForCutoverSourceComplete(0, 160)
+	testutils.FatalIfError(t, err, "failed to wait for cutover source complete")
 
 	err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`, `"test_schema"."Orders_US"`, `"test_schema"."Orders_EU"`, `"test_schema"."Orders_APAC"`,
 		`test_schema."Customers_Other"`, `test_schema."Customers_Part11"`, `"TestSchemaCase"."Customers_Part12"`, `"TestSchemaCase".customers_part22`, `public.customers_part21`}, "id")
@@ -1298,7 +1298,7 @@ func validatingPartitionConsistencyCheck(lm *LiveMigrationTest) {
 
 func TestLiveMigrationWithIterationsOnPartitionedTableWithChildPK(t *testing.T) {
 	//TODO: remove this skip once we support have 2025.2.3 backport for the fix
-	t.Skip("Skipping this test as it is not supported yet for now as it will error out at fallback phase with 2.31 YB")
+	// t.Skip("Skipping this test as it is not supported yet for now as it will error out at fallback phase with 2.31 YB")
 	t.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
 	t.Setenv("YB_EXTERNAL_PORT", "5433")
 	t.Setenv("YB_EXTERNAL_USER", "yugabyte")

--- a/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
@@ -1169,7 +1169,7 @@ func TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas(
 	err = lm.ValidateDataConsistency([]string{`"TestSchemaCase"."orders"`, `"public"."customers"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
 
-	err = lm.InitiateCutoverToTarget(false, nil)
+	err = lm.InitiateCutoverToTarget(true, nil)
 	testutils.FatalIfError(t, err, "failed to initiate cutover to target")
 
 	err = lm.WaitForCutoverComplete(0, 30)

--- a/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
@@ -465,6 +465,13 @@ func TestLiveMigrationPartitionedTableWithChildPK(t *testing.T) {
 	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
 	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
 
+	defer func() {
+		os.Unsetenv("YB_EXTERNAL_HOST")
+		os.Unsetenv("YB_EXTERNAL_PORT")
+		os.Unsetenv("YB_EXTERNAL_USER")
+		os.Unsetenv("YB_EXTERNAL_PASSWORD")
+	}()
+
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
 
@@ -646,6 +653,13 @@ func TestLiveMigrationPartitionedTableWithChildTablesHavingDifferentPK(t *testin
 	os.Setenv("YB_EXTERNAL_PORT", "5433")
 	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
 	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
+	defer func() {
+		os.Unsetenv("YB_EXTERNAL_HOST")
+		os.Unsetenv("YB_EXTERNAL_PORT")
+		os.Unsetenv("YB_EXTERNAL_USER")
+		os.Unsetenv("YB_EXTERNAL_PASSWORD")
+	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -859,6 +873,13 @@ func TestLiveMigrationWithMultiLevelPartitioningWithChildTablesHasPK(t *testing.
 	os.Setenv("YB_EXTERNAL_PORT", "5433")
 	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
 	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
+	defer func() {
+		os.Unsetenv("YB_EXTERNAL_HOST")
+		os.Unsetenv("YB_EXTERNAL_PORT")
+		os.Unsetenv("YB_EXTERNAL_USER")
+		os.Unsetenv("YB_EXTERNAL_PASSWORD")
+	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -1129,6 +1150,13 @@ func TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas(
 	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
 	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
 
+	defer func() {
+		os.Unsetenv("YB_EXTERNAL_HOST")
+		os.Unsetenv("YB_EXTERNAL_PORT")
+		os.Unsetenv("YB_EXTERNAL_USER")
+		os.Unsetenv("YB_EXTERNAL_PASSWORD")
+	}()
+
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
 
@@ -1310,6 +1338,13 @@ func TestLiveMigrationWithIterationsOnPartitionedTableWithChildPK(t *testing.T) 
 	os.Setenv("YB_EXTERNAL_PORT", "5433")
 	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
 	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
+	defer func() {
+		os.Unsetenv("YB_EXTERNAL_HOST")
+		os.Unsetenv("YB_EXTERNAL_PORT")
+		os.Unsetenv("YB_EXTERNAL_USER")
+		os.Unsetenv("YB_EXTERNAL_PASSWORD")
+	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")

--- a/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
@@ -20,7 +20,6 @@ package testlivemigration
 import (
 	"context"
 	"database/sql"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -454,23 +453,14 @@ UPDATE partitions
 DELETE rows for partition
 */
 func TestLiveMigrationPartitionedTableWithChildPK(t *testing.T) {
-	t.Parallel()
+	t.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	t.Setenv("YB_EXTERNAL_PORT", "5433")
+	t.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	t.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
 
 	lm := getLiveMigrationTestBasicForPartitionedTableWithChildPK(t, "test_partition_with_child_pk")
 
 	defer lm.Cleanup()
-
-	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
-	os.Setenv("YB_EXTERNAL_PORT", "5433")
-	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
-	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
-
-	defer func() {
-		os.Unsetenv("YB_EXTERNAL_HOST")
-		os.Unsetenv("YB_EXTERNAL_PORT")
-		os.Unsetenv("YB_EXTERNAL_USER")
-		os.Unsetenv("YB_EXTERNAL_PASSWORD")
-	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -563,7 +553,11 @@ Child Tables:
 This scenario is not supported yet and validating guardrail in export data for that
 */
 func TestLiveMigrationPartitionedTableWithChildTablesHavingDifferentPK(t *testing.T) {
-	t.Parallel()
+	t.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	t.Setenv("YB_EXTERNAL_PORT", "5433")
+	t.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	t.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
 	lm := NewLiveMigrationTest(t, &TestConfig{
 		SourceDB: ContainerConfig{
 			Type:         "postgresql",
@@ -648,18 +642,6 @@ func TestLiveMigrationPartitionedTableWithChildTablesHavingDifferentPK(t *testin
 	})
 
 	defer lm.Cleanup()
-
-	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
-	os.Setenv("YB_EXTERNAL_PORT", "5433")
-	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
-	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
-
-	defer func() {
-		os.Unsetenv("YB_EXTERNAL_HOST")
-		os.Unsetenv("YB_EXTERNAL_PORT")
-		os.Unsetenv("YB_EXTERNAL_USER")
-		os.Unsetenv("YB_EXTERNAL_PASSWORD")
-	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -755,7 +737,11 @@ UPDATE customers
 DELETE rows for partition - 100
 */
 func TestLiveMigrationWithMultiLevelPartitioningWithChildTablesHasPK(t *testing.T) {
-	t.Parallel()
+	t.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	t.Setenv("YB_EXTERNAL_PORT", "5433")
+	t.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	t.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
 	lm := NewLiveMigrationTest(t, &TestConfig{
 		SourceDB: ContainerConfig{
 			Type:         "postgresql",
@@ -868,18 +854,6 @@ func TestLiveMigrationWithMultiLevelPartitioningWithChildTablesHasPK(t *testing.
 	})
 
 	defer lm.Cleanup()
-
-	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
-	os.Setenv("YB_EXTERNAL_PORT", "5433")
-	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
-	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
-
-	defer func() {
-		os.Unsetenv("YB_EXTERNAL_HOST")
-		os.Unsetenv("YB_EXTERNAL_PORT")
-		os.Unsetenv("YB_EXTERNAL_USER")
-		os.Unsetenv("YB_EXTERNAL_PASSWORD")
-	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -995,7 +969,11 @@ with --use-partition-root=false, answering 'N' to the prompt, and then re-runnin
 import data after recreating the partitions.
 */
 func TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas(t *testing.T) {
-	t.Parallel()
+	t.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	t.Setenv("YB_EXTERNAL_PORT", "5433")
+	t.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	t.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
+
 	lm := NewLiveMigrationTest(t, &TestConfig{
 		SourceDB: ContainerConfig{
 			Type:         "postgresql",
@@ -1144,18 +1122,6 @@ func TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas(
 	})
 
 	defer lm.Cleanup()
-
-	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
-	os.Setenv("YB_EXTERNAL_PORT", "5433")
-	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
-	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
-
-	defer func() {
-		os.Unsetenv("YB_EXTERNAL_HOST")
-		os.Unsetenv("YB_EXTERNAL_PORT")
-		os.Unsetenv("YB_EXTERNAL_USER")
-		os.Unsetenv("YB_EXTERNAL_PASSWORD")
-	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")
@@ -1328,23 +1294,14 @@ func validatingPartitionConsistencyCheck(lm *LiveMigrationTest) {
 }
 
 func TestLiveMigrationWithIterationsOnPartitionedTableWithChildPK(t *testing.T) {
-	t.Parallel()
+	t.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
+	t.Setenv("YB_EXTERNAL_PORT", "5433")
+	t.Setenv("YB_EXTERNAL_USER", "yugabyte")
+	t.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
 
 	lm := getLiveMigrationTestBasicForPartitionedTableWithChildPK(t, "test_iterations_on_partitioned_table_with_child_pk")
 
 	defer lm.Cleanup()
-
-	os.Setenv("YB_EXTERNAL_HOST", "127.0.0.1")
-	os.Setenv("YB_EXTERNAL_PORT", "5433")
-	os.Setenv("YB_EXTERNAL_USER", "yugabyte")
-	os.Setenv("YB_EXTERNAL_PASSWORD", "yugabyte")
-
-	defer func() {
-		os.Unsetenv("YB_EXTERNAL_HOST")
-		os.Unsetenv("YB_EXTERNAL_PORT")
-		os.Unsetenv("YB_EXTERNAL_USER")
-		os.Unsetenv("YB_EXTERNAL_PASSWORD")
-	}()
 
 	err := lm.SetupContainers(context.Background())
 	testutils.FatalIfError(t, err, "failed to setup containers")

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1079,7 +1079,7 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 			   ingestion of UPDATE events via partition table on Target DB. and in other importers we are ingesting data via partition table.
 			   so use partition root table always for UPDATE events  in YB
 			*/
-			stmt, err := event.GetSQLStmt(yb, true)
+			stmt, err := event.GetSQLStmt(yb, yb.tconf.UsePartitionRoot)
 			if err != nil {
 				return fmt.Errorf("get sql stmt: %w", err)
 			}

--- a/yb-voyager/test/containers/yugabytedb_container.go
+++ b/yb-voyager/test/containers/yugabytedb_container.go
@@ -56,6 +56,11 @@ func (yb *YugabyteDBContainer) Start(ctx context.Context) (err error) {
 		utils.PrintAndLogf("Using external YugabyteDB at %s:%d (user=%s)", host, port, yb.User)
 		return nil
 	}
+	yb.external = false
+	yb.externalHost = ""
+	yb.externalPort = 0
+	yb.User = ""
+	yb.Password = ""
 
 	if yb.container != nil {
 		if yb.container.IsRunning() {
@@ -223,7 +228,7 @@ func (yb *YugabyteDBContainer) GetConnectionString() string {
 }
 
 func (yb *YugabyteDBContainer) GetConnection() (*sql.DB, error) {
-	if yb.container == nil {
+	if yb.container == nil && !yb.external {
 		utils.ErrExit("yugabytedb container is not started: nil")
 	}
 

--- a/yb-voyager/test/containers/yugabytedb_container.go
+++ b/yb-voyager/test/containers/yugabytedb_container.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +24,10 @@ type YugabyteDBContainer struct {
 	mutex sync.Mutex
 	ContainerConfig
 	container testcontainers.Container
+
+	external     bool
+	externalHost string
+	externalPort int
 }
 
 func (yb *YugabyteDBContainer) SetConfig(config ContainerConfig) {
@@ -31,6 +36,26 @@ func (yb *YugabyteDBContainer) SetConfig(config ContainerConfig) {
 func (yb *YugabyteDBContainer) Start(ctx context.Context) (err error) {
 	yb.mutex.Lock()
 	defer yb.mutex.Unlock()
+
+	// External-instance mode: skip docker entirely.
+	if host := os.Getenv("YB_EXTERNAL_HOST"); host != "" {
+		port, err := strconv.Atoi(os.Getenv("YB_EXTERNAL_PORT"))
+		if err != nil || port == 0 {
+			port = 5433
+		}
+		yb.external = true
+		yb.externalHost = host
+		yb.externalPort = port
+		// Optional: respect YB_EXTERNAL_USER / YB_EXTERNAL_PASSWORD overrides
+		if u := os.Getenv("YB_EXTERNAL_USER"); u != "" {
+			yb.User = u
+		}
+		if p := os.Getenv("YB_EXTERNAL_PASSWORD"); p != "" {
+			yb.Password = p
+		}
+		utils.PrintAndLogf("Using external YugabyteDB at %s:%d (user=%s)", host, port, yb.User)
+		return nil
+	}
 
 	if yb.container != nil {
 		if yb.container.IsRunning() {
@@ -120,6 +145,10 @@ func (yb *YugabyteDBContainer) Stop(ctx context.Context) error {
 	yb.mutex.Lock()
 	defer yb.mutex.Unlock()
 
+	if yb.external {
+		return nil
+	}
+
 	if yb.container == nil {
 		return nil
 	} else if !yb.container.IsRunning() {
@@ -145,6 +174,10 @@ func (yb *YugabyteDBContainer) Terminate(ctx context.Context) {
 		return
 	}
 
+	if yb.external {
+		return
+	}
+
 	err := yb.container.Terminate(ctx)
 	if err != nil {
 		log.Errorf("failed to terminate yugabytedb container: %v", err)
@@ -152,6 +185,11 @@ func (yb *YugabyteDBContainer) Terminate(ctx context.Context) {
 }
 
 func (yb *YugabyteDBContainer) GetHostPort() (string, int, error) {
+
+	if yb.external {
+		return yb.externalHost, yb.externalPort, nil
+	}
+
 	if yb.container == nil {
 		return "", -1, fmt.Errorf("yugabytedb container is not started: nil")
 	}

--- a/yb-voyager/test/containers/yugabytedb_container.go
+++ b/yb-voyager/test/containers/yugabytedb_container.go
@@ -59,8 +59,6 @@ func (yb *YugabyteDBContainer) Start(ctx context.Context) (err error) {
 	yb.external = false
 	yb.externalHost = ""
 	yb.externalPort = 0
-	yb.User = ""
-	yb.Password = ""
 
 	if yb.container != nil {
 		if yb.container.IsRunning() {


### PR DESCRIPTION
### Describe the changes in this pull request

Restores symmetry of `--use-partition-root=false` across all CDC event types
on YugabyteDB targets. Previously, UPDATE events were forcibly rewritten to
use the **root** partitioned table even when the user passed
`--use-partition-root=false`, because direct UPDATE on a partition child
under REPEATABLE READ triggered a YB-side bug
(`attribute N of type record has wrong type`, SQLSTATE 42804). With that
bug now fixed on the YB side, this PR drops the hard-coded override in
`ExecuteBatch` and lets the per-event partition-routing decision flow from
`tconf.UsePartitionRoot` for UPDATE just as it already did for INSERT and
DELETE.

The change is a one-line edit in
[`yb-voyager/src/tgtdb/yugabytedb.go`](yb-voyager/src/tgtdb/yugabytedb.go):
`event.GetSQLStmt(yb, true)` → `event.GetSQLStmt(yb, yb.tconf.UsePartitionRoot)`.

To validate this against a YB build that actually contains the DB-side fix,
the integration-test infrastructure was extended:

- A new GitHub Actions step provisions the patched YB build
  (`2025.2.4.0-b99961587`) directly on the runner and starts `yugabyted`
  with `--advertise_address=127.0.0.1`.
- `YugabyteDBContainer` gained an "external instance" mode controlled by
  `YB_EXTERNAL_HOST` / `YB_EXTERNAL_PORT` / `YB_EXTERNAL_USER` /
  `YB_EXTERNAL_PASSWORD`. When these are set, the container helper skips
  docker and points at the running yugabyted instead. The mode is reset
  on each `Start()` to avoid singleton-state leak across tests sharing
  the cached `containerRegistry` instance.
- The four affected partition tests in
  `live_migration_partitions_integrations_test.go` use `t.Setenv` to
  enable external-instance mode. Because `t.Setenv` is incompatible with
  `t.Parallel()` in Go, those tests have been switched to serial
  execution. The `ExecuteTargetDelta` (fallback) phase is left as
  `TODO` in three tests pending a 2025.2.3 backport of the same fix.

### Describe if there are any user-facing changes

Behavior change for live migration to YugabyteDB with
`--use-partition-root=false`: CDC `UPDATE` events are now ingested directly
against the partition leaf table, matching how INSERT and DELETE events
already behave under that flag. Previously UPDATE silently fell back to
the root regardless of the flag.

This requires the YugabyteDB target cluster to include the partition-child
UPDATE fix (preview `2.31.x` builds going forward / planned `2025.2.3` and
later stable backport). Older target clusters will still hit the
`attribute N of type record has wrong type` error on UPDATE; users on those
versions should keep `--use-partition-root=true` (the default).

No changes to the CLI surface, configuration, installation, or reports.

### How was this pull request tested?

- Existing live-migration partition integration tests now exercise the
  changed code path against the patched YB build:
  - `TestLiveMigrationPartitionedTableWithChildPK`
  - `TestLiveMigrationPartitionedTableWithChildTablesHavingDifferentPK`
  - `TestLiveMigrationWithMultiLevelPartitioningWithChildTablesHasPK`
  - `TestLiveMigrationPartitionedWithChildPKAndPartitionsAcrossDifferentSchemas`
  - `TestLiveMigrationWithIterationsOnPartitionedTableWithChildPK`
- The new GitHub Actions step downloads `yugabyte-2025.2.4.0-b99961587`
  and starts it on the runner; the integration-tests job points the test
  binary at it via the `YB_EXTERNAL_*` env vars.
- Fall-back phase (`ExecuteTargetDelta`) is intentionally TODO-commented
  in three tests until the YB fix is backported to 2025.2.3 — these are
  tracked inline in the test file and need a follow-up PR once the
  backport lands.
- Container-mode regression: tests that don't set `YB_EXTERNAL_HOST`
  still fall through to the docker path because `Start()` resets the
  external-mode fields on every call.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.