### PR TITLE
Fix flaky test TestValidateConfig_ConflictingAliasSectionsOutput

### DIFF
--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sort"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -160,18 +159,12 @@ import-data-to-target:
 	// Now verify that exactly one conflicting sections array contains 'export-data' and 'export-data-from-source'
 	assert.Len(t, validationErr.ConflictingSections, 2, "Expected exactly two conflicting sections array")
 
-	//sort the conflicting sections as in the validteConfigFile function we are iterating over the map where the order of keys is random
-	//so we need to sort the conflicting sections to ensure the order is consistent in test
-	sort.Slice(validationErr.ConflictingSections, func(i, j int) bool {
-		return validationErr.ConflictingSections[i][0] < validationErr.ConflictingSections[j][0]
-	})
-	// Now verify that one string array contains only 'export-data' and 'export-data-from-source'
-	assert.Len(t, validationErr.ConflictingSections[0], 2, "Expected the conflicting sections array to contain exactly two sections")
-	assert.ElementsMatch(t, validationErr.ConflictingSections[0], []string{"export-data", "export-data-from-source"}, "Expected 'export-data' and 'export-data-from-source' to be in the conflicting sections")
-	// Now verify that the other string array contains only 'import-data' and 'import-data-to-target'
-	assert.Len(t, validationErr.ConflictingSections[1], 2, "Expected the conflicting sections array to contain exactly two sections")
-	assert.ElementsMatch(t, validationErr.ConflictingSections[1], []string{"import-data", "import-data-to-target"}, "Expected 'import-data' and 'import-data-to-target' to be in the conflicting sections")
-
+	//matching the conflicting sections with ElementsMatch as in the validteConfigFile function we are iterating over the map where the order of keys is random
+	//so the order of these arrays is not consistent in test,
+	assert.ElementsMatch(t, [][]string{
+		{"export-data", "export-data-from-source"},
+		{"import-data", "import-data-to-target"},
+	}, validationErr.ConflictingSections, "Expected conflicting sections to match")
 	// Ensure that all other sets are empty
 	assert.Empty(t, validationErr.InvalidGlobalKeys, "Expected InvalidGlobalKeys to be empty")
 	assert.Empty(t, validationErr.InvalidSectionKeys, "Expected InvalidSectionKeys to be empty")

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -34,7 +35,6 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/types"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
-
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
 
@@ -160,6 +160,11 @@ import-data-to-target:
 	// Now verify that exactly one conflicting sections array contains 'export-data' and 'export-data-from-source'
 	assert.Len(t, validationErr.ConflictingSections, 2, "Expected exactly two conflicting sections array")
 
+	//sort the conflicting sections as in the validteConfigFile function we are iterating over the map where the order of keys is random
+	//so we need to sort the conflicting sections to ensure the order is consistent in test
+	sort.Slice(validationErr.ConflictingSections, func(i, j int) bool {
+		return validationErr.ConflictingSections[i][0] < validationErr.ConflictingSections[j][0]
+	})
 	// Now verify that one string array contains only 'export-data' and 'export-data-from-source'
 	assert.Len(t, validationErr.ConflictingSections[0], 2, "Expected the conflicting sections array to contain exactly two sections")
 	assert.ElementsMatch(t, validationErr.ConflictingSections[0], []string{"export-data", "export-data-from-source"}, "Expected 'export-data' and 'export-data-from-source' to be in the conflicting sections")


### PR DESCRIPTION
### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
