### PR TITLE
Warn on export-data-from-target when YB server series is newer than the CDC logical connector

### DIFF
--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -417,7 +417,7 @@ func shouldWarnServerSeriesNewerThanConnector(connectorYBVersion, serverYBVersio
 	// Same release type: compare series numerically.
 	if connSeries.ReleaseType() == serverSeries.ReleaseType() {
 		if serverSeries.GreaterThanOrEqual(connSeries) && !serverSeries.Equal(connSeries) {
-			return true, fmt.Sprintf("the target YugabyteDB server release %s is newer than the connector's release %s", serverSeries.Series(), connSeries.Series()), nil
+			return true, fmt.Sprintf("the target YugabyteDB server release %s is newer than the connector's release %s", serverYBVersion, connectorYBVersion), nil
 		}
 		return false, "", nil
 	}
@@ -427,7 +427,7 @@ func shouldWarnServerSeriesNewerThanConnector(connectorYBVersion, serverYBVersio
 	case ybversion.STABLE_OLD:
 		return false, "", nil
 	case ybversion.PREVIEW:
-		return true, fmt.Sprintf("the target YugabyteDB server is on preview release %s, which the connector was not built for", serverSeries.Series()), nil
+		return true, fmt.Sprintf("the target YugabyteDB server is on preview release %s, which the connector was not built for", serverYBVersion), nil
 	default:
 		return false, "", goerrors.Errorf("cannot compare connector series %s (%s) with server series %s (%s)", connSeries.Series(), connSeries.ReleaseType(), serverSeries.Series(), serverSeries.ReleaseType())
 	}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -192,6 +192,7 @@ func exportDataCommandFn(cmd *cobra.Command, args []string) {
 		utils.PrintAndLogf("Note: Beta feature to accelerate data export is enabled by setting BETA_FAST_DATA_EXPORT environment variable")
 	}
 	printLiveMigrationLimitations()
+	warnIfYBServerNewerThanLogicalConnector(msr)
 	utils.PrintAndLogf("export of data for source type as '%s'", source.DBType)
 	sqlname.SourceDBType = source.DBType
 	setSourceDetailsForChangesOnly(msr)
@@ -383,6 +384,118 @@ func isCDCSavepointFixedInTargetDBVersion(dbVersionStr string) (bool, string) {
 		return false, ""
 	}
 	return ybVer.GreaterThanOrEqual(minFixedVersion), minFixedVersion.String()
+}
+
+// shouldWarnServerSeriesNewerThanConnector reports whether to warn that the target YB
+// server may be incompatible with the logical connector. Compatibility is by release
+// SERIES (YEAR.TRACK) — the connector tag's trailing part (".3" in "2025.2.3") is a
+// connector-internal counter, not a YB patch, so a "2025.2" connector supports all
+// 2025.2.x. Warn when:
+//   - the server series is newer than the connector's series, or
+//   - the server series is unrecognized (ErrUnsupportedSeries) — likely newer, or
+//   - the server is on a PREVIEW series the connector was not built for.
+//
+// Do not warn when the server series is <= the connector's, or is a pre-calendar
+// STABLE_OLD (2.x) series (the newer, backward-compatible connector covers it).
+// Ref: https://docs.yugabyte.com/stable/releases/versioning/
+func shouldWarnServerSeriesNewerThanConnector(connectorYBVersion, serverYBVersion string) (bool, string, error) {
+	connSeries, err := ybversion.NewYBVersion(ybversion.SeriesVersion(connectorYBVersion))
+	if err != nil {
+		// The connector's series should always be a known YB series; if not, we cannot
+		// reason about it, so skip rather than warn.
+		return false, "", goerrors.Errorf("parsing connector series from %q: %w", connectorYBVersion, err)
+	}
+
+	serverSeries, err := ybversion.NewYBVersion(ybversion.SeriesVersion(serverYBVersion))
+	if err != nil {
+		if errors.Is(err, ybversion.ErrUnsupportedSeries) {
+			return true, fmt.Sprintf("the target YugabyteDB server %q is on a release series this Voyager build does not recognize (likely newer than the bundled connector)", serverYBVersion), nil
+		}
+		return false, "", goerrors.Errorf("parsing server series from %q: %w", serverYBVersion, err)
+	}
+
+	// Same release type: compare series numerically.
+	if connSeries.ReleaseType() == serverSeries.ReleaseType() {
+		if serverSeries.GreaterThanOrEqual(connSeries) && !serverSeries.Equal(connSeries) {
+			return true, fmt.Sprintf("the target YugabyteDB server series %s is newer than the connector's series %s", serverSeries.Series(), connSeries.Series()), nil
+		}
+		return false, "", nil
+	}
+
+	// Connector is stable; verdict depends on the server's release type.
+	switch serverSeries.ReleaseType() {
+	case ybversion.STABLE_OLD:
+		return false, "", nil
+	case ybversion.PREVIEW:
+		return true, fmt.Sprintf("the target YugabyteDB server is on preview series %s, which the connector was not built for", serverSeries.Series()), nil
+	default:
+		return false, "", goerrors.Errorf("cannot compare connector series %s (%s) with server series %s (%s)", connSeries.Series(), connSeries.ReleaseType(), serverSeries.Series(), serverSeries.ReleaseType())
+	}
+}
+
+// warnIfYBServerNewerThanLogicalConnector warns (and prompts to continue) when the target
+// YB server is on a newer release series than the logical connector supports — forward-
+// compatibility is not guaranteed. Only applies to the logical connector in the
+// export-data-from-target (fall-back/fall-forward) flow; a no-op for the gRPC connector or
+// when versions cannot be determined.
+func warnIfYBServerNewerThanLogicalConnector(msr *metadb.MigrationStatusRecord) {
+	if msr == nil || msr.UseYBgRPCConnector {
+		return
+	}
+	if !isTargetDBExporter(exporterRole) || !changeStreamingIsEnabled(exportType) {
+		return
+	}
+	if msr.TargetDBConf == nil || msr.TargetDBConf.DBVersion == "" {
+		return
+	}
+
+	// Resolve the Debezium distribution if it has not been located yet, so that we can
+	// inspect the logical connector jar that will actually be used for this export.
+	if dbzm.DEBEZIUM_DIST_DIR == "" {
+		if err := dbzm.FindDebeziumDistribution(source.DBType, false); err != nil {
+			log.Warnf("skipping connector/YB version compatibility check: %v", err)
+			return
+		}
+	}
+
+	connectorYBVersion, err := dbzm.GetLogicalConnectorYBVersion()
+	if err != nil {
+		// Multiple connector jars is a broken install: run.sh would load an undefined
+		// connector from the classpath, so we must stop rather than run blindly.
+		if errors.Is(err, dbzm.ErrMultipleLogicalConnectorVersions) {
+			utils.ErrExit("%v.\nThe %q directory must contain exactly one YugabyteDB logical replication connector jar. "+
+				"Remove the stale connector jar(s) so that only the intended version remains, then retry.",
+				err, filepath.Join(dbzm.DEBEZIUM_DIST_DIR, "yb-connector"))
+		}
+		// Otherwise best-effort: never block migration because we could not detect the version.
+		log.Warnf("skipping connector/YB version compatibility check: %v", err)
+		return
+	}
+
+	serverYBVersion, err := extractYBVersion(msr.TargetDBConf.DBVersion)
+	if err != nil {
+		log.Warnf("skipping connector/YB version compatibility check: %v", err)
+		return
+	}
+
+	warn, reason, err := shouldWarnServerSeriesNewerThanConnector(connectorYBVersion, serverYBVersion)
+	if err != nil {
+		log.Warnf("skipping connector/YB version compatibility check: %v", err)
+		return
+	}
+	if !warn {
+		return
+	}
+
+	utils.PrintAndLogfWarning(
+		"\nWarning: %s.\n"+
+			"Forward-compatibility of the YugabyteDB logical replication connector is not guaranteed, which may lead to silent data-capture issues during live migration.\n"+
+			"It is recommended to upgrade YugabyteDB Voyager to a version bundling a connector built for your YugabyteDB server series.\n",
+		reason,
+	)
+	if !utils.AskPrompt("Do you want to continue anyway") {
+		utils.ErrExit("aborting export data from target due to connector/YugabyteDB series mismatch")
+	}
 }
 
 func printLiveMigrationLimitations() {

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -409,7 +409,7 @@ func shouldWarnServerSeriesNewerThanConnector(connectorYBVersion, serverYBVersio
 	serverSeries, err := ybversion.NewYBVersion(ybversion.SeriesVersion(serverYBVersion))
 	if err != nil {
 		if errors.Is(err, ybversion.ErrUnsupportedSeries) {
-			return true, fmt.Sprintf("the target YugabyteDB server %q is on a release series this Voyager build does not recognize (likely newer than the bundled connector)", serverYBVersion), nil
+			return true, fmt.Sprintf("the target YugabyteDB server %q is on a release this Voyager build does not recognize (likely newer than the bundled connector)", serverYBVersion), nil
 		}
 		return false, "", goerrors.Errorf("parsing server series from %q: %w", serverYBVersion, err)
 	}
@@ -417,7 +417,7 @@ func shouldWarnServerSeriesNewerThanConnector(connectorYBVersion, serverYBVersio
 	// Same release type: compare series numerically.
 	if connSeries.ReleaseType() == serverSeries.ReleaseType() {
 		if serverSeries.GreaterThanOrEqual(connSeries) && !serverSeries.Equal(connSeries) {
-			return true, fmt.Sprintf("the target YugabyteDB server series %s is newer than the connector's series %s", serverSeries.Series(), connSeries.Series()), nil
+			return true, fmt.Sprintf("the target YugabyteDB server release %s is newer than the connector's release %s", serverSeries.Series(), connSeries.Series()), nil
 		}
 		return false, "", nil
 	}
@@ -427,7 +427,7 @@ func shouldWarnServerSeriesNewerThanConnector(connectorYBVersion, serverYBVersio
 	case ybversion.STABLE_OLD:
 		return false, "", nil
 	case ybversion.PREVIEW:
-		return true, fmt.Sprintf("the target YugabyteDB server is on preview series %s, which the connector was not built for", serverSeries.Series()), nil
+		return true, fmt.Sprintf("the target YugabyteDB server is on preview release %s, which the connector was not built for", serverSeries.Series()), nil
 	default:
 		return false, "", goerrors.Errorf("cannot compare connector series %s (%s) with server series %s (%s)", connSeries.Series(), connSeries.ReleaseType(), serverSeries.Series(), serverSeries.ReleaseType())
 	}
@@ -490,11 +490,11 @@ func warnIfYBServerNewerThanLogicalConnector(msr *metadb.MigrationStatusRecord) 
 	utils.PrintAndLogfWarning(
 		"\nWarning: %s.\n"+
 			"Forward-compatibility of the YugabyteDB logical replication connector is not guaranteed, which may lead to silent data-capture issues during live migration.\n"+
-			"It is recommended to upgrade YugabyteDB Voyager to a version bundling a connector built for your YugabyteDB server series.\n",
+			"It is recommended to upgrade YugabyteDB Voyager to a version bundling a connector built for your YugabyteDB server release.\n",
 		reason,
 	)
 	if !utils.AskPrompt("Do you want to continue anyway") {
-		utils.ErrExit("aborting export data from target due to connector/YugabyteDB series mismatch")
+		utils.ErrExit("aborting export data from target due to connector/YugabyteDB release mismatch")
 	}
 }
 

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -188,13 +188,13 @@ func TestShouldWarnServerSeriesNewerThanConnector(t *testing.T) {
 		expectedWarn     bool
 		wantErr          bool
 	}{
-		{"same series, server higher maintenance is NOT newer", "2025.2.3", "2025.2.9.0", false, false},
-		{"same series, server higher connector-counter-equivalent is NOT newer", "2025.2.3", "2025.2.4.0", false, false},
-		{"same series exact", "2025.2.3", "2025.2.0.0", false, false},
-		{"server on newer series warns", "2024.2.5", "2025.1.0.0", true, false},
-		{"server on older series does not warn", "2025.2.3", "2024.2.8.0", false, false},
-		{"server on unrecognized (newer) series warns", "2025.2.3", "2026.1.0.0", true, false},
-		{"connector 2-segment series tag, same series", "2025.2", "2025.2.9.0", false, false},
+		{"same release, server higher maintenance is NOT newer", "2025.2.3", "2025.2.9.0", false, false},
+		{"same release, server higher connector-counter-equivalent is NOT newer", "2025.2.3", "2025.2.4.0", false, false},
+		{"same release exact", "2025.2.3", "2025.2.0.0", false, false},
+		{"server on newer release warns", "2024.2.5", "2025.1.0.0", true, false},
+		{"server on older release does not warn", "2025.2.3", "2024.2.8.0", false, false},
+		{"server on unrecognized (newer) release warns", "2025.2.3", "2026.1.0.0", true, false},
+		{"connector 2-segment release tag, same release", "2025.2", "2025.2.9.0", false, false},
 		{"preview server warns (connector not built for preview)", "2025.2.3", "2.25.1.0", true, false},
 		{"stable-old server does not warn (connector is newer and backward-compatible)", "2025.2.3", "2.20.1.0", false, false},
 		{"unparseable server version returns error", "2025.2.3", "not-a-version", false, true},

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -179,3 +179,36 @@ func TestIsCDCSavepointFixedInTargetDBVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldWarnServerSeriesNewerThanConnector(t *testing.T) {
+	tests := []struct {
+		name             string
+		connectorVersion string
+		serverYBVersion  string
+		expectedWarn     bool
+		wantErr          bool
+	}{
+		{"same series, server higher maintenance is NOT newer", "2025.2.3", "2025.2.9.0", false, false},
+		{"same series, server higher connector-counter-equivalent is NOT newer", "2025.2.3", "2025.2.4.0", false, false},
+		{"same series exact", "2025.2.3", "2025.2.0.0", false, false},
+		{"server on newer series warns", "2024.2.5", "2025.1.0.0", true, false},
+		{"server on older series does not warn", "2025.2.3", "2024.2.8.0", false, false},
+		{"server on unrecognized (newer) series warns", "2025.2.3", "2026.1.0.0", true, false},
+		{"connector 2-segment series tag, same series", "2025.2", "2025.2.9.0", false, false},
+		{"preview server warns (connector not built for preview)", "2025.2.3", "2.25.1.0", true, false},
+		{"stable-old server does not warn (connector is newer and backward-compatible)", "2025.2.3", "2.20.1.0", false, false},
+		{"unparseable server version returns error", "2025.2.3", "not-a-version", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warn, _, err := shouldWarnServerSeriesNewerThanConnector(tt.connectorVersion, tt.serverYBVersion)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedWarn, warn)
+		})
+	}
+}

--- a/yb-voyager/src/dbzm/connector_version_test.go
+++ b/yb-voyager/src/dbzm/connector_version_test.go
@@ -1,0 +1,178 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package dbzm
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLogicalConnectorYBVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		jarName  string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "current logical connector jar",
+			jarName:  "yugabytedb-source-connector-dz.2.5.2.yb.2025.2.3-jar-with-dependencies.jar",
+			expected: "2025.2.3",
+		},
+		{
+			name:     "older YB release",
+			jarName:  "yugabytedb-source-connector-dz.2.5.2.yb.2024.2.4-jar-with-dependencies.jar",
+			expected: "2024.2.4",
+		},
+		{
+			name:     "double-digit patch",
+			jarName:  "yugabytedb-source-connector-dz.2.5.2.yb.2025.2.10-jar-with-dependencies.jar",
+			expected: "2025.2.10",
+		},
+		{
+			// The gRPC connector tag embeds "yb.grpc.<ver>"; the logical-connector
+			// parser must not treat it as a logical-connector version.
+			name:    "grpc connector jar is rejected",
+			jarName: "debezium-connector-yugabytedb-dz.1.9.5.yb.grpc.2024.2.3.jar",
+			wantErr: true,
+		},
+		{
+			name:    "unrelated jar name",
+			jarName: "some-random-library-1.2.3.jar",
+			wantErr: true,
+		},
+		{
+			// With the series-level regex, the full token "2025.2.SNAPSHOT.6" is captured
+			// up to the first "-". The snapshot suffix is a connector-internal counter and
+			// is harmlessly ignored when series reduction happens later via SeriesVersion.
+			name:     "snapshot connector jar is now parsed successfully",
+			jarName:  "yugabytedb-source-connector-dz.2.5.2.yb.2025.2.SNAPSHOT.6-jar-with-dependencies.jar",
+			expected: "2025.2.SNAPSHOT.6",
+			wantErr:  false,
+		},
+		{
+			name:     "connector jar that ships a PATCH segment is accepted",
+			jarName:  "yugabytedb-source-connector-dz.2.5.2.yb.2025.2.3.1-jar-with-dependencies.jar",
+			expected: "2025.2.3.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLogicalConnectorYBVersion(tt.jarName)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetLogicalConnectorYBVersion(t *testing.T) {
+	origDistDir := DEBEZIUM_DIST_DIR
+	t.Cleanup(func() { DEBEZIUM_DIST_DIR = origDistDir })
+
+	t.Run("picks the connector jar among other jars", func(t *testing.T) {
+		distDir := t.TempDir()
+		connectorDir := filepath.Join(distDir, "yb-connector")
+		require.NoError(t, os.MkdirAll(connectorDir, 0755))
+		// Noise jars that should be ignored, plus the actual connector jar.
+		for _, name := range []string{
+			"some-dependency-1.2.3.jar",
+			"yugabytedb-source-connector-dz.2.5.2.yb.2025.2.3-jar-with-dependencies.jar",
+		} {
+			require.NoError(t, os.WriteFile(filepath.Join(connectorDir, name), []byte("x"), 0644))
+		}
+		DEBEZIUM_DIST_DIR = distDir
+
+		got, err := GetLogicalConnectorYBVersion()
+		assert.NoError(t, err)
+		assert.Equal(t, "2025.2.3", got)
+	})
+
+	t.Run("returns the version when duplicate jars share the same version", func(t *testing.T) {
+		distDir := t.TempDir()
+		connectorDir := filepath.Join(distDir, "yb-connector")
+		require.NoError(t, os.MkdirAll(connectorDir, 0755))
+		for _, name := range []string{
+			"yugabytedb-source-connector-dz.2.5.2.yb.2025.2.3-jar-with-dependencies.jar",
+			"yugabytedb-source-connector-dz.2.5.2.yb.2025.2.3-shaded.jar",
+		} {
+			require.NoError(t, os.WriteFile(filepath.Join(connectorDir, name), []byte("x"), 0644))
+		}
+		DEBEZIUM_DIST_DIR = distDir
+
+		got, err := GetLogicalConnectorYBVersion()
+		assert.NoError(t, err)
+		assert.Equal(t, "2025.2.3", got)
+	})
+
+	t.Run("errors when multiple connector jars have different versions", func(t *testing.T) {
+		distDir := t.TempDir()
+		connectorDir := filepath.Join(distDir, "yb-connector")
+		require.NoError(t, os.MkdirAll(connectorDir, 0755))
+		for _, name := range []string{
+			"yugabytedb-source-connector-dz.2.5.2.yb.2025.2.3-jar-with-dependencies.jar",
+			"yugabytedb-source-connector-dz.2.5.2.yb.2025.2.4-jar-with-dependencies.jar",
+		} {
+			require.NoError(t, os.WriteFile(filepath.Join(connectorDir, name), []byte("x"), 0644))
+		}
+		DEBEZIUM_DIST_DIR = distDir
+
+		_, err := GetLogicalConnectorYBVersion()
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrMultipleLogicalConnectorVersions),
+			"expected ErrMultipleLogicalConnectorVersions, got: %v", err)
+	})
+
+	t.Run("errors when no connector jar is present", func(t *testing.T) {
+		distDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(distDir, "yb-connector"), 0755))
+		DEBEZIUM_DIST_DIR = distDir
+
+		_, err := GetLogicalConnectorYBVersion()
+		assert.Error(t, err)
+	})
+
+	t.Run("errors when distribution dir is unresolved", func(t *testing.T) {
+		DEBEZIUM_DIST_DIR = ""
+		_, err := GetLogicalConnectorYBVersion()
+		assert.Error(t, err)
+	})
+
+	t.Run("returns the token for a snapshot connector jar", func(t *testing.T) {
+		distDir := t.TempDir()
+		connectorDir := filepath.Join(distDir, "yb-connector")
+		require.NoError(t, os.MkdirAll(connectorDir, 0755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(connectorDir, "yugabytedb-source-connector-dz.2.5.2.yb.2025.2.SNAPSHOT.6-jar-with-dependencies.jar"),
+			[]byte("x"), 0644))
+		DEBEZIUM_DIST_DIR = distDir
+
+		got, err := GetLogicalConnectorYBVersion()
+		assert.NoError(t, err)
+		assert.Equal(t, "2025.2.SNAPSHOT.6", got)
+	})
+}

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -16,11 +16,14 @@ limitations under the License.
 package dbzm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -75,6 +78,73 @@ func FindDebeziumDistribution(sourceDBType string, useYBgRPCConnector bool) erro
 		DEBEZIUM_DIST_DIR = filepath.Join(DEBEZIUM_DIST_DIR, pathSuffix)
 	}
 	return nil
