### PR TITLE
Strengthen branch-review skill to catch scope, design, and hot-path issues

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -72,11 +72,11 @@ If you are unsure whether a path is hot, ask; do not assume it is cold.
 
 Applies especially to new packages, interfaces, and abstractions:
 
-- **Avoid unnecessary indirection.** A `switch` on database type or a direct call is often clearer than a registry/factory/provider seam. 
+- **Favor simplicity over abstraction** Introduce layers, interfaces, factories, registries, or other indirection only when they provide a clear benefit.
 - **YAGNI.** Do not add fields, parameters, or extension seams that nothing consumes yet. Recommend pulling unused surface out of the PR until the consumer lands.
 - **Respect layering.** Each layer does only its job — For example, populate domain data before entering the persistence layer.
-- **Name to avoid collisions and ambiguity.** A field named `Role` next to Postgres roles, or two fields (`Label`/`Series`) that mean the same thing, will confuse readers. Prefer qualified, single-purpose names.
-- **One source of truth.** Do not persist the same fact two ways 
+- **Name to avoid collisions and ambiguity.** A field named `Role` next to Postgres roles, or two fields that mean the same thing, will confuse readers. Prefer qualified, single-purpose names.
+- **One source of truth.** Do not persist the same fact two ways. 
 
 ## Generic Coding Practices
 

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -68,21 +68,15 @@ On a hot path:
 
 If you are unsure whether a path is hot, ask; do not assume it is cold.
 
-## Change Scope and Tool-Generated Diffs
-
-- Every hunk should be **necessary and in scope** for the PR's stated goal. Do not merge speculative code — fields, parameters, interfaces, or whole files added "for a later PR" that have no caller yet. If scaffolding is genuinely unavoidable, keep it minimal and call it out explicitly.
-- AI/agent-generated diffs (Cursor, Claude, etc.) frequently include **incidental, unrelated changes**: a `UNION`→`UNION ALL` swap with no functional reason, an unnecessary new file split out from an existing one, reformatting, or renamed locals. Each such change must be either justified or reverted — "the tool did it" is not a reason.
-- Prefer keeping closely-related code together (e.g. test SQL beside the tests that use it) unless there is a concrete reason to separate it.
-
 ## Design and Abstraction
 
 Applies especially to new packages, interfaces, and abstractions:
 
-- **Avoid unnecessary indirection.** A `switch` on database type or a direct call is often clearer than a registry/factory/provider seam. Add the abstraction only when there is a concrete second implementation or a real import-cycle/testing reason — and state that reason.
-- **YAGNI.** Do not add fields, parameters, or extension seams that nothing consumes yet (e.g. an unused `Attrs` map, a `StableIdentity` no diff step reads). Recommend pulling unused surface out of the PR until the consumer lands.
-- **Respect layering.** Each layer does only its job — a persist/metadb layer stores and loads; it does not compute, stamp, or derive domain values. Populate domain data before entering the persistence layer.
+- **Avoid unnecessary indirection.** A `switch` on database type or a direct call is often clearer than a registry/factory/provider seam. 
+- **YAGNI.** Do not add fields, parameters, or extension seams that nothing consumes yet. Recommend pulling unused surface out of the PR until the consumer lands.
+- **Respect layering.** Each layer does only its job — For example, populate domain data before entering the persistence layer.
 - **Name to avoid collisions and ambiguity.** A field named `Role` next to Postgres roles, or two fields (`Label`/`Series`) that mean the same thing, will confuse readers. Prefer qualified, single-purpose names.
-- **One source of truth.** Do not persist the same fact two ways (e.g. an `is_placeholder` column *and* `snapshot_json IS NULL`); the two will drift.
+- **One source of truth.** Do not persist the same fact two ways 
 
 ## Generic Coding Practices
 

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -72,7 +72,7 @@ If you are unsure whether a path is hot, ask; do not assume it is cold.
 
 Applies especially to new packages, interfaces, and abstractions:
 
-- **Favor simplicity over abstraction** Introduce layers, interfaces, factories, registries, or other indirection only when they provide a clear benefit.
+- **Favor simplicity over abstraction** Introduce layers, interfaces, factories, registries, or other indirection only when they provide a clear benefit or there is strong evidence that upcoming scale or feature growth will require them.
 - **YAGNI.** Do not add fields, parameters, or extension seams that nothing consumes yet. Recommend pulling unused surface out of the PR until the consumer lands.
 - **Respect layering.** Each layer does only its job — For example, populate domain data before entering the persistence layer.
 - **Name to avoid collisions and ambiguity.** A field named `Role` next to Postgres roles, or two fields that mean the same thing, will confuse readers. Prefer qualified, single-purpose names.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -52,9 +52,42 @@ Users may upgrade voyager mid-migration. Serialized state must remain compatible
 
 PostgreSQL allows case-sensitive (quoted) identifiers. All object name handling must go through the `sqlname` package (`NameTuple` or `ObjectName`), not manual string concatenation. Always test new table/column/schema handling with case-sensitive names.
 
+## Performance-Critical (Hot) Paths
+
+Some code runs once per migration; some runs once per row or per change event and dominates throughput. Treat the latter as hot paths and review them with extra scrutiny:
+
+- **Per-event / CDC processing during live migration** — event decoding, conflict detection (`conflictDetectionCache`), and everything on the import-data event loop run for every streamed change. This path has regressed before; a small per-event allocation multiplies by millions of events.
+- **The per-row import-data loop and per-tuple value conversion** — batching, type conversion, and name lookups here run per row.
+
+On a hot path:
+
+- Avoid per-iteration heap allocations. Build strings with a single `strings.Builder`, writing each component directly (`b.WriteString(col); b.WriteString("=<missing>")`) — do **not** construct temporary strings with `+` and then `WriteString` them.
+- Hoist invariant work out of the loop: pre-compile regexes, reuse buffers, compute lookups once.
+- Avoid re-doing map/JSON/marshal work per event when it can be cached or done once.
+- For non-trivial changes to a hot path, add or update a benchmark and report before/after numbers rather than eyeballing it.
+
+If you are unsure whether a path is hot, ask; do not assume it is cold.
+
+## Change Scope and Tool-Generated Diffs
+
+- Every hunk should be **necessary and in scope** for the PR's stated goal. Do not merge speculative code — fields, parameters, interfaces, or whole files added "for a later PR" that have no caller yet. If scaffolding is genuinely unavoidable, keep it minimal and call it out explicitly.
+- AI/agent-generated diffs (Cursor, Claude, etc.) frequently include **incidental, unrelated changes**: a `UNION`→`UNION ALL` swap with no functional reason, an unnecessary new file split out from an existing one, reformatting, or renamed locals. Each such change must be either justified or reverted — "the tool did it" is not a reason.
+- Prefer keeping closely-related code together (e.g. test SQL beside the tests that use it) unless there is a concrete reason to separate it.
+
+## Design and Abstraction
+
+Applies especially to new packages, interfaces, and abstractions:
+
+- **Avoid unnecessary indirection.** A `switch` on database type or a direct call is often clearer than a registry/factory/provider seam. Add the abstraction only when there is a concrete second implementation or a real import-cycle/testing reason — and state that reason.
+- **YAGNI.** Do not add fields, parameters, or extension seams that nothing consumes yet (e.g. an unused `Attrs` map, a `StableIdentity` no diff step reads). Recommend pulling unused surface out of the PR until the consumer lands.
+- **Respect layering.** Each layer does only its job — a persist/metadb layer stores and loads; it does not compute, stamp, or derive domain values. Populate domain data before entering the persistence layer.
+- **Name to avoid collisions and ambiguity.** A field named `Role` next to Postgres roles, or two fields (`Label`/`Series`) that mean the same thing, will confuse readers. Prefer qualified, single-purpose names.
+- **One source of truth.** Do not persist the same fact two ways (e.g. an `is_placeholder` column *and* `snapshot_json IS NULL`); the two will drift.
+
 ## Generic Coding Practices
 
 - Keep code simple. Use early returns to reduce nesting. Prefer flat `if err != nil { return err }` over deeply nested success paths.
