### PR TITLE
Add YB replica identity CHANGE guardrail

### DIFF
--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -1343,20 +1343,22 @@ func (yb *YugabyteDB) GetMissingExportDataPermissions(exportType string, finalTa
 			return nil, false, fmt.Errorf("error in checking table replica identity: %w", err)
 		}
 		if len(tablesWithoutReplicaIdentityChange) > 0 {
-			combinedResult = append(combinedResult, fmt.Sprintf("\n%s[%s]", color.RedString("Tables not having replica identity CHANGE: "), strings.Join(tablesWithoutReplicaIdentityChange, ", ")))
+			combinedResult = append(combinedResult, fmt.Sprintf("\n%s[%s]", color.RedString("Tables not having replica identity CHANGE: "), strings.Join(lo.Map(tablesWithoutReplicaIdentityChange, func(t sqlname.NameTuple, _ int) string {
+				return t.ForOutput()
+			}), ", ")))
 		}
 	}
 
 	return combinedResult, len(combinedResult) > 0, nil
 }
 
-func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname.NameTuple) ([]string, error) {
+// TODO: migrate postgres.go listTablesMissingReplicaIdentityFull from queryTableList string to []NameTuple,
+// then consolidate both into a shared helper parameterized by expected relreplident char and label.
+func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname.NameTuple) ([]sqlname.NameTuple, error) {
 	var tableNamePairs []string
-	qualifiedNameByCatalogKey := make(map[string]string)
 	for _, table := range tableList {
 		sname, tname := table.ForCatalogQuery()
 		tableNamePairs = append(tableNamePairs, fmt.Sprintf("('%s','%s')", sname, tname))
-		qualifiedNameByCatalogKey[sname+"."+tname] = table.ForOutput()
 	}
 
 	checkTableReplicaIdentityQuery := fmt.Sprintf(`
@@ -1386,7 +1388,7 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname
 		}
 	}()
 
-	var tablesWithoutReplicaIdentityChange []string
+	tablesWithoutIdentityChangeKeys := make(map[string]bool)
 	var tableSchemaName, tableName, replicaIdentity, status string
 
 	for rows.Next() {
@@ -1395,7 +1397,7 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname
 			return nil, fmt.Errorf("error in scanning query rows for table names: %w", err)
 		}
 		if status == MISSING {
-			tablesWithoutReplicaIdentityChange = append(tablesWithoutReplicaIdentityChange, qualifiedNameByCatalogKey[tableSchemaName+"."+tableName])
+			tablesWithoutIdentityChangeKeys[tableSchemaName+"."+tableName] = true
 		}
 	}
 
@@ -1403,7 +1405,14 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname
 		return nil, fmt.Errorf("error iterating over query rows: %w", err)
 	}
 
-	return tablesWithoutReplicaIdentityChange, nil
+	var result []sqlname.NameTuple
+	for _, table := range tableList {
+		sname, tname := table.ForCatalogQuery()
+		if tablesWithoutIdentityChangeKeys[sname+"."+tname] {
+			result = append(result, table)
+		}
+	}
+	return result, nil
 }
 
 func (yb *YugabyteDB) GetMissingAssessMigrationPermissions() ([]string, bool, error) {

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -1352,9 +1352,11 @@ func (yb *YugabyteDB) GetMissingExportDataPermissions(exportType string, finalTa
 
 func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname.NameTuple) ([]string, error) {
 	var tableNamePairs []string
+	qualifiedNameByCatalogKey := make(map[string]string)
 	for _, table := range tableList {
 		sname, tname := table.ForCatalogQuery()
 		tableNamePairs = append(tableNamePairs, fmt.Sprintf("('%s','%s')", sname, tname))
+		qualifiedNameByCatalogKey[sname+"."+tname] = table.ForOutput()
 	}
 
 	checkTableReplicaIdentityQuery := fmt.Sprintf(`
@@ -1393,7 +1395,7 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname
 			return nil, fmt.Errorf("error in scanning query rows for table names: %w", err)
 		}
 		if status == MISSING {
-			tablesWithoutReplicaIdentityChange = append(tablesWithoutReplicaIdentityChange, sqlname.NewSourceName(tableSchemaName, tableName).Qualified.MinQuoted)
+			tablesWithoutReplicaIdentityChange = append(tablesWithoutReplicaIdentityChange, qualifiedNameByCatalogKey[tableSchemaName+"."+tableName])
 		}
 	}
 

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	goerrors "github.com/go-errors/errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pglogrepl"
@@ -1334,7 +1335,70 @@ func (yb *YugabyteDB) GetMissingExportSchemaPermissions(queryTableList string) (
 }
 
 func (yb *YugabyteDB) GetMissingExportDataPermissions(exportType string, finalTableList []sqlname.NameTuple) ([]string, bool, error) {
-	return nil, false, nil
+	var combinedResult []string
+
+	qualifiedMinQuotedTableNames := lo.Map(finalTableList, func(table sqlname.NameTuple, _ int) string {
+		return table.ForOutput()
+	})
+	queryTableList := fmt.Sprintf("'%s'", strings.Join(qualifiedMinQuotedTableNames, "','"))
+
+	missingTables, err := yb.listTablesMissingReplicaIdentityChange(queryTableList)
+	if err != nil {
+		return nil, false, fmt.Errorf("error in checking table replica identity: %w", err)
+	}
+	if len(missingTables) > 0 {
+		combinedResult = append(combinedResult, fmt.Sprintf("\n%s[%s]", color.RedString("Tables missing replica identity CHANGE: "), strings.Join(missingTables, ", ")))
+	}
+
+	return combinedResult, len(combinedResult) > 0, nil
+}
+
+func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(queryTableList string) ([]string, error) {
+	checkTableReplicaIdentityQuery := fmt.Sprintf(`
+	SELECT
+		n.nspname AS schema_name,
+		c.relname AS table_name,
+		c.relreplident AS replica_identity,
+		CASE
+			WHEN c.relreplident <> 'c'
+			THEN '%s'
+			ELSE '%s'
+		END AS status
+	FROM pg_class c
+	JOIN pg_namespace n ON c.relnamespace = n.oid
+	WHERE (quote_ident(n.nspname) || '.' || quote_ident(c.relname)) IN (%s)
+	AND c.relkind IN ('r', 'p');
+	`, MISSING, GRANTED, queryTableList)
+
+	rows, err := yb.db.Query(checkTableReplicaIdentityQuery)
+	if err != nil {
+		return nil, fmt.Errorf("error in querying(%q) source YugabyteDB for checking table replica identity: %w", checkTableReplicaIdentityQuery, err)
+	}
+	defer func() {
+		closeErr := rows.Close()
+		if closeErr != nil {
+			log.Warnf("close rows for query %q: %v", checkTableReplicaIdentityQuery, closeErr)
+		}
+	}()
+
+	var missingTables []string
+	var tableSchemaName, tableName, replicaIdentity, status string
+
+	for rows.Next() {
+		err = rows.Scan(&tableSchemaName, &tableName, &replicaIdentity, &status)
+		if err != nil {
+			return nil, fmt.Errorf("error in scanning query rows for table names: %w", err)
+		}
+		if status == MISSING {
+			missingTables = append(missingTables, fmt.Sprintf(`%s."%s"`, tableSchemaName, tableName))
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating over query rows: %w", err)
+	}
+
+	return missingTables, nil
 }
 
 func (yb *YugabyteDB) GetMissingAssessMigrationPermissions() ([]string, bool, error) {

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -1337,23 +1337,26 @@ func (yb *YugabyteDB) GetMissingExportSchemaPermissions(queryTableList string) (
 func (yb *YugabyteDB) GetMissingExportDataPermissions(exportType string, finalTableList []sqlname.NameTuple) ([]string, bool, error) {
 	var combinedResult []string
 
-	qualifiedMinQuotedTableNames := lo.Map(finalTableList, func(table sqlname.NameTuple, _ int) string {
-		return table.ForOutput()
-	})
-	queryTableList := fmt.Sprintf("'%s'", strings.Join(qualifiedMinQuotedTableNames, "','"))
-
-	missingTables, err := yb.listTablesMissingReplicaIdentityChange(queryTableList)
-	if err != nil {
-		return nil, false, fmt.Errorf("error in checking table replica identity: %w", err)
-	}
-	if len(missingTables) > 0 {
-		combinedResult = append(combinedResult, fmt.Sprintf("\n%s[%s]", color.RedString("Tables missing replica identity CHANGE: "), strings.Join(missingTables, ", ")))
+	if !yb.source.IsYBGrpcConnector && (exportType == utils.CHANGES_ONLY || exportType == utils.SNAPSHOT_AND_CHANGES) {
+		tablesWithoutReplicaIdentityChange, err := yb.listTablesMissingReplicaIdentityChange(finalTableList)
+		if err != nil {
+			return nil, false, fmt.Errorf("error in checking table replica identity: %w", err)
+		}
+		if len(tablesWithoutReplicaIdentityChange) > 0 {
+			combinedResult = append(combinedResult, fmt.Sprintf("\n%s[%s]", color.RedString("Tables not having replica identity CHANGE: "), strings.Join(tablesWithoutReplicaIdentityChange, ", ")))
+		}
 	}
 
 	return combinedResult, len(combinedResult) > 0, nil
 }
 
-func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(queryTableList string) ([]string, error) {
+func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(tableList []sqlname.NameTuple) ([]string, error) {
+	var tableNamePairs []string
+	for _, table := range tableList {
+		sname, tname := table.ForCatalogQuery()
+		tableNamePairs = append(tableNamePairs, fmt.Sprintf("('%s','%s')", sname, tname))
+	}
+
 	checkTableReplicaIdentityQuery := fmt.Sprintf(`
 	SELECT
 		n.nspname AS schema_name,
@@ -1366,9 +1369,9 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(queryTableList stri
 		END AS status
 	FROM pg_class c
 	JOIN pg_namespace n ON c.relnamespace = n.oid
-	WHERE (quote_ident(n.nspname) || '.' || quote_ident(c.relname)) IN (%s)
+	WHERE (n.nspname, c.relname) IN (%s)
 	AND c.relkind IN ('r', 'p');
-	`, MISSING, GRANTED, queryTableList)
+	`, MISSING, GRANTED, strings.Join(tableNamePairs, ","))
 
 	rows, err := yb.db.Query(checkTableReplicaIdentityQuery)
 	if err != nil {
@@ -1381,7 +1384,7 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(queryTableList stri
 		}
 	}()
 
-	var missingTables []string
+	var tablesWithoutReplicaIdentityChange []string
 	var tableSchemaName, tableName, replicaIdentity, status string
 
 	for rows.Next() {
@@ -1390,7 +1393,7 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(queryTableList stri
 			return nil, fmt.Errorf("error in scanning query rows for table names: %w", err)
 		}
 		if status == MISSING {
-			missingTables = append(missingTables, fmt.Sprintf(`%s."%s"`, tableSchemaName, tableName))
+			tablesWithoutReplicaIdentityChange = append(tablesWithoutReplicaIdentityChange, sqlname.NewSourceName(tableSchemaName, tableName).Qualified.MinQuoted)
 		}
 	}
 
@@ -1398,7 +1401,7 @@ func (yb *YugabyteDB) listTablesMissingReplicaIdentityChange(queryTableList stri
 		return nil, fmt.Errorf("error iterating over query rows: %w", err)
 	}
 
-	return missingTables, nil
+	return tablesWithoutReplicaIdentityChange, nil
 }
 
 func (yb *YugabyteDB) GetMissingAssessMigrationPermissions() ([]string, bool, error) {

--- a/yb-voyager/src/srcdb/yugabytedb_test.go
+++ b/yb-voyager/src/srcdb/yugabytedb_test.go
@@ -789,6 +789,87 @@ func TestYugabyteGetColumnsWithSupportedTypes_AllScenarios(t *testing.T) {
 	})
 }
 
+func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
+	testYugabyteDBSource.TestContainer.ExecuteSqls(
+		`CREATE SCHEMA ri_test;`,
+		`CREATE TABLE ri_test.with_full_identity (
+			id INT PRIMARY KEY,
+			name VARCHAR(100)
+		);`,
+		`ALTER TABLE ri_test.with_full_identity REPLICA IDENTITY FULL;`,
+		`CREATE TABLE ri_test.without_identity (
+			id INT PRIMARY KEY,
+			name VARCHAR(100)
+		);`,
+	)
+	defer testYugabyteDBSource.TestContainer.ExecuteSqls(`DROP SCHEMA ri_test CASCADE;`)
+
+	ybDB := testYugabyteDBSource.DB().(*YugabyteDB)
+
+	tableWithFull := testutils.CreateNameTupleWithSourceName("ri_test.with_full_identity", "ri_test", constants.YUGABYTEDB)
+	tableWithoutIdentity := testutils.CreateNameTupleWithSourceName("ri_test.without_identity", "ri_test", constants.YUGABYTEDB)
+
+	// Case 1: Table WITH REPLICA IDENTITY FULL → should NOT appear in result
+	t.Run("TableWithFullReplicaIdentityNotMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithFull})
+		assert.NilError(t, err)
+		assert.Equal(t, 0, len(result), "Expected no tables missing replica identity, got: %v", result)
+	})
+
+	// Case 2: Table WITHOUT replica identity change (default 'd') → IS in result
+	t.Run("TableWithDefaultReplicaIdentityIsMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithoutIdentity})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity, got: %v", result)
+		assert.Equal(t, `ri_test.without_identity`, result[0])
+	})
+
+	// Case 3: Mixed list → only the default-identity table appears
+	t.Run("MixedListOnlyDefaultAppears", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithFull, tableWithoutIdentity})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity, got: %v", result)
+		assert.Equal(t, `ri_test.without_identity`, result[0])
+	})
+
+	// Case 4: exportType = "snapshot-only" → check skipped, empty result, hasMissing = false
+	t.Run("SnapshotOnlyExportTypeSkipsCheck", func(t *testing.T) {
+		ybDB.source.IsYBGrpcConnector = false
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_ONLY, []sqlname.NameTuple{tableWithoutIdentity})
+		assert.NilError(t, err)
+		assert.Equal(t, false, hasMissing)
+		assert.Equal(t, 0, len(msgs))
+	})
+
+	// Case 5: exportType = "changes-only" → missing table appears in result
+	t.Run("ChangesOnlyExportTypeDetectsMissing", func(t *testing.T) {
+		ybDB.source.IsYBGrpcConnector = false
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutIdentity})
+		assert.NilError(t, err)
+		assert.Equal(t, true, hasMissing)
+		assert.Equal(t, 1, len(msgs))
+	})
+
+	// Case 6: exportType = "snapshot-and-changes" → missing table appears in result
+	t.Run("SnapshotAndChangesExportTypeDetectsMissing", func(t *testing.T) {
+		ybDB.source.IsYBGrpcConnector = false
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_AND_CHANGES, []sqlname.NameTuple{tableWithoutIdentity})
+		assert.NilError(t, err)
+		assert.Equal(t, true, hasMissing)
+		assert.Equal(t, 1, len(msgs))
+	})
+
+	// Case 7: IsYBGrpcConnector = true → check skipped entirely, empty result
+	t.Run("GRPCConnectorSkipsCheck", func(t *testing.T) {
+		ybDB.source.IsYBGrpcConnector = true
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutIdentity})
+		assert.NilError(t, err)
+		assert.Equal(t, false, hasMissing)
+		assert.Equal(t, 0, len(msgs))
+		ybDB.source.IsYBGrpcConnector = false // restore
+	})
+}
+
 func TestYugabyteGetPrimaryKeyColumns(t *testing.T) {
 	testYugabyteDBSource.TestContainer.ExecuteSqls(
 		`CREATE SCHEMA test_schema;`,

--- a/yb-voyager/src/srcdb/yugabytedb_test.go
+++ b/yb-voyager/src/srcdb/yugabytedb_test.go
@@ -790,52 +790,55 @@ func TestYugabyteGetColumnsWithSupportedTypes_AllScenarios(t *testing.T) {
 }
 
 func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
+	// In YugabyteDB, the default replica identity for new tables is already CHANGE ('c'),
+	// unlike PostgreSQL which defaults to DEFAULT ('d'). To test a table without CHANGE
+	// identity we must explicitly alter it to FULL ('f').
 	testYugabyteDBSource.TestContainer.ExecuteSqls(
 		`CREATE SCHEMA ri_test;`,
-		`CREATE TABLE ri_test.with_full_identity (
+		`CREATE TABLE ri_test.with_change_identity (
 			id INT PRIMARY KEY,
 			name VARCHAR(100)
 		);`,
-		`ALTER TABLE ri_test.with_full_identity REPLICA IDENTITY FULL;`,
-		`CREATE TABLE ri_test.without_identity (
+		`CREATE TABLE ri_test.without_change_identity (
 			id INT PRIMARY KEY,
 			name VARCHAR(100)
 		);`,
+		`ALTER TABLE ri_test.without_change_identity REPLICA IDENTITY FULL;`,
 	)
 	defer testYugabyteDBSource.TestContainer.ExecuteSqls(`DROP SCHEMA ri_test CASCADE;`)
 
 	ybDB := testYugabyteDBSource.DB().(*YugabyteDB)
 
-	tableWithFull := testutils.CreateNameTupleWithSourceName("ri_test.with_full_identity", "ri_test", constants.YUGABYTEDB)
-	tableWithoutIdentity := testutils.CreateNameTupleWithSourceName("ri_test.without_identity", "ri_test", constants.YUGABYTEDB)
+	tableWithChange := testutils.CreateNameTupleWithSourceName("ri_test.with_change_identity", "ri_test", constants.YUGABYTEDB)
+	tableWithoutChange := testutils.CreateNameTupleWithSourceName("ri_test.without_change_identity", "ri_test", constants.YUGABYTEDB)
 
-	// Case 1: Table WITH REPLICA IDENTITY FULL → should NOT appear in result
-	t.Run("TableWithFullReplicaIdentityNotMissing", func(t *testing.T) {
-		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithFull})
+	// Case 1: Table with default YB replica identity (CHANGE) → should NOT appear in result
+	t.Run("TableWithChangeReplicaIdentityNotMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithChange})
 		assert.NilError(t, err)
-		assert.Equal(t, 0, len(result), "Expected no tables missing replica identity, got: %v", result)
+		assert.Equal(t, 0, len(result), "Expected no tables missing replica identity CHANGE, got: %v", result)
 	})
 
-	// Case 2: Table WITHOUT replica identity change (default 'd') → IS in result
-	t.Run("TableWithDefaultReplicaIdentityIsMissing", func(t *testing.T) {
-		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithoutIdentity})
+	// Case 2: Table with REPLICA IDENTITY FULL (not CHANGE) → IS in result
+	t.Run("TableWithFullReplicaIdentityIsMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithoutChange})
 		assert.NilError(t, err)
-		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity, got: %v", result)
-		assert.Equal(t, `ri_test.without_identity`, result[0])
+		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
+		assert.Equal(t, `ri_test.without_change_identity`, result[0])
 	})
 
-	// Case 3: Mixed list → only the default-identity table appears
-	t.Run("MixedListOnlyDefaultAppears", func(t *testing.T) {
-		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithFull, tableWithoutIdentity})
+	// Case 3: Mixed list → only the non-CHANGE table appears
+	t.Run("MixedListOnlyNonChangeAppears", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithChange, tableWithoutChange})
 		assert.NilError(t, err)
-		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity, got: %v", result)
-		assert.Equal(t, `ri_test.without_identity`, result[0])
+		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
+		assert.Equal(t, `ri_test.without_change_identity`, result[0])
 	})
 
 	// Case 4: exportType = "snapshot-only" → check skipped, empty result, hasMissing = false
 	t.Run("SnapshotOnlyExportTypeSkipsCheck", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = false
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_ONLY, []sqlname.NameTuple{tableWithoutIdentity})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_ONLY, []sqlname.NameTuple{tableWithoutChange})
 		assert.NilError(t, err)
 		assert.Equal(t, false, hasMissing)
 		assert.Equal(t, 0, len(msgs))
@@ -844,7 +847,7 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 	// Case 5: exportType = "changes-only" → missing table appears in result
 	t.Run("ChangesOnlyExportTypeDetectsMissing", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = false
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutIdentity})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutChange})
 		assert.NilError(t, err)
 		assert.Equal(t, true, hasMissing)
 		assert.Equal(t, 1, len(msgs))
@@ -853,7 +856,7 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 	// Case 6: exportType = "snapshot-and-changes" → missing table appears in result
 	t.Run("SnapshotAndChangesExportTypeDetectsMissing", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = false
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_AND_CHANGES, []sqlname.NameTuple{tableWithoutIdentity})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_AND_CHANGES, []sqlname.NameTuple{tableWithoutChange})
 		assert.NilError(t, err)
 		assert.Equal(t, true, hasMissing)
 		assert.Equal(t, 1, len(msgs))
@@ -862,7 +865,7 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 	// Case 7: IsYBGrpcConnector = true → check skipped entirely, empty result
 	t.Run("GRPCConnectorSkipsCheck", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = true
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutIdentity})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutChange})
 		assert.NilError(t, err)
 		assert.Equal(t, false, hasMissing)
 		assert.Equal(t, 0, len(msgs))

--- a/yb-voyager/src/srcdb/yugabytedb_test.go
+++ b/yb-voyager/src/srcdb/yugabytedb_test.go
@@ -845,7 +845,7 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithFull})
 		assert.NilError(t, err)
 		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
-		assert.Equal(t, `ri_test.with_full_identity`, result[0])
+		assert.Equal(t, tableWithFull, result[0])
 	})
 
 	// Case 3: Table with REPLICA IDENTITY DEFAULT ('d') → IS in result
@@ -853,7 +853,7 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithDefault})
 		assert.NilError(t, err)
 		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
-		assert.Equal(t, `ri_test.with_default_identity`, result[0])
+		assert.Equal(t, tableWithDefault, result[0])
 	})
 
 	// Case 4: Table with REPLICA IDENTITY NOTHING ('n') → IS in result
@@ -861,7 +861,7 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithNothing})
 		assert.NilError(t, err)
 		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
-		assert.Equal(t, `ri_test.with_nothing_identity`, result[0])
+		assert.Equal(t, tableWithNothing, result[0])
 	})
 
 	// Case 5: All three non-CHANGE types together → all three reported
@@ -887,7 +887,7 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{caseSensitiveMissing})
 		assert.NilError(t, err)
 		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
-		assert.Equal(t, `"RiTest"."CaseSensitive"`, result[0])
+		assert.Equal(t, caseSensitiveMissing, result[0])
 	})
 
 	// Case 9: Case-sensitive quoted name with CHANGE identity → NOT reported

--- a/yb-voyager/src/srcdb/yugabytedb_test.go
+++ b/yb-voyager/src/srcdb/yugabytedb_test.go
@@ -792,25 +792,46 @@ func TestYugabyteGetColumnsWithSupportedTypes_AllScenarios(t *testing.T) {
 func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 	// In YugabyteDB, the default replica identity for new tables is already CHANGE ('c'),
 	// unlike PostgreSQL which defaults to DEFAULT ('d'). To test a table without CHANGE
-	// identity we must explicitly alter it to FULL ('f').
+	// identity we must explicitly alter it.
+	//
+	// YugabyteDB supports four replica identity modes (INDEX is not supported):
+	//   c = CHANGE   (YB default — only changed columns; NOT reported)
+	//   d = DEFAULT  (PK columns only)
+	//   f = FULL     (all columns)
+	//   n = NOTHING  (nothing)
+	// All modes other than CHANGE should be reported as missing.
 	testYugabyteDBSource.TestContainer.ExecuteSqls(
 		`CREATE SCHEMA ri_test;`,
-		`CREATE TABLE ri_test.with_change_identity (
-			id INT PRIMARY KEY,
-			name VARCHAR(100)
-		);`,
-		`CREATE TABLE ri_test.without_change_identity (
-			id INT PRIMARY KEY,
-			name VARCHAR(100)
-		);`,
-		`ALTER TABLE ri_test.without_change_identity REPLICA IDENTITY FULL;`,
+		// CHANGE identity (YB default — should NOT be reported)
+		`CREATE TABLE ri_test.with_change_identity (id INT PRIMARY KEY, name VARCHAR(100));`,
+		// FULL identity
+		`CREATE TABLE ri_test.with_full_identity (id INT PRIMARY KEY, name VARCHAR(100));`,
+		`ALTER TABLE ri_test.with_full_identity REPLICA IDENTITY FULL;`,
+		// DEFAULT identity ('d')
+		`CREATE TABLE ri_test.with_default_identity (id INT PRIMARY KEY, name VARCHAR(100));`,
+		`ALTER TABLE ri_test.with_default_identity REPLICA IDENTITY DEFAULT;`,
+		// NOTHING identity ('n')
+		`CREATE TABLE ri_test.with_nothing_identity (id INT PRIMARY KEY, name VARCHAR(100));`,
+		`ALTER TABLE ri_test.with_nothing_identity REPLICA IDENTITY NOTHING;`,
+		// Case-sensitive schema and table names
+		`CREATE SCHEMA "RiTest";`,
+		`CREATE TABLE "RiTest"."CaseSensitive" (id INT PRIMARY KEY, name VARCHAR(100));`,
+		`ALTER TABLE "RiTest"."CaseSensitive" REPLICA IDENTITY FULL;`,
+		`CREATE TABLE "RiTest"."WithChange" (id INT PRIMARY KEY, name VARCHAR(100));`,
 	)
-	defer testYugabyteDBSource.TestContainer.ExecuteSqls(`DROP SCHEMA ri_test CASCADE;`)
+	defer testYugabyteDBSource.TestContainer.ExecuteSqls(
+		`DROP SCHEMA ri_test CASCADE;`,
+		`DROP SCHEMA "RiTest" CASCADE;`,
+	)
 
 	ybDB := testYugabyteDBSource.DB().(*YugabyteDB)
 
 	tableWithChange := testutils.CreateNameTupleWithSourceName("ri_test.with_change_identity", "ri_test", constants.YUGABYTEDB)
-	tableWithoutChange := testutils.CreateNameTupleWithSourceName("ri_test.without_change_identity", "ri_test", constants.YUGABYTEDB)
+	tableWithFull := testutils.CreateNameTupleWithSourceName("ri_test.with_full_identity", "ri_test", constants.YUGABYTEDB)
+	tableWithDefault := testutils.CreateNameTupleWithSourceName("ri_test.with_default_identity", "ri_test", constants.YUGABYTEDB)
+	tableWithNothing := testutils.CreateNameTupleWithSourceName("ri_test.with_nothing_identity", "ri_test", constants.YUGABYTEDB)
+	caseSensitiveMissing := testutils.CreateNameTupleWithSourceName(`"RiTest"."CaseSensitive"`, "RiTest", constants.YUGABYTEDB)
+	caseSensitiveChange := testutils.CreateNameTupleWithSourceName(`"RiTest"."WithChange"`, "RiTest", constants.YUGABYTEDB)
 
 	// Case 1: Table with default YB replica identity (CHANGE) → should NOT appear in result
 	t.Run("TableWithChangeReplicaIdentityNotMissing", func(t *testing.T) {
@@ -819,53 +840,94 @@ func TestYugabyteReplicaIdentityGuardrail(t *testing.T) {
 		assert.Equal(t, 0, len(result), "Expected no tables missing replica identity CHANGE, got: %v", result)
 	})
 
-	// Case 2: Table with REPLICA IDENTITY FULL (not CHANGE) → IS in result
+	// Case 2: Table with REPLICA IDENTITY FULL → IS in result
 	t.Run("TableWithFullReplicaIdentityIsMissing", func(t *testing.T) {
-		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithoutChange})
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithFull})
 		assert.NilError(t, err)
 		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
-		assert.Equal(t, `ri_test.without_change_identity`, result[0])
+		assert.Equal(t, `ri_test.with_full_identity`, result[0])
 	})
 
-	// Case 3: Mixed list → only the non-CHANGE table appears
+	// Case 3: Table with REPLICA IDENTITY DEFAULT ('d') → IS in result
+	t.Run("TableWithDefaultReplicaIdentityIsMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithDefault})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
+		assert.Equal(t, `ri_test.with_default_identity`, result[0])
+	})
+
+	// Case 4: Table with REPLICA IDENTITY NOTHING ('n') → IS in result
+	t.Run("TableWithNothingReplicaIdentityIsMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithNothing})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
+		assert.Equal(t, `ri_test.with_nothing_identity`, result[0])
+	})
+
+	// Case 5: All three non-CHANGE types together → all three reported
+	t.Run("AllNonChangeTypesAllReported", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{
+			tableWithFull, tableWithDefault, tableWithNothing,
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, 3, len(result), "Expected all 3 non-CHANGE tables to be reported, got: %v", result)
+	})
+
+	// Case 6: Mixed list (CHANGE + all non-CHANGE types) → only non-CHANGE tables appear
 	t.Run("MixedListOnlyNonChangeAppears", func(t *testing.T) {
-		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{tableWithChange, tableWithoutChange})
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{
+			tableWithChange, tableWithFull, tableWithDefault, tableWithNothing,
+		})
 		assert.NilError(t, err)
-		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
-		assert.Equal(t, `ri_test.without_change_identity`, result[0])
+		assert.Equal(t, 3, len(result), "Expected 3 tables missing replica identity CHANGE, got: %v", result)
 	})
 
-	// Case 4: exportType = "snapshot-only" → check skipped, empty result, hasMissing = false
+	// Case 8: Case-sensitive quoted names — missing table uses quoted output format
+	t.Run("CaseSensitiveTableNameIsMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{caseSensitiveMissing})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(result), "Expected 1 table missing replica identity CHANGE, got: %v", result)
+		assert.Equal(t, `"RiTest"."CaseSensitive"`, result[0])
+	})
+
+	// Case 9: Case-sensitive quoted name with CHANGE identity → NOT reported
+	t.Run("CaseSensitiveTableWithChangeNotMissing", func(t *testing.T) {
+		result, err := ybDB.listTablesMissingReplicaIdentityChange([]sqlname.NameTuple{caseSensitiveChange})
+		assert.NilError(t, err)
+		assert.Equal(t, 0, len(result), "Expected no tables missing replica identity CHANGE, got: %v", result)
+	})
+
+	// Case 10: exportType = "snapshot-only" → check skipped, empty result, hasMissing = false
 	t.Run("SnapshotOnlyExportTypeSkipsCheck", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = false
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_ONLY, []sqlname.NameTuple{tableWithoutChange})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_ONLY, []sqlname.NameTuple{tableWithFull})
 		assert.NilError(t, err)
 		assert.Equal(t, false, hasMissing)
 		assert.Equal(t, 0, len(msgs))
 	})
 
-	// Case 5: exportType = "changes-only" → missing table appears in result
+	// Case 11: exportType = "changes-only" → missing table appears in result
 	t.Run("ChangesOnlyExportTypeDetectsMissing", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = false
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutChange})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithFull})
 		assert.NilError(t, err)
 		assert.Equal(t, true, hasMissing)
 		assert.Equal(t, 1, len(msgs))
 	})
 
-	// Case 6: exportType = "snapshot-and-changes" → missing table appears in result
+	// Case 12: exportType = "snapshot-and-changes" → missing table appears in result
 	t.Run("SnapshotAndChangesExportTypeDetectsMissing", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = false
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_AND_CHANGES, []sqlname.NameTuple{tableWithoutChange})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.SNAPSHOT_AND_CHANGES, []sqlname.NameTuple{tableWithFull})
 		assert.NilError(t, err)
 		assert.Equal(t, true, hasMissing)
 		assert.Equal(t, 1, len(msgs))
 	})
 
-	// Case 7: IsYBGrpcConnector = true → check skipped entirely, empty result
+	// Case 13: IsYBGrpcConnector = true → check skipped entirely, empty result
 	t.Run("GRPCConnectorSkipsCheck", func(t *testing.T) {
 		ybDB.source.IsYBGrpcConnector = true
-		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithoutChange})
+		msgs, hasMissing, err := ybDB.GetMissingExportDataPermissions(utils.CHANGES_ONLY, []sqlname.NameTuple{tableWithFull})
 		assert.NilError(t, err)
 		assert.Equal(t, false, hasMissing)
 		assert.Equal(t, 0, len(msgs))

--- a/yb-voyager/src/testlivemigration/export_data_from_target_failures_test.go
+++ b/yb-voyager/src/testlivemigration/export_data_from_target_failures_test.go
@@ -39,7 +39,10 @@ const (
 	ffExportFailureWaitCutover           = 120 // seconds; passed as time.Duration to helpers that multiply by time.Second
 )
 
-// ffExportFailureSchemaSQL returns DDL for a single table in test_schema_ff (drop/create schema + table + replica identity).
+// ffExportFailureSchemaSQL returns DDL for a single table in test_schema_ff (drop/create schema + table).
+// The REPLICA IDENTITY FULL is intentionally NOT included here; it is applied only to the
+// PostgreSQL source via SourceSetupSchemaSQL so that the YugabyteDB target retains its
+// default REPLICA IDENTITY CHANGE (required by the replica identity guardrail).
 func ffExportFailureSchemaSQL(tableFQ string) []string {
 	return []string{
 		"DROP SCHEMA IF EXISTS test_schema_ff CASCADE;",
@@ -50,6 +53,12 @@ func ffExportFailureSchemaSQL(tableFQ string) []string {
 			value INTEGER,
 			created_at TIMESTAMP DEFAULT NOW()
 		);`, tableFQ),
+	}
+}
+
+// ffExportFailureSourceSetupSQL returns source-only SQL for replica identity setup.
+func ffExportFailureSourceSetupSQL(tableFQ string) []string {
+	return []string{
 		fmt.Sprintf(`ALTER TABLE %s REPLICA IDENTITY FULL;`, tableFQ),
 	}
 }
@@ -70,16 +79,18 @@ func newFFExportFailureLiveMigrationTest(t *testing.T, dbStem, tableShort string
 	tableFQ := fmt.Sprintf("%s.%s", ffExportFailureSchema, tableShort)
 	initial, srcDelta, tgtDelta := ffExportFailureDeltaSQL(tableFQ, snapshotRows)
 	schemaSQL := ffExportFailureSchemaSQL(tableFQ)
+	sourceSetupSQL := ffExportFailureSourceSetupSQL(tableFQ)
 	lm := NewLiveMigrationTest(t, &TestConfig{
-		SourceDB:        ContainerConfig{Type: "postgresql", ForLive: true, DatabaseName: dbStem},
-		TargetDB:        ContainerConfig{Type: "yugabytedb", DatabaseName: dbStem + "_yb"},
-		SourceReplicaDB: ContainerConfig{Type: "postgresql", DatabaseName: dbStem + "_replica"},
-		SchemaNames:     []string{ffExportFailureSchema},
-		SchemaSQL:       schemaSQL,
-		InitialDataSQL:  initial,
-		SourceDeltaSQL:  srcDelta,
-		TargetDeltaSQL:  tgtDelta,
-		CleanupSQL:      []string{"DROP SCHEMA IF EXISTS test_schema_ff CASCADE;"},
+		SourceDB:             ContainerConfig{Type: "postgresql", ForLive: true, DatabaseName: dbStem},
+		TargetDB:             ContainerConfig{Type: "yugabytedb", DatabaseName: dbStem + "_yb"},
+		SourceReplicaDB:      ContainerConfig{Type: "postgresql", DatabaseName: dbStem + "_replica"},
+		SchemaNames:          []string{ffExportFailureSchema},
+		SchemaSQL:            schemaSQL,
+		SourceSetupSchemaSQL: sourceSetupSQL,
+		InitialDataSQL:       initial,
+		SourceDeltaSQL:       srcDelta,
+		TargetDeltaSQL:       tgtDelta,
+		CleanupSQL:           []string{"DROP SCHEMA IF EXISTS test_schema_ff CASCADE;"},
 	})
 	return lm, tableFQ
 }


### PR DESCRIPTION
### Describe the changes in this pull request

This PR adds an export-data guardrail for YugabyteDB when it is used as the source database in the export-from-target flow. The guardrail checks the exported table list against `pg_class.relreplident` and reports any table whose replica identity is not `CHANGE`. This mirrors the existing PostgreSQL live migration guardrail that requires replica identity `FULL`, but uses YugabyteDB's expected `CHANGE` identity for the YB CDC path.

The check runs through `YugabyteDB.GetMissingExportDataPermissions`, so failures are surfaced through the existing export-data permissions/configuration guardrail path. If non-CHANGE tables are found, Voyager lists them under `Tables missing replica identity CHANGE`.

### Describe if there are any user-facing changes

Users running `export data from target` with YugabyteDB logical CDC will now get a blocking guardrail error if any exported YB table does not have replica identity `CHANGE`.

There are no command-line, configuration, installation, or report format changes.

<img width="854" height="546" alt="image" src="https://github.com/user-attachments/assets/289850b8-a1b1-48c8-ba7f-fa4f0d82ea76" />


### How was this pull request tested?

Locally

No new unit tests were added.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |