### PR TITLE
Add root-PK partitioned coverage to iteration resumption test; rename partition-iteration-test to use-partition-root-false-test

### DIFF
--- a/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
@@ -79,9 +79,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 456
       faker_seed: 456
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 5
       update_max_retries: 1
 

--- a/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
@@ -79,9 +79,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 456
       faker_seed: 456
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 5
       update_max_retries: 1
 

--- a/migtests/tests/resumption/live-migration/iteration-test/partitioned-extras.sql
+++ b/migtests/tests/resumption/live-migration/iteration-test/partitioned-extras.sql
@@ -1,0 +1,9 @@
+-- Applied after pg/partitions/schema.sql: drop the p1/p2 cross-schema block (this test is
+-- public-only) and add DEFAULT partitions so the generator's random values always route.
+
+DROP SCHEMA IF EXISTS p1 CASCADE;
+DROP SCHEMA IF EXISTS p2 CASCADE;
+
+CREATE TABLE public.sales_region_default              PARTITION OF public.sales_region              DEFAULT;
+CREATE TABLE public.sales_default                     PARTITION OF public.sales                     DEFAULT;
+CREATE TABLE public.test_partitions_sequences_default PARTITION OF public.test_partitions_sequences DEFAULT;

--- a/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
@@ -45,7 +45,7 @@ generator_source:
     generator:
       schema_name: public
       manual_table_list: []
-      exclude_table_list: [cutover_table]
+      exclude_table_list: [cutover_table, cust_active, cust_arr_small, cust_arr_large, cust_part11, cust_part12, cust_part21, cust_part22, cust_other]
       num_iterations: -1
       wait_after_operations: 1000
       wait_duration_seconds: 1
@@ -58,6 +58,30 @@ generator_source:
       delete_rows: 1
       insert_max_retries: 5
       update_max_retries: 1
+      # Pin region/sale_date/status to valid partition values so generated rows route
+      # across the real partitions (DEFAULT partitions in partitioned-init.sql catch any strays).
+      column_overrides:
+        sales_region:
+          region:
+            type: choice
+            values: ["London", "Sydney", "Boston"]
+        test_partitions_sequences:
+          region:
+            type: choice
+            values: ["London", "Sydney", "Boston"]
+        sales:
+          sale_date:
+            type: timestamp_range
+            min: "2019-10-01 00:00:00"
+            max: "2020-06-30 23:59:59"
+        customers:
+          statuses:
+            type: choice
+            values: ["ACTIVE", "RECURRING", "REACTIVATED"]
+          arr:
+            type: int_range
+            min: 0
+            max: 200
 
 # Fallback (target) event generator configuration.
 # This will be used later when we start a generator on the target side.
@@ -73,7 +97,7 @@ generator_target:
     generator:
       schema_name: public
       manual_table_list: []
-      exclude_table_list: [cutover_table]
+      exclude_table_list: [cutover_table, cust_active, cust_arr_small, cust_arr_large, cust_part11, cust_part12, cust_part21, cust_part22, cust_other]
       num_iterations: -1
       wait_after_operations: 5000
       wait_duration_seconds: 1
@@ -86,8 +110,34 @@ generator_target:
       delete_rows: 2
       insert_max_retries: 5
       update_max_retries: 1
+      # Pin region/sale_date/status to valid partition values so generated rows route
+      # across the real partitions (DEFAULT partitions in partitioned-init.sql catch any strays).
+      column_overrides:
+        sales_region:
+          region:
+            type: choice
+            values: ["London", "Sydney", "Boston"]
+        test_partitions_sequences:
+          region:
+            type: choice
+            values: ["London", "Sydney", "Boston"]
+        sales:
+          sale_date:
+            type: timestamp_range
+            min: "2019-10-01 00:00:00"
+            max: "2020-06-30 23:59:59"
+        customers:
+          statuses:
+            type: choice
+            values: ["ACTIVE", "RECURRING", "REACTIVATED"]
+          arr:
+            type: int_range
+            min: 0
+            max: 200
 
 voyager:
+  # use-partition-root defaults to "true" (import via the partition ROOT), so it's left unset here.
+  # (partition-iteration-test covers the use-partition-root=false / non-default case.)
   cutover_to_target:
     flags:
       prepare-for-fall-back: true
@@ -101,9 +151,25 @@ stages:
     action: reset_databases
     targets: [source, target]
 
+  # Shared flat (non-partitioned) schema — the baseline this test has always used.
   - name: create_source_schema
     action: run_sql
     sql_path: ../common-sql/init.sql
+    use_admin: true
+
+  # Additional "normal" partitioned tables (PK on the partition root), reused DIRECTLY from the
+  # pg/partitions schema. Imported with use-partition-root=true (default) so CDC routes through
+  # the root. This is an ADDITION to the flat schema above, not a replacement.
+  - name: create_partitioned_source_schema
+    action: run_sql
+    sql_path: ../../../pg/partitions/schema.sql
+    use_admin: true
+
+  # Adjust the pg/partitions schema for live CDC: drop the p1/p2 cross-schema block (public-only
+  # export) and add DEFAULT partitions so the event generator's random values always route.
+  - name: create_partitioned_extras
+    action: run_sql
+    sql_path: ./partitioned-extras.sql
     use_admin: true
 
   - name: increase_temp_file_limit_source

--- a/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
@@ -105,9 +105,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 456
       faker_seed: 456
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 5
       update_max_retries: 1
       # Pin region/sale_date/status to valid partition values so generated rows route

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -102,9 +102,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 67890
       faker_seed: 67890
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 50
       update_max_retries: 3
       column_overrides:


### PR DESCRIPTION
### Describe the changes in this pull request

The live-migration iteration resumption test (`iteration-test`) previously ran only flat (non-partitioned) tables via the shared `common-sql/init.sql`. This PR makes it cover **"normal" partitioned tables with the PRIMARY KEY on the partition root**, imported with `--use-partition-root=true` so CDC routes through the root. Together with the renamed `use-partition-root=false` test, this gives the resumption suite coverage of both partitioned import modes — the scenario that surfaces the read-restart behaviour observed on YB 2025.2.4 / 2026.1.

`iteration-test` now uses a dedicated `init.sql` (RANGE / LIST / HASH / multilevel / multi-column-range / shared-sequence families, all root-PK) instead of the shared flat schema, with generator `column_overrides` so random values route across the real partitions, and DEFAULT partitions as a safety net. `customers.arr` is `numeric(10,2)` (fixed scale) to avoid row-hash false-positives from CDC trailing-zero normalization on unbounded numeric. Flat-table coverage is unchanged — it still lives in the four other resumption tests that share `common-sql/init.sql`.

`partition-iteration-test` is renamed to `use-partition-root-false-test` to make its purpose explicit (no PK on root, PK on children, `--use-partition-root=false`). The two tests now form a matched pair: root-PK / `true` vs child-PK / `false`.

### Describe if there are any user-facing changes

No user-facing changes. This PR only touches end-to-end migration test scenarios under `migtests/` (no command line, configuration, installation, or report changes).

### How was this pull request tested?

Ran the `iteration-test` scenario end-to-end via `scripts/live-migration-resumption/orchestrator.py` against **YugabyteDB 2026.1.0.0** (PostgreSQL source). Both resumption iterations completed, both cutover directions (to-target and to-source), and all `row_count_validations`, `row_hash_validations`, and `validate_archive_changes` stages passed. The new partitioned DDL was also validated against PostgreSQL 17. No Go unit/integration code is touched — changes are test-scenario files only.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