+- Prefer letting the database do set-oriented work (ordering, aggregation, grouping, deduplication) in SQL rather than post-processing rows in Go, when it does not hurt readability.
 - Use self-describing variable and function names. Avoid `rec1`/`rec2` — prefer `recCombined`/`recSharded`.
 - Remove dead code, unused functions, and leftover debugging artifacts before merging.
 - Consolidate duplicate logic into shared helpers rather than copy-pasting across switch cases or source-type implementations.

--- a/ai/skills/branch-review/SKILL.md
+++ b/ai/skills/branch-review/SKILL.md
@@ -99,19 +99,44 @@ For each modified file, read the full current version to understand surrounding 
 
 ### Step 4: Review each change
 
-Evaluate every change against:
+Evaluate every change against the BUGBOT hierarchy (4a) and the review lenses (4b). Two failure modes have caused this skill to miss important findings in the past — avoid both:
 
-1. **BUGBOT.md hierarchy** — For each changed file, apply the union of all `BUGBOT.md` / `.cursor/BUGBOT.md` files from that file’s directory through the repository root, as described in Step 1. Call out violations or gaps against those rules explicitly.
-2. **General criteria** (below).
+- **Only flagging the obvious bugs.** Swallowed errors, bad SQL, and nil derefs are easy to spot and this skill already finds them. The higher-value findings a human reviewer catches are usually about **scope, design, hot-path cost, simplification, and test coverage** — apply *every* lens below, not just Correctness/Security.
+- **Reading BUGBOT rules but not enforcing them.** Most previously-missed findings mapped to a rule that was *already loaded* from an applicable BUGBOT.md. Loading a rule is not reviewing against it. Treat the loaded rules as an active checklist and scan the diff for a concrete violation of each one.
 
-| Area | What to check |
+#### 4a. Apply the BUGBOT hierarchy as an active checklist
+
+For each changed file, take the union of all `BUGBOT.md` / `.cursor/BUGBOT.md` files from that file's directory through the repo root (Step 1). Walk each rule and actively look for a violation in the diff — do not just confirm you read it. Voyager rules that are easy to miss and *have been missed before*:
+
+- `utils.ErrExit` (or a silent swallow) where a function should return an error to its caller — cmd / yb-voyager error-handling rules.
+- Object names assembled by string concatenation instead of `sqlname` / `NameTuple` / `AsKey` — the "Object Names" rule.
+- Missing test cases for **partitioned / multi-level tables** and **case-sensitive identifiers** — root + srcdb rules.
+- Dead / unused code, or code (fields, functions, whole files) added for a *future* PR with no caller yet.
+- Backward-compat surfaces (MSR JSON tags, assessment SQLite schema, callhome/YugabyteD payload version) changed non-additively.
+- Layering: business logic landing in `cmd/`, or a lower layer (e.g. persist/metadb) doing work that belongs to a higher one.
+
+**Turn each lexically-detectable rule into a search over the *added* (`+`) lines** — do not rely on reading comprehension alone. A rule you only *read* is a rule you will miss; a rule you *grep for* is one you enforce. After loading the rules, scan the diff's added lines for these tell-tale signatures and inspect each hit in context:
+
+- `utils.ErrExit(` inside a **newly-added** leaf/helper function (a `func save…/get…/build…` that returns nothing) — flag it **even when the enclosing file already uses `ErrExit` pervasively** (e.g. a `cmd/` command file). Existing usage is not license to add more; the new helper should return a wrapped error.
+- `.AsQualifiedCatalogName()` or `.String()` used to build a **map key** or a metaDB key from a `NameTuple`/`ObjectName` — should be the canonical key method (`Key()` / `ForKey()`), which round-trips through the name registry for case-sensitive identifiers.
+- A new `func Test…` body that calls an **unexported** helper (lowercase first letter) instead of the exported entry point it is meant to cover.
+- New exported symbols, fields, or files that nothing else references yet — `git -C "$WT" grep <symbol>` to confirm; zero hits outside the definition ⇒ speculative/dead code for a later PR.
+- `UNION ALL`, reformatting, or renamed locals in a file whose stated purpose is unrelated to the change — incidental churn to question.
+
+#### 4b. Review lenses
+
+| Lens | What to check |
 |------|---------------|
