### PR TITLE
Add yugabytedb-amp target-db-type for offline migration into YugabyteDB AMP

### DIFF
--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -75,7 +75,7 @@ var allowedSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"name", "db-host", "db-port", "db-user", "db-password", "db-name",
+	"name", "db-type", "db-host", "db-port", "db-user", "db-password", "db-name",
 	"db-schema", "ssl-cert", "ssl-mode", "ssl-key", "ssl-root-cert", "ssl-crl",
 )
 

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -35,7 +35,7 @@ const (
 	MYSQL                           = "mysql"
 	POSTGRESQL                      = "postgresql"
 	YUGABYTEDB                      = "yugabytedb"
-	YUGABYTEDB_AMP                  = "ybamp" // YugabyteDB AMP (yb-amp): PostgreSQL-compatible compute over YugabyteDB storage
+	YUGABYTEDB_AMP                  = "yugabytedb-amp" // YugabyteDB AMP (yb-amp): PostgreSQL-compatible compute over YugabyteDB storage
 	LAST_SPLIT_NUM                  = 0
 	SPLIT_INFO_PATTERN              = "[0-9]*.[0-9]*.[0-9]*.[0-9]*.[0-9]*"
 	LAST_SPLIT_PATTERN              = "0.[0-9]*.[0-9]*.[0-9]*.[0-9]*"

--- a/yb-voyager/cmd/constants.go
+++ b/yb-voyager/cmd/constants.go
@@ -35,6 +35,7 @@ const (
 	MYSQL                           = "mysql"
 	POSTGRESQL                      = "postgresql"
 	YUGABYTEDB                      = "yugabytedb"
+	YUGABYTEDB_AMP                  = "ybamp" // YugabyteDB AMP (yb-amp): PostgreSQL-compatible compute over YugabyteDB storage
 	LAST_SPLIT_NUM                  = 0
 	SPLIT_INFO_PATTERN              = "[0-9]*.[0-9]*.[0-9]*.[0-9]*.[0-9]*"
 	LAST_SPLIT_PATTERN              = "0.[0-9]*.[0-9]*.[0-9]*.[0-9]*"

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -232,6 +232,13 @@ func exportSchema(cmd *cobra.Command) error {
 	}
 	printSchemaFilesPaths(tableTransformer, mviewTransformer, indexTransformer)
 
+	// Record whether YB-flavored optimizations (colocation recommendations or
+	// the performance/sharding transforms that emit `SET yb_*`) were written
+	// into the main schema files. When true, the pre-transformation originals
+	// were retained as backup_<file>; import-schema uses this to pick the plain
+	// originals for a PostgreSQL-compatible target like yb-amp.
+	setSchemaOptimizationsApplied(assessmentRecommendationsApplied || !bool(skipPerfOptimizations))
+
 	packAndSendExportSchemaPayload(COMPLETE, nil)
 
 	saveSourceDBConfInMSR()
@@ -400,6 +407,15 @@ func setSchemaIsExported() {
 	})
 	if err != nil {
 		utils.ErrExit("set schema is exported: update migration status record: %w", err)
+	}
+}
+
+func setSchemaOptimizationsApplied(applied bool) {
+	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		record.SchemaOptimizationsApplied = applied
+	})
+	if err != nil {
+		utils.ErrExit("record schema optimizations applied: update migration status record: %w", err)
 	}
 }
 

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -232,13 +232,6 @@ func exportSchema(cmd *cobra.Command) error {
 	}
 	printSchemaFilesPaths(tableTransformer, mviewTransformer, indexTransformer)
 
-	// Record whether YB-flavored optimizations (colocation recommendations or
-	// the performance/sharding transforms that emit `SET yb_*`) were written
-	// into the main schema files. When true, the pre-transformation originals
-	// were retained as backup_<file>; import-schema uses this to pick the plain
-	// originals for a PostgreSQL-compatible target like yb-amp.
-	setSchemaOptimizationsApplied(assessmentRecommendationsApplied || !bool(skipPerfOptimizations))
-
 	packAndSendExportSchemaPayload(COMPLETE, nil)
 
 	saveSourceDBConfInMSR()
@@ -407,15 +400,6 @@ func setSchemaIsExported() {
 	})
 	if err != nil {
 		utils.ErrExit("set schema is exported: update migration status record: %w", err)
-	}
-}
-
-func setSchemaOptimizationsApplied(applied bool) {
-	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-		record.SchemaOptimizationsApplied = applied
-	})
-	if err != nil {
-		utils.ErrExit("record schema optimizations applied: update migration status record: %w", err)
 	}
 }
 
@@ -805,8 +789,23 @@ func applyMviewFileTransformations(modifiedMviews []string, colocatedMviews []st
 	mviewTransformer := sqltransformer.NewMviewFileTransformer()
 	mviewTransformer.ShardedMviews = modifiedMviews
 	mviewTransformer.ColocatedMviews = colocatedMviews
+	// mviewBackupPath is the plain <mview.sql>.orig the colocation step wrote (if
+	// it ran). Hand it to the transformer so Transform can materialize the plain
+	// backup_<base> sibling that import-schema looks for on a PostgreSQL-compatible
+	// target like yb-amp.
 	mviewTransformer.BackupFilePath = mviewBackupPath
 	mviewTransformer.ColocationRecommendationsApplied = assessmentRecommendationsApplied
+
+	mviewFilePath := utils.GetObjectFilePath(schemaDir, MVIEW)
+	if mviewBackupPath != "" && utils.FileOrFolderExists(mviewFilePath) {
+		backUpFile, err := mviewTransformer.Transform(mviewFilePath)
+		if err != nil {
+			// Mirror the table-transform behavior: don't fail export over a backup hiccup.
+			log.Infof("skipping error while transforming mview file %s: %v", mviewFilePath, err)
+			return mviewTransformer, nil
+		}
+		log.Infof("Plain MVIEW DDLs backed up to %s", backUpFile)
+	}
 	return mviewTransformer, nil
 }
 func applyIndexFileTransformations() (*sqltransformer.IndexFileTransformer, error) {

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -556,16 +556,16 @@ func applyShardedTablesRecommendation(shardedTables []string, colocatedTables []
 		}
 	}
 
-	// rename existing table.sql file to table.sql.orig
-	backupPath := filePath + ".orig"
-	log.Infof("renaming existing file '%s' --> '%s.orig'", filePath, backupPath)
-	err := os.Rename(filePath, filePath+".orig")
+	// Back up the pristine original (skip-if-exists, consistent backup_<base> name)
+	// before overwriting it with the colocation-modified schema, so a
+	// PostgreSQL-compatible target (yb-amp) can import the un-transformed DDL.
+	backupPath, err := sqltransformer.EnsurePlainBackup(filePath)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("error renaming file %s: %w", filePath, err)
+		return nil, nil, "", fmt.Errorf("backing up original schema file %s: %w", filePath, err)
 	}
 
-	// create new table.sql file for modified schema
-	log.Infof("creating file %q to store the modified recommended schema", filePath)
+	// overwrite filePath with the modified (colocation-applied) schema
+	log.Infof("writing the modified recommended schema to %q", filePath)
 	file, err := os.Create(filePath)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("error creating file '%q' storing the modified recommended schema: %w", filePath, err)
@@ -789,23 +789,11 @@ func applyMviewFileTransformations(modifiedMviews []string, colocatedMviews []st
 	mviewTransformer := sqltransformer.NewMviewFileTransformer()
 	mviewTransformer.ShardedMviews = modifiedMviews
 	mviewTransformer.ColocatedMviews = colocatedMviews
-	// mviewBackupPath is the plain <mview.sql>.orig the colocation step wrote (if
-	// it ran). Hand it to the transformer so Transform can materialize the plain
-	// backup_<base> sibling that import-schema looks for on a PostgreSQL-compatible
-	// target like yb-amp.
+	// mviewBackupPath is the plain backup_<base> the colocation step created (if it
+	// ran via EnsurePlainBackup). The mview file is only ever mutated by that step,
+	// so this transformer applies no content changes — it just carries metadata.
 	mviewTransformer.BackupFilePath = mviewBackupPath
 	mviewTransformer.ColocationRecommendationsApplied = assessmentRecommendationsApplied
-
-	mviewFilePath := utils.GetObjectFilePath(schemaDir, MVIEW)
-	if mviewBackupPath != "" && utils.FileOrFolderExists(mviewFilePath) {
-		backUpFile, err := mviewTransformer.Transform(mviewFilePath)
-		if err != nil {
-			// Mirror the table-transform behavior: don't fail export over a backup hiccup.
-			log.Infof("skipping error while transforming mview file %s: %v", mviewFilePath, err)
-			return mviewTransformer, nil
-		}
-		log.Infof("Plain MVIEW DDLs backed up to %s", backUpFile)
-	}
 	return mviewTransformer, nil
 }
 func applyIndexFileTransformations() (*sqltransformer.IndexFileTransformer, error) {

--- a/yb-voyager/cmd/finalizeSchemaPostDataImport.go
+++ b/yb-voyager/cmd/finalizeSchemaPostDataImport.go
@@ -35,6 +35,7 @@ func init() {
 	registerCommonGlobalFlags(finalizeSchemaPostDataImportCmd)
 	registerCommonImportFlags(finalizeSchemaPostDataImportCmd)
 	registerTargetDBConnFlags(finalizeSchemaPostDataImportCmd)
+	registerTargetDBTypeFlag(finalizeSchemaPostDataImportCmd)
 	BoolVar(finalizeSchemaPostDataImportCmd.Flags(), &tconf.IgnoreIfExists, "ignore-exist", false,
 		"ignore errors if object already exists (default false)")
 	BoolVar(finalizeSchemaPostDataImportCmd.Flags(), &flagRefreshMViews, "refresh-mviews", false,

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -681,21 +681,20 @@ func validateFFDBSchemaFlag() {
 }
 
 // defaultAdaptiveParallelismMode returns the adaptive-parallelism mode to use when the
-// user did NOT pass --adaptive-parallelism. It is per-target:
-//   - YUGABYTEDB: Balanced — adaptive parallelism uses the YB cluster control API
-//     (yb_servers(), tserver metrics) and is the recommended default.
-//   - YUGABYTEDB_AMP: Disabled — yb-amp is a stateless PG17 compute with no YB cluster
-//     control API, so adaptive parallelism is not available; --parallel-jobs controls
-//     import parallelism instead.
+// user did NOT pass --adaptive-parallelism. Adaptive parallelism relies on the YugabyteDB
+// cluster control API (yb_servers(), tserver metrics), so it is the recommended default
+// (Balanced) ONLY for a real YugabyteDB target. Every other target — yb-amp (stateless
+// PG17 compute) and the PostgreSQL fall-forward/fall-back targets — has no such API, so it
+// defaults to Disabled; --parallel-jobs controls import parallelism there.
 //
-// Defaulting amp to Disabled is also what lets a user pass --parallel-jobs for amp without
-// having to also pass --adaptive-parallelism disabled (validateParallelismFlags only
-// conflicts --parallel-jobs with an *enabled* adaptive mode).
+// Defaulting non-YB targets to Disabled is also what lets a user pass --parallel-jobs for
+// them without having to also pass --adaptive-parallelism disabled (validateParallelismFlags
+// only conflicts --parallel-jobs with an *enabled* adaptive mode).
 func defaultAdaptiveParallelismMode(targetDBType string) types.AdaptiveParallelismMode {
-	if targetDBType == YUGABYTEDB_AMP {
-		return types.DisabledAdaptiveParallelismMode
+	if targetDBType == YUGABYTEDB {
+		return types.BalancedAdaptiveParallelismMode
 	}
-	return types.BalancedAdaptiveParallelismMode
+	return types.DisabledAdaptiveParallelismMode
 }
 
 func validateParallelismFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -198,11 +198,19 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &tconf.RunGuardrailsChecks, "run-guardrails-checks", true, "Run guardrails checks during import")
 }
 
-func registerTargetDBConnFlags(cmd *cobra.Command) {
+// registerTargetDBTypeFlag registers --target-db-type. It is intentionally
+// NOT part of registerTargetDBConnFlags: the choice of target engine is only
+// meaningful for the commands that import schema/data into the target
+// (import schema, import data / ...toTarget, finalize-schema-post-data-import).
+// Commands like import-data-file and compare-performance always target a real
+// YugabyteDB, so they don't expose it.
+func registerTargetDBTypeFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tconf.TargetDBType, "target-db-type", "",
 		fmt.Sprintf("type of the target database to import into. Supported values: %s (default), %s (YugabyteDB AMP — a PostgreSQL-compatible compute over YugabyteDB storage)",
 			YUGABYTEDB, YUGABYTEDB_AMP))
+}
 
+func registerTargetDBConnFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&tconf.Host, "target-db-host", "127.0.0.1",
 		"host on which the YugabyteDB server is running")
 

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -102,7 +102,7 @@ func validateImportFlags(cmd *cobra.Command, importerRole string) error {
 	case SOURCE_DB_IMPORTER_ROLE:
 		getSourceDBPassword(cmd)
 	}
-	validateParallelismFlags()
+	validateParallelismFlags(cmd)
 
 	return nil
 }
@@ -698,7 +698,20 @@ func defaultAdaptiveParallelismMode(targetDBType string) types.AdaptiveParalleli
 	return types.BalancedAdaptiveParallelismMode
 }
 
