### PR TITLE
Send source schema OIDs to the callhome in the source db details

### DIFF
--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -1525,6 +1525,7 @@ normalize_callhome_json() {
             .db_version = "IGNORED" |
             .db_system_identifier = "IGNORED" |
             .db_id = "IGNORED" |
+            .schema_oids = "IGNORED" |
             .target_db_details = "IGNORED" |
             .total_db_size_bytes = "IGNORED"
         elif type == "array" then

--- a/migtests/tests/pg/assessment-report-test/expected_callhome_payloads/assess_migration_callhome.json
+++ b/migtests/tests/pg/assessment-report-test/expected_callhome_payloads/assess_migration_callhome.json
@@ -3237,7 +3237,7 @@
     "db_type": "postgresql",
     "db_version": "17.6 (Ubuntu 17.6-2.pgdg22.04+1)",
     "host": "",
-    "payload_version": 1.1,
+    "payload_version": 1.2,
     "schema_names": [
       "schema_a1717e859fc83d39",
       "schema_ae9b85f2c9255e63",

--- a/migtests/tests/pg/datatypes/expected_callhome_payloads/assess_migration_callhome.json
+++ b/migtests/tests/pg/datatypes/expected_callhome_payloads/assess_migration_callhome.json
@@ -936,7 +936,7 @@
     "db_type": "postgresql",
     "db_version": "17.6 (Ubuntu 17.6-2.pgdg22.04+1)",
     "host": "",
-    "payload_version": 1.1,
+    "payload_version": 1.2,
     "schema_names": [
         "schema_d7108fd530c9b1c2"
     ],

--- a/migtests/tests/pg/datatypes/expected_callhome_payloads/export_data_callhome.json
+++ b/migtests/tests/pg/datatypes/expected_callhome_payloads/export_data_callhome.json
@@ -22,7 +22,7 @@
     "db_type": "postgresql",
     "db_version": "17.6 (Ubuntu 17.6-2.pgdg22.04+1)",
     "host": "",
-    "payload_version": 1.1,
+    "payload_version": 1.2,
     "schema_names": [
       "schema_d7108fd530c9b1c2"
     ],

--- a/migtests/tests/pg/datatypes/expected_callhome_payloads/export_schema_callhome.json
+++ b/migtests/tests/pg/datatypes/expected_callhome_payloads/export_schema_callhome.json
@@ -104,7 +104,7 @@
       "db_type": "postgresql",
       "db_version": "17.6 (Ubuntu 17.6-2.pgdg22.04+1)",
       "host": "",
-      "payload_version": 1.1,
+      "payload_version": 1.2,
       "schema_names": [
         "schema_d7108fd530c9b1c2"
       ],

--- a/migtests/tests/pg/datatypes/expected_callhome_payloads/import_data_callhome.json
+++ b/migtests/tests/pg/datatypes/expected_callhome_payloads/import_data_callhome.json
@@ -12,6 +12,7 @@
       "enable_yb_adaptive_parallelism": true,
       "adaptive_parallelism_max": 4,
       "error_policy_snapshot": "abort",
+      "iterative_cutover_enabled": false,
       "start_clean": false,
       "data_metrics": {
         "migration_snapshot_total_rows": 101,

--- a/migtests/tests/pg/datatypes/expected_callhome_payloads/import_data_callhome.json
+++ b/migtests/tests/pg/datatypes/expected_callhome_payloads/import_data_callhome.json
@@ -4,7 +4,7 @@
     "migration_type": "offline",
     "migration_uuid": "507f2869-f4bb-4459-b776-79c2f85f8d7e",
     "phase_payload": {
-      "payload_version": 1.5,
+      "payload_version": 1.6,
       "batch_size": 20000,
       "control_plane_type": "",
       "parallel_jobs": 1,

--- a/yb-voyager/cmd/callhome_payload_builder.go
+++ b/yb-voyager/cmd/callhome_payload_builder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/samber/lo"
@@ -184,6 +185,8 @@ func anonymizeQualifiedTableNames(tableNames []string) []string {
 
 // anonymizeSourceDBDetails creates anonymized source DB details for callhome
 func anonymizeSourceDBDetails(source *srcdb.Source) callhome.SourceDBDetails {
+	// Sort schema oids to ensure consistent order
+	slices.Sort(source.SchemaOids)
 	details := callhome.SourceDBDetails{
 		PayloadVersion:     callhome.SOURCE_DB_DETAILS_PAYLOAD_VERSION,
 		DBType:             source.DBType,

--- a/yb-voyager/cmd/callhome_payload_builder.go
+++ b/yb-voyager/cmd/callhome_payload_builder.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/samber/lo"

--- a/yb-voyager/cmd/callhome_payload_builder.go
+++ b/yb-voyager/cmd/callhome_payload_builder.go
@@ -191,6 +191,7 @@ func anonymizeSourceDBDetails(source *srcdb.Source) callhome.SourceDBDetails {
 		DBSize:             source.DBSize,
 		DBSystemIdentifier: source.DBSystemIdentifier,
 		DBID:               source.DBID,
+		SchemaOids:         source.SchemaOids,
 	}
 
 	// Anonymize database name

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -533,18 +533,7 @@ func exportData() bool {
 		utils.ErrExit("schema name matcher: %w", err)
 	}
 
-	source.DBVersion = source.DB().GetVersion()
-	source.DBSize, err = source.DB().GetDatabaseSize()
-	if err != nil {
-		log.Errorf("error getting database size: %v", err) //can just log as this is used for call-home only
-	}
-
-	// Get PostgreSQL system identifier while still connected
-	source.FetchPGDBSystemIdentifier()
-	err = source.DB().FetchDBID()
-	if err != nil {
-		log.Errorf("error getting database id: %v", err) //can just log as this is used for call-home only
-	}
+	source.FetchSourceInfo()
 
 	msr, err := metaDB.GetMigrationStatusRecord()
 	if err != nil {

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -151,20 +151,8 @@ func exportSchema(cmd *cobra.Command) error {
 	}
 
 	checkSourceDBCharset()
-	sourceDBVersion := source.DB().GetVersion()
-	source.DBVersion = sourceDBVersion
-	source.DBSize, err = source.DB().GetDatabaseSize()
-	if err != nil {
-		log.Errorf("error getting database size: %v", err) //can just log as this is used for call-home only
-	}
-
-	// Get PostgreSQL system identifier while still connected
-	source.FetchPGDBSystemIdentifier()
-	err = source.DB().FetchDBID()
-	if err != nil {
-		log.Errorf("error getting database id: %v", err) //can just log as this is used for call-home only
-	}
-	utils.PrintAndLogf("%s version: %s\n", source.DBType, sourceDBVersion)
+	source.FetchSourceInfo()
+	utils.PrintAndLogf("%s version: %s\n", source.DBType, source.DBVersion)
 
 	// Check if the source database has the required permissions for exporting schema.
 	if source.RunGuardrailsChecks {

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -93,8 +93,9 @@ type Payload struct {
 Version History
 1.0: Introduced DBName and SchemaNames fields
 1.1: Added db_id (PostgreSQL/YugabyteDB: pg_database.oid; Oracle: v$database.dbid; MySQL: 0)
+1.2: Added schema_oids field (PostgreSQL/YugabyteDB: pg_namespace.oid)
 */
-var SOURCE_DB_DETAILS_PAYLOAD_VERSION = "1.1"
+var SOURCE_DB_DETAILS_PAYLOAD_VERSION = "1.2"
 
 type SourceDBDetails struct {
 	PayloadVersion     string   `json:"payload_version"`
@@ -107,6 +108,7 @@ type SourceDBDetails struct {
 	DBID               int64    `json:"db_id"`                          // postgresql/yugabytedb: pg_database.oid;
 	DBName             string   `json:"db_name,omitempty"`              //Anonymized database name
 	SchemaNames        []string `json:"schema_names,omitempty"`         //Anonymized schema names
+	SchemaOids         []int64  `json:"schema_oids"`                    //Schema oids
 }
 
 // SHOULD NOT REMOVE THESE (host, db_version, node_count, total_cores) FIELDS of TargetDBDetails as parsing these specifically here

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -86,7 +86,7 @@ type Payload struct {
 	Status           string    `json:"status"`
 }
 
-// SHOULD NOT REMOVE THESE (host, db_type, db_version, total_db_size_bytes, db_id) FIELDS of SourceDBDetails as parsing these specifically here
+// SHOULD NOT REMOVE THESE (host, db_type, db_version, total_db_size_bytes) FIELDS of SourceDBDetails as parsing these specifically here
 // https://github.com/yugabyte/yugabyte-growth/blob/ad5df306c50c05136df77cd6548a1091ae577046/diagnostics_v2/main.py#L549
 
 /*

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -105,10 +105,10 @@ type SourceDBDetails struct {
 	DBSize             int64    `json:"total_db_size_bytes"`            //bytes
 	Role               string   `json:"role,omitempty"`                 //for differentiating replica details
 	DBSystemIdentifier int64    `json:"db_system_identifier,omitempty"` //Database system identifier for unique instance identification (currently only implemented for PostgreSQL)
-	DBID               int64    `json:"db_id"`                          // postgresql/yugabytedb: pg_database.oid;
+	DBID               int64    `json:"db_id,omitempty"`                // postgresql/yugabytedb: pg_database.oid;
 	DBName             string   `json:"db_name,omitempty"`              //Anonymized database name
 	SchemaNames        []string `json:"schema_names,omitempty"`         //Anonymized schema names
-	SchemaOids         []int64  `json:"schema_oids"`                    //Schema oids
+	SchemaOids         []int64  `json:"schema_oids,omitempty"`          //Schema oids
 }
 
 // SHOULD NOT REMOVE THESE (host, db_version, node_count, total_cores) FIELDS of TargetDBDetails as parsing these specifically here

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -67,10 +67,10 @@ func TestCallhomeStructs(t *testing.T) {
 				DBSize             int64    `json:"total_db_size_bytes"`
 				Role               string   `json:"role,omitempty"`
 				DBSystemIdentifier int64    `json:"db_system_identifier,omitempty"`
-				DBID               int64    `json:"db_id"`
+				DBID               int64    `json:"db_id,omitempty"`
 				DBName             string   `json:"db_name,omitempty"`
 				SchemaNames        []string `json:"schema_names,omitempty"`
-				SchemaOids         []int64  `json:"schema_oids"`
+				SchemaOids         []int64  `json:"schema_oids,omitempty"`
 			}{},
 		},
 		{

--- a/yb-voyager/src/callhome/diagnostics_test.go
+++ b/yb-voyager/src/callhome/diagnostics_test.go
@@ -70,6 +70,7 @@ func TestCallhomeStructs(t *testing.T) {
 				DBID               int64    `json:"db_id"`
 				DBName             string   `json:"db_name,omitempty"`
 				SchemaNames        []string `json:"schema_names,omitempty"`
+				SchemaOids         []int64  `json:"schema_oids"`
 			}{},
 		},
 		{

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -292,6 +292,10 @@ func (ms *MySQL) FetchDBID() error {
 	return nil
 }
 
+func (ms *MySQL) FetchSchemaOids() error {
+	return nil
+}
+
 func (ms *MySQL) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList []sqlname.NameTuple, useDebezium bool) ([]sqlname.NameTuple, []sqlname.NameTuple) {
 	return tableList, nil
 }

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -355,6 +355,10 @@ func (ora *Oracle) FetchDBID() error {
 	return nil
 }
 
+func (ora *Oracle) FetchSchemaOids() error {
+	return nil
+}
+
 func (ora *Oracle) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList []sqlname.NameTuple, useDebezium bool) ([]sqlname.NameTuple, []sqlname.NameTuple) {
 	var filteredTableList, unsupportedTableList []sqlname.NameTuple
 

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -653,6 +653,35 @@ func (pg *PostgreSQL) FetchDBID() error {
 	return nil
 }
 
+func (pg *PostgreSQL) FetchSchemaOids() error {
+	var oids []int64
+	schemaList := sqlname.JoinIdentifiersUnquoted(pg.source.Schemas, "','")
+	query := fmt.Sprintf(`SELECT oid FROM pg_namespace WHERE nspname IN ('%s')`, schemaList)
+	rows, err := pg.db.Query(query)
+	if err != nil {
+		return fmt.Errorf("error in querying source database for schema oids: %q: %w", query, err)
+	}
+	defer func() {
+		closeErr := rows.Close()
+		if closeErr != nil {
+			log.Warnf("close rows for query %q: %v", query, closeErr)
+		}
+	}()
+	for rows.Next() {
+		var oid int64
+		err = rows.Scan(&oid)
+		if err != nil {
+			return fmt.Errorf("error in scanning query rows for schema oids: %w", err)
+		}
+		oids = append(oids, oid)
+	}
+	pg.source.SchemaOids = oids
+	if rows.Err() != nil {
+		return fmt.Errorf("error in scanning query rows for schema oids: %w", rows.Err())
+	}
+	return nil
+}
+
 func (pg *PostgreSQL) FilterUnsupportedTables(migrationUUID uuid.UUID, tableList []sqlname.NameTuple, useDebezium bool) ([]sqlname.NameTuple, []sqlname.NameTuple) {
 	return tableList, nil
 }

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -675,10 +675,10 @@ func (pg *PostgreSQL) FetchSchemaOids() error {
 		}
 		oids = append(oids, oid)
 	}
-	pg.source.SchemaOids = oids
 	if rows.Err() != nil {
 		return fmt.Errorf("error in scanning query rows for schema oids: %w", rows.Err())
 	}
+	pg.source.SchemaOids = oids
 	return nil
 }
 

--- a/yb-voyager/src/srcdb/source.go
+++ b/yb-voyager/src/srcdb/source.go
@@ -63,6 +63,7 @@ type Source struct {
 	DBSize                    int64                `json:"db_size"`
 	DBSystemIdentifier        int64                `json:"db_system_identifier"`
 	DBID                      int64                `json:"db_id,omitempty"` // Source-specific numeric id for call-home; see FetchDBID()
+	SchemaOids                []int64              `json:"schema_oids"`     //Schema oids
 	StrExportObjectTypeList   string               `json:"str_export_object_type_list"`
 	StrExcludeObjectTypeList  string               `json:"str_exclude_object_type_list"`
 	RunGuardrailsChecks       utils.BoolStr        `json:"run_guardrails_checks"`
@@ -98,6 +99,10 @@ func (s *Source) FetchSourceInfo() {
 	err = s.DB().FetchDBID()
 	if err != nil {
 		log.Errorf("error getting database id: %v", err) // can just log as this is used for call-home only
+	}
+	err = s.DB().FetchSchemaOids()
+	if err != nil {
+		log.Errorf("error getting schema oids: %v", err) // can just log as this is used for call-home only
 	}
 }
 

--- a/yb-voyager/src/srcdb/srcdb.go
+++ b/yb-voyager/src/srcdb/srcdb.go
@@ -34,6 +34,7 @@ type SourceDB interface {
 	GetTableApproxRowCount(tableName sqlname.NameTuple) int64
 	GetVersion() string
 	FetchDBID() error
+	FetchSchemaOids() error
 	GetAllSchemaNamesIdentifiers() ([]sqlname.Identifier, error)
 	GetAllTableNames() []*sqlname.SourceName
 	GetAllTableNamesRaw(schemaName string) ([]string, error)

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -460,6 +460,35 @@ func (yb *YugabyteDB) FetchDBID() error {
 	return nil
 }
 
+func (yb *YugabyteDB) FetchSchemaOids() error {
+	var oids []int64
+	schemaList := sqlname.JoinIdentifiersUnquoted(yb.source.Schemas, "','")
+	query := fmt.Sprintf(`SELECT oid FROM pg_namespace WHERE nspname IN ('%s')`, schemaList)
+	rows, err := yb.db.Query(query)
+	if err != nil {
+		return fmt.Errorf("error in querying source database for schema oids: %q: %w", query, err)
+	}
+	defer func() {
+		closeErr := rows.Close()
+		if closeErr != nil {
+			log.Warnf("close rows for query %q: %v", query, closeErr)
+		}
+	}()
+	for rows.Next() {
+		var oid int64
+		err = rows.Scan(&oid)
+		if err != nil {
+			return fmt.Errorf("error in scanning query rows for schema oids: %w", err)
+		}
+		oids = append(oids, oid)
+	}
+	yb.source.SchemaOids = oids
+	if rows.Err() != nil {
+		return fmt.Errorf("error in scanning query rows for schema oids: %w", rows.Err())
+	}
+	return nil
+}
+
 // Thsi function returns some types like UDTs, ENums, etc.. fo which we need to check if there are any tables having columns of Array of these types for gRPC connector.
 func (yb *YugabyteDB) getAllUserDefinedTypesInSchema(schemaName string) []string {
 	query := fmt.Sprintf(`SELECT typname

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -482,10 +482,10 @@ func (yb *YugabyteDB) FetchSchemaOids() error {
 		}
 		oids = append(oids, oid)
 	}
-	yb.source.SchemaOids = oids
 	if rows.Err() != nil {
 		return fmt.Errorf("error in scanning query rows for schema oids: %w", rows.Err())
 	}
+	yb.source.SchemaOids = oids
 	return nil
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request
Adds a field in the source DB details to also send the schema OIDs for unique identity, two migrations in callhome on the same DB ID and with the same schema OIDs.

### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

manually
```
callhome=# select migration_phase,source_db_details from diagnostics where migration_uuid='b1097a26-57ed-4678-9842-3dc9611eef21';
-[ RECORD 1 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
migration_phase   | assess-migration
source_db_details | {"host": "", "db_id": 1632131, "db_name": "db_1fb007232479fbe7", "db_type": "postgresql", "db_version": "17.2 (Debian 17.2-1.pgdg120+1)", "schema_oids": [2200, 1632132], "schema_names": ["schema_5f50868529bea433", "schema_103d6939255641b0"], "payload_version": "1.2", "total_db_size_bytes": 3006464, "db_system_identifier": 7449422312135041063}
-[ RECORD 3 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
migration_phase   | export-data
source_db_details | {"host": "", "db_id": 1632131, "db_name": "db_1fb007232479fbe7", "db_type": "postgresql", "db_version": "17.2 (Debian 17.2-1.pgdg120+1)", "schema_oids": [2200, 1632132], "schema_names": ["schema_5f50868529bea433", "schema_103d6939255641b0"], "payload_version": "1.2", "total_db_size_bytes": 3006464, "db_system_identifier": 7449422312135041063}
-[ RECORD 4 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
migration_phase   | export-schema
source_db_details | {"host": "", "db_id": 1632131, "db_name": "db_1fb007232479fbe7", "db_type": "postgresql", "db_version": "17.2 (Debian 17.2-1.pgdg120+1)", "schema_oids": [2200, 1632132], "schema_names": ["schema_5f50868529bea433", "schema_103d6939255641b0"], "payload_version": "1.2", "total_db_size_bytes": 3006464, "db_system_identifier": 7449422312135041063}

callhome=# 

```

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
yes added a new field in source-db-details json but increased the payload version to 1.2

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
