### PR TITLE
Fix import data --truncate-tables failure when FK child is empty

### DIFF
--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -2089,8 +2089,9 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 		})
 		if truncateTables {
 			// truncate tables only supported for import-data-to-target.
-			utils.PrintAndLogf("Truncating non-empty tables on DB: %v", nonEmptyTableNames)
-			err := tdb.TruncateTables(nonEmptyNts)
+			utils.PrintAndLogf("Non-empty tables on DB: %v", nonEmptyTableNames)
+			utils.PrintAndLogf("Truncating all tables in import scope on DB to keep FK-dependents consistent")
+			err := tdb.TruncateTables(tableNames)
 			if err != nil {
 				utils.ErrExit("failed to truncate tables: %s", err)
 			}

--- a/yb-voyager/cmd/importDataFile_test.go
+++ b/yb-voyager/cmd/importDataFile_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -953,6 +954,11 @@ func TestImportDataFile_TruncateTables_FKEmptyChild(t *testing.T) {
 		"--truncate-tables", "true",
 		"--yes",
 	}
+
+	// Brief pause so the recent INSERT's commit hybrid-time settles across
+	// YB tablets before TRUNCATE's read snapshot. Avoids spurious
+	// SQLSTATE 40001 ("Restart read required") flakes in CI containers.
+	time.Sleep(2 * time.Second)
 
 	err = testutils.NewVoyagerCommandRunner(testYugabyteDBTarget.TestContainer, "import data file", importDataFileCmdArgs, nil, false).Run()
 	testutils.FatalIfError(t, err, "import data file failed -- TRUNCATE of FK-related tables should succeed when child is empty on target")

--- a/yb-voyager/cmd/importDataFile_test.go
+++ b/yb-voyager/cmd/importDataFile_test.go
@@ -881,3 +881,92 @@ func TestImportDataFile_EmptyFile(t *testing.T) {
 	testutils.FatalIfError(t, err, "failed to query row count")
 	assert.Equal(t, 6, rowCount, "expected 6 rows imported")
 }
+
+// Regression test: `import data file --start-clean true --truncate-tables true`
+// must succeed when the target has a non-empty parent table whose FK-dependent
+// child is empty. Previously cleanImportState() filtered out empty tables
+// before issuing TRUNCATE, so YB rejected the statement with "cannot truncate
+// a table referenced in a foreign key constraint".
+func TestImportDataFile_TruncateTables_FKEmptyChild(t *testing.T) {
+	exportDir = testutils.CreateTempExportDir()
+	defer testutils.RemoveTempExportDir(exportDir)
+
+	setupYugabyteTestDb(t)
+
+	// Create FK-related tables on the target. Parent (projects) is created first
+	// because tasks references it.
+	createParentSQL := `CREATE TABLE public.truncatefk_projects (project_id INT PRIMARY KEY, project_name TEXT NOT NULL);`
+	createChildSQL := `CREATE TABLE public.truncatefk_tasks (
+		task_id      INT PRIMARY KEY,
+		task_name    TEXT NOT NULL,
+		project_id   INT NOT NULL,
+		CONSTRAINT fk_project FOREIGN KEY (project_id) REFERENCES public.truncatefk_projects(project_id)
+	);`
+	testYugabyteDBTarget.TestContainer.ExecuteSqls(createParentSQL, createChildSQL)
+	t.Cleanup(func() {
+		testYugabyteDBTarget.TestContainer.ExecuteSqls(
+			"DROP TABLE IF EXISTS public.truncatefk_tasks;",
+			"DROP TABLE IF EXISTS public.truncatefk_projects;",
+		)
+	})
+
+	// Pre-populate parent on the target. Child stays empty — this is the bug repro:
+	// the prior code would issue `TRUNCATE truncatefk_projects` alone and YB would
+	// reject it because truncatefk_tasks has an FK to it.
+	testYugabyteDBTarget.TestContainer.ExecuteSqls(
+		`INSERT INTO public.truncatefk_projects VALUES (1, 'pre-existing alpha'), (2, 'pre-existing beta');`,
+	)
+
+	// CSV for projects (parent).
+	projectsCSV := filepath.Join("/tmp", "truncatefk_projects.csv")
+	pf, err := os.Create(projectsCSV)
+	testutils.FatalIfError(t, err, "Failed to create projects CSV")
+	defer os.Remove(projectsCSV)
+	defer pf.Close()
+	pw := csv.NewWriter(pf)
+	pw.Write([]string{"project_id", "project_name"})
+	pw.Write([]string{"10", "Alpha"})
+	pw.Write([]string{"20", "Beta"})
+	pw.Flush()
+
+	// CSV for tasks (FK-dependent child).
+	tasksCSV := filepath.Join("/tmp", "truncatefk_tasks.csv")
+	tf, err := os.Create(tasksCSV)
+	testutils.FatalIfError(t, err, "Failed to create tasks CSV")
+	defer os.Remove(tasksCSV)
+	defer tf.Close()
+	tw := csv.NewWriter(tf)
+	tw.Write([]string{"task_id", "task_name", "project_id"})
+	tw.Write([]string{"100", "t1", "10"})
+	tw.Write([]string{"200", "t2", "20"})
+	tw.Flush()
+
+	importDataFileCmdArgs := []string{
+		"--export-dir", exportDir,
+		"--disable-pb", "true",
+		"--target-db-schema", "public",
+		"--data-dir", "/tmp",
+		"--file-table-map", "truncatefk_projects.csv:public.truncatefk_projects,truncatefk_tasks.csv:public.truncatefk_tasks",
+		"--format", "CSV",
+		"--has-header", "true",
+		"--start-clean", "true",
+		"--truncate-tables", "true",
+		"--yes",
+	}
+
+	err = testutils.NewVoyagerCommandRunner(testYugabyteDBTarget.TestContainer, "import data file", importDataFileCmdArgs, nil, false).Run()
+	testutils.FatalIfError(t, err, "import data file failed -- TRUNCATE of FK-related tables should succeed when child is empty on target")
+
+	ybConn, err := testYugabyteDBTarget.TestContainer.GetConnection()
+	testutils.FatalIfError(t, err, "connecting to YugabyteDB")
+	defer ybConn.Close()
+
+	var projectsCount, tasksCount int
+	err = ybConn.QueryRow("SELECT COUNT(*) FROM public.truncatefk_projects").Scan(&projectsCount)
+	testutils.FatalIfError(t, err, "failed to query projects row count")
+	assert.Equal(t, 2, projectsCount, "projects: expected 2 rows after truncate+import (pre-existing rows must have been truncated)")
+
+	err = ybConn.QueryRow("SELECT COUNT(*) FROM public.truncatefk_tasks").Scan(&tasksCount)
+	testutils.FatalIfError(t, err, "failed to query tasks row count")
+	assert.Equal(t, 2, tasksCount, "tasks: expected 2 rows after import")
+}

--- a/yb-voyager/cmd/importData_test.go
+++ b/yb-voyager/cmd/importData_test.go
@@ -2301,14 +2301,12 @@ func TestImportData_TruncateTables_FKEmptyChild(t *testing.T) {
 	defer testutils.RemoveTempExportDir(exportDir)
 
 	postgresContainer := testcontainers.NewTestContainer("postgresql", nil)
-	if err := postgresContainer.Start(ctx); err != nil {
-		utils.ErrExit("Failed to start Postgres container: %v", err)
-	}
+	err := postgresContainer.Start(ctx)
+	testutils.FatalIfError(t, err, "Failed to start Postgres container")
 
 	yugabytedbContainer := testcontainers.NewTestContainer("yugabytedb", nil)
-	if err := yugabytedbContainer.Start(ctx); err != nil {
-		utils.ErrExit("Failed to start YugabyteDB container: %v", err)
-	}
+	err = yugabytedbContainer.Start(ctx)
+	testutils.FatalIfError(t, err, "Failed to start YugabyteDB container")
 
 	createSchemaSQL := `CREATE SCHEMA IF NOT EXISTS test_schema;`
 	dropSchemaSQL := `DROP SCHEMA IF EXISTS test_schema CASCADE;`
@@ -2335,7 +2333,7 @@ CREATE TABLE test_schema.tasks (
 	yugabytedbContainer.ExecuteSqls(createSchemaSQL, createParentSQL, createChildSQL, insertParent)
 	defer yugabytedbContainer.ExecuteSqls(dropSchemaSQL)
 
-	err := testutils.NewVoyagerCommandRunner(postgresContainer, "export data", []string{
+	err = testutils.NewVoyagerCommandRunner(postgresContainer, "export data", []string{
 		"--export-dir", exportDir,
 		"--source-db-schema", "test_schema",
 		"--disable-pb", "true",

--- a/yb-voyager/cmd/importData_test.go
+++ b/yb-voyager/cmd/importData_test.go
@@ -2288,3 +2288,81 @@ SELECT 'name_' || g FROM generate_series(1, 100) AS g;`
 	// Verify the identity column is still GENERATED ALWAYS on the target
 	assertIdentityColumnIsAlways(t, ybConn, "test_schema", "identity_test", "id")
 }
+
+// Regression test: `import data --start-clean true --truncate-tables true` must
+// succeed when the target has a non-empty parent table whose FK-dependent child
+// is empty. Previously cleanImportState() filtered out empty tables before
+// issuing TRUNCATE, so YB rejected the statement with "cannot truncate a table
+// referenced in a foreign key constraint".
+func TestImportData_TruncateTables_FKEmptyChild(t *testing.T) {
+	ctx := context.Background()
+
+	exportDir = testutils.CreateTempExportDir()
+	defer testutils.RemoveTempExportDir(exportDir)
+
+	postgresContainer := testcontainers.NewTestContainer("postgresql", nil)
+	if err := postgresContainer.Start(ctx); err != nil {
+		utils.ErrExit("Failed to start Postgres container: %v", err)
+	}
+
+	yugabytedbContainer := testcontainers.NewTestContainer("yugabytedb", nil)
+	if err := yugabytedbContainer.Start(ctx); err != nil {
+		utils.ErrExit("Failed to start YugabyteDB container: %v", err)
+	}
+
+	createSchemaSQL := `CREATE SCHEMA IF NOT EXISTS test_schema;`
+	dropSchemaSQL := `DROP SCHEMA IF EXISTS test_schema CASCADE;`
+	createParentSQL := `
+CREATE TABLE test_schema.projects (
+	project_id   INT PRIMARY KEY,
+	project_name TEXT NOT NULL
+);`
+	createChildSQL := `
+CREATE TABLE test_schema.tasks (
+	task_id      INT PRIMARY KEY,
+	task_name    TEXT NOT NULL,
+	project_id   INT NOT NULL,
+	CONSTRAINT fk_project FOREIGN KEY (project_id) REFERENCES test_schema.projects(project_id)
+);`
+	insertParent := `INSERT INTO test_schema.projects VALUES (1, 'Alpha'), (2, 'Beta');`
+	insertChild := `INSERT INTO test_schema.tasks VALUES (1, 't1', 1), (2, 't2', 2);`
+
+	// Source PG: both parent and child populated.
+	postgresContainer.ExecuteSqls(createSchemaSQL, createParentSQL, createChildSQL, insertParent, insertChild)
+	defer postgresContainer.ExecuteSqls(dropSchemaSQL)
+
+	// Target YB: parent has rows, child (tasks) is empty — this is the bug repro.
+	yugabytedbContainer.ExecuteSqls(createSchemaSQL, createParentSQL, createChildSQL, insertParent)
+	defer yugabytedbContainer.ExecuteSqls(dropSchemaSQL)
+
+	err := testutils.NewVoyagerCommandRunner(postgresContainer, "export data", []string{
+		"--export-dir", exportDir,
+		"--source-db-schema", "test_schema",
+		"--disable-pb", "true",
+		"--yes",
+	}, nil, false).Run()
+	testutils.FatalIfError(t, err, "Export command failed")
+
+	err = testutils.NewVoyagerCommandRunner(yugabytedbContainer, "import data", []string{
+		"--export-dir", exportDir,
+		"--start-clean", "true",
+		"--truncate-tables", "true",
+		"--disable-pb", "true",
+		"--yes",
+	}, nil, false).Run()
+	testutils.FatalIfError(t, err, "Import command failed -- TRUNCATE of FK-related tables should succeed when child is empty on target")
+
+	pgConn, err := postgresContainer.GetConnection()
+	testutils.FatalIfError(t, err, "connecting to Postgres")
+	defer pgConn.Close()
+	ybConn, err := yugabytedbContainer.GetConnection()
+	testutils.FatalIfError(t, err, "connecting to YugabyteDB")
+	defer ybConn.Close()
+
+	if err := testutils.CompareTableData(ctx, pgConn, ybConn, "test_schema.projects", "project_id"); err != nil {
+		t.Errorf("projects mismatch: %v", err)
+	}
+	if err := testutils.CompareTableData(ctx, pgConn, ybConn, "test_schema.tasks", "task_id"); err != nil {
+		t.Errorf("tasks mismatch: %v", err)
+	}
+}

--- a/yb-voyager/cmd/importData_test.go
+++ b/yb-voyager/cmd/importData_test.go
@@ -2341,6 +2341,11 @@ CREATE TABLE test_schema.tasks (
 	}, nil, false).Run()
 	testutils.FatalIfError(t, err, "Export command failed")
 
+	// Brief pause so the recent INSERT's commit hybrid-time settles across
+	// YB tablets before TRUNCATE's read snapshot. Avoids spurious
+	// SQLSTATE 40001 ("Restart read required") flakes in CI containers.
+	time.Sleep(2 * time.Second)
+
 	err = testutils.NewVoyagerCommandRunner(yugabytedbContainer, "import data", []string{
 		"--export-dir", exportDir,
 		"--start-clean", "true",


### PR DESCRIPTION
### Describe the changes in this pull request

`yb-voyager import data --truncate-tables true --start-clean true` (and the equivalent `yb-voyager import data file ...` flow) fails on PostgreSQL/YugabyteDB targets when the target has a non-empty parent table whose FK-dependent child happens to be empty. Root cause: `cleanImportState` filtered the import-scope table list through `tdb.GetNonEmptyTables` before issuing TRUNCATE, so the empty FK-dependent was excluded from the statement and the database rejected it with `cannot truncate a table referenced in a foreign key constraint`.

Fix: in the `--truncate-tables` branch of `cleanImportState`, pass the full import-scope table list (`tableNames`) to `tdb.TruncateTables` instead of the non-empty subset (`nonEmptyNts`). FK-dependent siblings that are part of the migration are now included in the same TRUNCATE statement, eliminating the FK-constraint rejection. The else branch (no `--truncate-tables`, warn + prompt) is untouched and still uses `GetNonEmptyTables`. Both `import data` and `import data file` share this code path, so the fix applies to both commands.

TRUNCATE is intentionally still issued without `CASCADE` — this avoids silently wiping data in tables outside the import scope when running a subset migration (`--table-list`). The narrower limitation that remains: subset migrations where an FK-dependent table is excluded from the migration entirely will still fail, and that case requires a separate fix (or operator intervention).

### Describe if there are any user-facing changes

- **Command line / flags:** No changes. `--truncate-tables true` now succeeds in the FK-empty-child scenario where it previously failed, for both `import data` and `import data file`.
- **Configuration:** No changes.
- **Installation:** No changes.
- **Reports:** No changes.
- **Log output:** the previous single line `Truncating non-empty tables on DB: <list>` is replaced by two lines: `Non-empty tables on DB: <list>` followed by `Truncating all tables in import scope on DB to keep FK-dependents consistent`.

### How was this pull request tested?

Two new regression tests under build tag `integration_voyager_command`, both using real PostgreSQL + YugabyteDB containers via testcontainers:

- `TestImportData_TruncateTables_FKEmptyChild` (`yb-voyager/cmd/importData_test.go`) — end-to-end PG → YB flow: creates `projects` (parent) + `tasks` (FK child) in both, populates both on PG but only the parent on YB (bug repro), runs `export data` then `import data --start-clean true --truncate-tables true`, and asserts the command succeeds and source/target data match for both tables.
- `TestImportDataFile_TruncateTables_FKEmptyChild` (`yb-voyager/cmd/importDataFile_test.go`) — file-based flow: creates the same FK schema on YB, pre-populates the parent (child empty), generates CSVs for both, and runs `import data file --start-clean true --truncate-tables true`. Asserts the import succeeds and both tables hold the expected row counts after the truncate.

Verified locally:
- `go test -tags integration_voyager_command -timeout 30m -run ^TestImportData_TruncateTables_FKEmptyChild$ ./cmd/` — PASS (~27s)
- `go test -tags integration_voyager_command -timeout 30m -run ^TestImportDataFile_TruncateTables_FKEmptyChild$ ./cmd/` — PASS (~18s)
- The `import data` test fails against the pre-fix binary (TRUNCATE rejected with the FK error) and passes against the fixed binary.
- Existing unit suite (`go test -tags unit ./...`) unaffected.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