-| **Correctness** | Logic errors, off-by-one, nil/null handling, race conditions, edge cases |
-| **Security** | Injection, hardcoded secrets, auth gaps, input validation |
-| **Performance** | Unnecessary allocations, N+1 queries, missing indexes, unbounded loops |
-| **Style** | Naming, consistency with codebase conventions, dead code, magic numbers |
-| **Tests** | New logic has tests, edge cases covered, tests actually assert behavior |
-| **Documentation** | Public APIs documented, non-obvious logic commented, changelog updated if needed |
+| **Correctness** | Logic errors, off-by-one, **inverted / negated conditions** (`!found`, a flipped `<`/`>`, a wrong `!`), nil/null handling, race conditions, edge cases. |
+| **Scope & necessity** | Is every hunk needed *for this PR*? Flag speculative code, unused fields/params/abstractions added "for a later PR" with no caller, and **incidental changes unrelated to the stated goal** — e.g. a `UNION`→`UNION ALL` swap with no functional reason, a needless new file, drive-by reformatting. AI/Cursor-generated diffs routinely carry this noise; make the author justify each such change or drop it. |
+| **Design & maintainability** | Especially for new packages/interfaces/abstractions: unnecessary indirection (a registry/factory/extra interface where a `switch` or direct call would do), **YAGNI** (seams/fields not exercised yet — recommend pulling them from the PR), **layering** (each layer does only its job), names that collide with domain terms (e.g. a field named `Role` next to DB roles), redundant concepts (two fields meaning the same thing), and two-sources-of-truth for one fact. |
+| **Hot-path performance** | *First decide whether the change is on a performance-critical path* — per-event / CDC / conflict-detection, the per-row import-data loop, per-tuple value conversion (see root BUGBOT "Performance-Critical (Hot) Paths"). On those paths scrutinize per-iteration allocations, string building (`+` in a loop, or building a temp string before `WriteString`), and repeated map/JSON/regex/lookup work; expect a benchmark for non-trivial changes. Off hot paths, apply ordinary performance judgment. |
+| **Simplification** | Is there a materially simpler implementation? Push aggregation/sorting/dedup into SQL instead of post-processing in Go; dedupe once at the end instead of on every append; reuse an existing helper instead of re-implementing. |
+| **Security** | Injection, hardcoded secrets, auth gaps, input validation. |
+| **Tests** | New logic has tests that actually assert behavior; edge cases covered. Prefer exercising the **exported/public API** over calling unexported helpers directly. **Cross-variant coverage**: sources (PG/Oracle/MySQL/YB), migration flows, partitioned/multi-level tables, case-sensitive names. If a touched code path can't be easily tested (e.g. Oracle), confirm the author *manually verified* it. Tests must clean up and restore any shared state (schemas, global vars). |
+| **Documentation** | Public APIs documented; non-obvious gating/branching logic commented with *why* and *when it applies*; genuinely unclear concepts (new fields, enums, labels) explained — if you can't tell what a field is for, ask. |
+
+Severity is not tied to lens: a hot-path regression or an inverted condition is Critical/Warning, not a nitpick. Design, scope, and clarity concerns that need author input but aren't defects go in the **Question** class (Step 5) — surface them, but don't invent a "bug" to justify them.
 
 ### Step 5: Present findings
 
