### PR TITLE
Fix import-data hang when --adaptive-parallelism-max is below computed default parallel-jobs

### DIFF
--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -71,7 +71,18 @@ type ConnectionPool struct {
 	pendingConnsToCloseLock sync.Mutex
 }
 
-func NewConnectionPool(params *ConnectionParams) *ConnectionPool {
+func NewConnectionPool(params *ConnectionParams) (*ConnectionPool, error) {
+	// NumConnections > NumMaxConnections would deadlock the init loop below
+	// (idleConns has only NumMaxConnections slots, but the loop tries to drain
+	// NumConnections from it). Refuse to start instead of hanging silently.
+	if params.NumConnections > params.NumMaxConnections {
+		return nil, fmt.Errorf("invalid pool config: NumConnections (%d) > NumMaxConnections (%d)",
+			params.NumConnections, params.NumMaxConnections)
+	}
+	if params.NumConnections < 0 || params.NumMaxConnections < 1 {
+		return nil, fmt.Errorf("invalid pool config: NumConnections=%d NumMaxConnections=%d (must be >=0 and >=1)",
+			params.NumConnections, params.NumMaxConnections)
+	}
 	pool := &ConnectionPool{
 		params:                    params,
 		conns:                     make(chan *pgx.Conn, params.NumMaxConnections),
@@ -91,7 +102,7 @@ func NewConnectionPool(params *ConnectionParams) *ConnectionPool {
 	if pool.params.SessionInitScript == nil {
 		pool.params.SessionInitScript = defaultSessionVars
 	}
-	return pool
+	return pool, nil
 }
 
 func (pool *ConnectionPool) GetNumConnections() int {

--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -76,11 +76,11 @@ func NewConnectionPool(params *ConnectionParams) (*ConnectionPool, error) {
 	// (idleConns has only NumMaxConnections slots, but the loop tries to drain
 	// NumConnections from it). Refuse to start instead of hanging silently.
 	if params.NumConnections > params.NumMaxConnections {
-		return nil, fmt.Errorf("invalid pool config: NumConnections (%d) > NumMaxConnections (%d)",
+		return nil, goerrors.Errorf("invalid pool config: NumConnections (%d) > NumMaxConnections (%d)",
 			params.NumConnections, params.NumMaxConnections)
 	}
 	if params.NumConnections < 0 || params.NumMaxConnections < 1 {
-		return nil, fmt.Errorf("invalid pool config: NumConnections=%d NumMaxConnections=%d (must be >=0 and >=1)",
+		return nil, goerrors.Errorf("invalid pool config: NumConnections=%d NumMaxConnections=%d (must be >=0 and >=1)",
 			params.NumConnections, params.NumMaxConnections)
 	}
 	pool := &ConnectionPool{

--- a/yb-voyager/src/tgtdb/conn_pool_test.go
+++ b/yb-voyager/src/tgtdb/conn_pool_test.go
@@ -41,7 +41,8 @@ func TestBasic(t *testing.T) {
 		ConnUriList:       []string{testYugabyteDBTarget.GetConnectionString()},
 		SessionInitScript: []string{},
 	}
-	pool := NewConnectionPool(connParams)
+	pool, err := NewConnectionPool(connParams)
+	assert.NoError(t, err)
 	assert.Equal(t, size, len(pool.conns))
 
 	// WHEN: multiple goroutines acquire connection, perform some operation
@@ -76,7 +77,8 @@ func TestIncreaseConnectionsUptoMax(t *testing.T) {
 		ConnUriList:       []string{testYugabyteDBTarget.GetConnectionString()},
 		SessionInitScript: []string{},
 	}
-	pool := NewConnectionPool(connParams)
+	pool, err := NewConnectionPool(connParams)
+	assert.NoError(t, err)
 	assert.Equal(t, size, len(pool.conns))
 
 	// WHEN: multiple goroutines acquire connection, perform some operation
@@ -119,7 +121,8 @@ func TestDecreaseConnectionsUptoMin(t *testing.T) {
 		ConnUriList:       []string{testYugabyteDBTarget.GetConnectionString()},
 		SessionInitScript: []string{},
 	}
-	pool := NewConnectionPool(connParams)
+	pool, err := NewConnectionPool(connParams)
+	assert.NoError(t, err)
 	assert.Equal(t, size, len(pool.conns))
 
 	// WHEN: multiple goroutines acquire connection, perform some operation
@@ -162,7 +165,8 @@ func TestUpdateConnectionsRandom(t *testing.T) {
 		ConnUriList:       []string{testYugabyteDBTarget.GetConnectionString()},
 		SessionInitScript: []string{},
 	}
-	pool := NewConnectionPool(connParams)
+	pool, err := NewConnectionPool(connParams)
+	assert.NoError(t, err)
 	assert.Equal(t, size, len(pool.conns))
 
 	// WHEN: multiple goroutines acquire connection, perform some operation
@@ -217,7 +221,8 @@ func TestRemoveConnectionsForHosts(t *testing.T) {
 		ConnUriList:       []string{testYugabyteDBTarget.GetConnectionString()},
 		SessionInitScript: []string{},
 	}
-	pool := NewConnectionPool(connParams)
+	pool, err := NewConnectionPool(connParams)
+	assert.NoError(t, err)
 	assert.Equal(t, size, len(pool.conns))
 	assert.Equal(t, size, len(pool.idleConns))
 

--- a/yb-voyager/src/tgtdb/parallelism_unit_test.go
+++ b/yb-voyager/src/tgtdb/parallelism_unit_test.go
@@ -1,0 +1,144 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tgtdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/types"
+)
+
+// Regression test for an adaptive-parallelism hang:
+// when --adaptive-parallelism-max was less than the auto-computed Parallelism
+// (clusterCores/4), the conn-pool init deadlocked silently. Now Parallelism
+// is capped to MaxParallelism before the pool is created.
+func TestSetDefaultParallelism_AdaptiveMax_CapsComputedParallelism(t *testing.T) {
+	// Mimics the post-fetch state: Parallelism would be set by fetchDefaultParallelJobs
+	// to clusterCores/4 = 72 for a 288-core cluster; user passed --adaptive-parallelism-max=12.
+	tconf := &TargetConf{
+		Parallelism:             72,
+		MaxParallelism:          12,
+		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
+	}
+	applyAdaptiveCap(tconf)
+
+	assert.Equal(t, 12, tconf.Parallelism, "Parallelism should be capped to MaxParallelism")
+	assert.Equal(t, 12, tconf.MaxParallelism, "MaxParallelism should remain user-supplied value")
+}
+
+func TestSetDefaultParallelism_AdaptiveNoUserMax_DefaultsMaxTo4xParallelism(t *testing.T) {
+	tconf := &TargetConf{
+		Parallelism:             50,
+		MaxParallelism:          0,
+		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
+	}
+	applyAdaptiveCap(tconf)
+	assert.Equal(t, 50, tconf.Parallelism)
+	assert.Equal(t, 200, tconf.MaxParallelism)
+}
+
+func TestSetDefaultParallelism_AdaptiveDisabled_MaxEqualsParallelism(t *testing.T) {
+	tconf := &TargetConf{
+		Parallelism:             8,
+		MaxParallelism:          0,
+		AdaptiveParallelismMode: types.DisabledAdaptiveParallelismMode,
+	}
+	applyAdaptiveCap(tconf)
+	assert.Equal(t, 8, tconf.Parallelism)
+	assert.Equal(t, 8, tconf.MaxParallelism)
+}
+
+func TestSetDefaultParallelism_AdaptiveMaxAboveParallelism_LeavesAsIs(t *testing.T) {
+	tconf := &TargetConf{
+		Parallelism:             10,
+		MaxParallelism:          40,
+		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
+	}
+	applyAdaptiveCap(tconf)
+	assert.Equal(t, 10, tconf.Parallelism)
+	assert.Equal(t, 40, tconf.MaxParallelism)
+}
+
+// applyAdaptiveCap mirrors the reconciliation block in setDefaultParallelism.
+// We can't call setDefaultParallelism directly without a target DB (it goes
+// through fetchDefaultParallelJobs → fetchCores), so this helper captures the
+// part under test. If setDefaultParallelism's logic changes, update both.
+func applyAdaptiveCap(tconf *TargetConf) {
+	if tconf.AdaptiveParallelismMode.IsEnabled() {
+		if tconf.MaxParallelism <= 0 {
+			tconf.MaxParallelism = tconf.Parallelism * 4
+		} else if tconf.Parallelism > tconf.MaxParallelism {
+			tconf.Parallelism = tconf.MaxParallelism
+		}
+	} else {
+		tconf.MaxParallelism = tconf.Parallelism
+	}
+}
+
+// Regression: previously NewConnectionPool would deadlock when
+// NumConnections > NumMaxConnections — the second init loop would block
+// forever trying to drain from an empty idleConns channel.
+func TestNewConnectionPool_RejectsInvertedSizes(t *testing.T) {
+	done := make(chan struct{})
+	var pool *ConnectionPool
+	var err error
+	go func() {
+		pool, err = NewConnectionPool(&ConnectionParams{
+			NumConnections:    72,
+			NumMaxConnections: 12,
+			ConnUriList:       []string{"postgres://stub"},
+			SessionInitScript: []string{},
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		assert.Error(t, err, "expected error for NumConnections > NumMaxConnections")
+		assert.Nil(t, pool)
+	case <-time.After(2 * time.Second):
+		t.Fatal("NewConnectionPool deadlocked instead of returning an error")
+	}
+}
+
+func TestNewConnectionPool_AcceptsValidSizes(t *testing.T) {
+	// NumConnections == NumMaxConnections and NumConnections < NumMaxConnections both fine.
+	for _, c := range []struct{ n, max int }{{10, 10}, {5, 20}, {0, 1}} {
+		pool, err := NewConnectionPool(&ConnectionParams{
+			NumConnections:    c.n,
+			NumMaxConnections: c.max,
+			ConnUriList:       []string{"postgres://stub"},
+			SessionInitScript: []string{},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, pool)
+		assert.Equal(t, c.n, pool.size)
+	}
+}
+
+func TestNewConnectionPool_RejectsZeroMax(t *testing.T) {
+	pool, err := NewConnectionPool(&ConnectionParams{
+		NumConnections:    0,
+		NumMaxConnections: 0,
+	})
+	assert.Error(t, err)
+	assert.Nil(t, pool)
+}

--- a/yb-voyager/src/tgtdb/parallelism_unit_test.go
+++ b/yb-voyager/src/tgtdb/parallelism_unit_test.go
@@ -33,48 +33,48 @@ import (
 func TestReconcileAdaptiveParallelism_CapsParallelismToUserMax(t *testing.T) {
 	// Mimics the post-fetch state: Parallelism would be set by fetchDefaultParallelJobs
 	// to clusterCores/4 = 72 for a 288-core cluster; user passed --adaptive-parallelism-max=12.
-	tconf := &TargetConf{
+	yb := &TargetYugabyteDB{Tconf: &TargetConf{
 		Parallelism:             72,
 		MaxParallelism:          12,
 		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
-	}
-	reconcileAdaptiveParallelism(tconf)
+	}}
+	yb.reconcileAdaptiveParallelism()
 
-	assert.Equal(t, 12, tconf.Parallelism, "Parallelism should be capped to MaxParallelism")
-	assert.Equal(t, 12, tconf.MaxParallelism, "MaxParallelism should remain user-supplied value")
+	assert.Equal(t, 12, yb.Tconf.Parallelism, "Parallelism should be capped to MaxParallelism")
+	assert.Equal(t, 12, yb.Tconf.MaxParallelism, "MaxParallelism should remain user-supplied value")
 }
 
 func TestReconcileAdaptiveParallelism_NoUserMax_DefaultsTo4xParallelism(t *testing.T) {
-	tconf := &TargetConf{
+	yb := &TargetYugabyteDB{Tconf: &TargetConf{
 		Parallelism:             50,
 		MaxParallelism:          0,
 		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
-	}
-	reconcileAdaptiveParallelism(tconf)
-	assert.Equal(t, 50, tconf.Parallelism)
-	assert.Equal(t, 200, tconf.MaxParallelism)
+	}}
+	yb.reconcileAdaptiveParallelism()
+	assert.Equal(t, 50, yb.Tconf.Parallelism)
+	assert.Equal(t, 200, yb.Tconf.MaxParallelism)
 }
 
 func TestReconcileAdaptiveParallelism_Disabled_MaxEqualsParallelism(t *testing.T) {
-	tconf := &TargetConf{
+	yb := &TargetYugabyteDB{Tconf: &TargetConf{
 		Parallelism:             8,
 		MaxParallelism:          0,
 		AdaptiveParallelismMode: types.DisabledAdaptiveParallelismMode,
-	}
-	reconcileAdaptiveParallelism(tconf)
-	assert.Equal(t, 8, tconf.Parallelism)
-	assert.Equal(t, 8, tconf.MaxParallelism)
+	}}
+	yb.reconcileAdaptiveParallelism()
+	assert.Equal(t, 8, yb.Tconf.Parallelism)
+	assert.Equal(t, 8, yb.Tconf.MaxParallelism)
 }
 
 func TestReconcileAdaptiveParallelism_MaxAboveParallelism_LeavesAsIs(t *testing.T) {
-	tconf := &TargetConf{
+	yb := &TargetYugabyteDB{Tconf: &TargetConf{
 		Parallelism:             10,
 		MaxParallelism:          40,
 		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
-	}
-	reconcileAdaptiveParallelism(tconf)
-	assert.Equal(t, 10, tconf.Parallelism)
-	assert.Equal(t, 40, tconf.MaxParallelism)
+	}}
+	yb.reconcileAdaptiveParallelism()
+	assert.Equal(t, 10, yb.Tconf.Parallelism)
+	assert.Equal(t, 40, yb.Tconf.MaxParallelism)
 }
 
 // Regression: previously NewConnectionPool would deadlock when

--- a/yb-voyager/src/tgtdb/parallelism_unit_test.go
+++ b/yb-voyager/src/tgtdb/parallelism_unit_test.go
@@ -30,7 +30,7 @@ import (
 // when --adaptive-parallelism-max was less than the auto-computed Parallelism
 // (clusterCores/4), the conn-pool init deadlocked silently. Now Parallelism
 // is capped to MaxParallelism before the pool is created.
-func TestSetDefaultParallelism_AdaptiveMax_CapsComputedParallelism(t *testing.T) {
+func TestReconcileAdaptiveParallelism_CapsParallelismToUserMax(t *testing.T) {
 	// Mimics the post-fetch state: Parallelism would be set by fetchDefaultParallelJobs
 	// to clusterCores/4 = 72 for a 288-core cluster; user passed --adaptive-parallelism-max=12.
 	tconf := &TargetConf{
@@ -38,59 +38,43 @@ func TestSetDefaultParallelism_AdaptiveMax_CapsComputedParallelism(t *testing.T)
 		MaxParallelism:          12,
 		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
 	}
-	applyAdaptiveCap(tconf)
+	reconcileAdaptiveParallelism(tconf)
 
 	assert.Equal(t, 12, tconf.Parallelism, "Parallelism should be capped to MaxParallelism")
 	assert.Equal(t, 12, tconf.MaxParallelism, "MaxParallelism should remain user-supplied value")
 }
 
-func TestSetDefaultParallelism_AdaptiveNoUserMax_DefaultsMaxTo4xParallelism(t *testing.T) {
+func TestReconcileAdaptiveParallelism_NoUserMax_DefaultsTo4xParallelism(t *testing.T) {
 	tconf := &TargetConf{
 		Parallelism:             50,
 		MaxParallelism:          0,
 		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
 	}
-	applyAdaptiveCap(tconf)
+	reconcileAdaptiveParallelism(tconf)
 	assert.Equal(t, 50, tconf.Parallelism)
 	assert.Equal(t, 200, tconf.MaxParallelism)
 }
 
-func TestSetDefaultParallelism_AdaptiveDisabled_MaxEqualsParallelism(t *testing.T) {
+func TestReconcileAdaptiveParallelism_Disabled_MaxEqualsParallelism(t *testing.T) {
 	tconf := &TargetConf{
 		Parallelism:             8,
 		MaxParallelism:          0,
 		AdaptiveParallelismMode: types.DisabledAdaptiveParallelismMode,
 	}
-	applyAdaptiveCap(tconf)
+	reconcileAdaptiveParallelism(tconf)
 	assert.Equal(t, 8, tconf.Parallelism)
 	assert.Equal(t, 8, tconf.MaxParallelism)
 }
 
-func TestSetDefaultParallelism_AdaptiveMaxAboveParallelism_LeavesAsIs(t *testing.T) {
+func TestReconcileAdaptiveParallelism_MaxAboveParallelism_LeavesAsIs(t *testing.T) {
 	tconf := &TargetConf{
 		Parallelism:             10,
 		MaxParallelism:          40,
 		AdaptiveParallelismMode: types.BalancedAdaptiveParallelismMode,
 	}
-	applyAdaptiveCap(tconf)
+	reconcileAdaptiveParallelism(tconf)
 	assert.Equal(t, 10, tconf.Parallelism)
 	assert.Equal(t, 40, tconf.MaxParallelism)
-}
-
-// applyAdaptiveCap mirrors the reconciliation block in setDefaultParallelism.
-// We can't call setDefaultParallelism directly without a target DB (it goes
-// through fetchDefaultParallelJobs → fetchCores), so this helper captures the
-// part under test. If setDefaultParallelism's logic changes, update both.
-func applyAdaptiveCap(tconf *TargetConf) {
-	if tconf.AdaptiveParallelismMode.IsEnabled() {
-		if tconf.MaxParallelism <= 0 {
-			tconf.MaxParallelism = tconf.Parallelism * 4
-		} else if tconf.Parallelism > tconf.MaxParallelism {
-			tconf.Parallelism = tconf.MaxParallelism
-		}
-	} else {
-		tconf.MaxParallelism = tconf.Parallelism
-	}
 }
 
 // Regression: previously NewConnectionPool would deadlock when

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -263,7 +263,11 @@ func (pg *TargetPostgreSQL) InitConnPool() error {
 		// works fine as we check the support of any session variable before using it in the script.
 		// So upsert and disable transaction will never be used for PG
 	}
-	pg.connPool = NewConnectionPool(params)
+	var err error
+	pg.connPool, err = NewConnectionPool(params)
+	if err != nil {
+		return fmt.Errorf("creating connection pool: %w", err)
+	}
 	return nil
 }
 

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1485,19 +1485,25 @@ func (yb *TargetYugabyteDB) setDefaultParallelism(tconfs []*TargetConf, nodeCoun
 		log.Infof("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", yb.tconf.Parallelism)
 	}
 
-	if yb.tconf.AdaptiveParallelismMode.IsEnabled() {
-		if yb.tconf.MaxParallelism <= 0 {
-			yb.tconf.MaxParallelism = yb.tconf.Parallelism * 4
-		} else if yb.tconf.Parallelism > yb.tconf.MaxParallelism {
-			// User-supplied --adaptive-parallelism-max may be below the auto-computed default
-			// parallel-jobs (clusterCores/4). Cap initial parallelism so the conn pool invariant
-			// NumConnections <= NumMaxConnections holds; otherwise NewConnectionPool deadlocks.
+	reconcileAdaptiveParallelism(yb.tconf)
+}
+
+// reconcileAdaptiveParallelism finalizes Parallelism / MaxParallelism on tconf
+// once both have been resolved (user-supplied or auto-computed). When adaptive
+// parallelism is enabled and the auto-computed Parallelism exceeds the user-
+// supplied MaxParallelism, Parallelism is capped — otherwise NewConnectionPool
+// deadlocks on its init loop because NumConnections > NumMaxConnections.
+func reconcileAdaptiveParallelism(tconf *TargetConf) {
+	if tconf.AdaptiveParallelismMode.IsEnabled() {
+		if tconf.MaxParallelism <= 0 {
+			tconf.MaxParallelism = tconf.Parallelism * 4
+		} else if tconf.Parallelism > tconf.MaxParallelism {
 			log.Warnf("Computed default parallel-jobs (%d) exceeds --adaptive-parallelism-max (%d); capping initial parallelism to %d",
-				yb.tconf.Parallelism, yb.tconf.MaxParallelism, yb.tconf.MaxParallelism)
-			yb.tconf.Parallelism = yb.tconf.MaxParallelism
+				tconf.Parallelism, tconf.MaxParallelism, tconf.MaxParallelism)
+			tconf.Parallelism = tconf.MaxParallelism
 		}
 	} else {
-		yb.tconf.MaxParallelism = yb.tconf.Parallelism
+		tconf.MaxParallelism = tconf.Parallelism
 	}
 }
 

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -312,7 +312,10 @@ func (yb *TargetYugabyteDB) InitConnPool() error {
 		ConnUriList:       targetUriList,
 		SessionInitScript: yb.Tconf.SessionVars,
 	}
-	yb.connPool = NewConnectionPool(params)
+	yb.connPool, err = NewConnectionPool(params)
+	if err != nil {
+		return fmt.Errorf("creating connection pool: %w", err)
+	}
 	redactedParams := &ConnectionParams{}
 	//Whenever adding new fields to CONNECTION PARAMS check if that needs to be redacted while logging
 	err = copier.Copy(redactedParams, params)
@@ -1485,6 +1488,13 @@ func (yb *TargetYugabyteDB) setDefaultParallelism(tconfs []*TargetConf, nodeCoun
 	if yb.tconf.AdaptiveParallelismMode.IsEnabled() {
 		if yb.tconf.MaxParallelism <= 0 {
 			yb.tconf.MaxParallelism = yb.tconf.Parallelism * 4
+		} else if yb.tconf.Parallelism > yb.tconf.MaxParallelism {
+			// User-supplied --adaptive-parallelism-max may be below the auto-computed default
+			// parallel-jobs (clusterCores/4). Cap initial parallelism so the conn pool invariant
+			// NumConnections <= NumMaxConnections holds; otherwise NewConnectionPool deadlocks.
+			log.Warnf("Computed default parallel-jobs (%d) exceeds --adaptive-parallelism-max (%d); capping initial parallelism to %d",
+				yb.tconf.Parallelism, yb.tconf.MaxParallelism, yb.tconf.MaxParallelism)
+			yb.tconf.Parallelism = yb.tconf.MaxParallelism
 		}
 	} else {
 		yb.tconf.MaxParallelism = yb.tconf.Parallelism

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1498,12 +1498,11 @@ func reconcileAdaptiveParallelism(tconf *TargetConf) {
 	// mode --parallel-jobs is rejected up front (see validateParallelismFlags), so
 	// Parallelism here is always the auto-computed clusterCores/4.
 	if tconf.AdaptiveParallelismMode.IsEnabled() {
-		switch {
-		case tconf.MaxParallelism <= 0:
+		if tconf.MaxParallelism <= 0 {
 			// --adaptive-parallelism={balanced,aggressive} without --adaptive-parallelism-max:
 			// default the ceiling to 4x the auto-computed Parallelism (≈ clusterCores).
 			tconf.MaxParallelism = tconf.Parallelism * 4
-		case tconf.Parallelism > tconf.MaxParallelism:
+		} else if tconf.Parallelism > tconf.MaxParallelism {
 			// --adaptive-parallelism={balanced,aggressive} with --adaptive-parallelism-max
 			// set below the auto-computed Parallelism: cap Parallelism so the conn pool
 			// invariant NumConnections <= NumMaxConnections holds (otherwise NewConnectionPool
@@ -1511,9 +1510,8 @@ func reconcileAdaptiveParallelism(tconf *TargetConf) {
 			log.Warnf("Computed default parallel-jobs (%d) exceeds --adaptive-parallelism-max (%d); capping initial parallelism to %d",
 				tconf.Parallelism, tconf.MaxParallelism, tconf.MaxParallelism)
 			tconf.Parallelism = tconf.MaxParallelism
-			// default case: --adaptive-parallelism-max already >= auto-computed Parallelism,
-			// nothing to reconcile.
 		}
+		// else: --adaptive-parallelism-max already >= auto-computed Parallelism, nothing to reconcile.
 	} else {
 		// --adaptive-parallelism=disabled (default): pool size is fixed, so the ceiling
 		// equals Parallelism (whether user-supplied via --parallel-jobs or auto-computed).

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1494,15 +1494,29 @@ func (yb *TargetYugabyteDB) setDefaultParallelism(tconfs []*TargetConf, nodeCoun
 // supplied MaxParallelism, Parallelism is capped — otherwise NewConnectionPool
 // deadlocks on its init loop because NumConnections > NumMaxConnections.
 func reconcileAdaptiveParallelism(tconf *TargetConf) {
+	// Adaptive enabled means --adaptive-parallelism is balanced or aggressive. In this
+	// mode --parallel-jobs is rejected up front (see validateParallelismFlags), so
+	// Parallelism here is always the auto-computed clusterCores/4.
 	if tconf.AdaptiveParallelismMode.IsEnabled() {
-		if tconf.MaxParallelism <= 0 {
+		switch {
+		case tconf.MaxParallelism <= 0:
+			// --adaptive-parallelism={balanced,aggressive} without --adaptive-parallelism-max:
+			// default the ceiling to 4x the auto-computed Parallelism (≈ clusterCores).
 			tconf.MaxParallelism = tconf.Parallelism * 4
-		} else if tconf.Parallelism > tconf.MaxParallelism {
+		case tconf.Parallelism > tconf.MaxParallelism:
+			// --adaptive-parallelism={balanced,aggressive} with --adaptive-parallelism-max
+			// set below the auto-computed Parallelism: cap Parallelism so the conn pool
+			// invariant NumConnections <= NumMaxConnections holds (otherwise NewConnectionPool
+			// deadlocks on its init loop).
 			log.Warnf("Computed default parallel-jobs (%d) exceeds --adaptive-parallelism-max (%d); capping initial parallelism to %d",
 				tconf.Parallelism, tconf.MaxParallelism, tconf.MaxParallelism)
 			tconf.Parallelism = tconf.MaxParallelism
+			// default case: --adaptive-parallelism-max already >= auto-computed Parallelism,
+			// nothing to reconcile.
 		}
 	} else {
+		// --adaptive-parallelism=disabled (default): pool size is fixed, so the ceiling
+		// equals Parallelism (whether user-supplied via --parallel-jobs or auto-computed).
 		tconf.MaxParallelism = tconf.Parallelism
 	}
 }

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1489,10 +1489,8 @@ func (yb *TargetYugabyteDB) setDefaultParallelism(tconfs []*TargetConf, nodeCoun
 }
 
 // reconcileAdaptiveParallelism finalizes Parallelism / MaxParallelism on tconf
-// once both have been resolved (user-supplied or auto-computed). When adaptive
-// parallelism is enabled and the auto-computed Parallelism exceeds the user-
-// supplied MaxParallelism, Parallelism is capped — otherwise NewConnectionPool
-// deadlocks on its init loop because NumConnections > NumMaxConnections.
+// once both have been resolved (user-supplied or auto-computed), enforcing the
+// invariant Parallelism <= MaxParallelism that the connection pool requires.
 func reconcileAdaptiveParallelism(tconf *TargetConf) {
 	// Adaptive enabled means --adaptive-parallelism is balanced or aggressive. In this
 	// mode --parallel-jobs is rejected up front (see validateParallelismFlags), so
@@ -1504,9 +1502,7 @@ func reconcileAdaptiveParallelism(tconf *TargetConf) {
 			tconf.MaxParallelism = tconf.Parallelism * 4
 		} else if tconf.Parallelism > tconf.MaxParallelism {
 			// --adaptive-parallelism={balanced,aggressive} with --adaptive-parallelism-max
-			// set below the auto-computed Parallelism: cap Parallelism so the conn pool
-			// invariant NumConnections <= NumMaxConnections holds (otherwise NewConnectionPool
-			// deadlocks on its init loop).
+			// set below the auto-computed Parallelism: cap Parallelism to the user's ceiling.
 			log.Warnf("Computed default parallel-jobs (%d) exceeds --adaptive-parallelism-max (%d); capping initial parallelism to %d",
 				tconf.Parallelism, tconf.MaxParallelism, tconf.MaxParallelism)
 			tconf.Parallelism = tconf.MaxParallelism

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1485,33 +1485,33 @@ func (yb *TargetYugabyteDB) setDefaultParallelism(tconfs []*TargetConf, nodeCoun
 		log.Infof("Using %d parallel jobs by default. Use --parallel-jobs to specify a custom value", yb.tconf.Parallelism)
 	}
 
-	reconcileAdaptiveParallelism(yb.tconf)
+	yb.reconcileAdaptiveParallelism()
 }
 
-// reconcileAdaptiveParallelism finalizes Parallelism / MaxParallelism on tconf
+// reconcileAdaptiveParallelism finalizes Parallelism / MaxParallelism on yb.Tconf
 // once both have been resolved (user-supplied or auto-computed), enforcing the
 // invariant Parallelism <= MaxParallelism that the connection pool requires.
-func reconcileAdaptiveParallelism(tconf *TargetConf) {
+func (yb *TargetYugabyteDB) reconcileAdaptiveParallelism() {
 	// Adaptive enabled means --adaptive-parallelism is balanced or aggressive. In this
 	// mode --parallel-jobs is rejected up front (see validateParallelismFlags), so
 	// Parallelism here is always the auto-computed clusterCores/4.
-	if tconf.AdaptiveParallelismMode.IsEnabled() {
-		if tconf.MaxParallelism <= 0 {
+	if yb.Tconf.AdaptiveParallelismMode.IsEnabled() {
+		if yb.Tconf.MaxParallelism <= 0 {
 			// --adaptive-parallelism={balanced,aggressive} without --adaptive-parallelism-max:
 			// default the ceiling to 4x the auto-computed Parallelism (≈ clusterCores).
-			tconf.MaxParallelism = tconf.Parallelism * 4
-		} else if tconf.Parallelism > tconf.MaxParallelism {
+			yb.Tconf.MaxParallelism = yb.Tconf.Parallelism * 4
+		} else if yb.Tconf.Parallelism > yb.Tconf.MaxParallelism {
 			// --adaptive-parallelism={balanced,aggressive} with --adaptive-parallelism-max
 			// set below the auto-computed Parallelism: cap Parallelism to the user's ceiling.
 			log.Warnf("Computed default parallel-jobs (%d) exceeds --adaptive-parallelism-max (%d); capping initial parallelism to %d",
-				tconf.Parallelism, tconf.MaxParallelism, tconf.MaxParallelism)
-			tconf.Parallelism = tconf.MaxParallelism
+				yb.Tconf.Parallelism, yb.Tconf.MaxParallelism, yb.Tconf.MaxParallelism)
+			yb.Tconf.Parallelism = yb.Tconf.MaxParallelism
 		}
 		// else: --adaptive-parallelism-max already >= auto-computed Parallelism, nothing to reconcile.
 	} else {
 		// --adaptive-parallelism=disabled (default): pool size is fixed, so the ceiling
 		// equals Parallelism (whether user-supplied via --parallel-jobs or auto-computed).
-		tconf.MaxParallelism = tconf.Parallelism
+		yb.Tconf.MaxParallelism = yb.Tconf.Parallelism
 	}
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request

Fix a silent hang during `import data` when the user passes
`--adaptive-parallelism-max N` without `--parallel-jobs`, and the
auto-computed default parallel-jobs (`clusterCores / 4`) exceeds `N`.

The hang reproduces on clusters where total cluster cores ÷ 4 is larger
than the user's `--adaptive-parallelism-max` (e.g. 9 tservers × 32 cores
= 288 cores → default Parallelism = 72; user supplies
`--adaptive-parallelism-max 12`). `setDefaultParallelism` was not
reconciling the two, and `NewConnectionPool` then blocked forever on
the init loop because it tried to drain 72 elements from a channel of
capacity 12.

Two fixes:
1. `setDefaultParallelism` (yb-voyager/src/tgtdb/yugabytedb.go) now
   caps `Parallelism` to `MaxParallelism` when adaptive parallelism is
   enabled and the auto-computed default exceeds the user-supplied max,
   logging a `Warnf` so the cap is visible in the log.
2. `NewConnectionPool` (yb-voyager/src/tgtdb/conn_pool.go) now returns
   `(*ConnectionPool, error)` and refuses to start when
   `NumConnections > NumMaxConnections` (or sizes are otherwise
   invalid), so any future invariant violation fails fast instead of
   silently deadlocking. Existing callers in `yugabytedb.go` and
   `postgres.go` are updated to propagate the error.

No change to `validateParallelismFlags` — voyager already rejects
`--parallel-jobs` together with adaptive parallelism, so the only
path to a mismatch is the auto-computed default, which is now handled.

### Describe if there are any user-facing changes

- A run that previously hung silently now either starts successfully
  with a warning log (`Computed default parallel-jobs (X) exceeds
  --adaptive-parallelism-max (Y); capping initial parallelism to Y`),
  or, in the unlikely case of any future invariant violation, exits
  with `creating connection pool: invalid pool config: NumConnections
  (X) > NumMaxConnections (Y)` instead of hanging.
- No changes to CLI flags, configuration, installation, or reports.

### How was this pull request tested?

New `unit`-tagged tests in `yb-voyager/src/tgtdb/parallelism_unit_test.go`:
- `TestSetDefaultParallelism_AdaptiveMax_CapsComputedParallelism` —
  the regression case (Parallelism=72, MaxParallelism=12 → capped to 12).
- `TestSetDefaultParallelism_AdaptiveNoUserMax_DefaultsMaxTo4xParallelism`
  — existing default-max path preserved.
- `TestSetDefaultParallelism_AdaptiveDisabled_MaxEqualsParallelism` —
  non-adaptive path preserved.
- `TestSetDefaultParallelism_AdaptiveMaxAboveParallelism_LeavesAsIs` —
  no-cap-needed case.
- `TestNewConnectionPool_RejectsInvertedSizes` — uses a 2s timeout to
  prove there's no deadlock and an error is returned.
- `TestNewConnectionPool_AcceptsValidSizes`,
  `TestNewConnectionPool_RejectsZeroMax` — boundary cases.

Verified locally: `go build ./...`, `go vet ./...`, and
`go test -tags unit -count=1 ./...` all pass, including `./cmd/...`
and `./src/tgtdb/...`. Existing integration-tagged tests in
`conn_pool_test.go` were updated to the new `NewConnectionPool`
signature (compile-verified; not run locally — they need a live YB
testcontainer).

Not yet exercised: end-to-end import-data run reproducing the original
user scenario (9-tserver cluster + `--adaptive-parallelism-max 12`).
The unit tests cover the deterministic logic; an e2e run would only
re-confirm what the unit tests already verify.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.