### PR TITLE
De-flake CDC batch-failure tests (TestCDCMultiTableBatchFailureAndResume + 2 related)

### DIFF
--- a/yb-voyager/src/testlivemigration/export_data_cdc_failures_test.go
+++ b/yb-voyager/src/testlivemigration/export_data_cdc_failures_test.go
@@ -113,15 +113,13 @@ func TestCDCBatchFailureAndResume(t *testing.T) {
 	bytemanHelper, err := testutils.NewBytemanHelper(exportDir)
 	require.NoError(t, err, "Failed to create Byteman helper")
 
-	bytemanHelper.AddRuleFromBuilder(
-		testutils.NewRule("fail_cdc_batch_2").
-			AtMarker(testutils.MarkerCDC, "before-batch-streaming").
-			If("incrementCounter(\"cdc_batch\") == 2").
-			ThrowException("java.lang.RuntimeException", "TEST: Simulated batch processing failure on batch 2"),
+	bytemanHelper.AddCDCBatchFailAfterWritesRule(
+		"fail_cdc_batch_after_writes",
+		"TEST: Simulated batch processing failure at batch start after writes",
 	)
 	require.NoError(t, bytemanHelper.WriteRules())
 
-	// Run 1: export with Byteman injection - should fail on 2nd CDC batch
+	// Run 1: export with Byteman injection - should fail on a streaming batch after some events have been written.
 	err = lm.StartExportDataWithEnv(true, nil, bytemanHelper.GetEnv())
 	require.NoError(t, err, "Failed to start export")
 
@@ -154,7 +152,7 @@ func TestCDCBatchFailureAndResume(t *testing.T) {
 		time.Sleep(batchSeparationWaitTime)
 	}
 
-	matched, err := bytemanHelper.WaitForInjection(">>> BYTEMAN: fail_cdc_batch_2", 90*time.Second)
+	matched, err := bytemanHelper.WaitForInjection(">>> BYTEMAN: fail_cdc_batch_after_writes", 90*time.Second)
 	require.NoError(t, err, "Should be able to read debezium logs")
 	require.True(t, matched, "Byteman injection should have occurred and been logged")
 
@@ -165,7 +163,13 @@ func TestCDCBatchFailureAndResume(t *testing.T) {
 
 	eventCountAfterFailure, err := testutils.CountEventsInQueueSegments(exportDir)
 	require.NoError(t, err, "Should be able to count CDC events after failure")
-	require.Equal(t, 20, eventCountAfterFailure, "Should have exactly 20 events (batch 1) before failure")
+	// Exact count depends on how Debezium grouped the source-side INSERT/UPDATE/DELETEs
+	// into handleBatch calls. What we require: at least one batch was committed before the
+	// failure (>=1), and the failure prevented at least some events from making it through (<60).
+	require.GreaterOrEqual(t, eventCountAfterFailure, 1,
+		"Failure should have occurred after at least one batch of CDC events was committed")
+	require.Less(t, eventCountAfterFailure, 60,
+		"Failure should have prevented some CDC events from being written before resume")
 
 	testutils.VerifyNoEventIDDuplicates(t, exportDir)
 
@@ -380,14 +384,12 @@ func TestCDCMultipleBatchFailures(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Run 1: fail on 2nd streaming batch
+	// Run 1: fail on a streaming batch after some events have been written.
 	bytemanHelperRun1, err := testutils.NewBytemanHelper(exportDir)
 	require.NoError(t, err, "Failed to create Byteman helper (run 1)")
-	bytemanHelperRun1.AddRuleFromBuilder(
-		testutils.NewRule("fail_cdc_batch_run1").
-			AtMarker(testutils.MarkerCDC, "before-batch-streaming").
-			If("incrementCounter(\"cdc_batch\") == 2").
-			ThrowException("java.lang.RuntimeException", "TEST: Simulated batch failure on run 1"),
+	bytemanHelperRun1.AddCDCBatchFailAfterWritesRule(
+		"fail_cdc_batch_run1",
+		"TEST: Simulated batch failure on run 1",
 	)
 	require.NoError(t, bytemanHelperRun1.WriteRules())
 
@@ -407,7 +409,7 @@ func TestCDCMultipleBatchFailures(t *testing.T) {
 		time.Sleep(batchSeparationWaitTime)
 	}
 
-	matched, err := bytemanHelperRun1.WaitForInjection(">>> BYTEMAN: fail_cdc_batch_run1", 90*time.Second)
+	matched, err := bytemanHelperRun1.WaitForInjection(">>> BYTEMAN: fail_cdc_batch_run1 - throwing", 90*time.Second)
 	require.NoError(t, err, "Should be able to read debezium logs (run 1)")
 	require.True(t, matched, "Byteman injection should have occurred (run 1)")
 
@@ -418,18 +420,22 @@ func TestCDCMultipleBatchFailures(t *testing.T) {
 
 	eventCountAfterRun1, err := testutils.CountEventsInQueueSegments(exportDir)
 	require.NoError(t, err, "Should be able to count events after run 1")
-	require.Equal(t, 20, eventCountAfterRun1, "Expected 20 CDC events after run 1 (batch 1 only)")
+	// At least one batch's worth of events was committed; not all 40 events made it.
+	require.GreaterOrEqual(t, eventCountAfterRun1, 1,
+		"Run 1 failure should have occurred after at least one batch was committed")
+	require.Less(t, eventCountAfterRun1, 40,
+		"Run 1 failure should have prevented some events (out of 40 generated) from being written")
 	testutils.VerifyNoEventIDDuplicates(t, exportDir)
 	assertRowCount(90)
 
-	// Run 2: fail on 2nd streaming batch again (replay batch2 succeeds, batch3 fails)
+	// Run 2: resume, then fail again on a streaming batch after some events have been written.
+	// Debezium replays from the last committed offset (= end of whatever ran 1 committed);
+	// subsequent batches include the un-committed replay events + the new batch3 inserts.
 	bytemanHelperRun2, err := testutils.NewBytemanHelper(exportDir)
 	require.NoError(t, err, "Failed to create Byteman helper (run 2)")
-	bytemanHelperRun2.AddRuleFromBuilder(
-		testutils.NewRule("fail_cdc_batch_run2").
-			AtMarker(testutils.MarkerCDC, "before-batch-streaming").
-			If("incrementCounter(\"cdc_batch\") == 2").
-			ThrowException("java.lang.RuntimeException", "TEST: Simulated batch failure on run 2"),
+	bytemanHelperRun2.AddCDCBatchFailAfterWritesRule(
+		"fail_cdc_batch_run2",
+		"TEST: Simulated batch failure on run 2",
 	)
 	require.NoError(t, bytemanHelperRun2.WriteRules())
 
@@ -444,7 +450,7 @@ func TestCDCMultipleBatchFailures(t *testing.T) {
 	)
 	time.Sleep(batchSeparationWaitTime)
 
-	matched, err = bytemanHelperRun2.WaitForInjection(">>> BYTEMAN: fail_cdc_batch_run2", 90*time.Second)
+	matched, err = bytemanHelperRun2.WaitForInjection(">>> BYTEMAN: fail_cdc_batch_run2 - throwing", 90*time.Second)
 	require.NoError(t, err, "Should be able to read debezium logs (run 2)")
 	require.True(t, matched, "Byteman injection should have occurred (run 2)")
 
@@ -455,7 +461,12 @@ func TestCDCMultipleBatchFailures(t *testing.T) {
 
 	eventCountAfterRun2, err := testutils.CountEventsInQueueSegments(exportDir)
 	require.NoError(t, err, "Should be able to count events after run 2")
-	require.Equal(t, 40, eventCountAfterRun2, "Expected 40 CDC events after run 2 (batch 1 + replayed batch 2)")
+	// Run 2 must have made progress (queue strictly larger than after run 1) and must
+	// have failed before all 60 events made it through.
+	require.Greater(t, eventCountAfterRun2, eventCountAfterRun1,
+		"Run 2 should have committed at least one more batch's worth of events")
+	require.Less(t, eventCountAfterRun2, 60,
+		"Run 2 failure should have prevented some events from being written")
 	testutils.VerifyNoEventIDDuplicates(t, exportDir)
 	assertRowCount(110)
 
@@ -549,11 +560,9 @@ func TestCDCMultiTableBatchFailureAndResume(t *testing.T) {
 	bytemanHelper, err := testutils.NewBytemanHelper(exportDir)
 	require.NoError(t, err, "Failed to create Byteman helper")
 
-	bytemanHelper.AddRuleFromBuilder(
-		testutils.NewRule("fail_multi_tbl_batch_2").
-			AtMarker(testutils.MarkerCDC, "before-batch-streaming").
-			If("incrementCounter(\"cdc_batch\") == 2").
-			ThrowException("java.lang.RuntimeException", "TEST: Simulated multi-table batch failure on batch 2"),
+	bytemanHelper.AddCDCBatchFailAfterWritesRule(
+		"fail_multi_tbl_after_writes",
+		"TEST: Simulated multi-table failure at batch start after writes",
 	)
 	require.NoError(t, bytemanHelper.WriteRules())
 
@@ -586,7 +595,7 @@ func TestCDCMultiTableBatchFailureAndResume(t *testing.T) {
 		time.Sleep(batchSeparationWaitTime)
 	}
 
-	matched, err := bytemanHelper.WaitForInjection(">>> BYTEMAN: fail_multi_tbl_batch_2", 90*time.Second)
+	matched, err := bytemanHelper.WaitForInjection(">>> BYTEMAN: fail_multi_tbl_after_writes", 90*time.Second)
 	require.NoError(t, err, "Should be able to read debezium logs")
 	require.True(t, matched, "Byteman injection should have occurred and been logged")
 
@@ -597,7 +606,13 @@ func TestCDCMultiTableBatchFailureAndResume(t *testing.T) {
 
 	eventCountAfterFailure, err := testutils.CountEventsInQueueSegments(exportDir)
 	require.NoError(t, err, "Should be able to count CDC events after failure")
-	require.Equal(t, 20, eventCountAfterFailure, "Should have exactly 20 events (batch 1 from both tables) before failure")
+	// Exact count depends on how Debezium batched the source-side INSERTs into handleBatch calls.
+	// What we require: at least one batch's events were committed before the failure (>=1),
+	// and the failure prevented at least some events from making it through (<60).
+	require.GreaterOrEqual(t, eventCountAfterFailure, 1,
+		"Failure should have occurred after at least one batch of CDC events was committed")
+	require.Less(t, eventCountAfterFailure, 60,
+		"Failure should have prevented some CDC events from being written before resume")
 
 	testutils.VerifyNoEventIDDuplicates(t, exportDir)
 

--- a/yb-voyager/test/utils/byteman_helper.go
+++ b/yb-voyager/test/utils/byteman_helper.go
@@ -68,6 +68,45 @@ func (b *BytemanHelper) AddRuleFromBuilder(builder *RuleBuilder) {
 	b.AddRule(builder.Build())
 }
 
+// AddCDCBatchFailAfterWritesRule installs a pair of Byteman rules that together cause
+// Debezium to throw at the START of a streaming handleBatch, but only after some prior
+// batch has produced at least one queue write.
+//
+// This is robust against the flake where the very first streaming handleBatch carries
+// only filtered records (e.g. transaction-boundary / heartbeat events that don't make
+// it past checkIfEventNeedsToBeWritten). A simple "throw on the Nth handleBatch" rule
+// fires regardless of whether any user data has actually landed in the queue, which can
+// leave the queue empty when the failure trips.
+//
+// The two installed rules:
+//  1. A counter rule that increments "<ruleName>_events_written" on every
+//     before-write-record marker (i.e. only when an event is actually being queued).
+//  2. The failure rule that throws at before-batch-streaming when
+//     handleBatch_count > 1 AND events_written > 0.
+//
+// On firing, Debezium logs ">>> BYTEMAN: <ruleName> - throwing at next batch start after writes".
+// Tests should use this string with WaitForInjection.
+//
+// Counters are namespaced by ruleName so multiple injection rules in the same JVM do
+// not interfere.
+func (b *BytemanHelper) AddCDCBatchFailAfterWritesRule(ruleName, throwMessage string) {
+	b.AddRule(fmt.Sprintf(`RULE %s_count_writes
+CLASS com.yugabyte.ybvoyager.BytemanMarkers
+METHOD cdc
+AT ENTRY
+IF $1.equals("before-write-record")
+DO incrementCounter("%s_events_written")
+ENDRULE`, ruleName, ruleName))
+	b.AddRule(fmt.Sprintf(`RULE %s
+CLASS com.yugabyte.ybvoyager.BytemanMarkers
+METHOD cdc
+AT ENTRY
+IF $1.equals("before-batch-streaming") && incrementCounter("%s_cdc_batch") > 1 && readCounter("%s_events_written") > 0
+DO traceln(">>> BYTEMAN: %s - throwing at next batch start after writes");
+   throw new java.lang.RuntimeException("%s")
+ENDRULE`, ruleName, ruleName, ruleName, ruleName, throwMessage))
+}
+
 // WriteRules writes all added rules to the Byteman rule file.
 // This must be called before running tests with Byteman.
 func (b *BytemanHelper) WriteRules() error {


### PR DESCRIPTION
## Summary

- Fixes the flake in `TestCDCMultiTableBatchFailureAndResume` (and the same latent flake in `TestCDCBatchFailureAndResume` and `TestCDCMultipleBatchFailures`) by gating the Byteman exception injection on actual queue writes rather than `handleBatch` invocation count.
- Adds `BytemanHelper.AddCDCBatchFailAfterWritesRule` — a reusable helper that installs a pair of rules: one counts events that pass `checkIfEventNeedsToBeWritten`, the other throws at the next `before-batch-streaming` only when at least one prior batch produced writes.
- Loosens post-failure count assertions from exact equality to bounded ranges; end-to-end correctness still pinned by `finalEventCount == 60`, `VerifyNoEventIDDuplicates`, `ValidateRowCount`, and per-operation `ChangesCount`.

## Root cause

`incrementCounter("cdc_batch") == 2` at the `before-batch-streaming` marker advances on every streaming `handleBatch`, including ones whose records all get filtered out by `checkIfEventNeedsToBeWritten` (transaction-boundary records, heartbeats, etc.). When Debezium's first streaming batch happened to contain only such records, the counter still went 1 → 2 and the throw fired before any user data was written, leaving `eventCountAfterFailure == 0` when the test expected `20`. Observed in CI: [run 25863423824](https://github.com/yugabyte/yb-voyager/actions/runs/25863423824/job/75999070716).

## Fix

The new helper installs two rules:

```
RULE <name>_count_writes
... AT entry of cdc("before-write-record")
DO incrementCounter("<name>_events_written")

RULE <name>
... AT entry of cdc("before-batch-streaming")
IF  incrementCounter("<name>_cdc_batch") > 1
    && readCounter("<name>_events_written") > 0
DO  throw
```

The throw fires at the start of a streaming `handleBatch` only after some earlier batch has actually committed events. Filtered-empty first batches no longer trip it.

Loosened assertions:
| Test | Was | Now |
|---|---|---|
| `TestCDCBatchFailureAndResume` | `Equal(20)` | `>= 1 && < 60` |
| `TestCDCMultipleBatchFailures` run 1 | `Equal(20)` | `>= 1 && < 40` |
| `TestCDCMultipleBatchFailures` run 2 | `Equal(40)` | `> run1 && < 60` |
| `TestCDCMultiTableBatchFailureAndResume` | `Equal(20)` | `>= 1 && < 60` |

`TestFirstCDCBatchFailure` (which intentionally asserts `eventCount == 0` by failing on the very first batch entry) is deterministic by construction and left unchanged.

## Test plan

- [x] `TestCDCMultiTableBatchFailureAndResume` — 13 consecutive local runs, 13/13 pass (66–75 s, post-fail=20, final=60)
- [x] `TestCDCBatchFailureAndResume` — 3 consecutive local runs, 3/3 pass (71–72 s)
- [x] `TestCDCMultipleBatchFailures` — 3 consecutive local runs, 3/3 pass (95–96 s, counts `[20, 40, 60]`)
- [ ] CI Failpoint: Export job is green on this branch
- [ ] CI runs the same three tests across multiple iterations (or back-to-back PRs) without re-introducing the flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)