### PR TITLE
Add post-cutover-to-target row validations in iteration resumption tests

### DIFF
--- a/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
@@ -237,6 +237,12 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  - name: row_count_validations
+    action: row_count_validations
+
+  - name: row_hash_validations
+    action: row_hash_validations
+
   - name: start_fallback_exporter_from_target
     action: voyager_export_from_target_start
 

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -281,6 +281,12 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  - name: row_count_validations
+    action: row_count_validations
+
+  - name: row_hash_validations
+    action: row_hash_validations
+
   - name: start_fallback_exporter_from_target
     action: voyager_export_from_target_start
 


### PR DESCRIPTION
### Describe the changes in this pull request

The iterative live-migration-with-fallback resumption tests (`iteration-test` and `partition-iteration-test`) previously ran row-count and row-hash validations only at the **end** of each iteration, after cutover-to-source. This PR adds the same source↔target validations in the **mid-phase**, immediately after cutover-to-target completes and the forward export/import pipeline is drained and stopped — before the fallback exporter/importer, the target event generator, and (for the partition test) `run_target_dml` write anything on the target.

At that point the snapshot plus all forward CDC has been applied to the target, the source generator has already stopped, and the fallback side has not started — so source and target must be identical. Validating here catches forward-direction data drift per iteration instead of only detecting it after the full forward + fallback round-trip (which made it ambiguous whether a mismatch originated in the forward or fallback leg).

The change is scenario-only: it reuses the existing `row_count_validations` and `row_hash_validations` orchestrator actions (which default to a source↔target comparison). No orchestrator or helper changes were required.

### Describe if there are any user-facing changes

No user-facing changes. This is a test-only change (migtests resumption scenarios).

### How was this pull request tested?

Ran the resumption orchestrator locally against a PostgreSQL source and a YugabyteDB target through the live-migration-with-fallback loop for `iteration-test`; the new mid-phase `row_count_validations` / `row_hash_validations` stages execute after each cutover-to-target and pass. Extended multi-iteration runs for both `iteration-test` and `partition-iteration-test` are being exercised via the Jenkins `yb-voyager-live-migration-resumption` job before merge.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.