### PR TITLE
Fix get-data-migration-report nil-pointer panic when target metadata not yet created

### DIFF
--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -699,13 +699,20 @@ func updateImportedEventsCountsInTheRow(row *RowData, tableNameTup sqlname.NameT
 		}
 	}
 
-	if importerRole != SOURCE_DB_IMPORTER_ROLE && msr.ExportTypeFromSource == SNAPSHOT_AND_CHANGES {
+	if importerRole != SOURCE_DB_IMPORTER_ROLE && msr.ExportTypeFromSource == SNAPSHOT_AND_CHANGES && snapshotImportedRowsMap != nil {
 		rowCountPair, _ := snapshotImportedRowsMap.Get(tableNameTup)
 		row.ImportedSnapshotRows = rowCountPair.Imported
 		row.ErroredImportedSnapshotRows = rowCountPair.Errored
 	}
 
-	eventCounter, _ := eventsImportedMap.Get(tableNameTup)
+	if eventsImportedMap == nil {
+		// Import has not produced any events yet; leave counts at zero.
+		return nil
+	}
+	eventCounter, ok := eventsImportedMap.Get(tableNameTup)
+	if !ok || eventCounter == nil {
+		return nil
+	}
 	row.ImportedInserts = eventCounter.NumInserts
 	row.ImportedUpdates = eventCounter.NumUpdates
 	row.ImportedDeletes = eventCounter.NumDeletes

--- a/yb-voyager/cmd/getDataMigrationReport_unit_test.go
+++ b/yb-voyager/cmd/getDataMigrationReport_unit_test.go
@@ -1,0 +1,75 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	pgconn5 "github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
+)
+
+// fakeQueryErrTDB embeds the TargetDB interface (methods are nil at runtime but
+// only Query is exercised here) and forces Query to return a fixed error.
+type fakeQueryErrTDB struct {
+	tgtdb.TargetDB
+	queryErr error
+}
+
+func (f *fakeQueryErrTDB) Query(string) (*sql.Rows, error) { return nil, f.queryErr }
+
+func newTestTuple(name string) sqlname.NameTuple {
+	obj := sqlname.NewObjectName(constants.POSTGRESQL, "public", "public", name)
+	return sqlname.NameTuple{SourceName: obj, CurrentName: obj}
+}
+
+func TestGetImportedEventsStatsForTableListMissingMetadataTable(t *testing.T) {
+	origTdb := tdb
+	defer func() { tdb = origTdb }()
+	tdb = &fakeQueryErrTDB{queryErr: &pgconn5.PgError{Code: "42P01", Message: `relation "ybvoyager_metadata.ybvoyager_imported_event_count_by_table" does not exist`}}
+
+	tups := []sqlname.NameTuple{newTestTuple("t1"), newTestTuple("t2")}
+	state := NewImportDataState(t.TempDir())
+	got, err := state.GetImportedEventsStatsForTableList(tups, uuid.New())
+	require.NoError(t, err, "42P01 (table not created yet) must be treated as zero events, not an error")
+	require.NotNil(t, got)
+	for _, tup := range tups {
+		c, ok := got.Get(tup)
+		require.True(t, ok)
+		require.NotNil(t, c)
+		require.Zero(t, c.NumInserts)
+		require.Zero(t, c.NumUpdates)
+		require.Zero(t, c.NumDeletes)
+	}
+}
+
+func TestGetImportedEventsStatsForTableListPropagatesOtherErrors(t *testing.T) {
+	origTdb := tdb
+	defer func() { tdb = origTdb }()
+	tdb = &fakeQueryErrTDB{queryErr: fmt.Errorf("connection refused")}
+	state := NewImportDataState(t.TempDir())
+	_, err := state.GetImportedEventsStatsForTableList([]sqlname.NameTuple{newTestTuple("t1")}, uuid.New())
+	require.Error(t, err, "non-42P01 errors must still propagate")
+}

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -695,6 +695,10 @@ func (s *ImportDataState) GetImportedEventsStatsForTable(tableNameTup sqlname.Na
 	err := tdb.QueryRow(query).Scan(&eventCounter.TotalEvents,
 		&eventCounter.NumInserts, &eventCounter.NumUpdates, &eventCounter.NumDeletes)
 	if err != nil {
+		if tgtdb.IsUndefinedTableError(err) {
+			// Event-count metadata table not created on target yet → no events imported.
+			return &eventCounter, nil
+		}
 		log.Errorf("error in getting import stats from target db: %v", err)
 		return nil, fmt.Errorf("error in getting import stats from target db: %w", err)
 	}
@@ -722,6 +726,12 @@ func (s *ImportDataState) GetImportedEventsStatsForTableList(tableNameTupList []
 	log.Infof("query to get import stats for tables '%s': %s", tableListQuery, query)
 	rows, err := tdb.Query(query)
 	if err != nil {
+		if tgtdb.IsUndefinedTableError(err) {
+			// Event-count metadata table not created on target yet → no events imported.
+			// tablesToEventCounter is already zero-initialized above; return it.
+			log.Infof("event-count metadata table not present yet; reporting zero imported events")
+			return tablesToEventCounter, nil
+		}
 		log.Errorf("error in getting import stats from target db: %v", err)
 		return nil, fmt.Errorf("error in getting import stats from target db: %w", err)
 	}

--- a/yb-voyager/src/tgtdb/undefined_table_error_unit_test.go
+++ b/yb-voyager/src/tgtdb/undefined_table_error_unit_test.go
@@ -1,0 +1,37 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tgtdb
+
+import (
+	"fmt"
+	"testing"
+
+	pgconn5 "github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUndefinedTableError(t *testing.T) {
+	require.True(t, IsUndefinedTableError(&pgconn5.PgError{Code: "42P01"}))
+
+	wrapped := fmt.Errorf("query failed: %w", &pgconn5.PgError{Code: "42P01"})
+	require.True(t, IsUndefinedTableError(wrapped))
+
+	require.False(t, IsUndefinedTableError(&pgconn5.PgError{Code: "42501"}))
+	require.False(t, IsUndefinedTableError(fmt.Errorf("boom")))
+	require.False(t, IsUndefinedTableError(nil))
+}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -423,6 +423,28 @@ func IsPgErrorCodeNonRetryable(err error) bool {
 	return false
 }
 
+// IsUndefinedTableError reports whether err is a PostgreSQL/YugabyteDB
+// "relation does not exist" error (SQLSTATE 42P01). This is the expected state
+// when get-data-migration-report reads the ybvoyager_metadata event-count
+// tables before import-data has created them on the target.
+func IsUndefinedTableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	const undefinedTable = "42P01"
+	// The YB/PG targets use the pgx v5 stdlib driver, so errors surface as pgconn5.
+	var pgErr5 *pgconn5.PgError
+	if errors.As(err, &pgErr5) {
+		return pgErr5.Code == undefinedTable
+	}
+	// Fallback for any pgx v4 code paths.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == undefinedTable
+	}
+	return false
+}
+
 func (yb *TargetYugabyteDB) IsNonRetryableCopyError(err error) bool {
 	if err == nil {
 		return false


### PR DESCRIPTION
## Problem

`get data-migration-report` panics with a nil-pointer dereference when it runs **before `import data` has created the target's `ybvoyager_metadata` event-count tables** — a real window in live migration, where the report is polled while `export data` / `import data` run concurrently. This is the single largest source of failures in the `integration_live_migration` and failpoint CI jobs, and it reproduces **across unrelated branches and on `main`** (i.e. it is systemic, not a per-PR regression).

Observed in CI:
```
[get data-migration-report] error while getting imported events counts for target DB:
  ERROR: relation "ybvoyager_metadata.ybvoyager_imported_event_count_by_table" does not exist (SQLSTATE 42P01)
[get data-migration-report] panic: runtime error: invalid memory address or nil pointer dereference
>>> Command FAILED: get data-migration-report (Exit Code: 2)
```

## Root cause (two stacked issues)

1. `ImportDataState.GetImportedEventsStatsForTable{,List}` query `ybvoyager_imported_event_count_by_table`. When that table doesn't exist yet the query returns **SQLSTATE 42P01** and the functions return `(nil, err)` — discarding the zero-initialized counter map they had just built (whose own comment already documents the intent: *"in case import streaming is not started yet ... initialising the tuples with empty counters"*).
2. The error reaches `utils.ErrExit`, which the live-migration **test framework monkey-patches to record-and-continue**. Execution then proceeds with a `nil` events map into `updateImportedEventsCountsInTheRow`, which dereferences it → panic (exit code 2).

"Table not created yet" is semantically identical to "zero events imported", and running the report before streaming starts is legitimate — so the correct behavior is to report zeros, not error.

## Changes

- **`tgtdb.IsUndefinedTableError`** — new helper next to `IsPgErrorCodeNonRetryable`, matching SQLSTATE `42P01`. Checks `pgconn` (pgx v5 stdlib, the driver the YB/PG targets actually use) with a pgx v4 fallback.
- **`GetImportedEventsStatsForTable` / `GetImportedEventsStatsForTableList`** — on `42P01`, return the zero-valued counter(s) instead of an error. **Any other error still propagates unchanged.**
- **`updateImportedEventsCountsInTheRow`** — defensive nil-guards on the events and snapshot maps, so the report can never panic even if a map is nil.

## Tests (both container-free, `unit`-tagged — deterministic, no Docker)

- `TestIsUndefinedTableError` — direct + wrapped `42P01` → true; other SQLSTATE / plain error / nil → false.
- `TestGetImportedEventsStatsForTableListMissingMetadataTable` — drives the **real** function via a fake target returning `42P01`; asserts a zero-filled map + `nil` error (reproduces the original failure, which errored before this fix).
- `TestGetImportedEventsStatsForTableListPropagatesOtherErrors` — a non-`42P01` error still surfaces.

## Verification

```
go build ./...                                   # ok
go vet -tags unit ./cmd/... ./src/tgtdb/...       # ok
go test -tags unit ./src/tgtdb/... -run TestIsUndefinedTableError    # PASS
go test -tags unit ./cmd/... -run TestGetImportedEventsStatsForTableList  # PASS
```

## Scope / notes

- Deliberately container-free tests, to avoid adding load to the already-contended shared-container CI jobs.
- The sibling snapshot-rows path reads from the on-disk data-file descriptor for the target role, so it is not affected by the missing metadata schema; the nil-guard covers it defensively regardless.
- Separately, the shared-container + parallelism contention in the live-migration suite is a follow-up (container-per-test / pool), to be sized against real runner memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)