### PR TITLE
[DB-21724] Increase target-side CDC event volume in live-migration resumption tests

### DIFF
--- a/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
@@ -79,9 +79,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 456
       faker_seed: 456
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 5
       update_max_retries: 1
 

--- a/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
@@ -79,9 +79,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 456
       faker_seed: 456
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 5
       update_max_retries: 1
 

--- a/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/iteration-test/scenario.yaml.template
@@ -105,9 +105,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 456
       faker_seed: 456
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 5
       update_max_retries: 1
       # Pin region/sale_date/status to valid partition values so generated rows route

--- a/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/partition-iteration-test/scenario.yaml.template
@@ -102,9 +102,9 @@ generator_target:
       operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
       random_seed: 67890
       faker_seed: 67890
-      insert_rows: 6
-      update_rows: 4
-      delete_rows: 2
+      insert_rows: 30
+      update_rows: 20
+      delete_rows: 10
       insert_max_retries: 50
       update_max_retries: 3
       column_overrides:


### PR DESCRIPTION
## Summary

Increases target-side (fall-back) **CDC event volume** across the live-migration resumption tests toward parity with the forward/source leg. Over an equal soak the target generator produces far fewer change events than the source leg, because YB writes are latency-bound so fewer operations complete in the window (measured: target was ~1/8th of source on `iteration-test`).

Ticket: **DB-21724**

## Change

`generator_target` (target side) only — `insert/update/delete_rows` `6/4/2 → 30/20/10` (keeps the `3:2:1` ratio), so each statement emits more rows without extra round-trips. Source generators unchanged. Applied to the fall-back tests:

- `iteration-test`
- `fallback-resumption-test`
- `fallback-unique-conflict-test`
- `partition-iteration-test`

**Not touched:** fall-forward (`fallf-*`) tests, and especially `fallf-large-row-resumption-test` (intentional `1/1/1` × 2 MB rows).

## Verification

Measured on the `live-migration-resumption` pipeline (YB 2025.2.3), `iteration-test`, via the exported-event counter in `meta.db` (`SELECT exporter_role, SUM(num_total) FROM exported_events_stats GROUP BY exporter_role`):

| generator_target | source (forward) | target (fall-back) |
|---|---|---|
| `6/4/2` (baseline) | 406K | 48K (~12% of source) |
| `12/8/4` | 406K | 172K (~42% of source) — **verified ~3.6×** |
| `30/20/10` (this PR) | 406K | targeting ~parity — re-verification in progress |

Source is unchanged throughout (only `generator_target` is bumped). Full runs pass all stages with row-count + row-hash validations on both legs.



Main Vs branch runs

- iteration-test: 49K → 376K ([main #979](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/979/) vs [branch #978](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/978/))
- partition-iteration-test: 64K → 123K ([main #977](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/977/) vs [branch #976](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/976/))
- fallback-resumption-test: 449K → 1.32M ([main #981](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/981/) vs [branch #980](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/980/))
- fallback-unique-conflict-test: 167K → 1.13M ([main #975](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/975/) vs [branch #974](https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/974/))




