### PR TITLE
Discourage disabling run-guardrails-checks in help and config templates

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -190,7 +190,7 @@ func init() {
 	assessMigrationCmd.Flags().Int64Var(&intervalForCapturingIOPS, "iops-capture-interval", 120,
 		"Interval (in seconds) at which voyager will gather IOPS metadata from source database for the given schema(s). (only valid for PostgreSQL)")
 
-	BoolVar(assessMigrationCmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", true, "run guardrails checks before assess migration. (only valid for PostgreSQL)")
+	BoolVar(assessMigrationCmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", true, "run guardrails checks before assess migration. (only valid for PostgreSQL) Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.")
 
 	assessMigrationCmd.Flags().StringVar(&targetDbVersionStrFlag, "target-db-version", "",
 		fmt.Sprintf("Target YugabyteDB version to assess migration for (in format A.B.C.D). Defaults to latest stable version (%s)", ybversion.LatestStable.String()))

--- a/yb-voyager/cmd/export.go
+++ b/yb-voyager/cmd/export.go
@@ -55,7 +55,7 @@ func registerCommonExportFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &startClean, "start-clean", false,
 		"cleans up the project directory for schema or data files depending on the export command (default false)")
 
-	BoolVar(cmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", true, "run guardrails checks before export. (only valid for PostgreSQL)")
+	BoolVar(cmd.Flags(), &source.RunGuardrailsChecks, "run-guardrails-checks", true, "run guardrails checks before export. (only valid for PostgreSQL) Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.")
 }
 
 func registerCommonSourceDBConnFlags(cmd *cobra.Command) {

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -265,7 +265,7 @@ func registerCommonImportFlags(cmd *cobra.Command) {
 	BoolVar(cmd.Flags(), &tconf.ContinueOnError, "continue-on-error", false,
 		"Ignore errors and continue with the import")
 
-	BoolVar(cmd.Flags(), &tconf.RunGuardrailsChecks, "run-guardrails-checks", true, "Run guardrails checks during import")
+	BoolVar(cmd.Flags(), &tconf.RunGuardrailsChecks, "run-guardrails-checks", true, "Run guardrails checks during import. Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.")
 }
 
 // registerTargetDBTypeFlag registers --target-db-type. It is intentionally

--- a/yb-voyager/config-templates/live-migration-with-fall-back.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-back.yaml
@@ -185,6 +185,7 @@ assess-migration:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -238,6 +239,7 @@ export-schema:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -311,6 +313,7 @@ import-schema:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -358,6 +361,7 @@ export-data-from-source:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -453,6 +457,7 @@ import-data-to-target:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -557,6 +562,7 @@ finalize-schema-post-data-import:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -616,6 +622,7 @@ import-data-to-source:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command

--- a/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
@@ -245,6 +245,7 @@ assess-migration:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -298,6 +299,7 @@ export-schema:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -371,6 +373,7 @@ import-schema:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -418,6 +421,7 @@ export-data-from-source:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -513,6 +517,7 @@ import-data-to-target:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -566,6 +571,7 @@ import-data-to-source-replica:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -662,6 +668,7 @@ finalize-schema-post-data-import:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -191,6 +191,7 @@ assess-migration:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -244,6 +245,7 @@ export-schema:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -317,6 +319,7 @@ import-schema:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -364,6 +367,7 @@ export-data-from-source:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -461,6 +465,7 @@ import-data-to-target:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -557,6 +562,7 @@ finalize-schema-post-data-import:
   ### Run guardrails checks before the command is run. 
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command

--- a/yb-voyager/config-templates/offline-migration.yaml
+++ b/yb-voyager/config-templates/offline-migration.yaml
@@ -181,6 +181,7 @@ assess-migration:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -235,6 +236,7 @@ export-schema:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command
@@ -310,6 +312,7 @@ import-schema:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true 
 
   ### Log level for the command
@@ -361,6 +364,7 @@ export-data:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true
 
   ### Log level for the command
@@ -476,6 +480,7 @@ import-data:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true
 
   ### Log level for the command
@@ -512,6 +517,7 @@ finalize-schema-post-data-import:
   ### Note - This is only valid for PostgreSQL source database.
   ### Accepted values - (true, false, yes, no, 1, 0)
   ### Default - true
+  ### Warning - Setting this to false is unsafe: it skips critical pre-migration validations (such as source/target database permissions, binary dependencies, and version compatibility) and may lead to migration failures or data issues. Leave the default (true) unless you have a specific reason to disable checks.
   # run-guardrails-checks: true  
 
   ### Log level for the command


### PR DESCRIPTION
### Describe the changes in this pull request

This PR mirrors the documentation guidance from yugabyte-db docs PR [#32483](https://github.com/yugabyte/yugabyte-db/pull/32483#discussion_r3520827341) into yb-voyager's CLI help text and config-file templates. It adds a warning to the `run-guardrails-checks` flag explaining that setting it to `false` is unsafe — it skips critical pre-migration validations (source/target database permissions, binary dependencies, and version compatibility) and can lead to migration failures or data issues — and recommends leaving the default (`true`) unless there is a specific reason to disable the checks.

The warning was added to the three shared flag-registration sites — `registerCommonExportFlags` (`cmd/export.go`), `registerCommonImportFlags` (`cmd/import.go`), and assess-migration (`cmd/assessMigrationCommand.go`) — which cover every command that exposes the flag, and to each `run-guardrails-checks` entry across the offline and live-migration config templates. This is a docs/wording-only change; no behavior, defaults, or accepted values were modified.

### Describe if there are any user-facing changes

Yes — text only.
1. **Command line:** the `--run-guardrails-checks` help text (shown in `--help` for export, import, and assess-migration, and the commands they back) now includes the safety warning.
2. **Configuration:** the config-template comments for `run-guardrails-checks` now include a `### Warning - ...` line in the offline and all live-migration templates.
3. **Installation:** no change.
4. **Reports:** no change.

The flag's default (`true`) and accepted values are unchanged.

### How was this pull request tested?

`go build ./cmd/...` passes. This is a wording-only change with no functional logic, so no new tests were added. Existing config/help tests were checked — none assert the exact help-string or template text, so they remain green. Verified that each of the four config templates now has a warning line preceding every `run-guardrails-checks` entry (counts match: offline 6/6, live-migration 6/6, fall-back 7/7, fall-forward 7/7).

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
