### PR TITLE
Fix: Do not allow running different command names but same underlying command together 

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -172,7 +172,7 @@ var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
 var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"log-level", "run-guardrails-checks",
 	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb", "max-retries-streaming",
-	"prometheus-metrics-port",	
+	"prometheus-metrics-port",
 	// environment variables keys
 	"ybvoyager-max-colocated-batches-in-progress", "num-event-channels",
 	"event-channel-size", "max-events-per-batch", "max-interval-between-batches",
@@ -240,9 +240,9 @@ var allowedConfigSections = map[string]mapset.Set[string]{
 }
 
 // Define mutually exclusive section groups
-var aliasCommandsPrefixes = [][]string{
-	{"export-data", "export-data-from-source"},
-	{"import-data", "import-data-to-target"},
+var aliasCommandsPrefixes = map[string][]string{
+	"export-data": {"export-data", "export-data-from-source"},
+	"import-data": {"import-data", "import-data-to-target"},
 }
 
 // ConfigParam represents a CLI flag/Config/EnvVar whose value was set by the user depending on the mode of configuration.

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -297,7 +297,7 @@ func resolveToActiveIterationIfRequired(cmd *cobra.Command) error {
 	*/
 	cmdPath := cmd.CommandPath()
 	isFallbackCmd := slices.Contains(fallbackPhaseCommands, cmdPath)
-	//setting the metaDB to the iteration metaDB as the getCutoverStatus is using the global metaDB   
+	//setting the metaDB to the iteration metaDB as the getCutoverStatus is using the global metaDB
 	//and we are fetching the cutover status for the current iteration from this metaDB.
 	latestIterInForwardPhase := (GetCutoverStatus(iterationMetaDB) == NOT_INITIATED)
 
@@ -504,7 +504,20 @@ func validateExportDirFlag() {
 	}
 }
 
+var commandAliases = map[string]string{
+	"export-data-from-source": "export-data",
+	"import-data-to-target":   "import-data",
+}
+
 func GetCommandID(c *cobra.Command) string {
+	commandID := buildCommandID(c)
+	if alias, ok := commandAliases[commandID]; ok {
+		return alias
+	}
+	return commandID
+}
+
+func buildCommandID(c *cobra.Command) string {
 	if c.HasParent() {
 		p := GetCommandID(c.Parent())
 		if p == "" {

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -504,15 +504,12 @@ func validateExportDirFlag() {
 	}
 }
 
-var commandAliases = map[string]string{
-	"export-data-from-source": "export-data",
-	"import-data-to-target":   "import-data",
-}
-
 func GetCommandID(c *cobra.Command) string {
 	commandID := buildCommandID(c)
-	if alias, ok := commandAliases[commandID]; ok {
-		return alias
+	for alias, aliases := range aliasCommandsPrefixes {
+		if slices.Contains(aliases, commandID) {
+			return alias
+		}
 	}
 	return commandID
 }


### PR DESCRIPTION
Example - 
1. export data and export data from source 
2. import data and import data to target 


### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  4. Has the installation process changed? 
  5. Were there any changes to the reports? 
-->
yes, now running `yb-voyager export data` and `yb-voyager export data from source` commands together will error out
```
➜ ~ yb-voyager export data from source -c ~/export-dir-hackathon/config.yaml
Using config file: /Users/priyanshigupta/export-dir-hackathon/config.yaml
Using export-dir: /Users/priyanshigupta/export-dir
migrationID: fe5b8528-d141-41a2-b4c5-06985b595b89
....
export of data for source type as 'postgresql'
Continuing streaming from where we left off...
num tables to export: 6
table list for data export: [public.customers public.sales_region public.test_partitions_sequences public.range_columns_partition_test public.sales public.emp]
streaming changes to a local queue file...

➜  ~ yb-voyager export data from source -c ~/export-dir-hackathon/config.yaml 
Using config file: /Users/priyanshigupta/export-dir-hackathon/config.yaml
Using export-dir: /Users/priyanshigupta/export-dir
Another instance of yb-voyager 'export data' is running for this migration
```

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->
Manually 

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No
### Does your PR have changes to on-disk structures that can cause upgrade issues? 
No
---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