-func validateParallelismFlags() {
+func validateParallelismFlags(cmd *cobra.Command) {
+	// yb-amp has no YB cluster control API, so adaptive parallelism cannot work
+	// there. Reject any explicit request for it (CLI or config — Flags().Changed()
+	// is true in both, since config values are applied via Flags().Set()), pointing
+	// the user to --parallel-jobs. An explicit `--adaptive-parallelism disabled` is
+	// fine (not IsEnabled()).
+	if tconf.TargetDBType == YUGABYTEDB_AMP {
+		if cmd.Flags().Changed("adaptive-parallelism") && tconf.AdaptiveParallelismMode.IsEnabled() {
+			utils.ErrExit("adaptive parallelism is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs to control import parallelism.", YUGABYTEDB_AMP)
+		}
+		if cmd.Flags().Changed("adaptive-parallelism-max") {
+			utils.ErrExit("--adaptive-parallelism-max is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs.", YUGABYTEDB_AMP)
+		}
+	}
 	if tconf.AdaptiveParallelismMode.IsEnabled() {
 		if tconf.Parallelism > 0 {
 			utils.ErrExit("Error --parallel-jobs flag cannot be used when adaptive-parallelism is enabled (balanced/aggressive). If you wish to set the number of parallel jobs explicitly, disable adaptive parallelism using --adaptive-parallelism disabled")

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -28,6 +28,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/types"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -60,6 +61,7 @@ func init() {
 func validateImportFlags(cmd *cobra.Command, importerRole string) error {
 	checkOrSetDefaultTargetSSLMode()
 	validateTargetPortRange()
+	validateAmpTargetSourceCompatibility()
 
 	validateConflictsBetweenTableListFlags(tconf.TableList, tconf.ExcludeTableList)
 
@@ -117,6 +119,62 @@ func validateImportDataFlags() error {
 	}
 
 	return nil
+}
+
+// validateAmpTargetSourceCompatibility ensures yugabytedb-amp is only used with a
+// PostgreSQL source. yb-amp is a PG-wire compute; the offline PG->amp path is the
+// only flow that has been audited/supported (see ACTION_ITEMS.md). Other sources
+// (oracle/mysql) bring schema/type transforms and YB-specific assumptions that have
+// not been validated for amp. This runs from validateImportFlags, which is invoked
+// by the import-schema, import-data / ...toTarget, and finalize PreRuns *after*
+// sourceDBType is populated from the MSR, so it covers all import-side commands.
+func validateAmpTargetSourceCompatibility() {
+	if tconf.TargetDBType != YUGABYTEDB_AMP {
+		return
+	}
+	if sourceDBType != POSTGRESQL {
+		utils.ErrExit("--target-db-type %s is only supported with a PostgreSQL source (detected source: %q)", YUGABYTEDB_AMP, sourceDBType)
+	}
+}
+
+// validateAmpUnsupportedFlags rejects, fail-fast, the import-data flags that have no
+// meaning for a yugabytedb-amp target. yb-amp is a stateless PG17 compute with none of
+// the YB cluster features these flags drive (no per-node fan-out, no upsert fast-path,
+// no ON CONFLICT-aware COPY), so honoring them silently would be wrong:
+//   - --target-endpoints / --use-public-ip: no multi-node cluster to distribute across.
+//   - --enable-upsert: a silent no-op on the PG COPY path — never actually honored.
+//   - --on-primary-key-conflict (non ERROR-POLICY, e.g. IGNORE): amp's snapshot path is
+//     plain COPY and cannot honor ON CONFLICT, so IGNORE would degrade and then ABORT on
+//     a duplicate key. (Validity of the value itself is checked separately in
+//     validateOnPrimaryKeyConflictFlag.)
+//
+// Only relevant for the target-import role (these are import-data flags). Invoked from
+// the import-data PreRun (shared by importDataCmd and importDataToTargetCmd).
+func validateAmpUnsupportedFlags(cmd *cobra.Command) {
+	if tconf.TargetDBType != YUGABYTEDB_AMP || importerRole != TARGET_DB_IMPORTER_ROLE {
+		return
+	}
+
+	notApplicable := func(flag string) {
+		utils.ErrExit("--%s is not applicable for --target-db-type %s", flag, YUGABYTEDB_AMP)
+	}
+
+	if tconf.TargetEndpoints != "" {
+		notApplicable("target-endpoints")
+	}
+	if bool(tconf.UsePublicIP) {
+		notApplicable("use-public-ip")
+	}
+	if bool(tconf.EnableUpsert) {
+		notApplicable("enable-upsert")
+	}
+	// --on-primary-key-conflict has already been upper-cased by validateOnPrimaryKeyConflictFlag
+	// when it runs (validateImportDataFlags -> validateOnPrimaryKeyConflictFlag); normalize here
+	// too so we are order-independent. Anything other than ERROR-POLICY (i.e. IGNORE / future
+	// UPDATE) cannot be honored by amp's plain-COPY snapshot path.
+	if strings.ToUpper(tconf.OnPrimaryKeyConflictAction) != constants.PRIMARY_KEY_CONFLICT_ACTION_ERROR_POLICY {
+		notApplicable("on-primary-key-conflict")
+	}
 }
 
 func validateImportUsePartitionRootFlag() error {
@@ -620,6 +678,24 @@ func validateFFDBSchemaFlag() {
 	if tconf.SchemaConfig == "" && tconf.TargetDBType == ORACLE {
 		utils.ErrExit("Error --source-replica-db-schema flag is mandatory for import data to source-replica")
 	}
+}
+
+// defaultAdaptiveParallelismMode returns the adaptive-parallelism mode to use when the
+// user did NOT pass --adaptive-parallelism. It is per-target:
+//   - YUGABYTEDB: Balanced — adaptive parallelism uses the YB cluster control API
+//     (yb_servers(), tserver metrics) and is the recommended default.
+//   - YUGABYTEDB_AMP: Disabled — yb-amp is a stateless PG17 compute with no YB cluster
+//     control API, so adaptive parallelism is not available; --parallel-jobs controls
+//     import parallelism instead.
+//
+// Defaulting amp to Disabled is also what lets a user pass --parallel-jobs for amp without
+// having to also pass --adaptive-parallelism disabled (validateParallelismFlags only
+// conflicts --parallel-jobs with an *enabled* adaptive mode).
+func defaultAdaptiveParallelismMode(targetDBType string) types.AdaptiveParallelismMode {
+	if targetDBType == YUGABYTEDB_AMP {
+		return types.DisabledAdaptiveParallelismMode
+	}
+	return types.BalancedAdaptiveParallelismMode
 }
 
 func validateParallelismFlags() {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -199,6 +199,10 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 }
 
 func registerTargetDBConnFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&tconf.TargetDBType, "target-db-type", "",
+		fmt.Sprintf("type of the target database to import into. Supported values: %s (default), %s (YugabyteDB AMP — a PostgreSQL-compatible compute over YugabyteDB storage)",
+			YUGABYTEDB, YUGABYTEDB_AMP))
+
 	cmd.Flags().StringVar(&tconf.Host, "target-db-host", "127.0.0.1",
 		"host on which the YugabyteDB server is running")
 
@@ -412,6 +416,10 @@ func validateTargetPortRange() {
 			tconf.Port = YUGABYTEDB_YSQL_DEFAULT_PORT
 		} else if tconf.TargetDBType == POSTGRESQL {
 			tconf.Port = POSTGRES_DEFAULT_PORT
+		} else if tconf.TargetDBType == YUGABYTEDB_AMP {
+			// yb-amp compute endpoints are assigned deployment-specific ports
+			// (there is no canonical default like YSQL's 5433), so require it.
+			utils.ErrExit("--target-db-port is required for --target-db-type %s (yb-amp compute endpoints use deployment-specific ports)", YUGABYTEDB_AMP)
 		}
 		return
 	}
@@ -432,17 +440,36 @@ func validateTargetSchemaFlag() {
 	}
 
 	if tconf.SchemaConfig == "" {
-		if tconf.TargetDBType == YUGABYTEDB {
+		if tconf.TargetDBType == YUGABYTEDB || tconf.TargetDBType == YUGABYTEDB_AMP {
+			// yb-amp follows the PostgreSQL/YugabyteDB convention: default
+			// schema is "public" and PG-source schemas are preserved.
 			tconf.SchemaConfig = YUGABYTEDB_DEFAULT_SCHEMA
 		} else if tconf.TargetDBType == ORACLE {
 			tconf.SchemaConfig = tconf.User
 		}
 		return
-	} else if tconf.TargetDBType != POSTGRESQL {
+	} else if tconf.TargetDBType != POSTGRESQL && tconf.TargetDBType != YUGABYTEDB_AMP {
 		splits := strings.Split(tconf.SchemaConfig, ",")
 		if len(splits) > 1 {
 			utils.ErrExit("Error --target-db-schema flag can only contain one schema name. Got: %s", tconf.SchemaConfig)
 		}
+	}
+}
+
+// validateTargetDBTypeFlag ensures --target-db-type holds a value that is
+// supported for import-to-target. Fall-forward / fall-back roles derive
+// TargetDBType from the source DB type (oracle/postgresql/yugabytedb), so
+// this guardrail only applies to the target-import roles.
+func validateTargetDBTypeFlag() {
+	if importerRole != TARGET_DB_IMPORTER_ROLE && importerRole != IMPORT_FILE_ROLE {
+		return
+	}
+	switch tconf.TargetDBType {
+	case YUGABYTEDB, YUGABYTEDB_AMP:
+		// supported target types for import-to-target
+	default:
+		utils.ErrExit("unsupported --target-db-type %q for import to target. Supported values: %s, %s",
+			tconf.TargetDBType, YUGABYTEDB, YUGABYTEDB_AMP)
 	}
 }
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -116,13 +116,18 @@ var importDataCmd = &cobra.Command{
 			importerRole = TARGET_DB_IMPORTER_ROLE
 		}
 		validateTargetDBTypeFlag()
-		if tconf.AdaptiveParallelismMode == "" {
-			tconf.AdaptiveParallelismMode = types.BalancedAdaptiveParallelismMode
+
+		// Adaptive-parallelism default is per-target (Balanced for YugabyteDB, Disabled
+		// for yugabytedb-amp). yb-amp is a stateless PG17 compute with no YB cluster
+		// control API (yb_servers(), tserver metrics), so adaptive parallelism cannot
+		// work there; --parallel-jobs is used instead.
+		if !cmd.Flags().Changed("adaptive-parallelism") {
+			tconf.AdaptiveParallelismMode = defaultAdaptiveParallelismMode(tconf.TargetDBType)
 		}
-		// Adaptive parallelism needs the YB-cluster control API (yb_servers(),
-		// tserver metrics), which yb-amp's PostgreSQL compute does not expose.
-		// If the user explicitly asked for it, fail fast with a clear pointer to
-		// --parallel-jobs; otherwise silently disable it.
+		// amp guardrails: any explicit enabled adaptive mode (balanced/aggressive) or an
+		// explicit --adaptive-parallelism-max is unsupported. An explicit
+		// --adaptive-parallelism disabled is fine, and so is --parallel-jobs N on its own
+		// (the default above is Disabled for amp, so validateParallelismFlags won't flag it).
 		if tconf.TargetDBType == YUGABYTEDB_AMP {
 			if cmd.Flags().Changed("adaptive-parallelism") && tconf.AdaptiveParallelismMode.IsEnabled() {
 				utils.ErrExit("adaptive parallelism is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs to control import parallelism.", YUGABYTEDB_AMP)
@@ -130,7 +135,6 @@ var importDataCmd = &cobra.Command{
 			if cmd.Flags().Changed("adaptive-parallelism-max") {
 				utils.ErrExit("--adaptive-parallelism-max is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs.", YUGABYTEDB_AMP)
 			}
-			tconf.AdaptiveParallelismMode = types.DisabledAdaptiveParallelismMode
 		}
 
 		err := retrieveMigrationUUID()
@@ -138,6 +142,9 @@ var importDataCmd = &cobra.Command{
 			utils.ErrExit("failed to get migration UUID: %w", err)
 		}
 		sourceDBType = GetSourceDBTypeFromMSR()
+		// validateImportFlags runs the parallelism conflict check (validateParallelismFlags)
+		// and the amp source-compat check; the adaptive-parallelism default above must be
+		// resolved before this point.
 		err = validateImportFlags(cmd, importerRole)
 		if err != nil {
 			utils.ErrExit("Error validating import flags: %s", err.Error())
@@ -147,6 +154,11 @@ var importDataCmd = &cobra.Command{
 		if err != nil {
 			utils.ErrExit("Error validating import data flags: %s", err.Error())
 		}
+
+		// Reject the import-data flags that are not applicable for a yugabytedb-amp target.
+		// Run after validateImportDataFlags so --on-primary-key-conflict has been validated
+		// (the generic validity check) before we report it as not applicable for amp.
+		validateAmpUnsupportedFlags(cmd)
 
 		err = validateImportUsePartitionRootFlag()
 		if err != nil {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -115,8 +115,15 @@ var importDataCmd = &cobra.Command{
 		if importerRole == "" {
 			importerRole = TARGET_DB_IMPORTER_ROLE
 		}
+		validateTargetDBTypeFlag()
 		if tconf.AdaptiveParallelismMode == "" {
 			tconf.AdaptiveParallelismMode = types.BalancedAdaptiveParallelismMode
+		}
+		// yb-amp's PostgreSQL compute exposes no YB-cluster control API
+		// (yb_servers(), tserver metrics), so adaptive parallelism does not
+		// apply — force it off regardless of the requested/default mode.
+		if tconf.TargetDBType == YUGABYTEDB_AMP {
+			tconf.AdaptiveParallelismMode = types.DisabledAdaptiveParallelismMode
 		}
 
 		err := retrieveMigrationUUID()
@@ -1568,13 +1575,11 @@ func importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataS
 	concurrentBatchProductionSem := semaphore.NewWeighted(int64(maxConcurrentBatchProductions))
 
 	var taskPicker FileTaskPicker
-	var yb *tgtdb.TargetYugabyteDB
-	var ok bool
-	if importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE {
-		yb, ok = tdb.(*tgtdb.TargetYugabyteDB)
-		if !ok {
-			return goerrors.Errorf("expected tdb to be of type TargetYugabyteDB, got: %T", tdb)
-		}
+	// The colocation-aware task picker only applies to a real YugabyteDB
+	// target. yb-amp (PostgreSQL-compatible, no colocation/tablets) and the
+	// PG fall-forward/back roles use the sequential picker instead.
+	yb, isYB := tdb.(*tgtdb.TargetYugabyteDB)
+	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && isYB {
 		taskPicker, err = NewColocatedCappedRandomTaskPicker(maxShardedTasksInProgress, maxColocatedBatchesInProgress, pendingTasks, state, yb, colocatedBatchImportQueue, tableTypes)
 		if err != nil {
 			return fmt.Errorf("create colocated aware randmo task picker: %w", err)
@@ -1676,6 +1681,12 @@ func getTableTypes(tasks []*ImportFileTask) (*utils.StructMap[sqlname.NameTuple,
 	if !slices.Contains([]string{TARGET_DB_IMPORTER_ROLE, IMPORT_FILE_ROLE}, importerRole) {
 		return nil, nil
 	}
+	// Colocation is a YugabyteDB-only concept. yb-amp uses plain PostgreSQL
+	// heap storage and the sequential task picker, which does not consult
+	// table types — so there is nothing to compute here.
+	if tconf.TargetDBType == YUGABYTEDB_AMP {
+		return nil, nil
+	}
 
 	tableTypes := utils.NewStructMap[sqlname.NameTuple, string]()
 	yb, ok := tdb.(YbTargetDBColocatedChecker)
@@ -1718,7 +1729,11 @@ func createFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchI
 	var err error
 	var batchProducer FileBatchProducer
 
-	if importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE {
+	// tableTypes (the colocation map) is only populated for a real YugabyteDB
+	// target. For yb-amp (PostgreSQL-compatible, no colocation) and the PG
+	// fall-forward/back roles it is nil, so they take the plain sequential
+	// importer path below.
+	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && tableTypes != nil {
 		tableType, ok := tableTypes.Get(task.TableNameTup)
 		if !ok {
 			return nil, goerrors.Errorf("table type not found for table: %s", task.TableNameTup.ForOutput())
@@ -1756,6 +1771,12 @@ func createFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchI
 
 func startMonitoringTargetYBHealth() error {
 	if !slices.Contains([]string{TARGET_DB_IMPORTER_ROLE, IMPORT_FILE_ROLE}, importerRole) {
+		return nil
+	}
+	// yb-amp's PostgreSQL compute has no YB-cluster health API (node /
+	// disk-usage / replication metrics live in the storage tier, not the
+	// compute), so target health monitoring does not apply.
+	if tconf.TargetDBType == YUGABYTEDB_AMP {
 		return nil
 	}
 	if skipNodeHealthChecks && skipDiskUsageHealthChecks && skipReplicationChecks {
@@ -2183,7 +2204,7 @@ func getTargetSchemaName(tableName string) string {
 	if len(parts) == 2 {
 		return parts[0]
 	}
-	if tconf.TargetDBType == POSTGRESQL {
+	if tconf.TargetDBType == POSTGRESQL || tconf.TargetDBType == YUGABYTEDB_AMP {
 		defaultSchema, noDefaultSchema := GetDefaultPGSchema(tconf.Schemas)
 		if noDefaultSchema {
 			utils.ErrExit("no default schema for table: %q ", tableName)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -119,10 +119,17 @@ var importDataCmd = &cobra.Command{
 		if tconf.AdaptiveParallelismMode == "" {
 			tconf.AdaptiveParallelismMode = types.BalancedAdaptiveParallelismMode
 		}
-		// yb-amp's PostgreSQL compute exposes no YB-cluster control API
-		// (yb_servers(), tserver metrics), so adaptive parallelism does not
-		// apply — force it off regardless of the requested/default mode.
+		// Adaptive parallelism needs the YB-cluster control API (yb_servers(),
+		// tserver metrics), which yb-amp's PostgreSQL compute does not expose.
+		// If the user explicitly asked for it, fail fast with a clear pointer to
+		// --parallel-jobs; otherwise silently disable it.
 		if tconf.TargetDBType == YUGABYTEDB_AMP {
+			if cmd.Flags().Changed("adaptive-parallelism") && tconf.AdaptiveParallelismMode.IsEnabled() {
+				utils.ErrExit("adaptive parallelism is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs to control import parallelism.", YUGABYTEDB_AMP)
+			}
+			if cmd.Flags().Changed("adaptive-parallelism-max") {
+				utils.ErrExit("--adaptive-parallelism-max is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs.", YUGABYTEDB_AMP)
+			}
 			tconf.AdaptiveParallelismMode = types.DisabledAdaptiveParallelismMode
 		}
 
@@ -1578,8 +1585,11 @@ func importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataS
 	// The colocation-aware task picker only applies to a real YugabyteDB
 	// target. yb-amp (PostgreSQL-compatible, no colocation/tablets) and the
 	// PG fall-forward/back roles use the sequential picker instead.
-	yb, isYB := tdb.(*tgtdb.TargetYugabyteDB)
-	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && isYB {
+	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && tconf.TargetDBType == YUGABYTEDB {
+		yb, ok := tdb.(*tgtdb.TargetYugabyteDB)
+		if !ok {
+			return goerrors.Errorf("expected tdb to be of type TargetYugabyteDB, got: %T", tdb)
+		}
 		taskPicker, err = NewColocatedCappedRandomTaskPicker(maxShardedTasksInProgress, maxColocatedBatchesInProgress, pendingTasks, state, yb, colocatedBatchImportQueue, tableTypes)
 		if err != nil {
 			return fmt.Errorf("create colocated aware randmo task picker: %w", err)
@@ -2319,6 +2329,8 @@ func init() {
 	importDataToTargetCmd.Flags().MarkHidden("continue-on-error")
 	registerTargetDBConnFlags(importDataCmd)
 	registerTargetDBConnFlags(importDataToTargetCmd)
+	registerTargetDBTypeFlag(importDataCmd)
+	registerTargetDBTypeFlag(importDataToTargetCmd)
 	registerImportDataCommonFlags(importDataCmd)
 	registerImportDataCommonFlags(importDataToTargetCmd)
 	registerImportUsePartitionRootFlagToTarget(importDataCmd)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -117,24 +117,12 @@ var importDataCmd = &cobra.Command{
 		}
 		validateTargetDBTypeFlag()
 
-		// Adaptive-parallelism default is per-target (Balanced for YugabyteDB, Disabled
-		// for yugabytedb-amp). yb-amp is a stateless PG17 compute with no YB cluster
-		// control API (yb_servers(), tserver metrics), so adaptive parallelism cannot
-		// work there; --parallel-jobs is used instead.
+		// Adaptive-parallelism default is per-target (Balanced for YugabyteDB,
+		// Disabled for yugabytedb-amp, which has no YB cluster control API so
+		// adaptive parallelism cannot work there). The explicit-flag guardrails
+		// for amp live in validateParallelismFlags (invoked via validateImportFlags).
 		if !cmd.Flags().Changed("adaptive-parallelism") {
 			tconf.AdaptiveParallelismMode = defaultAdaptiveParallelismMode(tconf.TargetDBType)
-		}
-		// amp guardrails: any explicit enabled adaptive mode (balanced/aggressive) or an
-		// explicit --adaptive-parallelism-max is unsupported. An explicit
-		// --adaptive-parallelism disabled is fine, and so is --parallel-jobs N on its own
-		// (the default above is Disabled for amp, so validateParallelismFlags won't flag it).
-		if tconf.TargetDBType == YUGABYTEDB_AMP {
-			if cmd.Flags().Changed("adaptive-parallelism") && tconf.AdaptiveParallelismMode.IsEnabled() {
-				utils.ErrExit("adaptive parallelism is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs to control import parallelism.", YUGABYTEDB_AMP)
-			}
-			if cmd.Flags().Changed("adaptive-parallelism-max") {
-				utils.ErrExit("--adaptive-parallelism-max is only supported for YugabyteDB targets. For --target-db-type %s, use --parallel-jobs.", YUGABYTEDB_AMP)
-			}
 		}
 
 		err := retrieveMigrationUUID()
@@ -1703,10 +1691,10 @@ func getTableTypes(tasks []*ImportFileTask) (*utils.StructMap[sqlname.NameTuple,
 	if !slices.Contains([]string{TARGET_DB_IMPORTER_ROLE, IMPORT_FILE_ROLE}, importerRole) {
 		return nil, nil
 	}
-	// Colocation is a YugabyteDB-only concept. yb-amp uses plain PostgreSQL
-	// heap storage and the sequential task picker, which does not consult
-	// table types — so there is nothing to compute here.
-	if tconf.TargetDBType == YUGABYTEDB_AMP {
+	// Colocation is a YugabyteDB-only concept; table types are only meaningful
+	// for a real YugabyteDB target. Non-YB targets (yb-amp, etc.) use plain heap
+	// storage and the sequential task picker, which does not consult table types.
+	if tconf.TargetDBType != YUGABYTEDB {
 		return nil, nil
 	}
 
@@ -1755,7 +1743,10 @@ func createFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchI
 	// target. For yb-amp (PostgreSQL-compatible, no colocation) and the PG
 	// fall-forward/back roles it is nil, so they take the plain sequential
 	// importer path below.
-	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && tableTypes != nil {
+	// The colocation-aware importer applies only to a real YugabyteDB target;
+	// tableTypes is populated (non-nil) exactly for that case (see getTableTypes).
+	// Non-YB targets (yb-amp, etc.) take the plain sequential importer below.
+	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && tconf.TargetDBType == YUGABYTEDB {
 		tableType, ok := tableTypes.Get(task.TableNameTup)
 		if !ok {
 			return nil, goerrors.Errorf("table type not found for table: %s", task.TableNameTup.ForOutput())
@@ -1795,10 +1786,10 @@ func startMonitoringTargetYBHealth() error {
 	if !slices.Contains([]string{TARGET_DB_IMPORTER_ROLE, IMPORT_FILE_ROLE}, importerRole) {
 		return nil
 	}
-	// yb-amp's PostgreSQL compute has no YB-cluster health API (node /
-	// disk-usage / replication metrics live in the storage tier, not the
-	// compute), so target health monitoring does not apply.
-	if tconf.TargetDBType == YUGABYTEDB_AMP {
+	// Target health monitoring (node / disk-usage / replication metrics) is a
+	// YugabyteDB-cluster concept. Non-YB targets (yb-amp's stateless PG17 compute,
+	// etc.) expose no such API, so it does not apply.
+	if tconf.TargetDBType != YUGABYTEDB {
 		return nil
 	}
 	if skipNodeHealthChecks && skipDiskUsageHealthChecks && skipReplicationChecks {

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -237,7 +237,7 @@ func checkImportDataFileFlags(cmd *cobra.Command) {
 	getTargetPassword(cmd)
 	validateTargetPortRange()
 	validateTargetSchemaFlag()
-	validateParallelismFlags()
+	validateParallelismFlags(cmd)
 
 	err := validateImportDataFlags()
 	if err != nil {

--- a/yb-voyager/cmd/importDataFileTaskPicker_test.go
+++ b/yb-voyager/cmd/importDataFileTaskPicker_test.go
@@ -1251,6 +1251,7 @@ func TestColocatedCappedRandomTaskPickerSingleTaskSharded(t *testing.T) {
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -1311,6 +1312,7 @@ func TestColocatedCappedRandomTaskPickerSingleTaskColocated(t *testing.T) {
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -1379,6 +1381,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksSharded(t *testing.T) {
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -1496,6 +1499,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksColocated(t *testing.T) {
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -1627,6 +1631,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksColocatedAndSharded(t *test
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -1790,6 +1795,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksSameTableColocated(t *testi
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -1907,6 +1913,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksSameTableSharded(t *testing
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -2038,6 +2045,7 @@ func TestColocatedCappedRandomTaskPickeResumable(t *testing.T) {
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -2130,6 +2138,7 @@ func TestColocatedCappedRandomTaskPickerShardedTasksOrderedByRowCount(t *testing
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 
@@ -2192,6 +2201,7 @@ func TestColocatedCappedRandomTaskPickerShardedTasksOrderedByFileSize(t *testing
 		},
 	}
 	tdb = dummyYb
+	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
 	tableTypes, err := getTableTypes(tasks)
 	testutils.FatalIfError(t, err)
 

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -156,7 +156,12 @@ func importSchema() error {
 	if err != nil {
 		return fmt.Errorf("failed to get target db version: %w", err)
 	}
-	utils.PrintAndLogf("YugabyteDB version: %s\n", importTargetDBVersion)
+	if tconf.TargetDBType == YUGABYTEDB_AMP {
+		// yb-amp is a PostgreSQL-compatible compute; version() reports "PostgreSQL 17.x".
+		utils.PrintAndLogf("Target (yugabytedb-amp) version: %s\n", importTargetDBVersion)
+	} else {
+		utils.PrintAndLogf("YugabyteDB version: %s\n", importTargetDBVersion)
+	}
 
 	if err := promptIfColocatedTablesInNonColocatedDB(conn); err != nil {
 		log.Warnf("failed to prompt for colocated tables in non-colocated DB: %v", err)
@@ -372,6 +377,12 @@ func assessmentRecommendedColocatedTables() (bool, error) {
 }
 
 func promptIfColocatedTablesInNonColocatedDB(conn *pgx.Conn) error {
+	// Colocation is not a yb-amp concept; the underlying check runs
+	// yb_is_database_colocated(), a YB-only function absent on yb-amp's PG17
+	// compute (it would fatally ErrExit). Skip the prompt entirely for yb-amp.
+	if tconf.TargetDBType == YUGABYTEDB_AMP {
+		return nil
+	}
 	migrationAssessmentDoneAndApplied, err := MigrationAssessmentDoneAndApplied()
 	if err != nil {
 		return fmt.Errorf("failed to check if the migration assessment is completed and applied recommendations on schema in export schema: %w", err)

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -56,6 +56,7 @@ var importSchemaCmd = &cobra.Command{
 		if importerRole == "" {
 			importerRole = TARGET_DB_IMPORTER_ROLE
 		}
+		validateTargetDBTypeFlag()
 
 		err := retrieveMigrationUUID()
 		if err != nil {

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -84,6 +84,7 @@ func init() {
 	registerCommonGlobalFlags(importSchemaCmd)
 	registerCommonImportFlags(importSchemaCmd)
 	registerTargetDBConnFlags(importSchemaCmd)
+	registerTargetDBTypeFlag(importSchemaCmd)
 	registerImportSchemaFlags(importSchemaCmd)
 }
 

--- a/yb-voyager/cmd/importSchema.go
+++ b/yb-voyager/cmd/importSchema.go
@@ -377,10 +377,11 @@ func assessmentRecommendedColocatedTables() (bool, error) {
 }
 
 func promptIfColocatedTablesInNonColocatedDB(conn *pgx.Conn) error {
-	// Colocation is not a yb-amp concept; the underlying check runs
-	// yb_is_database_colocated(), a YB-only function absent on yb-amp's PG17
-	// compute (it would fatally ErrExit). Skip the prompt entirely for yb-amp.
-	if tconf.TargetDBType == YUGABYTEDB_AMP {
+	// Colocation is a YugabyteDB-only concept; the underlying check runs
+	// yb_is_database_colocated(), a YB-only function absent on non-YB targets
+	// like yb-amp's PG17 compute (it would fatally ErrExit). Only run it for a
+	// real YugabyteDB target.
+	if tconf.TargetDBType != YUGABYTEDB {
 		return nil
 	}
 	migrationAssessmentDoneAndApplied, err := MigrationAssessmentDoneAndApplied()

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -96,12 +96,13 @@ func originalSchemaFilePath(filePath string) string {
 }
 
 func generateAnalyzeReport(targetYBDBVersion string) (string, error) {
-	// yb-amp reports a plain-PostgreSQL version ("PostgreSQL 17.x"), not the
-	// YugabyteDB "<pg>-YB-<yb>-<build>" string this report's version parsing
-	// expects, and the analyze report is YB-version-oriented. Skip it for yb-amp:
-	// returning an empty path also drops the YB-flavored analyze nudge downstream.
-	if tconf.TargetDBType == YUGABYTEDB_AMP {
-		log.Infof("skipping analyze-schema report generation for yb-amp target")
+	// The analyze-schema report is YugabyteDB-version-oriented: its version parsing
+	// expects the YugabyteDB "<pg>-YB-<yb>-<build>" string, which non-YB targets
+	// don't report (yb-amp reports a plain "PostgreSQL 17.x"). Only generate it for
+	// a real YugabyteDB target; returning an empty path also drops the YB-flavored
+	// analyze nudge downstream.
+	if tconf.TargetDBType != YUGABYTEDB {
+		log.Infof("skipping analyze-schema report generation for non-YugabyteDB target %q", tconf.TargetDBType)
 		return "", nil
 	}
 

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -220,6 +220,17 @@ func shouldSkipDDL(stmt string, objType string) (bool, error) {
 		return true, nil
 	}
 
+	// yb-amp is a PostgreSQL-compatible compute and does not recognize
+	// YugabyteDB-specific GUCs. The schema optimizer emits statements like
+	// `SET yb_use_hash_splitting_by_default TO ON` to steer YB sharding;
+	// those parameters don't exist on yb-amp's PG17 and would abort the
+	// import. Strip every `SET yb_*` so the remaining DDL applies as plain
+	// PostgreSQL (heap tables, no sharding clauses).
+	if tconf.TargetDBType == YUGABYTEDB_AMP && strings.HasPrefix(strings.TrimSpace(stmt), "SET YB_") {
+		log.Infof("Skipping YugabyteDB-specific session variable for yb-amp target: %s", stmt)
+		return true, nil
+	}
+
 	if objType != TABLE {
 		return false, nil
 	}

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -63,23 +63,16 @@ func importSchemaInternal(exportDir string, importObjectList []string,
 	skipFn func(string, string) bool) error {
 	schemaDir := filepath.Join(exportDir, "schema")
 
-	// yb-amp is PostgreSQL-compatible and rejects the YugabyteDB-specific
-	// optimizations (colocation, `SET yb_*` sharding steering) that
-	// export-schema bakes into the main schema files. When those optimizations
-	// were applied, export-schema also retained the pre-transformation
-	// originals as backup_<file>; import those plain-PG originals instead.
-	useOriginalSchemaFiles := false
-	if tconf.TargetDBType == YUGABYTEDB_AMP {
-		msr, err := metaDB.GetMigrationStatusRecord()
-		if err != nil {
-			return fmt.Errorf("get migration status record: %w", err)
-		}
-		useOriginalSchemaFiles = msr.SchemaOptimizationsApplied
-	}
-
 	for _, importObjectType := range importObjectList {
 		importObjectFilePath := utils.GetObjectFilePath(schemaDir, importObjectType)
-		if useOriginalSchemaFiles {
+		// yb-amp is PostgreSQL-compatible and rejects the YugabyteDB-specific
+		// optimizations (colocation, `SET yb_*` sharding steering) that
+		// export-schema bakes into the main schema files. Whenever export-schema
+		// transformed an object file it also retained the plain pre-transformation
+		// original as backup_<base>; for yb-amp, prefer that plain original purely
+		// by its existence (an object type with nothing to transform has no backup,
+		// so its normal file is already plain).
+		if tconf.TargetDBType == YUGABYTEDB_AMP {
 			if origPath := originalSchemaFilePath(importObjectFilePath); utils.FileOrFolderExists(origPath) {
 				log.Infof("yb-amp target: importing pre-transformation original %q instead of %q", origPath, importObjectFilePath)
 				importObjectFilePath = origPath
@@ -103,6 +96,15 @@ func originalSchemaFilePath(filePath string) string {
 }
 
 func generateAnalyzeReport(targetYBDBVersion string) (string, error) {
+	// yb-amp reports a plain-PostgreSQL version ("PostgreSQL 17.x"), not the
+	// YugabyteDB "<pg>-YB-<yb>-<build>" string this report's version parsing
+	// expects, and the analyze report is YB-version-oriented. Skip it for yb-amp:
+	// returning an empty path also drops the YB-flavored analyze nudge downstream.
+	if tconf.TargetDBType == YUGABYTEDB_AMP {
+		log.Infof("skipping analyze-schema report generation for yb-amp target")
+		return "", nil
+	}
+
 	//check if schema is already analyzed
 	path := filepath.Join(exportDir, "reports", fmt.Sprintf("%s.*", ANALYSIS_REPORT_FILE_NAME))
 	reportPath, ok := utils.FilePathForAnyFileExistsInGlobPattern(path) // basic check if report files exists then return that only

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -62,8 +62,29 @@ var notice *pgconn.Notice
 func importSchemaInternal(exportDir string, importObjectList []string,
 	skipFn func(string, string) bool) error {
 	schemaDir := filepath.Join(exportDir, "schema")
+
+	// yb-amp is PostgreSQL-compatible and rejects the YugabyteDB-specific
+	// optimizations (colocation, `SET yb_*` sharding steering) that
+	// export-schema bakes into the main schema files. When those optimizations
+	// were applied, export-schema also retained the pre-transformation
+	// originals as backup_<file>; import those plain-PG originals instead.
+	useOriginalSchemaFiles := false
+	if tconf.TargetDBType == YUGABYTEDB_AMP {
+		msr, err := metaDB.GetMigrationStatusRecord()
+		if err != nil {
+			return fmt.Errorf("get migration status record: %w", err)
+		}
+		useOriginalSchemaFiles = msr.SchemaOptimizationsApplied
+	}
+
 	for _, importObjectType := range importObjectList {
 		importObjectFilePath := utils.GetObjectFilePath(schemaDir, importObjectType)
+		if useOriginalSchemaFiles {
+			if origPath := originalSchemaFilePath(importObjectFilePath); utils.FileOrFolderExists(origPath) {
+				log.Infof("yb-amp target: importing pre-transformation original %q instead of %q", origPath, importObjectFilePath)
+				importObjectFilePath = origPath
+			}
+		}
 		if !utils.FileOrFolderExists(importObjectFilePath) {
 			continue
 		}
@@ -73,6 +94,12 @@ func importSchemaInternal(exportDir string, importObjectList []string,
 		}
 	}
 	return nil
+}
+
+// originalSchemaFilePath returns the backup_<base> sibling that export-schema
+// writes alongside any schema file it transforms (tables, indexes, mviews).
+func originalSchemaFilePath(filePath string) string {
+	return filepath.Join(filepath.Dir(filePath), "backup_"+filepath.Base(filePath))
 }
 
 func generateAnalyzeReport(targetYBDBVersion string) (string, error) {
@@ -217,17 +244,6 @@ func shouldSkipDDL(stmt string, objType string) (bool, error) {
 		strings.Contains(stmt, TRANSACTION_TIMEOUT_SESSION_VAR) {
 		//skip these session variables
 		log.Infof("Skipping session variable: %s", stmt)
-		return true, nil
-	}
-
-	// yb-amp is a PostgreSQL-compatible compute and does not recognize
-	// YugabyteDB-specific GUCs. The schema optimizer emits statements like
-	// `SET yb_use_hash_splitting_by_default TO ON` to steer YB sharding;
-	// those parameters don't exist on yb-amp's PG17 and would abort the
-	// import. Strip every `SET yb_*` so the remaining DDL applies as plain
-	// PostgreSQL (heap tables, no sharding clauses).
-	if tconf.TargetDBType == YUGABYTEDB_AMP && strings.HasPrefix(strings.TrimSpace(stmt), "SET YB_") {
-		log.Infof("Skipping YugabyteDB-specific session variable for yb-amp target: %s", stmt)
 		return true, nil
 	}
 

--- a/yb-voyager/src/constants/constants.go
+++ b/yb-voyager/src/constants/constants.go
@@ -36,7 +36,7 @@ const (
 	// PostgreSQL 17 compute backed by YugabyteDB storage. On the wire it is
 	// PostgreSQL-compatible, so identifier quoting, DDL and COPY semantics
 	// follow the PostgreSQL rules.
-	YUGABYTEDB_AMP = "ybamp"
+	YUGABYTEDB_AMP = "yugabytedb-amp"
 
 	// AssessmentIssue Categoes - used by YugabyteD payload and Migration Complexity Explainability
 	// TODO: soon to be renamed as SCHEMA, SCHEMA_PLPGSQL, DML_QUERY, MIGRATION_CAVEAT, "DATATYPE"

--- a/yb-voyager/src/constants/constants.go
+++ b/yb-voyager/src/constants/constants.go
@@ -32,6 +32,11 @@ const (
 	POSTGRESQL = "postgresql"
 	ORACLE     = "oracle"
 	MYSQL      = "mysql"
+	// YUGABYTEDB_AMP (yb-amp) is YugabyteDB AMP: a stateless, patched
+	// PostgreSQL 17 compute backed by YugabyteDB storage. On the wire it is
+	// PostgreSQL-compatible, so identifier quoting, DDL and COPY semantics
+	// follow the PostgreSQL rules.
+	YUGABYTEDB_AMP = "ybamp"
 
 	// AssessmentIssue Categoes - used by YugabyteD payload and Migration Complexity Explainability
 	// TODO: soon to be renamed as SCHEMA, SCHEMA_PLPGSQL, DML_QUERY, MIGRATION_CAVEAT, "DATATYPE"

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -44,6 +44,14 @@ type MigrationStatusRecord struct {
 	SourceExportedTableListWithLeafPartitions []string          `json:"SourceExportedTableListWithLeafPartitions"` // will be same as `TableListExportedFromSource` for Oracle and MySQL but will have leaf partitions in case of PG
 	TargetExportedTableListWithLeafPartitions []string          `json:"TargetExportedTableListWithLeafPartitions"` // will be the table list for export data from target with leaf partitions
 
+	// SchemaOptimizationsApplied records whether export-schema wrote
+	// YugabyteDB-flavored optimizations (colocation / sharding-steering GUCs)
+	// into the main schema files. When true, the pre-transformation originals
+	// are retained alongside as backup_<file>. import-schema uses this to
+	// decide, for a PostgreSQL-compatible target like yb-amp, whether it must
+	// fall back to those plain-PG originals instead of the YB-optimized files.
+	SchemaOptimizationsApplied bool `json:"SchemaOptimizationsApplied"`
+
 	SourceDBConf *srcdb.Source `json:"SourceDBConf"`
 
 	//All the cutover requested flags by initiate cutover command

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -44,14 +44,6 @@ type MigrationStatusRecord struct {
 	SourceExportedTableListWithLeafPartitions []string          `json:"SourceExportedTableListWithLeafPartitions"` // will be same as `TableListExportedFromSource` for Oracle and MySQL but will have leaf partitions in case of PG
 	TargetExportedTableListWithLeafPartitions []string          `json:"TargetExportedTableListWithLeafPartitions"` // will be the table list for export data from target with leaf partitions
 
-	// SchemaOptimizationsApplied records whether export-schema wrote
-	// YugabyteDB-flavored optimizations (colocation / sharding-steering GUCs)
-	// into the main schema files. When true, the pre-transformation originals
-	// are retained alongside as backup_<file>. import-schema uses this to
-	// decide, for a PostgreSQL-compatible target like yb-amp, whether it must
-	// fall back to those plain-PG originals instead of the YB-optimized files.
-	SchemaOptimizationsApplied bool `json:"SchemaOptimizationsApplied"`
-
 	SourceDBConf *srcdb.Source `json:"SourceDBConf"`
 
 	//All the cutover requested flags by initiate cutover command

--- a/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
+++ b/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
@@ -37,33 +37,22 @@ const (
 	HASH_SPLITTING_SESSION_VARIABLE_OFF            = "set yb_use_hash_splitting_by_default=off;"
 )
 
-// ensurePlainBackup creates the canonical backup_<base> sibling alongside `file`
-// and returns its path. The backup must always hold the PLAIN, pre-transform
-// DDL so a PostgreSQL-compatible target (yb-amp) can import the originals.
-//
-// existingPlainBackup, when non-empty, is an already-created plain backup of the
-// pre-transform DDL written by an earlier step (e.g. the colocation step renames
-// the plain file to <file>.orig before writing colocation clauses into `file`).
-// In that case we copy that plain file into backup_<base> rather than `file`,
-// because `file` has already been mutated by the earlier step and is no longer
-// plain. This is the fix for the clobber bug where copying the post-colocation
-// `file` into backup_<base> destroyed the plain backup.
-//
-// If backup_<base> already exists it is left untouched (skip-if-exists) so the
-// earliest/plain backup is preserved across multiple transform passes / re-runs.
-func ensurePlainBackup(file string, existingPlainBackup string) (string, error) {
+// EnsurePlainBackup creates the canonical backup_<base> sibling alongside `file`
+// and returns its path. It is the single place that produces a schema-file backup,
+// used by every step that mutates a schema file (the colocation recommender and the
+// file transformers) — each MUST call it BEFORE mutating `file`. Because the first
+// caller copies the still-pristine `file`, and it is skip-if-exists (never
+// overwrites an existing backup), backup_<base> always holds the plain,
+// pre-any-transformation pg_dump DDL. That is exactly what a PostgreSQL-compatible
+// target (yb-amp) imports.
+func EnsurePlainBackup(file string) (string, error) {
 	backUpFile := filepath.Join(filepath.Dir(file), fmt.Sprintf("backup_%s", filepath.Base(file)))
 	if utils.FileOrFolderExists(backUpFile) {
-		// Preserve the earliest (plain) backup; do not clobber it.
+		// Earliest (plain) backup wins; never clobber it.
 		return backUpFile, nil
 	}
-	src := file
-	if existingPlainBackup != "" && utils.FileOrFolderExists(existingPlainBackup) {
-		// `file` was already mutated by an earlier step; copy the plain original.
-		src = existingPlainBackup
-	}
-	if err := utils.CopyFile(src, backUpFile); err != nil {
-		return "", fmt.Errorf("failed to copy %s to %s: %w", src, backUpFile, err)
+	if err := utils.CopyFile(file, backUpFile); err != nil {
+		return "", fmt.Errorf("failed to back up %s to %s: %w", file, backUpFile, err)
 	}
 	return backUpFile, nil
 }
@@ -116,9 +105,8 @@ func (t *IndexFileTransformer) Transform(file string) (string, error) {
 
 	var err error
 	var parseTree *pg_query.ParseResult
-	// Index files have no earlier-step backup, so the plain backup is just a copy
-	// of `file` (still plain at this point), created skip-if-exists.
-	backUpFile, err := ensurePlainBackup(file, "")
+	// Back up the pristine file before transforming it (skip-if-exists).
+	backUpFile, err := EnsurePlainBackup(file)
 	if err != nil {
 		return "", err
 	}
@@ -226,12 +214,10 @@ func NewTableFileTransformer(skipMergeConstraints bool, sourceDBType string, ski
 func (t *TableFileTransformer) Transform(file string) (string, error) {
 	var err error
 	var parseTree *pg_query.ParseResult
-	// The colocation step (applyShardedTablesRecommendation) runs before this and,
-	// when it fires, renames the PLAIN table file to <file>.orig and sets
-	// t.BackupFilePath to it before writing colocation clauses into `file`. By the
-	// time we get here `file` is post-colocation, so we must back up the plain
-	// .orig instead of `file` to keep backup_<base> plain (the clobber-bug fix).
-	backUpFile, err := ensurePlainBackup(file, t.BackupFilePath)
+	// Back up the pristine file before transforming it. The colocation step, if it
+	// ran, already created backup_<base> from the plain pre-colocation file, so this
+	// is skip-if-exists and the backup stays plain.
+	backUpFile, err := EnsurePlainBackup(file)
 	if err != nil {
 		return "", err
 	}
@@ -302,25 +288,14 @@ func NewMviewFileTransformer() *MviewFileTransformer {
 	return &MviewFileTransformer{}
 }
 
-// Transform does not modify the mview file content (mview transformations are,
-// for now, applied outside this transformer by the colocation step). Its only
-// job is to materialize the canonical plain backup_<base> sibling so a
-// PostgreSQL-compatible target (yb-amp) can import the pre-colocation original.
-// When the colocation step ran it set t.BackupFilePath to the plain <file>.orig;
-// ensurePlainBackup copies that plain file (not the post-colocation `file`) into
-// backup_<base>, skip-if-exists. When colocation did not run, no backup is made.
+// Transform does not modify the mview file content; mview mutations (colocation)
+// are applied by the colocation step, which also creates the plain backup_<base>
+// via EnsurePlainBackup before mutating. So this transformer is a pass-through.
 func (t *MviewFileTransformer) Transform(file string) (string, error) {
-	if t.BackupFilePath == "" {
-		// Nothing transformed the mview file (no colocation), so it is already
-		// plain; no backup needed.
-		return file, nil
-	}
-	backUpFile, err := ensurePlainBackup(file, t.BackupFilePath)
-	if err != nil {
-		return "", err
-	}
-	t.BackupFilePath = backUpFile
-	return backUpFile, nil
+	// The mview file is only ever mutated by the colocation step, which backs it up
+	// (EnsurePlainBackup) before mutating. This transformer applies no content
+	// changes of its own, so there is nothing to do here.
+	return file, nil
 }
 
 func (t *MviewFileTransformer) GetBackupFilePath() string {

--- a/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
+++ b/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
@@ -37,6 +37,37 @@ const (
 	HASH_SPLITTING_SESSION_VARIABLE_OFF            = "set yb_use_hash_splitting_by_default=off;"
 )
 
+// ensurePlainBackup creates the canonical backup_<base> sibling alongside `file`
+// and returns its path. The backup must always hold the PLAIN, pre-transform
+// DDL so a PostgreSQL-compatible target (yb-amp) can import the originals.
+//
+// existingPlainBackup, when non-empty, is an already-created plain backup of the
+// pre-transform DDL written by an earlier step (e.g. the colocation step renames
+// the plain file to <file>.orig before writing colocation clauses into `file`).
+// In that case we copy that plain file into backup_<base> rather than `file`,
+// because `file` has already been mutated by the earlier step and is no longer
+// plain. This is the fix for the clobber bug where copying the post-colocation
+// `file` into backup_<base> destroyed the plain backup.
+//
+// If backup_<base> already exists it is left untouched (skip-if-exists) so the
+// earliest/plain backup is preserved across multiple transform passes / re-runs.
+func ensurePlainBackup(file string, existingPlainBackup string) (string, error) {
+	backUpFile := filepath.Join(filepath.Dir(file), fmt.Sprintf("backup_%s", filepath.Base(file)))
+	if utils.FileOrFolderExists(backUpFile) {
+		// Preserve the earliest (plain) backup; do not clobber it.
+		return backUpFile, nil
+	}
+	src := file
+	if existingPlainBackup != "" && utils.FileOrFolderExists(existingPlainBackup) {
+		// `file` was already mutated by an earlier step; copy the plain original.
+		src = existingPlainBackup
+	}
+	if err := utils.CopyFile(src, backUpFile); err != nil {
+		return "", fmt.Errorf("failed to copy %s to %s: %w", src, backUpFile, err)
+	}
+	return backUpFile, nil
+}
+
 // =========================INDEX FILE TRANSFORMER=====================================
 type IndexFileTransformer struct {
 	//skipping the performance optimizations with this parameter
@@ -85,11 +116,11 @@ func (t *IndexFileTransformer) Transform(file string) (string, error) {
 
 	var err error
 	var parseTree *pg_query.ParseResult
-	backUpFile := filepath.Join(filepath.Dir(file), fmt.Sprintf("backup_%s", filepath.Base(file)))
-	//copy files
-	err = utils.CopyFile(file, backUpFile)
+	// Index files have no earlier-step backup, so the plain backup is just a copy
+	// of `file` (still plain at this point), created skip-if-exists.
+	backUpFile, err := ensurePlainBackup(file, "")
 	if err != nil {
-		return "", fmt.Errorf("failed to copy %s to %s: %w", file, backUpFile, err)
+		return "", err
 	}
 	parseTree, err = queryparser.ParseSqlFile(file)
 	if err != nil {
@@ -195,11 +226,14 @@ func NewTableFileTransformer(skipMergeConstraints bool, sourceDBType string, ski
 func (t *TableFileTransformer) Transform(file string) (string, error) {
 	var err error
 	var parseTree *pg_query.ParseResult
-	backUpFile := filepath.Join(filepath.Dir(file), fmt.Sprintf("backup_%s", filepath.Base(file)))
-	//copy files
-	err = utils.CopyFile(file, backUpFile)
+	// The colocation step (applyShardedTablesRecommendation) runs before this and,
+	// when it fires, renames the PLAIN table file to <file>.orig and sets
+	// t.BackupFilePath to it before writing colocation clauses into `file`. By the
+	// time we get here `file` is post-colocation, so we must back up the plain
+	// .orig instead of `file` to keep backup_<base> plain (the clobber-bug fix).
+	backUpFile, err := ensurePlainBackup(file, t.BackupFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to copy %s to %s: %w", file, backUpFile, err)
+		return "", err
 	}
 
 	parseTree, err = queryparser.ParseSqlFile(file)
@@ -268,8 +302,25 @@ func NewMviewFileTransformer() *MviewFileTransformer {
 	return &MviewFileTransformer{}
 }
 
+// Transform does not modify the mview file content (mview transformations are,
+// for now, applied outside this transformer by the colocation step). Its only
+// job is to materialize the canonical plain backup_<base> sibling so a
+// PostgreSQL-compatible target (yb-amp) can import the pre-colocation original.
+// When the colocation step ran it set t.BackupFilePath to the plain <file>.orig;
+// ensurePlainBackup copies that plain file (not the post-colocation `file`) into
+// backup_<base>, skip-if-exists. When colocation did not run, no backup is made.
 func (t *MviewFileTransformer) Transform(file string) (string, error) {
-	return file, nil
+	if t.BackupFilePath == "" {
+		// Nothing transformed the mview file (no colocation), so it is already
+		// plain; no backup needed.
+		return file, nil
+	}
+	backUpFile, err := ensurePlainBackup(file, t.BackupFilePath)
+	if err != nil {
+		return "", err
+	}
+	t.BackupFilePath = backUpFile
+	return backUpFile, nil
 }
 
 func (t *MviewFileTransformer) GetBackupFilePath() string {

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -1238,3 +1238,69 @@ func (pg *TargetPostgreSQL) GetEnabledTriggersAndFks() (enabledTriggers []string
 
 	return enabledTriggers, enabledFks, nil
 }
+
+// The three methods below satisfy namereg.YBDBInterface, which the name
+// registry requires of every import-to-target driver. They use standard
+// PostgreSQL catalog queries, so they are valid for any PostgreSQL-compatible
+// target — vanilla PostgreSQL and YugabyteDB AMP (which embeds this driver)
+// alike. TargetYugabyteDB keeps its own equivalents.
+
+func (pg *TargetPostgreSQL) GetAllSchemaNamesRaw() ([]string, error) {
+	query := "SELECT schema_name FROM information_schema.schemata"
+	rows, err := pg.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying target for schema names: %w", err)
+	}
+	defer rows.Close()
+
+	var schemaNames []string
+	for rows.Next() {
+		var schemaName string
+		if err = rows.Scan(&schemaName); err != nil {
+			return nil, fmt.Errorf("scanning schema name: %w", err)
+		}
+		schemaNames = append(schemaNames, schemaName)
+	}
+	return schemaNames, rows.Err()
+}
+
+func (pg *TargetPostgreSQL) GetAllTableNamesRaw(schemaName string) ([]string, error) {
+	query := fmt.Sprintf(`SELECT table_name
+			  FROM information_schema.tables
+			  WHERE table_type = 'BASE TABLE' AND
+			        table_schema = '%s';`, schemaName)
+	rows, err := pg.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying target (%q) for table names: %w", query, err)
+	}
+	defer rows.Close()
+
+	var tableNames []string
+	for rows.Next() {
+		var tableName string
+		if err = rows.Scan(&tableName); err != nil {
+			return nil, fmt.Errorf("scanning table name: %w", err)
+		}
+		tableNames = append(tableNames, tableName)
+	}
+	return tableNames, rows.Err()
+}
+
+func (pg *TargetPostgreSQL) GetAllSequencesRaw(schemaName string) ([]string, error) {
+	query := fmt.Sprintf(`SELECT sequencename FROM pg_sequences WHERE schemaname = '%s';`, schemaName)
+	rows, err := pg.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying target (%q) for sequence names: %w", query, err)
+	}
+	defer rows.Close()
+
+	var sequenceNames []string
+	for rows.Next() {
+		var sequenceName string
+		if err = rows.Scan(&sequenceName); err != nil {
+			return nil, fmt.Errorf("scanning sequence name: %w", err)
+		}
+		sequenceNames = append(sequenceNames, sequenceName)
+	}
+	return sequenceNames, rows.Err()
+}

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -74,6 +74,10 @@ const (
 	MYSQL      = "mysql"
 	POSTGRESQL = "postgresql"
 	YUGABYTEDB = "yugabytedb"
+	// YUGABYTEDB_AMP (yb-amp) is YugabyteDB AMP — a PostgreSQL-compatible
+	// compute backed by YugabyteDB storage. It reuses the PostgreSQL target
+	// driver (see newTargetYugabyteDBAmp).
+	YUGABYTEDB_AMP = "ybamp"
 )
 
 type Batch interface {
@@ -93,6 +97,8 @@ func NewTargetDB(tconf *TargetConf) TargetDB {
 		return newTargetPostgreSQL(tconf)
 	case YUGABYTEDB:
 		return newTargetYugabyteDB(tconf)
+	case YUGABYTEDB_AMP:
+		return newTargetYugabyteDBAmp(tconf)
 	}
 	return nil
 }

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -77,7 +77,7 @@ const (
 	// YUGABYTEDB_AMP (yb-amp) is YugabyteDB AMP — a PostgreSQL-compatible
 	// compute backed by YugabyteDB storage. It reuses the PostgreSQL target
 	// driver (see newTargetYugabyteDBAmp).
-	YUGABYTEDB_AMP = "ybamp"
+	YUGABYTEDB_AMP = "yugabytedb-amp"
 )
 
 type Batch interface {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -175,14 +175,14 @@ func (yb *TargetYugabyteDB) Init() error {
 // mistyped --target-db-type would proceed and misbehave (YB-only GUCs,
 // colocation, adaptive parallelism). Names the right target type to use.
 func (yb *TargetYugabyteDB) validateYugabyteDBTarget() error {
-	isYB, err := endpointIsRealYugabyteDB(yb)
+	isYB, err := endpointIsRealYugabyteDB(yb.db)
 	if err != nil {
 		return fmt.Errorf("validate target is YugabyteDB: %w", err)
 	}
 	if isYB {
 		return nil
 	}
-	if hasAmp, _ := endpointHasAmpGUCs(yb); hasAmp {
+	if hasAmp, _ := endpointHasAmpGUCs(yb.db); hasAmp {
 		return fmt.Errorf("the target at %s:%d is a YugabyteDB AMP (yb-amp) endpoint, not a standard YugabyteDB cluster. "+
 			"Use --target-db-type %s instead of %s",
 			yb.Tconf.Host, yb.Tconf.Port, YUGABYTEDB_AMP, YUGABYTEDB)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -135,6 +135,10 @@ func (yb *TargetYugabyteDB) Init() error {
 		return err
 	}
 
+	if err := yb.validateYugabyteDBTarget(); err != nil {
+		return err
+	}
+
 	if len(yb.Tconf.SessionVars) == 0 {
 		yb.Tconf.SessionVars = getYBSessionInitScript(yb.Tconf)
 	}
@@ -163,6 +167,29 @@ func (yb *TargetYugabyteDB) Init() error {
 		return goerrors.Errorf("schemas '%s' do not exist in target", strings.Join(notExistsSchemas, ","))
 	}
 	return nil
+}
+
+// validateYugabyteDBTarget confirms the connected endpoint is a genuine
+// YugabyteDB cluster, not a PostgreSQL-compatible look-alike. yb-amp and
+// plain PostgreSQL both speak the PG wire protocol, so without this a
+// mistyped --target-db-type would proceed and misbehave (YB-only GUCs,
+// colocation, adaptive parallelism). Names the right target type to use.
+func (yb *TargetYugabyteDB) validateYugabyteDBTarget() error {
+	isYB, err := endpointIsRealYugabyteDB(yb)
+	if err != nil {
+		return fmt.Errorf("validate target is YugabyteDB: %w", err)
+	}
+	if isYB {
+		return nil
+	}
+	if hasAmp, _ := endpointHasAmpGUCs(yb); hasAmp {
+		return fmt.Errorf("the target at %s:%d is a YugabyteDB AMP (yb-amp) endpoint, not a standard YugabyteDB cluster. "+
+			"Use --target-db-type %s instead of %s",
+			yb.Tconf.Host, yb.Tconf.Port, YUGABYTEDB_AMP, YUGABYTEDB)
+	}
+	return fmt.Errorf("the target at %s:%d does not look like a YugabyteDB cluster "+
+		"(no yb_servers() — it looks like plain PostgreSQL). Use the matching --target-db-type",
+		yb.Tconf.Host, yb.Tconf.Port)
 }
 
 func (yb *TargetYugabyteDB) Finalize() {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -183,11 +183,11 @@ func (yb *TargetYugabyteDB) validateYugabyteDBTarget() error {
 		return nil
 	}
 	if hasAmp, _ := endpointHasAmpGUCs(yb.db); hasAmp {
-		return fmt.Errorf("the target at %s:%d is a YugabyteDB AMP (yb-amp) endpoint, not a standard YugabyteDB cluster. "+
+		return goerrors.Errorf("the target at %s:%d is a YugabyteDB AMP (yb-amp) endpoint, not a standard YugabyteDB cluster. "+
 			"Use --target-db-type %s instead of %s",
 			yb.Tconf.Host, yb.Tconf.Port, YUGABYTEDB_AMP, YUGABYTEDB)
 	}
-	return fmt.Errorf("the target at %s:%d does not look like a YugabyteDB cluster "+
+	return goerrors.Errorf("the target at %s:%d does not look like a YugabyteDB cluster "+
 		"(no yb_servers() — it looks like plain PostgreSQL). Use the matching --target-db-type",
 		yb.Tconf.Host, yb.Tconf.Port)
 }

--- a/yb-voyager/src/tgtdb/yugabytedb_amp.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_amp.go
@@ -18,6 +18,7 @@ package tgtdb
 import (
 	"fmt"
 
+	goerrors "github.com/go-errors/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -68,11 +69,11 @@ func (amp *TargetYugabyteDBAmp) validateAmpTarget() error {
 	// Not yb-amp — name the right target type to use depending on whether
 	// this is a real YugabyteDB cluster or plain PostgreSQL.
 	if isYB, _ := endpointIsRealYugabyteDB(amp.db); isYB {
-		return fmt.Errorf("the target at %s:%d is a standard YugabyteDB cluster, not YugabyteDB AMP (yb-amp). "+
+		return goerrors.Errorf("the target at %s:%d is a standard YugabyteDB cluster, not YugabyteDB AMP (yb-amp). "+
 			"Use --target-db-type %s instead of %s",
 			amp.tconf.Host, amp.tconf.Port, YUGABYTEDB, YUGABYTEDB_AMP)
 	}
-	return fmt.Errorf("the target at %s:%d does not look like a YugabyteDB AMP (yb-amp) endpoint: "+
+	return goerrors.Errorf("the target at %s:%d does not look like a YugabyteDB AMP (yb-amp) endpoint: "+
 		"no '%s*' settings were found (it looks like plain PostgreSQL). "+
 		"If you are migrating to a standard YugabyteDB server, use --target-db-type %s instead of %s",
 		amp.tconf.Host, amp.tconf.Port, AMP_MARKER_SETTING_PREFIX, YUGABYTEDB, YUGABYTEDB_AMP)

--- a/yb-voyager/src/tgtdb/yugabytedb_amp.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_amp.go
@@ -16,6 +16,7 @@ limitations under the License.
 package tgtdb
 
 import (
+	"database/sql"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -35,8 +36,9 @@ import (
 // is no adaptive parallelism / colocation / tablet concept.
 //
 // We therefore reuse the PostgreSQL target driver wholesale (via
-// embedding) and layer on only the AMP-specific identity: a guardrail
-// that confirms the endpoint really is yb-amp.
+// embedding) — including the namereg.YBDBInterface methods, which now
+// live on TargetPostgreSQL — and layer on only the AMP-specific identity:
+// a guardrail that confirms the endpoint really is yb-amp.
 type TargetYugabyteDBAmp struct {
 	*TargetPostgreSQL
 }
@@ -52,6 +54,36 @@ func newTargetYugabyteDBAmp(tconf *TargetConf) *TargetYugabyteDBAmp {
 // "this is yb-amp" signal.
 const AMP_MARKER_SETTING_PREFIX = "yb_amp."
 
+// endpointProber is the minimal surface needed to fingerprint a target
+// endpoint. Both TargetPostgreSQL (and thus TargetYugabyteDBAmp) and
+// TargetYugabyteDB satisfy it.
+type endpointProber interface {
+	QueryRow(query string) *sql.Row
+}
+
+// endpointHasAmpGUCs reports whether the endpoint exposes any yb_amp.*
+// settings — the yb-amp fingerprint.
+func endpointHasAmpGUCs(p endpointProber) (bool, error) {
+	var count int
+	query := fmt.Sprintf("SELECT count(*) FROM pg_settings WHERE name LIKE '%s%%'", AMP_MARKER_SETTING_PREFIX)
+	if err := p.QueryRow(query).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// endpointIsRealYugabyteDB reports whether the endpoint is a genuine
+// YugabyteDB cluster. yb_servers() is a YugabyteDB built-in that is absent
+// on vanilla PostgreSQL and on yb-amp's PG17 compute, so its presence in
+// pg_proc is a reliable "real YB" signal.
+func endpointIsRealYugabyteDB(p endpointProber) (bool, error) {
+	var count int
+	if err := p.QueryRow("SELECT count(*) FROM pg_proc WHERE proname = 'yb_servers'").Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 func (amp *TargetYugabyteDBAmp) Init() error {
 	if err := amp.TargetPostgreSQL.Init(); err != nil {
 		return err
@@ -61,96 +93,33 @@ func (amp *TargetYugabyteDBAmp) Init() error {
 
 // validateAmpTarget confirms the connected compute is a yb-amp endpoint
 // rather than a vanilla PostgreSQL or YugabyteDB server, so a user who
-// mistypes --target-db-type gets a clear error instead of a subtly wrong
-// migration.
+// mistypes --target-db-type gets a clear, actionable error instead of a
+// subtly wrong migration.
 func (amp *TargetYugabyteDBAmp) validateAmpTarget() error {
-	var count int
-	query := fmt.Sprintf(
-		"SELECT count(*) FROM pg_settings WHERE name LIKE '%s%%'",
-		AMP_MARKER_SETTING_PREFIX)
-	if err := amp.QueryRow(query).Scan(&count); err != nil {
+	hasAmp, err := endpointHasAmpGUCs(amp)
+	if err != nil {
 		return fmt.Errorf("validate target is YugabyteDB AMP (yb-amp): %w", err)
 	}
-	if count == 0 {
-		return fmt.Errorf("the target at %s:%d does not look like a YugabyteDB AMP (yb-amp) endpoint: "+
-			"no '%s*' settings were found. If you are migrating to a standard YugabyteDB or PostgreSQL "+
-			"server, use the matching --target-db-type (yugabytedb) instead of '%s'",
-			amp.tconf.Host, amp.tconf.Port, AMP_MARKER_SETTING_PREFIX, YUGABYTEDB_AMP)
+	if hasAmp {
+		log.Infof("validated target as YugabyteDB AMP (yb-amp): found '%s*' settings; compute version=%s",
+			AMP_MARKER_SETTING_PREFIX, amp.GetVersion())
+		return nil
 	}
-	log.Infof("validated target as YugabyteDB AMP (yb-amp): found %d '%s*' settings; compute version=%s",
-		count, AMP_MARKER_SETTING_PREFIX, amp.GetVersion())
-	return nil
+	// Not yb-amp — name the right target type to use depending on whether
+	// this is a real YugabyteDB cluster or plain PostgreSQL.
+	if isYB, _ := endpointIsRealYugabyteDB(amp); isYB {
+		return fmt.Errorf("the target at %s:%d is a standard YugabyteDB cluster, not YugabyteDB AMP (yb-amp). "+
+			"Use --target-db-type %s instead of %s",
+			amp.tconf.Host, amp.tconf.Port, YUGABYTEDB, YUGABYTEDB_AMP)
+	}
+	return fmt.Errorf("the target at %s:%d does not look like a YugabyteDB AMP (yb-amp) endpoint: "+
+		"no '%s*' settings were found (it looks like plain PostgreSQL). "+
+		"If you are migrating to a standard YugabyteDB server, use --target-db-type %s instead of %s",
+		amp.tconf.Host, amp.tconf.Port, AMP_MARKER_SETTING_PREFIX, YUGABYTEDB, YUGABYTEDB_AMP)
 }
 
 func (amp *TargetYugabyteDBAmp) GetCallhomeTargetDBInfo() *callhome.TargetDBDetails {
 	// Reuse the PostgreSQL-shaped info (node count 1, cores, version). The
 	// target-db-type recorded by callhome already distinguishes ybamp.
 	return amp.TargetPostgreSQL.GetCallhomeTargetDBInfo()
-}
-
-// The three methods below satisfy namereg.YBDBInterface, which the name
-// registry requires of every import-to-target driver. TargetPostgreSQL does
-// not implement them (it is only used as a fall-forward/back target, where a
-// different registry path is taken), so we provide them here using the same
-// standard catalog queries the YugabyteDB driver uses — all valid on
-// yb-amp's PostgreSQL 17 compute.
-
-func (amp *TargetYugabyteDBAmp) GetAllSchemaNamesRaw() ([]string, error) {
-	query := "SELECT schema_name FROM information_schema.schemata"
-	rows, err := amp.Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("querying yb-amp target for schema names: %w", err)
-	}
-	defer rows.Close()
-
-	var schemaNames []string
-	for rows.Next() {
-		var schemaName string
-		if err = rows.Scan(&schemaName); err != nil {
-			return nil, fmt.Errorf("scanning schema name: %w", err)
-		}
-		schemaNames = append(schemaNames, schemaName)
-	}
-	return schemaNames, rows.Err()
-}
-
-func (amp *TargetYugabyteDBAmp) GetAllTableNamesRaw(schemaName string) ([]string, error) {
-	query := fmt.Sprintf(`SELECT table_name
-			  FROM information_schema.tables
-			  WHERE table_type = 'BASE TABLE' AND
-			        table_schema = '%s';`, schemaName)
-	rows, err := amp.Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("querying yb-amp target (%q) for table names: %w", query, err)
-	}
-	defer rows.Close()
-
-	var tableNames []string
-	for rows.Next() {
-		var tableName string
-		if err = rows.Scan(&tableName); err != nil {
-			return nil, fmt.Errorf("scanning table name: %w", err)
-		}
-		tableNames = append(tableNames, tableName)
-	}
-	return tableNames, rows.Err()
-}
-
-func (amp *TargetYugabyteDBAmp) GetAllSequencesRaw(schemaName string) ([]string, error) {
-	query := fmt.Sprintf(`SELECT sequencename FROM pg_sequences WHERE schemaname = '%s';`, schemaName)
-	rows, err := amp.Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("querying yb-amp target (%q) for sequence names: %w", query, err)
-	}
-	defer rows.Close()
-
-	var sequenceNames []string
-	for rows.Next() {
-		var sequenceName string
-		if err = rows.Scan(&sequenceName); err != nil {
-			return nil, fmt.Errorf("scanning sequence name: %w", err)
-		}
-		sequenceNames = append(sequenceNames, sequenceName)
-	}
-	return sequenceNames, rows.Err()
 }

--- a/yb-voyager/src/tgtdb/yugabytedb_amp.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_amp.go
@@ -16,12 +16,9 @@ limitations under the License.
 package tgtdb
 
 import (
-	"database/sql"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 )
 
 // TargetYugabyteDBAmp is the target driver for YugabyteDB AMP (yb-amp).
@@ -47,43 +44,6 @@ func newTargetYugabyteDBAmp(tconf *TargetConf) *TargetYugabyteDBAmp {
 	return &TargetYugabyteDBAmp{TargetPostgreSQL: newTargetPostgreSQL(tconf)}
 }
 
-// AMP_MARKER_SETTING_PREFIX matches the family of GUCs that yb-amp's
-// patched compute exposes (yb_amp.tenant_id, yb_amp.pageserver_connstring,
-// yb_amp.timeline_id, ...). Neither stock PostgreSQL nor YugabyteDB YSQL
-// has any setting under this namespace, so its presence is a reliable
-// "this is yb-amp" signal.
-const AMP_MARKER_SETTING_PREFIX = "yb_amp."
-
-// endpointProber is the minimal surface needed to fingerprint a target
-// endpoint. Both TargetPostgreSQL (and thus TargetYugabyteDBAmp) and
-// TargetYugabyteDB satisfy it.
-type endpointProber interface {
-	QueryRow(query string) *sql.Row
-}
-
-// endpointHasAmpGUCs reports whether the endpoint exposes any yb_amp.*
-// settings — the yb-amp fingerprint.
-func endpointHasAmpGUCs(p endpointProber) (bool, error) {
-	var count int
-	query := fmt.Sprintf("SELECT count(*) FROM pg_settings WHERE name LIKE '%s%%'", AMP_MARKER_SETTING_PREFIX)
-	if err := p.QueryRow(query).Scan(&count); err != nil {
-		return false, err
-	}
-	return count > 0, nil
-}
-
-// endpointIsRealYugabyteDB reports whether the endpoint is a genuine
-// YugabyteDB cluster. yb_servers() is a YugabyteDB built-in that is absent
-// on vanilla PostgreSQL and on yb-amp's PG17 compute, so its presence in
-// pg_proc is a reliable "real YB" signal.
-func endpointIsRealYugabyteDB(p endpointProber) (bool, error) {
-	var count int
-	if err := p.QueryRow("SELECT count(*) FROM pg_proc WHERE proname = 'yb_servers'").Scan(&count); err != nil {
-		return false, err
-	}
-	return count > 0, nil
-}
-
 func (amp *TargetYugabyteDBAmp) Init() error {
 	if err := amp.TargetPostgreSQL.Init(); err != nil {
 		return err
@@ -96,7 +56,7 @@ func (amp *TargetYugabyteDBAmp) Init() error {
 // mistypes --target-db-type gets a clear, actionable error instead of a
 // subtly wrong migration.
 func (amp *TargetYugabyteDBAmp) validateAmpTarget() error {
-	hasAmp, err := endpointHasAmpGUCs(amp)
+	hasAmp, err := endpointHasAmpGUCs(amp.db)
 	if err != nil {
 		return fmt.Errorf("validate target is YugabyteDB AMP (yb-amp): %w", err)
 	}
@@ -107,7 +67,7 @@ func (amp *TargetYugabyteDBAmp) validateAmpTarget() error {
 	}
 	// Not yb-amp — name the right target type to use depending on whether
 	// this is a real YugabyteDB cluster or plain PostgreSQL.
-	if isYB, _ := endpointIsRealYugabyteDB(amp); isYB {
+	if isYB, _ := endpointIsRealYugabyteDB(amp.db); isYB {
 		return fmt.Errorf("the target at %s:%d is a standard YugabyteDB cluster, not YugabyteDB AMP (yb-amp). "+
 			"Use --target-db-type %s instead of %s",
 			amp.tconf.Host, amp.tconf.Port, YUGABYTEDB, YUGABYTEDB_AMP)
@@ -116,10 +76,4 @@ func (amp *TargetYugabyteDBAmp) validateAmpTarget() error {
 		"no '%s*' settings were found (it looks like plain PostgreSQL). "+
 		"If you are migrating to a standard YugabyteDB server, use --target-db-type %s instead of %s",
 		amp.tconf.Host, amp.tconf.Port, AMP_MARKER_SETTING_PREFIX, YUGABYTEDB, YUGABYTEDB_AMP)
-}
-
-func (amp *TargetYugabyteDBAmp) GetCallhomeTargetDBInfo() *callhome.TargetDBDetails {
-	// Reuse the PostgreSQL-shaped info (node count 1, cores, version). The
-	// target-db-type recorded by callhome already distinguishes ybamp.
-	return amp.TargetPostgreSQL.GetCallhomeTargetDBInfo()
 }

--- a/yb-voyager/src/tgtdb/yugabytedb_amp.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_amp.go
@@ -1,0 +1,156 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tgtdb
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+)
+
+// TargetYugabyteDBAmp is the target driver for YugabyteDB AMP (yb-amp).
+//
+// yb-amp is "Agentic Multitenant Postgres": a stateless, patched
+// PostgreSQL 17 compute whose durable storage lives in a YugabyteDB
+// cluster. From a client's (and therefore Voyager's) perspective the
+// compute is plain PostgreSQL 17 on the wire — standard heap DDL (no YB
+// HASH/RANGE sharding clauses), standard PG COPY semantics, and standard
+// PG session GUCs. It does NOT understand YugabyteDB-specific GUCs such
+// as yb_enable_upsert_mode / yb_disable_transactional_writes, and there
+// is no adaptive parallelism / colocation / tablet concept.
+//
+// We therefore reuse the PostgreSQL target driver wholesale (via
+// embedding) and layer on only the AMP-specific identity: a guardrail
+// that confirms the endpoint really is yb-amp.
+type TargetYugabyteDBAmp struct {
+	*TargetPostgreSQL
+}
+
+func newTargetYugabyteDBAmp(tconf *TargetConf) *TargetYugabyteDBAmp {
+	return &TargetYugabyteDBAmp{TargetPostgreSQL: newTargetPostgreSQL(tconf)}
+}
+
+// AMP_MARKER_SETTING_PREFIX matches the family of GUCs that yb-amp's
+// patched compute exposes (yb_amp.tenant_id, yb_amp.pageserver_connstring,
+// yb_amp.timeline_id, ...). Neither stock PostgreSQL nor YugabyteDB YSQL
+// has any setting under this namespace, so its presence is a reliable
+// "this is yb-amp" signal.
+const AMP_MARKER_SETTING_PREFIX = "yb_amp."
+
+func (amp *TargetYugabyteDBAmp) Init() error {
+	if err := amp.TargetPostgreSQL.Init(); err != nil {
+		return err
+	}
+	return amp.validateAmpTarget()
+}
+
+// validateAmpTarget confirms the connected compute is a yb-amp endpoint
+// rather than a vanilla PostgreSQL or YugabyteDB server, so a user who
+// mistypes --target-db-type gets a clear error instead of a subtly wrong
+// migration.
+func (amp *TargetYugabyteDBAmp) validateAmpTarget() error {
+	var count int
+	query := fmt.Sprintf(
+		"SELECT count(*) FROM pg_settings WHERE name LIKE '%s%%'",
+		AMP_MARKER_SETTING_PREFIX)
+	if err := amp.QueryRow(query).Scan(&count); err != nil {
+		return fmt.Errorf("validate target is YugabyteDB AMP (yb-amp): %w", err)
+	}
+	if count == 0 {
+		return fmt.Errorf("the target at %s:%d does not look like a YugabyteDB AMP (yb-amp) endpoint: "+
+			"no '%s*' settings were found. If you are migrating to a standard YugabyteDB or PostgreSQL "+
+			"server, use the matching --target-db-type (yugabytedb) instead of '%s'",
+			amp.tconf.Host, amp.tconf.Port, AMP_MARKER_SETTING_PREFIX, YUGABYTEDB_AMP)
+	}
+	log.Infof("validated target as YugabyteDB AMP (yb-amp): found %d '%s*' settings; compute version=%s",
+		count, AMP_MARKER_SETTING_PREFIX, amp.GetVersion())
+	return nil
+}
+
+func (amp *TargetYugabyteDBAmp) GetCallhomeTargetDBInfo() *callhome.TargetDBDetails {
+	// Reuse the PostgreSQL-shaped info (node count 1, cores, version). The
+	// target-db-type recorded by callhome already distinguishes ybamp.
+	return amp.TargetPostgreSQL.GetCallhomeTargetDBInfo()
+}
+
+// The three methods below satisfy namereg.YBDBInterface, which the name
+// registry requires of every import-to-target driver. TargetPostgreSQL does
+// not implement them (it is only used as a fall-forward/back target, where a
+// different registry path is taken), so we provide them here using the same
+// standard catalog queries the YugabyteDB driver uses — all valid on
+// yb-amp's PostgreSQL 17 compute.
+
+func (amp *TargetYugabyteDBAmp) GetAllSchemaNamesRaw() ([]string, error) {
+	query := "SELECT schema_name FROM information_schema.schemata"
+	rows, err := amp.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying yb-amp target for schema names: %w", err)
+	}
+	defer rows.Close()
+
+	var schemaNames []string
+	for rows.Next() {
+		var schemaName string
+		if err = rows.Scan(&schemaName); err != nil {
+			return nil, fmt.Errorf("scanning schema name: %w", err)
+		}
+		schemaNames = append(schemaNames, schemaName)
+	}
+	return schemaNames, rows.Err()
+}
+
+func (amp *TargetYugabyteDBAmp) GetAllTableNamesRaw(schemaName string) ([]string, error) {
+	query := fmt.Sprintf(`SELECT table_name
+			  FROM information_schema.tables
+			  WHERE table_type = 'BASE TABLE' AND
+			        table_schema = '%s';`, schemaName)
+	rows, err := amp.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying yb-amp target (%q) for table names: %w", query, err)
+	}
+	defer rows.Close()
+
+	var tableNames []string
+	for rows.Next() {
+		var tableName string
+		if err = rows.Scan(&tableName); err != nil {
+			return nil, fmt.Errorf("scanning table name: %w", err)
+		}
+		tableNames = append(tableNames, tableName)
+	}
+	return tableNames, rows.Err()
+}
+
+func (amp *TargetYugabyteDBAmp) GetAllSequencesRaw(schemaName string) ([]string, error) {
+	query := fmt.Sprintf(`SELECT sequencename FROM pg_sequences WHERE schemaname = '%s';`, schemaName)
+	rows, err := amp.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying yb-amp target (%q) for sequence names: %w", query, err)
+	}
+	defer rows.Close()
+
+	var sequenceNames []string
+	for rows.Next() {
+		var sequenceName string
+		if err = rows.Scan(&sequenceName); err != nil {
+			return nil, fmt.Errorf("scanning sequence name: %w", err)
+		}
+		sequenceNames = append(sequenceNames, sequenceName)
+	}
+	return sequenceNames, rows.Err()
+}

--- a/yb-voyager/src/tgtdb/yugabytedb_common.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_common.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tgtdb
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Common helpers for YugabyteDB
+
+// AMP_MARKER_SETTING_PREFIX matches the family of GUCs that yb-amp's
+// patched compute exposes (yb_amp.tenant_id, yb_amp.pageserver_connstring,
+// yb_amp.timeline_id, ...). Neither stock PostgreSQL nor YugabyteDB YSQL
+// has any setting under this namespace, so its presence is a reliable
+// "this is yb-amp" signal.
+const AMP_MARKER_SETTING_PREFIX = "yb_amp."
+
+// endpointHasAmpGUCs reports whether the endpoint exposes any yb_amp.*
+// settings — the yb-amp fingerprint.
+func endpointHasAmpGUCs(db *sql.DB) (bool, error) {
+	var count int
+	query := fmt.Sprintf("SELECT count(*) FROM pg_settings WHERE name LIKE '%s%%'", AMP_MARKER_SETTING_PREFIX)
+	if err := db.QueryRow(query).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// endpointIsRealYugabyteDB reports whether the endpoint is a genuine
+// YugabyteDB cluster. yb_servers() is a YugabyteDB built-in that is absent
+// on vanilla PostgreSQL and on yb-amp's PG17 compute, so its presence in
+// pg_proc is a reliable "real YB" signal.
+func endpointIsRealYugabyteDB(db *sql.DB) (bool, error) {
+	var count int
+	if err := db.QueryRow("SELECT count(*) FROM pg_proc WHERE proname = 'yb_servers'").Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/yb-voyager/src/utils/sqlname/nametuple.go
+++ b/yb-voyager/src/utils/sqlname/nametuple.go
@@ -266,7 +266,7 @@ func (t NameTuple) Key() string {
 // ================================================
 func quote2(dbType, name string) string {
 	switch dbType {
-	case constants.POSTGRESQL, constants.YUGABYTEDB,
+	case constants.POSTGRESQL, constants.YUGABYTEDB, constants.YUGABYTEDB_AMP,
 		constants.ORACLE, constants.MYSQL:
 		return `"` + name + `"`
 	default:
@@ -276,7 +276,7 @@ func quote2(dbType, name string) string {
 
 func minQuote2(objectName, sourceDBType string) string {
 	switch sourceDBType {
-	case constants.YUGABYTEDB, constants.POSTGRESQL:
+	case constants.YUGABYTEDB, constants.POSTGRESQL, constants.YUGABYTEDB_AMP:
 		if IsAllLowercase(objectName) && !IsReservedKeywordPG(objectName) {
 			return objectName
 		} else {

--- a/yb-voyager/src/utils/sqlname/sqlname.go
+++ b/yb-voyager/src/utils/sqlname/sqlname.go
@@ -377,7 +377,7 @@ func IsCaseSensitive(s string, sourceDbType string) bool {
 	switch sourceDbType {
 	case constants.ORACLE:
 		return !IsAllUppercase(s)
-	case constants.POSTGRESQL, constants.YUGABYTEDB, constants.YUGABYTEDB_AMP:
+	case constants.POSTGRESQL:
 		return !IsAllLowercase(s)
 	case constants.MYSQL:
 		return false

--- a/yb-voyager/src/utils/sqlname/sqlname.go
+++ b/yb-voyager/src/utils/sqlname/sqlname.go
@@ -286,7 +286,7 @@ func quote(s string, dbType string) string {
 		return s
 	}
 	switch dbType {
-	case constants.POSTGRESQL, constants.YUGABYTEDB:
+	case constants.POSTGRESQL, constants.YUGABYTEDB, constants.YUGABYTEDB_AMP:
 		return `"` + strings.ToLower(s) + `"`
 	case constants.MYSQL:
 		return s // TODO - learn the semantics of quoting in MySQL.
@@ -302,7 +302,7 @@ func unquote(s string, dbType string) string {
 		return s[1 : len(s)-1]
 	}
 	switch dbType {
-	case constants.POSTGRESQL, constants.YUGABYTEDB:
+	case constants.POSTGRESQL, constants.YUGABYTEDB, constants.YUGABYTEDB_AMP:
 		return strings.ToLower(s)
 	case constants.MYSQL:
 		return s
@@ -330,7 +330,7 @@ func SetDifference(a, b []*SourceName) []*SourceName {
 func minQuote(objectName, sourceDBType string) string {
 	objectName = unquote(objectName, sourceDBType)
 	switch sourceDBType {
-	case constants.YUGABYTEDB, constants.POSTGRESQL:
+	case constants.YUGABYTEDB, constants.POSTGRESQL, constants.YUGABYTEDB_AMP:
 		if IsAllLowercase(objectName) && !IsReservedKeywordPG(objectName) {
 			return objectName
 		} else {
@@ -377,7 +377,7 @@ func IsCaseSensitive(s string, sourceDbType string) bool {
 	switch sourceDbType {
 	case constants.ORACLE:
 		return !IsAllUppercase(s)
-	case constants.POSTGRESQL:
+	case constants.POSTGRESQL, constants.YUGABYTEDB, constants.YUGABYTEDB_AMP:
 		return !IsAllLowercase(s)
 	case constants.MYSQL:
 		return false


### PR DESCRIPTION
### Describe the changes in this pull request

This PR adds a new target database type **`yugabytedb-amp`** (`--target-db-type yugabytedb-amp`) enabling offline migration (export-schema → import-schema → export-data → import-data, plus finalize-schema-post-data-import) from PostgreSQL into **YugabyteDB AMP (yb-amp)** — a stateless, patched PostgreSQL 17 compute backed by YugabyteDB storage that is PostgreSQL-compatible on the wire.

Because yb-amp speaks plain PostgreSQL (standard heap DDL, `COPY`, standard session GUCs) and exposes none of YugabyteDB's cluster control surface (`yb_servers()`, tserver metrics, colocation/tablets, adaptive parallelism), the new `TargetYugabyteDBAmp` driver **embeds the existing `TargetPostgreSQL` driver** and layers on only AMP-specific identity validation; the import code paths treat `yugabytedb-amp` as PostgreSQL-compatible and skip the YugabyteDB-only machinery.

Key design decisions:
- **Engine identity verified at driver `Init()`**, mutually exclusive among the three PG-wire-compatible engines: real YB (`yb_servers()`), yb-amp (`yb_amp.*` GUCs), and plain PostgreSQL. A mistyped `--target-db-type` fails fast naming the correct value.
- **YugabyteDB-only machinery gated by target type** — colocation-aware task picker, table-type/colocation lookup, target health monitoring, the `yb_is_database_colocated()` colocation prompt, and the YB-version analyze report all run only for a real YugabyteDB target; yb-amp uses the sequential importer and plain-PG paths.
- **Adaptive parallelism default is per-target** — Balanced for YugabyteDB, Disabled for every other target (yb-amp and the PostgreSQL fall-forward/fall-back targets, none of which have the cluster control API it needs). This lets `--parallel-jobs` be used for those targets without explicitly disabling adaptive parallelism.
- **Pristine schema for amp via consistent backups.** export-schema transforms the exported DDL for a YB target (colocation, `SET yb_*` sharding), which is invalid on yb-amp's PG17. A single helper `EnsurePlainBackup` is now called by every step that mutates a schema file (the colocation recommender and the file transformers) *before* it mutates, producing one consistent, skip-if-exists `backup_<file>` that always holds the pristine pg_dump DDL. import-schema imports that pristine `backup_<file>` for a yb-amp target (falling back to `object.sql` when none exists). This replaces an earlier `.orig`/MetaDB-flag scheme and is robust across all `--skip-colocation-recommendations` / `--skip-performance-recommendations` combinations.
- **Strict guardrails** reject flags that don't apply to yb-amp (`--target-endpoints`, `--use-public-ip`, `--enable-upsert`, and `--on-primary-key-conflict` other than `ERROR-POLICY`), and restrict a yb-amp target to a PostgreSQL source.

Live migration, fall-forward/fall-back, and assess-migration remain explicit non-goals.

### Describe if there are any user-facing changes

- **Command line:** New `--target-db-type` flag on `import schema`, `import data` / `import data to-target`, and `finalize-schema-post-data-import`; values `yugabytedb` (default) and `yugabytedb-amp`. For `yugabytedb-amp`: `--target-db-port` is required (no canonical default); the source must be PostgreSQL; and `--target-endpoints`, `--use-public-ip`, `--enable-upsert`, `--on-primary-key-conflict <non-ERROR-POLICY>`, `--adaptive-parallelism balanced|aggressive`, and `--adaptive-parallelism-max` are rejected with actionable errors. A target type that doesn't match the actual endpoint fails fast. The flag is intentionally NOT exposed on `import data file` or `compare-performance` (always real YugabyteDB). TLS works via the existing `--target-ssl-*` flags.
- **Configuration:** `--target-db-type` is settable via the config file (`target: db-type:`); parallelism flags behave identically whether set via CLI or config.
- **Installation / reports:** No changes.

### How was this pull request tested?

- **Unit:** `go build ./...`, `go vet`, and `go test -tags unit ./cmd/... ./src/tgtdb/... ./src/query/sqltransformer/... ./src/metadb/... ./src/utils/sqlname/...` all pass. The colocation task-picker unit tests were updated to set the YugabyteDB target type (they exercise the YB-only colocation path). No new dedicated unit tests were added for the amp paths.
- **Manual end-to-end (PostgreSQL → yb-amp):** full export-schema → import-schema → export-data → import-data verified — row counts match source, 0 FK orphans, view + indexes + constraints + sequences created, sequences correctly resumed; finalize-schema-post-data-import verified.
- **Backup/pristine correctness:** export→import-into-amp across the matrix {no assess-migration, assess-migration} × {default, `--skip-performance-recommendations`, `--skip-colocation-recommendations`, both}. In all 6 runs the file imported into yb-amp is byte-identical (the pristine pg_dump), free of colocation/`SET yb_*`, and imports cleanly; the YugabyteDB path is unaffected (transformed `object.sql` still carries colocation/sharding).
- **Guardrails** exercised via CLI and config file (wrong target type vs endpoint; the rejected amp flags; `--parallel-jobs` works for amp without disabling adaptive).
- **TLS:** validated a full PG → yb-amp migration over `--target-ssl-mode require` (TLSv1.3).
- **Gap / follow-up:** no automated integration tests for the `yugabytedb-amp` path yet; `integration_voyager_command`-style coverage would be a valuable follow-up.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No payload shape changes. Callhome reuses the PostgreSQL-shaped target info; the existing target-db-type field can now carry the value `yugabytedb-amp`. Payload version not incremented (no structural change).

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. export-schema now writes a `backup_<file>` sidecar in the schema directory (replacing the previous `<file>.orig`) before transforming; these are additive, informational backups that older binaries ignore (import reads the primary `object.sql`), so there is no upgrade concern. No MetaDB / name-registry / data-file / callhome / status-json shapes changed.

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |

---
_automated · Claude Code (Opus 4.8)_