### PR TITLE
Surface target-db-type in config templates and guardrail error-policy-snapshot for yb-amp

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -621,7 +621,7 @@ func registerFlagsForTarget(cmd *cobra.Command) {
 		"Adapt parallelism based on the resource usage (CPU, memory) of the target YugabyteDB cluster."+
 			"\n"+
 			"Specify the mode for adaptive parallelism behavior: disabled, balanced, aggressive "+
-			"(default: balanced for YugabyteDB targets; disabled for other target types e.g. yugabytedb-amp, since they have no cluster control API — use --parallel-jobs there)"+
+			"(default: balanced for YugabyteDB, disabled for YugabyteDB AMP)"+
 			"\n"+
 			"\tbalanced: Operate with moderate thresholds. Recommended to be used when there are other workloads running on the cluster.\n"+
 			"\taggressive: Operate with aggressive max-CPU thresholds for better performance. Recommended to be used when there are no other workloads running on the cluster.\n"+

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -186,7 +186,7 @@ func validateAmpUnsupportedFlags(cmd *cobra.Command) {
 }
 
 func validateImportUsePartitionRootFlag() error {
-	// --use-partition-root flag is only valid for live migration with PostgreSQL or YugabyteDB source
+	// --use-partition-root flag is only valid for live migration with a PostgreSQL source
 	//and only for the CDC streaming phase and snapshot part isn't supported right now.
 	if !importUsePartitionRoot {
 		// Only validate when flag is explicitly set to false (non-default)
@@ -202,8 +202,11 @@ func validateImportUsePartitionRootFlag() error {
 		if importerRole == SOURCE_REPLICA_DB_IMPORTER_ROLE {
 			return goerrors.Errorf("'--use-partition-root false' is not supported for source-replica")
 		}
-		if tconf.TargetDBType != POSTGRESQL && tconf.TargetDBType != YUGABYTEDB && tconf.TargetDBType != YUGABYTEDB_AMP {
-			return goerrors.Errorf("'--use-partition-root' flag is only valid for PostgreSQL to YugabyteDB migrations")
+		// --use-partition-root controls how PostgreSQL declarative-partitioned tables are
+		// streamed; it is meaningful only when the source database is PostgreSQL. The target
+		// engine (yugabytedb / yugabytedb-amp / a PG fall-back target) is irrelevant here.
+		if sourceDBType != POSTGRESQL {
+			return goerrors.Errorf("'--use-partition-root false' is only valid when the source database is PostgreSQL")
 		}
 	}
 	tconf.UsePartitionRoot = bool(importUsePartitionRoot)

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/types"
@@ -174,6 +175,13 @@ func validateAmpUnsupportedFlags(cmd *cobra.Command) {
 	// UPDATE) cannot be honored by amp's plain-COPY snapshot path.
 	if strings.ToUpper(tconf.OnPrimaryKeyConflictAction) != constants.PRIMARY_KEY_CONFLICT_ACTION_ERROR_POLICY {
 		notApplicable("on-primary-key-conflict")
+	}
+	// Only the default `abort` error policy is validated for amp. `stash-and-continue`
+	// (stashing errored snapshot rows and continuing) has not been tested on amp's
+	// plain-COPY path, so reject it explicitly rather than silently allowing it.
+	if errorPolicySnapshotFlag == importdata.StashAndContinueErrorPolicy {
+		utils.ErrExit("--error-policy-snapshot %s is not supported for --target-db-type %s; only the default %s error policy is supported",
+			importdata.StashAndContinueErrorPolicy, YUGABYTEDB_AMP, importdata.AbortErrorPolicy)
 	}
 }
 
@@ -609,7 +617,8 @@ func registerFlagsForTarget(cmd *cobra.Command) {
 	cmd.Flags().Var(&tconf.AdaptiveParallelismMode, "adaptive-parallelism",
 		"Adapt parallelism based on the resource usage (CPU, memory) of the target YugabyteDB cluster."+
 			"\n"+
-			"Specify the mode for adaptive parallelism behavior: disabled, balanced, aggressive (default balanced)"+
+			"Specify the mode for adaptive parallelism behavior: disabled, balanced, aggressive "+
+			"(default: balanced for YugabyteDB targets; disabled for other target types e.g. yugabytedb-amp, since they have no cluster control API — use --parallel-jobs there)"+
 			"\n"+
 			"\tbalanced: Operate with moderate thresholds. Recommended to be used when there are other workloads running on the cluster.\n"+
 			"\taggressive: Operate with aggressive max-CPU thresholds for better performance. Recommended to be used when there are no other workloads running on the cluster.\n"+

--- a/yb-voyager/config-templates/bulk-data-load.yaml
+++ b/yb-voyager/config-templates/bulk-data-load.yaml
@@ -133,7 +133,7 @@ import-data-file:
   ###   Voyager will use the given number of parallel jobs.
   ###   Any value < 1 falls back to N/4 or 2×node count if N is not available.
   ###   Note: Do not set this if adaptive-parallelism is enabled (balanced/aggressive).
-  adaptive-parallelism: balanced
+  # adaptive-parallelism: balanced
   # adaptive-parallelism-max: <integer>
   # parallel-jobs: <integer>   # Do not set if adaptive parallelism is enabled  
 
@@ -183,7 +183,7 @@ import-data-file:
   ### Disable progress bar/stats during data import 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false                                                                
+  disable-pb: false
 
 # ---------------------------------------------------------
 # End Migration Configuration

--- a/yb-voyager/config-templates/live-migration-with-fall-back.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-back.yaml
@@ -393,7 +393,7 @@ import-data-to-target:
   ###   Voyager will use the given number of parallel jobs.
   ###   Any value < 1 falls back to N/4 or 2×node count if N is not available.
   ###   Note: Do not set this if adaptive-parallelism is enabled (balanced/aggressive).
-  adaptive-parallelism: balanced
+  # adaptive-parallelism: balanced
   # adaptive-parallelism-max: <integer>
   # parallel-jobs: <integer>   # Do not set if adaptive parallelism is enabled  
 
@@ -422,7 +422,7 @@ import-data-to-target:
   ### Disable progress bar/stats during data import 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false         
+  disable-pb: false
 
   ### Use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import
   ### Note - you might need to configure database to have public_ip available by setting server-broadcast-addresses.

--- a/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
@@ -453,7 +453,7 @@ import-data-to-target:
   ###   Voyager will use the given number of parallel jobs.
   ###   Any value < 1 falls back to N/4 or 2×node count if N is not available.
   ###   Note: Do not set this if adaptive-parallelism is enabled (balanced/aggressive).
-  adaptive-parallelism: balanced
+  # adaptive-parallelism: balanced
   # adaptive-parallelism-max: <integer>
   # parallel-jobs: <integer>   # Do not set if adaptive parallelism is enabled   
 
@@ -482,7 +482,7 @@ import-data-to-target:
   ### Disable progress bar/stats during data import 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false         
+  disable-pb: false
 
   ### Use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import
   ### Note - you might need to configure database to have public_ip available by setting server-broadcast-addresses.

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -118,6 +118,12 @@ source:
 
 target:    
 
+  ### Target database type to import into. Supported values:
+  ###   yugabytedb (default) - a standard YugabyteDB cluster
+  ###   yugabytedb-amp       - YugabyteDB AMP: a PostgreSQL-compatible compute over YugabyteDB storage
+  ###   Note: yugabytedb-amp requires an explicit db-port (no default).
+  db-type: yugabytedb
+
   ### Host on which the YugabyteDB server is running. 
   ### Default - 127.0.0.1                          
   db-host: 127.0.0.1      
@@ -376,16 +382,18 @@ export-data-from-source:
 import-data-to-target:
 
   ### Control parallelism of data import
-  ### By default, Voyager enables adaptive parallelism which adjusts the number 
-  ### of parallel jobs based on the resource usage (CPU, memory) of the target 
-  ### YugabyteDB cluster.
+  ### By default, Voyager chooses the adaptive-parallelism mode based on the target database type:
+  ###   - yugabytedb: balanced - adaptive parallelism adjusts the number of parallel jobs based on
+  ###     the resource usage (CPU, memory) of the target YugabyteDB cluster.
+  ###   - yugabytedb-amp (and other non-YugabyteDB targets): disabled - these have no cluster control
+  ###     API, so set parallel-jobs to control import parallelism instead.
   ### The following flags are available to control parallelism:
   ### - adaptive-parallelism: Choose the mode for adaptive parallelism behavior.
   ###     balanced: Operate with moderate thresholds. Recommended to be used when there are other workloads running on the cluster.
   ###     aggressive: Operate with aggressive max-CPU thresholds for better performance. Recommended to be used when there are no other workloads running on the cluster.
   ###     disabled: Disable adaptive parallelism.
   ###   Accepted values: disabled, balanced, aggressive
-  ###   Default: balanced
+  ###   Default: balanced for yugabytedb targets; disabled for yugabytedb-amp and other non-YugabyteDB targets
   ### - adaptive-parallelism-max: Optional upper limit on parallel jobs when
   ###   adaptive parallelism is enabled. If not set, Voyager will use N/2,
   ###   where N is the number of available CPU cores.
@@ -393,7 +401,7 @@ import-data-to-target:
   ###   Voyager will use the given number of parallel jobs.
   ###   Any value < 1 falls back to N/4 or 2×node count if N is not available.
   ###   Note: Do not set this if adaptive-parallelism is enabled (balanced/aggressive).
-  adaptive-parallelism: balanced
+  # adaptive-parallelism: balanced
   # adaptive-parallelism-max: <integer>
   # parallel-jobs: <integer>   # Do not set if adaptive parallelism is enabled   
 
@@ -422,7 +430,7 @@ import-data-to-target:
   ### Disable progress bar/stats during data import 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false         
+  disable-pb: false
 
   ### Use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import
   ### Note - you might need to configure database to have public_ip available by setting server-broadcast-addresses.

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -385,15 +385,15 @@ import-data-to-target:
   ### By default, Voyager chooses the adaptive-parallelism mode based on the target database type:
   ###   - yugabytedb: balanced - adaptive parallelism adjusts the number of parallel jobs based on
   ###     the resource usage (CPU, memory) of the target YugabyteDB cluster.
-  ###   - yugabytedb-amp (and other non-YugabyteDB targets): disabled - these have no cluster control
-  ###     API, so set parallel-jobs to control import parallelism instead.
+  ###   - yugabytedb-amp: disabled - it has no cluster control API, so set parallel-jobs to control
+  ###     import parallelism instead.
   ### The following flags are available to control parallelism:
   ### - adaptive-parallelism: Choose the mode for adaptive parallelism behavior.
   ###     balanced: Operate with moderate thresholds. Recommended to be used when there are other workloads running on the cluster.
   ###     aggressive: Operate with aggressive max-CPU thresholds for better performance. Recommended to be used when there are no other workloads running on the cluster.
   ###     disabled: Disable adaptive parallelism.
   ###   Accepted values: disabled, balanced, aggressive
-  ###   Default: balanced for yugabytedb targets; disabled for yugabytedb-amp and other non-YugabyteDB targets
+  ###   Default: balanced for yugabytedb, disabled for yugabytedb-amp
   ### - adaptive-parallelism-max: Optional upper limit on parallel jobs when
   ###   adaptive parallelism is enabled. If not set, Voyager will use N/2,
   ###   where N is the number of available CPU cores.

--- a/yb-voyager/config-templates/offline-migration.yaml
+++ b/yb-voyager/config-templates/offline-migration.yaml
@@ -108,6 +108,12 @@ source:
 
 target:    
 
+  ### Target database type to import into. Supported values:
+  ###   yugabytedb (default) - a standard YugabyteDB cluster
+  ###   yugabytedb-amp       - YugabyteDB AMP: a PostgreSQL-compatible compute over YugabyteDB storage
+  ###   Note: yugabytedb-amp requires an explicit db-port (no default).
+  db-type: yugabytedb
+
   ### Host on which the YugabyteDB server is running. 
   ### Default - 127.0.0.1                          
   db-host: 127.0.0.1      
@@ -390,16 +396,18 @@ import-data:
   # exclude-table-list-file-path: <exclude-table-list-file-path>
 
   ### Control parallelism of data import
-  ### By default, Voyager enables adaptive parallelism which adjusts the number 
-  ### of parallel jobs based on the resource usage (CPU, memory) of the target 
-  ### YugabyteDB cluster.
+  ### By default, Voyager chooses the adaptive-parallelism mode based on the target database type:
+  ###   - yugabytedb: balanced - adaptive parallelism adjusts the number of parallel jobs based on
+  ###     the resource usage (CPU, memory) of the target YugabyteDB cluster.
+  ###   - yugabytedb-amp (and other non-YugabyteDB targets): disabled - these have no cluster control
+  ###     API, so set parallel-jobs to control import parallelism instead.
   ### The following flags are available to control parallelism:
   ### - adaptive-parallelism: Choose the mode for adaptive parallelism behavior.
   ###     balanced: Operate with moderate thresholds. Recommended to be used when there are other workloads running on the cluster.
   ###     aggressive: Operate with aggressive max-CPU thresholds for better performance. Recommended to be used when there are no other workloads running on the cluster.
   ###     disabled: Disable adaptive parallelism.
   ###   Accepted values: disabled, balanced, aggressive
-  ###   Default: balanced
+  ###   Default: balanced for yugabytedb targets; disabled for yugabytedb-amp and other non-YugabyteDB targets
   ### - adaptive-parallelism-max: Optional upper limit on parallel jobs when
   ###   adaptive parallelism is enabled. If not set, Voyager will use N/2,
   ###   where N is the number of available CPU cores.
@@ -407,7 +415,7 @@ import-data:
   ###   Voyager will use the given number of parallel jobs.
   ###   Any value < 1 falls back to N/4 or 2×node count if N is not available.
   ###   Note: Do not set this if adaptive-parallelism is enabled (balanced/aggressive).
-  adaptive-parallelism: balanced
+  # adaptive-parallelism: balanced
   # adaptive-parallelism-max: <integer>
   # parallel-jobs: <integer>   # Do not set if adaptive parallelism is enabled  
 
@@ -436,7 +444,7 @@ import-data:
   ### Disable progress bar/stats during data import 
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - false
-  # disable-pb: false         
+  disable-pb: false
 
   ### Use the public IPs of the nodes to distribute --parallel-jobs uniformly for data import
   ### Note - you might need to configure database to have public_ip available by setting server-broadcast-addresses.

--- a/yb-voyager/config-templates/offline-migration.yaml
+++ b/yb-voyager/config-templates/offline-migration.yaml
@@ -399,15 +399,15 @@ import-data:
   ### By default, Voyager chooses the adaptive-parallelism mode based on the target database type:
   ###   - yugabytedb: balanced - adaptive parallelism adjusts the number of parallel jobs based on
   ###     the resource usage (CPU, memory) of the target YugabyteDB cluster.
-  ###   - yugabytedb-amp (and other non-YugabyteDB targets): disabled - these have no cluster control
-  ###     API, so set parallel-jobs to control import parallelism instead.
+  ###   - yugabytedb-amp: disabled - it has no cluster control API, so set parallel-jobs to control
+  ###     import parallelism instead.
   ### The following flags are available to control parallelism:
   ### - adaptive-parallelism: Choose the mode for adaptive parallelism behavior.
   ###     balanced: Operate with moderate thresholds. Recommended to be used when there are other workloads running on the cluster.
   ###     aggressive: Operate with aggressive max-CPU thresholds for better performance. Recommended to be used when there are no other workloads running on the cluster.
   ###     disabled: Disable adaptive parallelism.
   ###   Accepted values: disabled, balanced, aggressive
-  ###   Default: balanced for yugabytedb targets; disabled for yugabytedb-amp and other non-YugabyteDB targets
+  ###   Default: balanced for yugabytedb, disabled for yugabytedb-amp
   ### - adaptive-parallelism-max: Optional upper limit on parallel jobs when
   ###   adaptive parallelism is enabled. If not set, Voyager will use N/2,
   ###   where N is the number of available CPU cores.


### PR DESCRIPTION
### Describe the changes in this pull request

A few config-template and guardrail improvements for the YugabyteDB AMP (yb-amp) target, following the offline (#3623) and live (#3634) yb-amp support now in `main`:

- Adds an active `target: db-type` field (values `yugabytedb` / `yugabytedb-amp`, with help) to the **offline** and **live** migration config templates, so users can select the target engine from the config file.
- Documents the now target-type-dependent **adaptive-parallelism default** — `balanced` for YugabyteDB, `disabled` for YugabyteDB AMP — in both the `--adaptive-parallelism` CLI help and the offline/live templates.
- Stops the templates from hardcoding `adaptive-parallelism: balanced`: it is commented out in **all five** templates (keeping `balanced` visible in the comment) so the dynamic per-target default takes effect; `parallel-jobs` stays commented for the same reason. `disable-pb: false` is uncommented in the same section so it remains a valid non-empty YAML map.
- Adds a guardrail rejecting `--error-policy-snapshot stash-and-continue` for `--target-db-type yugabytedb-amp` (not yet validated on amp's plain-COPY import path); the default `abort` continues to work. `batch-size` remains supported for amp.
- Fixes `--use-partition-root false` validation to gate on the **source** DB type (must be PostgreSQL) instead of the target engine (addresses review feedback on #3634). The flag governs how PostgreSQL declarative-partitioned tables are streamed during CDC — a source-schema concept — so the old target-based check incorrectly let a non-PostgreSQL source (e.g. Oracle/MySQL → YugabyteDB) pass.

This branch is based on the latest `main` (including the just-merged #3634), so `target: db-type: yugabytedb-amp` is now real for both offline and live flows.

### Describe if there are any user-facing changes

Yes.
1. **Command line:**
   - `--adaptive-parallelism` help updated to describe the target-type-dependent default.
   - New guardrail: `--error-policy-snapshot stash-and-continue` is rejected for `--target-db-type yugabytedb-amp`.
   - `--use-partition-root false` is now rejected when the source database is not PostgreSQL (previously gated on the target engine).
2. **Configuration:** offline/live templates gain a `target: db-type` field; all templates no longer set `adaptive-parallelism: balanced` by default (commented out) and instead have `disable-pb: false` active in the import section. No config keys were added or removed at the schema level (`target.db-type` was already an accepted key).
3. **Installation:** no change.
4. **Reports:** no change.

### How was this pull request tested?

- `go build ./...`, `go vet ./...`, `gofmt` — all clean.
- `go test -tags unit ./cmd/...` — passes (includes config-template parsing and error-policy config tests).
- Validated all five templates parse as YAML; each import section is a non-empty map with `adaptive-parallelism` commented out and `disable-pb: false` active; `target.db-type` reads back as `yugabytedb` on the offline/live templates only.
- For the `--use-partition-root` change: confirmed `sourceDBType` is populated (from the MSR) before the validation runs; no existing unit test encoded the old target-based behavior.
- No new unit tests added: the error-policy guardrail (`validateAmpUnsupportedFlags`) is `utils.ErrExit`-based (process exit), and `validateImportUsePartitionRootFlag` depends on the metaDB migration-status record + package globals — neither is covered by the current cmd unit harness without additional fixtures.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. Config templates are sample files shipped with the CLI; the guardrail, CLI-help, and validation changes don't touch any on-disk structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)