+}
+
+// logicalConnectorYBVersionRegex captures the connector version token after "yb." up to
+// the next "-" (e.g. "2025.2.3"):
+//   - only the first two segments matter (the YB series); the rest is a connector-internal
+//     counter, reduced later via ybversion.SeriesVersion.
+//   - the full token is kept so distinct jars can be told apart.
+//   - the required leading digit rejects the gRPC tag ("yb.grpc.<ver>").
+var logicalConnectorYBVersionRegex = regexp.MustCompile(`yb\.([0-9]+\.[0-9]+[^-]*)`)
+
+// ErrMultipleLogicalConnectorVersions means the yb-connector directory holds jars for
+// more than one connector version. run.sh puts every jar on the classpath, so which one
+// runs is undefined — callers treat this as fatal rather than guessing.
+var ErrMultipleLogicalConnectorVersions = errors.New("multiple logical connector versions found in distribution")
+
+// ParseLogicalConnectorYBVersion returns the connector version token from a jar name
+// (e.g. ".yb.2025.2.3-..." → "2025.2.3"):
+//   - only the first two segments (the YB series) matter for compatibility; the rest is a
+//     connector-internal counter.
+//   - the full token is returned so callers can distinguish distinct jars.
+//   - errors if the name has no "yb.<series>..." token (dependency jars, gRPC connector).
+func ParseLogicalConnectorYBVersion(jarName string) (string, error) {
+	match := logicalConnectorYBVersionRegex.FindStringSubmatch(jarName)
+	if len(match) < 2 {
+		return "", goerrors.Errorf("unable to extract a YugabyteDB connector version from jar name %q; expected a 'yb.<series>...' token", jarName)
+	}
+	return match[1], nil
+}
+
+// GetLogicalConnectorYBVersion returns the connector version token from the resolved
+// Debezium distribution (FindDebeziumDistribution must have run). run.sh puts every jar in
+// yb-connector on the classpath, so jars for multiple distinct tokens are a fatal
+// ambiguity → ErrMultipleLogicalConnectorVersions.
+func GetLogicalConnectorYBVersion() (string, error) {
+	if DEBEZIUM_DIST_DIR == "" {
+		return "", goerrors.Errorf("debezium distribution directory is not resolved")
+	}
+	connectorDir := filepath.Join(DEBEZIUM_DIST_DIR, "yb-connector")
+	jars, err := filepath.Glob(filepath.Join(connectorDir, "*.jar"))
+	if err != nil {
+		return "", goerrors.Errorf("listing logical connector jars in %s: %w", connectorDir, err)
+	}
+
+	// Collect distinct connector tokens (ignoring non-connector jars).
+	seen := make(map[string]bool)
+	var versions []string
+	for _, jar := range jars {
+		token, err := ParseLogicalConnectorYBVersion(filepath.Base(jar))
+		if err != nil {
+			// Not a connector jar (e.g. a dependency jar); ignore.
+			continue
+		}
+		if !seen[token] {
+			seen[token] = true
+			versions = append(versions, token)
+		}
+	}
+
+	switch len(versions) {
+	case 0:
+		return "", goerrors.Errorf("no logical connector jar found in %s", connectorDir)
+	case 1:
+		return versions[0], nil
+	default:
+		sort.Strings(versions)
+		return "", fmt.Errorf("found multiple logical connector jars with different versions %v in %s: %w", versions, connectorDir, ErrMultipleLogicalConnectorVersions)
+	}
 }
 
 func NewDebezium(config *Config) *Debezium {

--- a/yb-voyager/src/ybversion/yb_version.go
+++ b/yb-voyager/src/ybversion/yb_version.go
@@ -50,6 +50,22 @@ type YBVersion struct {
 	*version.Version
 }
 
+// SeriesVersion reduces a YB version to its release series in the YEAR.TRACK.0.0 form
+// NewYBVersion accepts, dropping everything after the first two segments. CDC connector
+// compatibility is per-series, so only YEAR.TRACK is compared.
+// Examples: "2025.2.3"->"2025.2.0.0", "2025.2"->"2025.2.0.0", "2.25.2.0"->"2.25.0.0".
+func SeriesVersion(v string) string {
+	segments := strings.Split(v, ".")
+	if len(segments) > 2 {
+		segments = segments[:2]
+	}
+	for len(segments) < 2 {
+		segments = append(segments, "0")
+	}
+	segments = append(segments, "0", "0")
+	return strings.Join(segments, ".")
+}
+
 func NewYBVersion(v string) (*YBVersion, error) {
 	v1, err := version.NewVersion(v)
 	if err != nil {

--- a/yb-voyager/src/ybversion/yb_version_test.go
+++ b/yb-voyager/src/ybversion/yb_version_test.go
@@ -86,3 +86,18 @@ func TestStableOldReleaseType(t *testing.T) {
 		assert.Equal(t, STABLE_OLD, ybVersion.ReleaseType())
 	}
 }
+
+func TestSeriesVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"2025.2.3", "2025.2.0.0"},   // 3-segment connector token: counter dropped, series kept
+		{"2025.2", "2025.2.0.0"},     // 2-segment: already just series, padded
+		{"2025.2.5.0", "2025.2.0.0"}, // 4-segment server version: everything after TRACK dropped
+		{"2.25.2.0", "2.25.0.0"},     // preview series: everything after TRACK dropped
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, SeriesVersion(tt.input))
+	}
+}


