### PR TITLE
De-flake TestExportFromTargetStartupFailureAndCutoverResume

### DIFF
--- a/yb-voyager/src/testlivemigration/export_data_from_target_failures_test.go
+++ b/yb-voyager/src/testlivemigration/export_data_from_target_failures_test.go
@@ -176,7 +176,7 @@ func TestExportFromTargetStartupFailureAndCutoverResume(t *testing.T) {
 	// Import processes cutover, then exec's into export-data-from-target.
 	// The exec'd process inherits GO_FAILPOINTS and crashes before setting the flag.
 	failMarkerPath := filepath.Join(lm.GetCurrentExportDir(), "logs", "failpoint-export-from-target-startup.log")
-	err = lm.WaitForImportFailpointAndProcessCrash(t, failMarkerPath, 120*time.Second, 60*time.Second)
+	err = lm.WaitForImportFailpointAndProcessCrash(t, failMarkerPath, 120*time.Second, 120*time.Second)
 	require.NoError(t, err, "Export-from-target should crash via failpoint")
 
 	// --- Step 5: Verify cutover is NOT complete ---

--- a/yb-voyager/src/testlivemigration/live_migration_testing_framework.go
+++ b/yb-voyager/src/testlivemigration/live_migration_testing_framework.go
@@ -803,33 +803,7 @@ func (lm *LiveMigrationTest) GetImportRunner() *testutils.VoyagerCommandRunner {
 }
 
 func (lm *LiveMigrationTest) WaitForImportFailpointAndProcessCrash(t *testing.T, markerPath string, markerTimeout, exitTimeout time.Duration) error {
-	matched, err := testutils.WaitForFailpointMarker(markerPath, markerTimeout, 2*time.Second)
-	if err != nil {
-		return goerrors.Errorf("error reading failpoint marker %s: %w", markerPath, err)
-	}
-	if !matched {
-		_ = lm.importCmd.Kill()
-		return goerrors.Errorf("failpoint marker %s did not trigger", markerPath)
-	}
-
-	t.Log("Failpoint marker detected; killing orphaned Debezium and waiting for exit...")
-	lm.KillDebezium(cmd.TARGET_DB_EXPORTER_FF_ROLE)
-	lm.KillDebezium(cmd.TARGET_DB_EXPORTER_FB_ROLE)
-
-	deadline := time.Now().Add(exitTimeout)
-	for {
-		if time.Now().After(deadline) {
-			_ = lm.importCmd.Kill()
-			return goerrors.Errorf("process did not exit after %s — expected a crash", exitTimeout)
-		}
-		if lm.importCmd.IsStopped() {
-			if lm.importCmd.ExitCode() == testutils.ExitCodeSuccess {
-				return goerrors.Errorf("process exited cleanly after failpoint — expected a crash")
-			}
-			return nil
-		}
-		time.Sleep(1 * time.Second)
-	}
+	return testutils.WaitForFailpointAndProcessCrash(t, lm.importCmd, markerPath, markerTimeout, exitTimeout)
 }
 
 func (lm *LiveMigrationTest) GetExportCommandStderr() string {


### PR DESCRIPTION
## Summary
- `TestExportFromTargetStartupFailureAndCutoverResume` was failing intermittently on the Failpoint Tests workflow (13/19 inspected red runs over the last month traced to this test, ~13% test-level rate). Every failure: `process did not exit after 1m0s — expected a crash` at `export_data_from_target_failures_test.go:180`.
- Root cause appears to be voyager's atexit chain (`Debezium.Stop`'s 100s SIGTERM grace, `CleanupChildProcesses`'s 60s per child) occasionally taking longer than the test's 60s `exitTimeout` on slow CI runners.
- This PR (a) makes `WaitForImportFailpointAndProcessCrash` consistent with the other three `WaitFor*FailpointAndProcessCrash` wrappers — a thin one-liner delegating to `testutils.WaitForFailpointAndProcessCrash` — and (b) bumps this test's `exitTimeout` from 60s → 120s to absorb the worst-case atexit latency.
- Local repro: 5 sequential runs with this change all cleared the failpoint-and-process-crash step in seconds (the single failure observed was an unrelated earlier-step snapshot timeout).

## Test plan
- [ ] Failpoint Tests workflow green on this branch across at least 3 consecutive runs.
- [ ] Other tests using `WaitForImportFailpointAndProcessCrash` (`live_migration_failure_test.go`, `import_data_snapshot_and_changes_snapshot_failures_test.go`, `import_data_cdc_failures_test.go`) continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)