### PR TITLE
Fix prepared-statement cache PID collision on multi-node import targets

### DIFF
--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -59,11 +59,18 @@ type ConnectionPool struct {
 	// in adaptive parallelism, we may want to reduce the pool size, but
 	// we would not want to close the connection, as we might need to increase the pool
 	// size in the future. So, we move the connections to idleConns instead.
-	idleConns                 chan *pgx.Conn
-	connIdToPreparedStmtCache map[uint32]map[string]bool // cache list of prepared statements per connection
-	nextUriIndex              int
-	disableThrottling         bool
-	size                      int // current size of the pool
+	idleConns chan *pgx.Conn
+	// cache list of prepared statements per connection, keyed by the connection
+	// object itself. We must NOT key this by the backend PID: PIDs are unique
+	// only within a single node, so two connections to different nodes of a
+	// multi-node cluster (or behind a load balancer) can share a PID. Keying by
+	// PID caused a collision where we assumed a statement was already prepared on
+	// a connection it had never been prepared on, skipped the Prepare call, and
+	// failed later when the batch referenced the unprepared statement.
+	connToPreparedStmtCache map[*pgx.Conn]map[string]bool
+	nextUriIndex            int
+	disableThrottling       bool
+	size                    int // current size of the pool
 	// in adaptive parallelism, we may want to reduce the pool size, but
 	// doing it synchronously may lead to contention. So, we increment the
 	// counter pendingConnsToClose, and close the connections asynchronously.
@@ -84,13 +91,13 @@ func NewConnectionPool(params *ConnectionParams) (*ConnectionPool, error) {
 			params.NumConnections, params.NumMaxConnections)
 	}
 	pool := &ConnectionPool{
-		params:                    params,
-		conns:                     make(chan *pgx.Conn, params.NumMaxConnections),
-		idleConns:                 make(chan *pgx.Conn, params.NumMaxConnections),
-		connIdToPreparedStmtCache: make(map[uint32]map[string]bool, params.NumMaxConnections),
-		disableThrottling:         false,
-		size:                      params.NumConnections,
-		pendingConnsToClose:       0,
+		params:                  params,
+		conns:                   make(chan *pgx.Conn, params.NumMaxConnections),
+		idleConns:               make(chan *pgx.Conn, params.NumMaxConnections),
+		connToPreparedStmtCache: make(map[*pgx.Conn]map[string]bool, params.NumMaxConnections),
+		disableThrottling:       false,
+		size:                    params.NumConnections,
+		pendingConnsToClose:     0,
 	}
 	for i := 0; i < params.NumMaxConnections; i++ {
 		pool.idleConns <- nil
@@ -192,10 +199,7 @@ func (pool *ConnectionPool) WithConn(fn func(*pgx.Conn) (bool, error)) error {
 			if errCloseConn != nil {
 				log.Warnf("closing the connection: %v", errCloseConn)
 			}
-			pool.Lock()
-			// assuming PID will still be available
-			delete(pool.connIdToPreparedStmtCache, conn.PgConn().PID())
-			pool.Unlock()
+			pool.removePreparedStmtCacheForConn(conn)
 
 			pool.pendingConnsToCloseLock.Lock()
 			if pool.pendingConnsToClose > 0 {
@@ -223,7 +227,7 @@ func (pool *ConnectionPool) WithConn(fn func(*pgx.Conn) (bool, error)) error {
 }
 
 func (pool *ConnectionPool) PrepareStatement(conn *pgx.Conn, stmtName string, stmt string) error {
-	if pool.isStmtAlreadyPreparedOnConn(conn.PgConn().PID(), stmtName) {
+	if pool.isStmtAlreadyPreparedOnConn(conn, stmtName) {
 		return nil
 	}
 
@@ -232,26 +236,35 @@ func (pool *ConnectionPool) PrepareStatement(conn *pgx.Conn, stmtName string, st
 		log.Errorf("failed to prepare statement %q: %s", stmtName, err)
 		return fmt.Errorf("failed to prepare statement %q: %w", stmtName, err)
 	}
-	pool.cachePreparedStmtForConn(conn.PgConn().PID(), stmtName)
+	pool.cachePreparedStmtForConn(conn, stmtName)
 	return err
 }
 
-func (pool *ConnectionPool) cachePreparedStmtForConn(connId uint32, ps string) {
+func (pool *ConnectionPool) cachePreparedStmtForConn(conn *pgx.Conn, ps string) {
 	pool.Lock()
 	defer pool.Unlock()
-	if pool.connIdToPreparedStmtCache[connId] == nil {
-		pool.connIdToPreparedStmtCache[connId] = make(map[string]bool)
+	if pool.connToPreparedStmtCache[conn] == nil {
+		pool.connToPreparedStmtCache[conn] = make(map[string]bool)
 	}
-	pool.connIdToPreparedStmtCache[connId][ps] = true
+	pool.connToPreparedStmtCache[conn][ps] = true
 }
 
-func (pool *ConnectionPool) isStmtAlreadyPreparedOnConn(connId uint32, ps string) bool {
+func (pool *ConnectionPool) isStmtAlreadyPreparedOnConn(conn *pgx.Conn, ps string) bool {
 	pool.Lock()
 	defer pool.Unlock()
-	if pool.connIdToPreparedStmtCache[connId] == nil {
+	if pool.connToPreparedStmtCache[conn] == nil {
 		return false
 	}
-	return pool.connIdToPreparedStmtCache[connId][ps]
+	return pool.connToPreparedStmtCache[conn][ps]
+}
+
+// removePreparedStmtCacheForConn drops the cached prepared-statement set for a
+// connection. It must be called whenever a connection is closed, so the entry
+// (which holds a live reference to the *pgx.Conn) does not leak.
+func (pool *ConnectionPool) removePreparedStmtCacheForConn(conn *pgx.Conn) {
+	pool.Lock()
+	defer pool.Unlock()
+	delete(pool.connToPreparedStmtCache, conn)
 }
 
 func (pool *ConnectionPool) createNewConnection() (*pgx.Conn, error) {
@@ -330,6 +343,7 @@ func (pool *ConnectionPool) RemoveConnectionsForHosts(servers []string) error {
 			if err != nil {
 				log.Warnf("closing the connection: %v", err)
 			}
+			pool.removePreparedStmtCacheForConn(conn)
 			pool.conns <- nil
 		} else {
 			pool.conns <- conn
@@ -349,6 +363,7 @@ func (pool *ConnectionPool) RemoveConnectionsForHosts(servers []string) error {
 			if err != nil {
 				log.Warnf("closing the connection: %v", err)
 			}
+			pool.removePreparedStmtCacheForConn(idleConn)
 			pool.idleConns <- nil
 		} else {
 			pool.idleConns <- idleConn

--- a/yb-voyager/src/tgtdb/conn_pool_unit_test.go
+++ b/yb-voyager/src/tgtdb/conn_pool_unit_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The prepared-statement cache helpers key only on the *pgx.Conn pointer; they
@@ -34,7 +35,7 @@ func newTestPool(t *testing.T) *ConnectionPool {
 		NumMaxConnections: 1,
 		ConnUriList:       []string{"postgres://localhost/test"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return pool
 }
 

--- a/yb-voyager/src/tgtdb/conn_pool_unit_test.go
+++ b/yb-voyager/src/tgtdb/conn_pool_unit_test.go
@@ -1,0 +1,92 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tgtdb
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// The prepared-statement cache helpers key only on the *pgx.Conn pointer; they
+// never dereference the connection. So we can exercise the collision logic with
+// bare conn objects and no real database.
+func newTestPool(t *testing.T) *ConnectionPool {
+	t.Helper()
+	pool, err := NewConnectionPool(&ConnectionParams{
+		NumConnections:    1,
+		NumMaxConnections: 1,
+		ConnUriList:       []string{"postgres://localhost/test"},
+	})
+	assert.NoError(t, err)
+	return pool
+}
+
+// Regression test for the PID-collision bug. Two distinct connections that
+// (under the old PID-keyed cache) could share a backend PID across nodes must
+// be tracked independently. Caching a statement on one connection must never
+// make us believe it is prepared on the other.
+func TestPreparedStmtCache_NoCrossConnCollision(t *testing.T) {
+	pool := newTestPool(t)
+
+	// Two separate connection objects. With the old uint32-PID key these could
+	// collide; with the *pgx.Conn key they are always distinct.
+	conn1 := &pgx.Conn{}
+	conn2 := &pgx.Conn{}
+
+	const stmt = "stmt_abc"
+
+	// Initially neither connection has the statement prepared.
+	assert.False(t, pool.isStmtAlreadyPreparedOnConn(conn1, stmt))
+	assert.False(t, pool.isStmtAlreadyPreparedOnConn(conn2, stmt))
+
+	// Prepare on conn1 only.
+	pool.cachePreparedStmtForConn(conn1, stmt)
+
+	assert.True(t, pool.isStmtAlreadyPreparedOnConn(conn1, stmt))
+	// conn2 must still report "not prepared" — this is the bug the PID key caused.
+	assert.False(t, pool.isStmtAlreadyPreparedOnConn(conn2, stmt))
+}
+
+// Distinct statement names on the same connection are tracked independently.
+func TestPreparedStmtCache_PerStatement(t *testing.T) {
+	pool := newTestPool(t)
+	conn := &pgx.Conn{}
+
+	pool.cachePreparedStmtForConn(conn, "stmt_a")
+
+	assert.True(t, pool.isStmtAlreadyPreparedOnConn(conn, "stmt_a"))
+	assert.False(t, pool.isStmtAlreadyPreparedOnConn(conn, "stmt_b"))
+}
+
+// Closing a connection must evict its cache entry so the entry (which holds a
+// live reference to the conn) does not leak.
+func TestPreparedStmtCache_RemoveOnClose(t *testing.T) {
+	pool := newTestPool(t)
+	conn := &pgx.Conn{}
+
+	pool.cachePreparedStmtForConn(conn, "stmt_a")
+	assert.True(t, pool.isStmtAlreadyPreparedOnConn(conn, "stmt_a"))
+
+	pool.removePreparedStmtCacheForConn(conn)
+
+	assert.False(t, pool.isStmtAlreadyPreparedOnConn(conn, "stmt_a"))
+	_, present := pool.connToPreparedStmtCache[conn]
+	assert.False(t, present, "cache entry should be removed on close")
+}


### PR DESCRIPTION
### Describe the changes in this pull request

Fixes a prepared-statement cache collision that caused `import data` to fail against multi-node YugabyteDB targets.
https://yugabyte.atlassian.net/browse/DB-19670
https://github.com/yugabyte/yb-voyager/issues/3266


The import connection pool (`ConnectionPool`) caches the set of prepared statements per connection so it can skip re-preparing a statement that is already prepared on a given connection. That cache was keyed by the connection's **backend PID** (`conn.PgConn().PID()`). Backend PIDs are only unique *within a single node* — two connections to different nodes of a multi-node cluster (or behind a load balancer) can report the same PID. On such a collision, voyager believed a statement was already prepared on a connection where it had never been prepared, skipped the `Prepare` call, and the batch later failed when it referenced the (non-existent) prepared statement — surfacing as a confusing `syntax error at or near ...` for the prepared-statement name.

This only affected multi-node targets. Single-node PostgreSQL targets used in `import-data-to-source` / `import-data-to-source-replica` (fall-back / fall-forward) never collide, which is why it was not seen there.

The fix keys the cache by the `*pgx.Conn` object itself instead of the PID. The connection object is unique per live connection regardless of which node it lands on or whether a load balancer is in front, so it cannot collide (a composite `(host, PID)` key would *not* have fixed the load-balancer case, where every connection reports the same host). A new `removePreparedStmtCacheForConn` helper is called on every connection-close path; this includes `RemoveConnectionsForHosts`, which previously closed connections without evicting their cache entry — harmless under PID keying but a leak once entries are keyed by a pointer that keeps the connection object alive.

### Describe if there are any user-facing changes

No user-facing changes. No changes to the command line, configuration, installation, or reports. This is an internal correctness fix; the visible effect is that `import data` to multi-node targets no longer intermittently fails with the prepared-statement error.

### How was this pull request tested?

- Added `unit`-tagged tests in `conn_pool_unit_test.go` (run in CI's default `unit` tier, no DB required):
  - `TestPreparedStmtCache_NoCrossConnCollision` — the regression test: a statement cached on one connection must not be reported as prepared on a different connection (the exact failure the PID key caused).
  - `TestPreparedStmtCache_PerStatement` — distinct statement names on the same connection are tracked independently.
  - `TestPreparedStmtCache_RemoveOnClose` — closing a connection evicts its cache entry.
- These exercise the cache helpers directly using bare `&pgx.Conn{}` values, since the helpers only use the connection as a map key and never dereference it — so no mocks or live database are needed.
- `go build ./...`, `go vet -tags unit ./src/tgtdb/`, and `go test -tags unit -run TestPreparedStmtCache ./src/tgtdb/` all pass.
- End-to-end verification against a real multi-node YB target was not added as an integration test; the unit tests cover the keying logic where the bug lived.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. The cache is in-memory only; no on-disk structures are affected.