### PR DESCRIPTION
### Describe the changes in this pull request

Adds a best-effort runtime guardrail in the **export-data-from-target** (fall-back / fall-forward) flow that warns when the target YugabyteDB server is on a **newer release series** than the bundled CDC logical replication connector. The YB CDC team does not guarantee forward-compatibility, so a server on a newer release train than the connector can silently misbehave during live migration.

Compatibility is keyed on the YB **release series** (`YEAR.TRACK`, e.g. `2025.2`): the connector is published once per series and supports every maintenance/patch within it, and the connector tag's trailing segment (the `.3` in `2025.2.3`) is a connector-internal counter, not a YB patch — so the check compares series only. At runtime it reads the series from the connector jar that will actually be loaded and compares it to the target server's series:

| Target server vs connector | Result |
| --- | --- |
| same series, or older series | no warning |
| newer series | warn + prompt to continue |
| series unrecognized by this Voyager build | warn + prompt (likely newer) |
| pre-calendar `STABLE_OLD` (`2.x`) series | no warning (newer, backward-compatible connector covers it) |
| `PREVIEW` series | warn + prompt |
| multiple connector jars in `yb-connector/` | abort with remediation (ambiguous classpath) |

### Describe if there are any user-facing changes

- **Command line:** Yes. During `export data from target`, if the target YB server is on a newer/unrecognized/preview series than the connector, an interactive warning + `[Y/N]` prompt is shown (non-blocking; auto-continues when non-interactive). If `yb-connector/` contains jars for more than one connector version, the command aborts with a message to remove the stale jar(s). No new flags.
- **Configuration:** No.
- **Installation:** No.
- **Reports:** No.

### How was this pull request tested?

New `-tags unit` tests (existing tests did not cover this):
- `cmd`: `TestShouldWarnServerSeriesNewerThanConnector` — same/newer/older/unrecognized series, `STABLE_OLD`, `PREVIEW`, different-release-type and unparseable inputs.
- `src/dbzm`: `TestParseLogicalConnectorYBVersion` and `TestGetLogicalConnectorYBVersion` — release/snapshot tokens, gRPC rejection, dependency-jar skipping, duplicate-same-version, and the multiple-distinct-version (`ErrMultipleLogicalConnectorVersions`) ambiguity.
- `src/ybversion`: `TestSeriesVersion`.

`go build -tags unit ./...`, `go vet -tags unit`, and the `cmd` / `dbzm` / `ybversion` unit suites all pass. No manual/integration testing was run (the changed logic is unit-covered; the runtime prompt is exercised via the decision-function tests).

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
