### PR TITLE
Fix duplicate error output for failures before logging initialization

### DIFF
--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -31,6 +31,7 @@ import (
 	goerrors "github.com/go-errors/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/tebeka/atexit"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
@@ -455,11 +456,16 @@ func isMigrationAssessmentDoneForConfig(dbConfig AssessMigrationDBConfig) bool {
 }
 
 func validateBulkAssessmentDirFlag() {
+	// This runs before InitLogging(), so logging is not yet redirected to the log
+	// file. Using utils.ErrExit here would print the message twice (once to stderr
+	// and again via logrus's default stderr output), so print to console directly.
 	if bulkAssessmentDir == "" {
-		utils.ErrExit(`ERROR required flag "bulk-assessment-dir" not set`)
+		fmt.Printf("ERROR required flag \"bulk-assessment-dir\" not set\n")
+		atexit.Exit(1)
 	}
 	if !utils.FileOrFolderExists(bulkAssessmentDir) {
-		utils.ErrExit("bulk-assessment-dir doesn't exists: %q\n", bulkAssessmentDir)
+		fmt.Printf("bulk-assessment-dir doesn't exists: %q\n", bulkAssessmentDir)
+		atexit.Exit(1)
 	} else {
 		if bulkAssessmentDir == "." {
 			fmt.Println("Note: Using current directory as bulk-assessment-dir")
@@ -467,7 +473,8 @@ func validateBulkAssessmentDirFlag() {
 		var err error
 		bulkAssessmentDir, err = filepath.Abs(bulkAssessmentDir)
 		if err != nil {
-			utils.ErrExit("Failed to get absolute path for bulk-assessment-dir: %q: %v\n", exportDir, err)
+			fmt.Printf("Failed to get absolute path for bulk-assessment-dir: %q: %v\n", exportDir, err)
+			atexit.Exit(1)
 		}
 		bulkAssessmentDir = filepath.Clean(bulkAssessmentDir)
 	}

--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -460,11 +460,11 @@ func validateBulkAssessmentDirFlag() {
 	// file. Using utils.ErrExit here would print the message twice (once to stderr
 	// and again via logrus's default stderr output), so print to console directly.
 	if bulkAssessmentDir == "" {
-		fmt.Printf("ERROR required flag \"bulk-assessment-dir\" not set\n")
+		fmt.Fprintf(os.Stderr, "ERROR required flag \"bulk-assessment-dir\" not set\n")
 		atexit.Exit(1)
 	}
 	if !utils.FileOrFolderExists(bulkAssessmentDir) {
-		fmt.Printf("bulk-assessment-dir doesn't exists: %q\n", bulkAssessmentDir)
+		fmt.Fprintf(os.Stderr, "bulk-assessment-dir doesn't exists: %q\n", bulkAssessmentDir)
 		atexit.Exit(1)
 	} else {
 		if bulkAssessmentDir == "." {
@@ -473,7 +473,7 @@ func validateBulkAssessmentDirFlag() {
 		var err error
 		bulkAssessmentDir, err = filepath.Abs(bulkAssessmentDir)
 		if err != nil {
-			fmt.Printf("Failed to get absolute path for bulk-assessment-dir: %q: %v\n", exportDir, err)
+			fmt.Fprintf(os.Stderr, "Failed to get absolute path for bulk-assessment-dir: %q: %v\n", bulkAssessmentDir, err)
 			atexit.Exit(1)
 		}
 		bulkAssessmentDir = filepath.Clean(bulkAssessmentDir)

--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -31,7 +31,6 @@ import (
 	goerrors "github.com/go-errors/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/tebeka/atexit"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
@@ -456,16 +455,13 @@ func isMigrationAssessmentDoneForConfig(dbConfig AssessMigrationDBConfig) bool {
 }
 
 func validateBulkAssessmentDirFlag() {
-	// This runs before InitLogging(), so logging is not yet redirected to the log
-	// file. Using utils.ErrExit here would print the message twice (once to stderr
-	// and again via logrus's default stderr output), so print to console directly.
+	// This runs before InitLogging(), so use utils.ErrExitPreLog instead of
+	// utils.ErrExit to avoid printing the message twice.
 	if bulkAssessmentDir == "" {
-		fmt.Fprintf(os.Stderr, "ERROR required flag \"bulk-assessment-dir\" not set\n")
-		atexit.Exit(1)
+		utils.ErrExitPreLog("ERROR required flag \"bulk-assessment-dir\" not set")
 	}
 	if !utils.FileOrFolderExists(bulkAssessmentDir) {
-		fmt.Fprintf(os.Stderr, "bulk-assessment-dir doesn't exists: %q\n", bulkAssessmentDir)
-		atexit.Exit(1)
+		utils.ErrExitPreLog("bulk-assessment-dir doesn't exists: %q", bulkAssessmentDir)
 	} else {
 		if bulkAssessmentDir == "." {
 			fmt.Println("Note: Using current directory as bulk-assessment-dir")
@@ -473,8 +469,7 @@ func validateBulkAssessmentDirFlag() {
 		var err error
 		bulkAssessmentDir, err = filepath.Abs(bulkAssessmentDir)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to get absolute path for bulk-assessment-dir: %q: %v\n", bulkAssessmentDir, err)
-			atexit.Exit(1)
+			utils.ErrExitPreLog("Failed to get absolute path for bulk-assessment-dir: %q: %v", bulkAssessmentDir, err)
 		}
 		bulkAssessmentDir = filepath.Clean(bulkAssessmentDir)
 	}

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -119,9 +119,8 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			validateBulkAssessmentDirFlag()
 			err := config.ValidateLogLevel()
 			if err != nil {
-				// not using utils.ErrExit as logging is not initialized yet
-				fmt.Printf("ERROR: %v\n", err)
-				atexit.Exit(1)
+				// logging is not initialized yet
+				utils.ErrExitPreLog("ERROR: %v", err)
 			}
 			if shouldLock(cmd) {
 				lockFPath := filepath.Join(bulkAssessmentDir, fmt.Sprintf(".%sLockfile.lck", GetCommandID(cmd)))
@@ -130,10 +129,8 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			}
 			err = InitLogging(bulkAssessmentDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
 			if err != nil {
-				// InitLogging failed, so logging is still on its default stderr output;
-				// avoid utils.ErrExit here as it would print the error twice.
-				fmt.Fprintf(os.Stderr, "ERROR: Failed to initialize logging: %v\n", err)
-				atexit.Exit(1)
+				// InitLogging failed, so use ErrExitPreLog to avoid printing twice.
+				utils.ErrExitPreLog("ERROR: Failed to initialize logging: %v", err)
 			}
 			startTime = time.Now()
 			log.Infof("Start time: %s\n", startTime)
@@ -152,9 +149,8 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			validateExportDirFlag()
 			err := config.ValidateLogLevel()
 			if err != nil {
-				// not using utils.ErrExit as logging is not initialized yet
-				fmt.Printf("ERROR: %v\n", err)
-				atexit.Exit(1)
+				// logging is not initialized yet
+				utils.ErrExitPreLog("ERROR: %v", err)
 			}
 			schemaDir = filepath.Join(exportDir, "schema")
 			if shouldLock(cmd) {
@@ -164,10 +160,8 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			}
 			err = InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
 			if err != nil {
-				// InitLogging failed, so logging is still on its default stderr output;
-				// avoid utils.ErrExit here as it would print the error twice.
-				fmt.Fprintf(os.Stderr, "ERROR: Failed to initialize logging: %v\n", err)
-				atexit.Exit(1)
+				// InitLogging failed, so use ErrExitPreLog to avoid printing twice.
+				utils.ErrExitPreLog("ERROR: Failed to initialize logging: %v", err)
 			}
 			startTime = time.Now()
 			log.Infof("Start time: %s\n", startTime)
@@ -268,10 +262,8 @@ func resolveToActiveIterationIfRequired(cmd *cobra.Command) error {
 	//this is just for any logs that might be printed before the iteration export dir is resolved
 	err := InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
 	if err != nil {
-		// InitLogging failed, so logging is still on its default stderr output;
-		// avoid utils.ErrExit here as it would print the error twice.
-		fmt.Fprintf(os.Stderr, "ERROR: Failed to initialize logging: %v\n", err)
-		atexit.Exit(1)
+		// InitLogging failed, so use ErrExitPreLog to avoid printing twice.
+		utils.ErrExitPreLog("ERROR: Failed to initialize logging: %v", err)
 	}
 	metaDB = initMetaDB(exportDir)
 	msr, err := metaDB.GetMigrationStatusRecord()
@@ -491,16 +483,13 @@ func registerExportDirFlag(cmd *cobra.Command) {
 }
 
 func validateExportDirFlag() {
-	// This runs before InitLogging(), so logging is not yet redirected to the log
-	// file. Using utils.ErrExit here would print the message twice (once to stderr
-	// and again via logrus's default stderr output), so print to console directly.
+	// This runs before InitLogging(), so use utils.ErrExitPreLog instead of
+	// utils.ErrExit to avoid printing the message twice.
 	if exportDir == "" {
-		fmt.Fprintf(os.Stderr, "ERROR required flag \"export-dir\" not set\n")
-		atexit.Exit(1)
+		utils.ErrExitPreLog("ERROR required flag \"export-dir\" not set")
 	}
 	if !utils.FileOrFolderExists(exportDir) {
-		fmt.Fprintf(os.Stderr, "export-dir doesn't exist: %q\n", exportDir)
-		atexit.Exit(1)
+		utils.ErrExitPreLog("export-dir doesn't exist: %q", exportDir)
 	} else {
 		if exportDir == "." {
 			fmt.Println("Note: Using current directory as export-dir")
@@ -508,8 +497,7 @@ func validateExportDirFlag() {
 		var err error
 		exportDir, err = filepath.Abs(exportDir)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to get absolute path for export-dir: %q: %v\n", exportDir, err)
-			atexit.Exit(1)
+			utils.ErrExitPreLog("Failed to get absolute path for export-dir: %q: %v", exportDir, err)
 		}
 		exportDir = filepath.Clean(exportDir)
 	}

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -132,7 +132,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			if err != nil {
 				// InitLogging failed, so logging is still on its default stderr output;
 				// avoid utils.ErrExit here as it would print the error twice.
-				fmt.Printf("ERROR: Failed to initialize logging: %v\n", err)
+				fmt.Fprintf(os.Stderr, "ERROR: Failed to initialize logging: %v\n", err)
 				atexit.Exit(1)
 			}
 			startTime = time.Now()
@@ -166,7 +166,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			if err != nil {
 				// InitLogging failed, so logging is still on its default stderr output;
 				// avoid utils.ErrExit here as it would print the error twice.
-				fmt.Printf("ERROR: Failed to initialize logging: %v\n", err)
+				fmt.Fprintf(os.Stderr, "ERROR: Failed to initialize logging: %v\n", err)
 				atexit.Exit(1)
 			}
 			startTime = time.Now()
@@ -270,7 +270,7 @@ func resolveToActiveIterationIfRequired(cmd *cobra.Command) error {
 	if err != nil {
 		// InitLogging failed, so logging is still on its default stderr output;
 		// avoid utils.ErrExit here as it would print the error twice.
-		fmt.Printf("ERROR: Failed to initialize logging: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to initialize logging: %v\n", err)
 		atexit.Exit(1)
 	}
 	metaDB = initMetaDB(exportDir)
@@ -495,11 +495,11 @@ func validateExportDirFlag() {
 	// file. Using utils.ErrExit here would print the message twice (once to stderr
 	// and again via logrus's default stderr output), so print to console directly.
 	if exportDir == "" {
-		fmt.Printf("ERROR required flag \"export-dir\" not set\n")
+		fmt.Fprintf(os.Stderr, "ERROR required flag \"export-dir\" not set\n")
 		atexit.Exit(1)
 	}
 	if !utils.FileOrFolderExists(exportDir) {
-		fmt.Printf("export-dir doesn't exist: %q\n", exportDir)
+		fmt.Fprintf(os.Stderr, "export-dir doesn't exist: %q\n", exportDir)
 		atexit.Exit(1)
 	} else {
 		if exportDir == "." {
@@ -508,7 +508,7 @@ func validateExportDirFlag() {
 		var err error
 		exportDir, err = filepath.Abs(exportDir)
 		if err != nil {
-			fmt.Printf("Failed to get absolute path for export-dir: %q: %v\n", exportDir, err)
+			fmt.Fprintf(os.Stderr, "Failed to get absolute path for export-dir: %q: %v\n", exportDir, err)
 			atexit.Exit(1)
 		}
 		exportDir = filepath.Clean(exportDir)

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -130,7 +130,10 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			}
 			err = InitLogging(bulkAssessmentDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
 			if err != nil {
-				utils.ErrExit("Failed to initialize logging: %w", err)
+				// InitLogging failed, so logging is still on its default stderr output;
+				// avoid utils.ErrExit here as it would print the error twice.
+				fmt.Printf("ERROR: Failed to initialize logging: %v\n", err)
+				atexit.Exit(1)
 			}
 			startTime = time.Now()
 			log.Infof("Start time: %s\n", startTime)
@@ -161,7 +164,10 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			}
 			err = InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
 			if err != nil {
-				utils.ErrExit("Failed to initialize logging: %w", err)
+				// InitLogging failed, so logging is still on its default stderr output;
+				// avoid utils.ErrExit here as it would print the error twice.
+				fmt.Printf("ERROR: Failed to initialize logging: %v\n", err)
+				atexit.Exit(1)
 			}
 			startTime = time.Now()
 			log.Infof("Start time: %s\n", startTime)
@@ -262,7 +268,10 @@ func resolveToActiveIterationIfRequired(cmd *cobra.Command) error {
 	//this is just for any logs that might be printed before the iteration export dir is resolved
 	err := InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
 	if err != nil {
-		utils.ErrExit("Failed to initialize logging: %w", err)
+		// InitLogging failed, so logging is still on its default stderr output;
+		// avoid utils.ErrExit here as it would print the error twice.
+		fmt.Printf("ERROR: Failed to initialize logging: %v\n", err)
+		atexit.Exit(1)
 	}
 	metaDB = initMetaDB(exportDir)
 	msr, err := metaDB.GetMigrationStatusRecord()
@@ -482,11 +491,16 @@ func registerExportDirFlag(cmd *cobra.Command) {
 }
 
 func validateExportDirFlag() {
+	// This runs before InitLogging(), so logging is not yet redirected to the log
+	// file. Using utils.ErrExit here would print the message twice (once to stderr
+	// and again via logrus's default stderr output), so print to console directly.
 	if exportDir == "" {
-		utils.ErrExit(`ERROR required flag "export-dir" not set`)
+		fmt.Printf("ERROR required flag \"export-dir\" not set\n")
+		atexit.Exit(1)
 	}
 	if !utils.FileOrFolderExists(exportDir) {
-		utils.ErrExit("export-dir doesn't exist: %q\n", exportDir)
+		fmt.Printf("export-dir doesn't exist: %q\n", exportDir)
+		atexit.Exit(1)
 	} else {
 		if exportDir == "." {
 			fmt.Println("Note: Using current directory as export-dir")
@@ -494,7 +508,8 @@ func validateExportDirFlag() {
 		var err error
 		exportDir, err = filepath.Abs(exportDir)
 		if err != nil {
-			utils.ErrExit("Failed to get absolute path for export-dir: %q: %w\n", exportDir, err)
+			fmt.Printf("Failed to get absolute path for export-dir: %q: %v\n", exportDir, err)
+			atexit.Exit(1)
 		}
 		exportDir = filepath.Clean(exportDir)
 	}

--- a/yb-voyager/src/utils/logging.go
+++ b/yb-voyager/src/utils/logging.go
@@ -38,6 +38,17 @@ var ErrExit = func(formatString string, args ...interface{}) {
 	atexit.Exit(1)
 }
 
+// ErrExitPreLog prints the message to stderr and exits with status 1.
+// Use it instead of ErrExit when logging has not been initialized yet (e.g. flag
+// validation that runs before InitLogging(), or when logging init itself fails).
+// It deliberately does not call log.Errorf: doing so before logging is redirected
+// to the log file would print the message twice (once here and again via logrus's
+// default stderr output).
+var ErrExitPreLog = func(formatString string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, formatString+"\n", args...)
+	atexit.Exit(1)
+}
+
 // OutputLogLevel represents different types of console messages
 type OutputLogLevel int
 


### PR DESCRIPTION
 ### Describe the changes in this pull request

  Errors raised during early command bootstrap — before `InitLogging()` runs —
  were printed to the console twice. `utils.ErrExit` both writes the message to
  stderr via `fmt.Fprintf` and logs it via `log.Errorf`. Once logging is
  initialized those go to two different destinations (console + log file), but
  before initialization logrus is still on its default stderr output, so the
  message lands on the terminal twice (the second copy carrying logrus's default
  `ERRO[0000]` prefix).

  This affects the pre-init validation/bootstrap window for every command, e.g.
  the `export-dir doesn't exist` error. The fix follows the convention already
  used elsewhere in this window (`initConfig`, `ValidateLogLevel`): pre-init
  failures print to the console directly and call `atexit.Exit(1)` instead of
  `utils.ErrExit`. Converted spots: `validateExportDirFlag`,
  `validateBulkAssessmentDirFlag`, and the three `InitLogging`-failure exits in
  `root.go`. `ErrExit` itself and all post-init call sites are unchanged, so
  behavior elsewhere is untouched.

  ### Describe if there are any user-facing changes

  Yes — minor console output only. Early-bootstrap errors (bad `--export-dir` /
  `--bulk-assessment-dir`, logging init failure) now print once instead of twice.
  No changes to command line flags, configuration, installation, or reports.

  ### How was this pull request tested?

  `go build ./cmd/...` and `go vet ./cmd/` pass clean. Manually reasoned through
  the pre-init code path. No new automated tests added — the change only affects
  console-output duplication during early exit, which existing tests don't assert
  on. Recommend a quick manual check: run any command with a non-existent
  `--export-dir` and confirm the error appears only once.

  ### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

  No.

  ### Does your PR have changes to on-disk structures that can cause upgrade issues?

  No.