### PR TITLE
Enforce pragmatic, structured finding format in pr-review-sweep skill

### DIFF
--- a/ai/skills/branch-review/SKILL.md
+++ b/ai/skills/branch-review/SKILL.md
@@ -115,7 +115,14 @@ Evaluate every change against:
 
 ### Step 5: Present findings
 
-Group findings by severity:
+Group findings by severity. Keep every finding pragmatic — no fluff. Each finding must use these bullet points, in this order:
+
+- Problem/Suggestion: <the issue or recommendation, if any>
+- Code line: <file:line of the failing/affected code>
+- Failure Code Case: <the case that breaks, if any>
+- Suggested Code Change: <the concrete fix; if any code is being suggested, give it in a fenced code block>
+
+Omit a bullet's value only when it genuinely does not apply (e.g. "if any" parts); never pad with restatements, praise, or generic advice.
 
 #### Critical — Must fix before merge
 Issues that cause bugs, security holes, or data loss.
@@ -123,7 +130,10 @@ Issues that cause bugs, security holes, or data loss.
 Format:
 ```
 **[CRITICAL]** `file:line` — Brief description
-> Explanation of the issue and suggested fix
+- Problem/Suggestion: ...
+- Code line: ...
+- Failure Code Case: ...
+- Suggested Code Change: ...
 ```
 
 #### Warning — Should fix
@@ -132,7 +142,10 @@ Issues that may cause problems or hurt maintainability.
 Format:
 ```
 **[WARNING]** `file:line` — Brief description
-> Explanation and recommendation
+- Problem/Suggestion: ...
+- Code line: ...
+- Failure Code Case: ...
+- Suggested Code Change: ...
 ```
 
 #### Suggestion — Nice to have
@@ -141,7 +154,10 @@ Style improvements, minor refactors, optional enhancements.
 Format:
 ```
 **[SUGGESTION]** `file:line` — Brief description
-> Rationale
+- Problem/Suggestion: ...
+- Code line: ...
+- Failure Code Case: ...
+- Suggested Code Change: ...
 ```
 
 ### Step 6: Summary

--- a/ai/skills/pr-review-sweep/SKILL.md
+++ b/ai/skills/pr-review-sweep/SKILL.md
@@ -119,7 +119,7 @@ Repo root: <REPO_ROOT>. Base branch: <BASE>.
      - Problem/Suggestion: <the issue or recommendation, if any>
      - Code line: <file:line of the failing/affected code>
      - Failure Code Case: <the case that breaks, if any>
-     - Suggested Code Change: <the concrete fix>
+     - Suggested Code Change: <the concrete fix; if any code is being suggested, give it in a fenced code block>
    Omit a bullet's value only when it genuinely does not apply (e.g. "if any"
    parts); never pad with restatements, praise, or generic advice.
 

--- a/ai/skills/pr-review-sweep/SKILL.md
+++ b/ai/skills/pr-review-sweep/SKILL.md
@@ -114,6 +114,15 @@ Repo root: <REPO_ROOT>. Base branch: <BASE>.
    HEAD is detached here; use "PR #<N>" as the branch name in the summary.
    If the `sem` tool is unavailable, omit the entity-modification tables.
 
+   Keep every finding pragmatic — no fluff. Each finding must use these
+   bullet points, in this order:
+     - Problem/Suggestion: <the issue or recommendation, if any>
+     - Code line: <file:line of the failing/affected code>
+     - Failure Code Case: <the case that breaks, if any>
+     - Suggested Code Change: <the concrete fix>
+   Omit a bullet's value only when it genuinely does not apply (e.g. "if any"
+   parts); never pad with restatements, praise, or generic advice.
+
 3. Read <REPO_ROOT>/ai/skills/post-pr-review/SKILL.md and apply it to post
    the findings to PR #<N>, with TWO overrides:
      a. Skip Step 6 (user confirmation) — post immediately after building

--- a/ai/skills/pr-review-sweep/SKILL.md
+++ b/ai/skills/pr-review-sweep/SKILL.md
@@ -114,15 +114,6 @@ Repo root: <REPO_ROOT>. Base branch: <BASE>.
    HEAD is detached here; use "PR #<N>" as the branch name in the summary.
    If the `sem` tool is unavailable, omit the entity-modification tables.
 
-   Keep every finding pragmatic — no fluff. Each finding must use these
-   bullet points, in this order:
-     - Problem/Suggestion: <the issue or recommendation, if any>
-     - Code line: <file:line of the failing/affected code>
-     - Failure Code Case: <the case that breaks, if any>
-     - Suggested Code Change: <the concrete fix; if any code is being suggested, give it in a fenced code block>
-   Omit a bullet's value only when it genuinely does not apply (e.g. "if any"
-   parts); never pad with restatements, praise, or generic advice.
-
 3. Read <REPO_ROOT>/ai/skills/post-pr-review/SKILL.md and apply it to post
    the findings to PR #<N>, with TWO overrides:
      a. Skip Step 6 (user confirmation) — post immediately after building


### PR DESCRIPTION
### Describe the changes in this pull request

Adds a "pragmatic, no fluff" constraint to the `pr-review-sweep` skill so that
every review finding produced by the per-PR subagent follows a fixed, structured
format. Each finding must now use four ordered bullets — Problem/Suggestion,
Code line, Failure Code Case, and Suggested Code Change — and the guidance
explicitly forbids padding with restatements, praise, or generic advice. This
keeps automated PR reviews terse and actionable, and makes posted findings
consistent across runs. The change is documentation/instructions only within the
skill prompt; the underlying review and posting logic (delegated to
`branch-review` and `post-pr-review`) is unchanged.

### Describe if there are any user-facing changes

No user-facing changes. This only affects the internal AI skill instructions
used to generate PR reviews; there are no changes to the CLI, configuration,
installation, or reports.

### How was this pull request tested?

No automated tests apply — this is a Markdown instruction file for an AI skill.
Verified by reviewing the rendered `SKILL.md` to confirm the new bullet format
and no-fluff guidance read correctly within the Step 4 subagent prompt.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

Example Output:
<img width="1066" height="376" alt="image" src="https://github.com/user-attachments/assets/0756c2fd-5a11-4a13-abaf-9ed9bb419b17" />
