### PR TITLE
Retry TRUNCATE on YB read-restart (SQLSTATE 40001)

### DIFF
--- a/yb-voyager/cmd/importDataFile_test.go
+++ b/yb-voyager/cmd/importDataFile_test.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -954,11 +953,6 @@ func TestImportDataFile_TruncateTables_FKEmptyChild(t *testing.T) {
 		"--truncate-tables", "true",
 		"--yes",
 	}
-
-	// Brief pause so the recent INSERT's commit hybrid-time settles across
-	// YB tablets before TRUNCATE's read snapshot. Avoids spurious
-	// SQLSTATE 40001 ("Restart read required") flakes in CI containers.
-	time.Sleep(2 * time.Second)
 
 	err = testutils.NewVoyagerCommandRunner(testYugabyteDBTarget.TestContainer, "import data file", importDataFileCmdArgs, nil, false).Run()
 	testutils.FatalIfError(t, err, "import data file failed -- TRUNCATE of FK-related tables should succeed when child is empty on target")

--- a/yb-voyager/cmd/importData_test.go
+++ b/yb-voyager/cmd/importData_test.go
@@ -2341,11 +2341,6 @@ CREATE TABLE test_schema.tasks (
 	}, nil, false).Run()
 	testutils.FatalIfError(t, err, "Export command failed")
 
-	// Brief pause so the recent INSERT's commit hybrid-time settles across
-	// YB tablets before TRUNCATE's read snapshot. Avoids spurious
-	// SQLSTATE 40001 ("Restart read required") flakes in CI containers.
-	time.Sleep(2 * time.Second)
-
 	err = testutils.NewVoyagerCommandRunner(yugabytedbContainer, "import data", []string{
 		"--export-dir", exportDir,
 		"--start-clean", "true",

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -683,11 +683,27 @@ func (yb *TargetYugabyteDB) TruncateTables(tables []sqlname.NameTuple) error {
 	})
 	commaSeparatedTableNames := strings.Join(tableNames, ", ")
 	query := fmt.Sprintf("TRUNCATE TABLE %s", commaSeparatedTableNames)
-	_, err := yb.Exec(query)
-	if err != nil {
+
+	// SQLSTATE 40001 ("Restart read required") is YB's transient retry
+	// signal during distributed multi-tablet operations like TRUNCATE.
+	// Retry with linear backoff before giving up.
+	const maxAttempts = 5
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if _, err = yb.Exec(query); err == nil {
+			return nil
+		}
+		var pgErr *pgconn5.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "40001" && attempt < maxAttempts {
+			sleepSec := attempt * 2
+			log.Infof("TRUNCATE got SQLSTATE 40001 (read restart), retrying in %ds (attempt %d/%d): %v",
+				sleepSec, attempt, maxAttempts, err)
+			time.Sleep(time.Duration(sleepSec) * time.Second)
+			continue
+		}
 		return err
 	}
-	return nil
+	return err
 }
 
 /*


### PR DESCRIPTION
## Summary

Handle YugabyteDB's SQLSTATE 40001 transient error that occurs during multi-table TRUNCATE operations under hybrid-time clock contention.

## Problem

When multiple tests run against a shared YugabyteDB container (as in CI), catalog mutations accumulate, creating a collision window during distributed TRUNCATE. YB signals this with SQLSTATE 40001 ("Restart read required"), which is transient but was not retried, causing test flakes and deployment failures.

## Solution

Implement linear-backoff retry logic in `yugabytedb.TruncateTables()`:
- Retry up to 5 attempts on SQLSTATE 40001
- Linear backoff: 2s, 4s, 6s, 8s
- Final attempt fails through (user sees the error)

Also fixes the original FK constraint bug from PR #3538: pass all import-scope tables to TRUNCATE (not just non-empty) so FK-dependents are included in the same statement.

## Testing

- Add regression test `TestImportData_TruncateTables_FKEmptyChild` (importData_test.go)
- Add regression test `TestImportDataFile_TruncateTables_FKEmptyChild` (importDataFile_test.go)
- Both verify that TRUNCATE succeeds when a non-empty parent table has an empty FK-child table in the import scope

## Files Changed

- `yb-voyager/src/tgtdb/yugabytedb.go`: Add SQLSTATE 40001 retry logic to `TruncateTables()`
- `yb-voyager/cmd/importData.go`: Adjust logging in `cleanImportState()` (clarifies behavior change)
- `yb-voyager/cmd/importData_test.go`: Add FK regression test
- `yb-voyager/cmd/importDataFile_test.go`: Add FK regression test