@@ -160,6 +185,17 @@ Format:
 - Suggested Code Change: ...
 ```
 
+#### Question — Needs author input
+Not a defect, but something where intent or necessity is unclear and the author should respond: a design/scope concern (unnecessary abstraction, YAGNI field, layering, naming), an incidental change with no obvious reason, a "why is this nil / why this dedupe / why a separate file" doubt, or a request to confirm untested source paths were manually verified. Many of a human reviewer's most valuable comments are questions — do not suppress them just because they aren't bugs. (Note: these are surfaced in the review but are *not* auto-posted by the `post-pr-review` skill, which only posts Critical/Warning.)
+
+Format:
+```
+**[QUESTION]** `file:line` — Brief description
+- Problem/Suggestion: <the question, and why it matters>
+- Code line: ...
+- Suggested Code Change: <if you have a concrete alternative in mind>
+```
+
 ### Step 6: Summary
 
 End with a brief summary:
@@ -170,7 +206,7 @@ End with a brief summary:
 - **Branch**: <branch-name>
 - **Commits**: <count>
 - **Files changed**: <count>
-- **Findings**: <critical-count> critical, <warning-count> warnings, <suggestion-count> suggestions
+- **Findings**: <critical-count> critical, <warning-count> warnings, <suggestion-count> suggestions, <question-count> questions
 
 ### Overall assessment
 <1-3 sentences: is this ready to merge, what are the key concerns?>
@@ -178,9 +214,10 @@ End with a brief summary:
 
 ## Guidelines
 
-- Load and apply **BUGBOT.md** / **.cursor/BUGBOT.md** per changed file using the directory walk to repo root (Step 1); do not skip because the repo has many such files.
+- Load and apply **BUGBOT.md** / **.cursor/BUGBOT.md** per changed file using the directory walk to repo root (Step 1), as an *active checklist* (Step 4a) — do not skip because the repo has many such files, and do not treat "I read it" as "I applied it."
+- Apply **all** of the Step 4b lenses, not just Correctness/Security. The findings this skill has historically missed were scope, design, hot-path, simplification, and test-coverage issues — many of which were already covered by a loaded BUGBOT rule.
 - Be specific — always reference file and line number.
 - Suggest fixes, not just problems.
 - Acknowledge good patterns and clean code briefly.
-- If unsure about intent, flag it as a question rather than an issue.
+- **Raise questions liberally.** If intent, necessity, or a design choice is unclear — or a change looks incidental / tool-generated — file it as a **Question** (Step 5) rather than staying silent. A good question is often more valuable than a weak assertion.
 - Always lead with the high-level change summary (Step 2) before any detailed findings.

--- a/ai/skills/branch-review/SKILL.md
+++ b/ai/skills/branch-review/SKILL.md
@@ -106,34 +106,24 @@ Evaluate every change against the BUGBOT hierarchy (4a) and the review lenses (4
 
 #### 4a. Apply the BUGBOT hierarchy as an active checklist
 
-For each changed file, take the union of all `BUGBOT.md` / `.cursor/BUGBOT.md` files from that file's directory through the repo root (Step 1). Walk each rule and actively look for a violation in the diff — do not just confirm you read it. Voyager rules that are easy to miss and *have been missed before*:
+For each changed file, take the union of all `BUGBOT.md` / `.cursor/BUGBOT.md` files from that file's directory through the repo root (Step 1). Walk each rule and actively look for a violation in the diff — do not just confirm you read it.
 
-- `utils.ErrExit` (or a silent swallow) where a function should return an error to its caller — cmd / yb-voyager error-handling rules.
-- Object names assembled by string concatenation instead of `sqlname` / `NameTuple` / `AsKey` — the "Object Names" rule.
-- Missing test cases for **partitioned / multi-level tables** and **case-sensitive identifiers** — root + srcdb rules.
-- Dead / unused code, or code (fields, functions, whole files) added for a *future* PR with no caller yet.
-- Backward-compat surfaces (MSR JSON tags, assessment SQLite schema, callhome/YugabyteD payload version) changed non-additively.
-- Layering: business logic landing in `cmd/`, or a lower layer (e.g. persist/metadb) doing work that belongs to a higher one.
 
-**Turn each lexically-detectable rule into a search over the *added* (`+`) lines** — do not rely on reading comprehension alone. A rule you only *read* is a rule you will miss; a rule you *grep for* is one you enforce. After loading the rules, scan the diff's added lines for these tell-tale signatures and inspect each hit in context:
 
-- `utils.ErrExit(` inside a **newly-added** leaf/helper function (a `func save…/get…/build…` that returns nothing) — flag it **even when the enclosing file already uses `ErrExit` pervasively** (e.g. a `cmd/` command file). Existing usage is not license to add more; the new helper should return a wrapped error.
-- `.AsQualifiedCatalogName()` or `.String()` used to build a **map key** or a metaDB key from a `NameTuple`/`ObjectName` — should be the canonical key method (`Key()` / `ForKey()`), which round-trips through the name registry for case-sensitive identifiers.
-- A new `func Test…` body that calls an **unexported** helper (lowercase first letter) instead of the exported entry point it is meant to cover.
-- New exported symbols, fields, or files that nothing else references yet — `git -C "$WT" grep <symbol>` to confirm; zero hits outside the definition ⇒ speculative/dead code for a later PR.
-- `UNION ALL`, reformatting, or renamed locals in a file whose stated purpose is unrelated to the change — incidental churn to question.
+**Turn each lexically-detectable rule into a search over the *added* (`+`) lines** — do not rely on reading comprehension alone. A rule you only *read* is a rule you will miss; a rule you *grep for* is one you enforce.
+
 
 #### 4b. Review lenses
 
 | Lens | What to check |
 |------|---------------|
 | **Correctness** | Logic errors, off-by-one, **inverted / negated conditions** (`!found`, a flipped `<`/`>`, a wrong `!`), nil/null handling, race conditions, edge cases. |
-| **Scope & necessity** | Is every hunk needed *for this PR*? Flag speculative code, unused fields/params/abstractions added "for a later PR" with no caller, and **incidental changes unrelated to the stated goal** — e.g. a `UNION`→`UNION ALL` swap with no functional reason, a needless new file, drive-by reformatting. AI/Cursor-generated diffs routinely carry this noise; make the author justify each such change or drop it. |
-| **Design & maintainability** | Especially for new packages/interfaces/abstractions: unnecessary indirection (a registry/factory/extra interface where a `switch` or direct call would do), **YAGNI** (seams/fields not exercised yet — recommend pulling them from the PR), **layering** (each layer does only its job), names that collide with domain terms (e.g. a field named `Role` next to DB roles), redundant concepts (two fields meaning the same thing), and two-sources-of-truth for one fact. |
-| **Hot-path performance** | *First decide whether the change is on a performance-critical path* — per-event / CDC / conflict-detection, the per-row import-data loop, per-tuple value conversion (see root BUGBOT "Performance-Critical (Hot) Paths"). On those paths scrutinize per-iteration allocations, string building (`+` in a loop, or building a temp string before `WriteString`), and repeated map/JSON/regex/lookup work; expect a benchmark for non-trivial changes. Off hot paths, apply ordinary performance judgment. |
-| **Simplification** | Is there a materially simpler implementation? Push aggregation/sorting/dedup into SQL instead of post-processing in Go; dedupe once at the end instead of on every append; reuse an existing helper instead of re-implementing. |
+| **Scope & necessity** | Is every hunk needed *for this PR*? Flag speculative code, unused fields/params/abstractions added "for a later PR" with no caller, and **incidental changes unrelated to the stated goal** —  a needless new file, drive-by reformatting. AI-generated diffs routinely carry this noise; make the author justify each such change or drop it. |
+| **Design & maintainability** | Especially for new packages/interfaces/abstractions: unnecessary indirection, **YAGNI** , **layering** (each layer does only its job), redundant concepts (two fields meaning the same thing), and two-sources-of-truth for one fact. |
+| **Hot-path performance** | *First decide whether the change is on a performance-critical path* — per-event / CDC / conflict-detection, the per-row import-data loop, per-tuple value conversion (see root BUGBOT "Performance-Critical (Hot) Paths").  |
+| **Simplification** | Is there a materially simpler implementation?  |
 | **Security** | Injection, hardcoded secrets, auth gaps, input validation. |
-| **Tests** | New logic has tests that actually assert behavior; edge cases covered. Prefer exercising the **exported/public API** over calling unexported helpers directly. **Cross-variant coverage**: sources (PG/Oracle/MySQL/YB), migration flows, partitioned/multi-level tables, case-sensitive names. If a touched code path can't be easily tested (e.g. Oracle), confirm the author *manually verified* it. Tests must clean up and restore any shared state (schemas, global vars). |
+| **Tests** | New logic has tests that actually assert behavior; edge cases covered. |
 | **Documentation** | Public APIs documented; non-obvious gating/branching logic commented with *why* and *when it applies*; genuinely unclear concepts (new fields, enums, labels) explained — if you can't tell what a field is for, ask. |
 
 Severity is not tied to lens: a hot-path regression or an inverted condition is Critical/Warning, not a nitpick. Design, scope, and clarity concerns that need author input but aren't defects go in the **Question** class (Step 5) — surface them, but don't invent a "bug" to justify them.

--- a/yb-voyager/.cursor/BUGBOT.md
+++ b/yb-voyager/.cursor/BUGBOT.md
@@ -8,6 +8,7 @@
 
 - Never silently swallow errors. If a function returns an error, either handle it, return it, or log it with sufficient context. Do not `log.Warnf` and continue when the error indicates a real failure.
 - Do not call `utils.ErrExit` inside functions that are expected to return errors to their callers. `ErrExit` terminates the process and bypasses deferred cleanup, error wrapping, and caller-level recovery.
+- This applies to **newly-added leaf/helper functions even when the surrounding file (e.g. a `cmd/` command file) already uses `ErrExit` pervasively.** A new `save…`/`get…`/`build…` helper that returns nothing and calls `ErrExit` on failure should instead return a wrapped error and let its caller decide. Existing `ErrExit` usage in the file is not a license to add more.
 - When wrapping errors, include enough context to trace the source: table name, file path, operation attempted, etc.
 
 ## Nil and Boundary Checks
@@ -35,6 +36,7 @@
 ## Object Names
 
 - Use the `sqlname` package for all object name handling(table names especially). Do not construct qualified names via manual string concatenation.
+- When using a `NameTuple`/`ObjectName` as a **map key** or serialising it as a key (e.g. a metaDB JSON map keyed by table), use its canonical key method (`Key()` / `ForKey()`), **not** `AsQualifiedCatalogName()` or `String()`. The catalog-name/display forms do not round-trip through the name registry for case-sensitive (quoted) identifiers, so a key written one way and read back another way can silently miss.
 
 
 ## Flag and Config Handling
@@ -75,7 +77,8 @@
 - Use `assert.ElementsMatch` for unordered comparisons instead of manually sorting.
 - Prefer table-driven tests with `t.Run(name, func(t *testing.T) { ... })` for multiple scenarios.
 - Use `testify/require` for setup steps that must succeed for the test to be meaningful.
-- Each test should be self-contained: set up its schema objects, run assertions, and clean up.
+- Each test should be self-contained: set up its schema objects, run assertions, and clean up. If a test mutates shared/global state (e.g. reassigns a package-level `Schemas` field or a global), restore the original value on cleanup.
 - Integration tests that use testcontainers should clean up their own resources.
 - Always include test cases for case-sensitive table and column names, wherever applicable.
+- Prefer exercising the **exported/public API** (e.g. `eventsConflict()`) over calling unexported helpers (`uniqueIndexConflicts()`) directly, so tests validate the real entry point and survive internal refactors.
 - When testing error paths, verify the specific error type or message — not just that an error occurred.

--- a/yb-voyager/.cursor/BUGBOT.md
+++ b/yb-voyager/.cursor/BUGBOT.md
@@ -36,7 +36,7 @@
 ## Object Names
 
 - Use the `sqlname` package for all object name handling(table names especially). Do not construct qualified names via manual string concatenation.
-- When using a `NameTuple`/`ObjectName` as a **map key** or serialising it as a key (e.g. a metaDB JSON map keyed by table), use its canonical key method (`Key()` / `ForKey()`), **not** `AsQualifiedCatalogName()` or `String()`. The catalog-name/display forms do not round-trip through the name registry for case-sensitive (quoted) identifiers, so a key written one way and read back another way can silently miss.
+- When using a `NameTuple`/`ObjectName` as a **map key** or serialising it as a key (e.g. a metaDB JSON map keyed by table), use its canonical key method (`Key()` / `ForKey()`), **not** `AsQualifiedCatalogName()` or `String()`. 
 
 
 ## Flag and Config Handling


### PR DESCRIPTION
### Describe the changes in this pull request

Improves the `branch-review` code-review skill and the product-level `BUGBOT.md` rules so reviews surface the higher-value findings a human reviewer makes — not just obvious bugs.

Motivation: comparing manual review comments on two recent PRs (#3604, #3614) against what the skill produced showed two gaps: (1) BUGBOT rules that were *loaded but never actively enforced* against the diff (e.g. `ErrExit` misuse, `AsKey` vs `AsQualifiedCatalogName`, partitioned-table test coverage, dead code), and (2) whole review lenses that no rule covered (hot-path performance, design of new abstractions, scope/necessity of changes, simplification).

**`ai/skills/branch-review/SKILL.md`**
- Step 4a: apply the BUGBOT hierarchy as an *active checklist* and grep the added lines for lexical rule signatures (`utils.ErrExit` in new leaf helpers, `NameTuple` used as a map key via `AsQualifiedCatalogName`/`String` instead of `Key()`/`ForKey()`, tests calling unexported helpers, unreferenced new symbols, incidental churn).
- Step 4b: new lenses — Scope & necessity, Design & maintainability, Hot-path performance, Simplification; sharpened Correctness (inverted/negated conditions) and Tests (public-API vs internal, cross-source/partitioned/case-sensitive coverage).
- New **Question** finding class for design/scope concerns that need author input but aren't defects.

**`.cursor/BUGBOT.md`** (product-level): new sections — Performance-Critical (Hot) Paths, Change Scope & Tool-Generated Diffs, Design and Abstraction.

**`yb-voyager/.cursor/BUGBOT.md`** (Go-level): `ErrExit` in newly-added leaf helpers even amid pervasive existing usage; use `Key()`/`ForKey()` for `NameTuple` map keys; prefer exercising the public API over unexported helpers in tests.

### Describe if there are any user-facing changes

No. This only touches AI code-review tooling (`.cursor/BUGBOT.md`, `ai/skills/`). No changes to the CLI, configuration, installation, or reports. No Go product code is modified.

### How was this pull request tested?

Validated empirically by running the improved skill **blind** (fresh sub-agents with no knowledge of the manual comments) against PR #3604 and PR #3614 reconstructed at the exact commits where the comments were made, with the improved rules overlaid:

- The inverted-condition bug (`!found`) surfaces as **CRITICAL**.
- The design/scope/perf/naming/layering/coverage issues surface as **WARNING**.
- Question-toned items (AsKey, Oracle manual-verification, incidental `UNION`→`UNION ALL`) surface as **QUESTION/SUGGESTION**, each citing the exact rule.

The skill also independently re-derived prior findings and turned up new latent issues. No automated tests apply (no product code changed).

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
