### PR TITLE
De-flake TestExportFromTargetStartupFailureAndCutoverResume: make Debezium stop timeout configurable

### DIFF
--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -266,6 +267,21 @@ func (d *Debezium) GetExportStatus() (*ExportStatus, error) {
 	return ReadExportStatus(statusFilePath)
 }
 
+// debeziumStopTimeoutSeconds returns the number of seconds Stop() waits after
+// sending SIGTERM before force-killing the Debezium process. Defaults to 100s
+// to preserve production behavior; overridable via the DEBEZIUM_STOP_TIMEOUT_SECONDS
+// env var. Tests set a low value so Debezium teardown does not race the test's
+// process-exit timeout (source of TestExportFromTargetStartupFailureAndCutoverResume flakes).
+func debeziumStopTimeoutSeconds() int {
+	const defaultTimeoutSeconds = 100
+	if v := os.Getenv("DEBEZIUM_STOP_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultTimeoutSeconds
+}
+
 // stops debezium process gracefully if it is running
 func (d *Debezium) Stop() error {
 	if d.IsRunning() {
@@ -276,7 +292,7 @@ func (d *Debezium) Stop() error {
 		}
 		go func() {
 			// wait for a certain time for debezium to shut down before force killing the process.
-			sigtermTimeout := 100
+			sigtermTimeout := debeziumStopTimeoutSeconds()
 			time.Sleep(time.Duration(sigtermTimeout) * time.Second)
 			if d.IsRunning() {
 				log.Warnf("Waited %d seconds for debezium process to stop. Force killing it now.", sigtermTimeout)

--- a/yb-voyager/src/dbzm/debezium_stop_timeout_unit_test.go
+++ b/yb-voyager/src/dbzm/debezium_stop_timeout_unit_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package dbzm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebeziumStopTimeoutSeconds(t *testing.T) {
+	t.Run("env unset defaults to 100", func(t *testing.T) {
+		os.Unsetenv("DEBEZIUM_STOP_TIMEOUT_SECONDS")
+		require.Equal(t, 100, debeziumStopTimeoutSeconds())
+	})
+
+	t.Run("valid env value is honored", func(t *testing.T) {
+		t.Setenv("DEBEZIUM_STOP_TIMEOUT_SECONDS", "20")
+		require.Equal(t, 20, debeziumStopTimeoutSeconds())
+	})
+
+	t.Run("non-positive value falls back to default", func(t *testing.T) {
+		t.Setenv("DEBEZIUM_STOP_TIMEOUT_SECONDS", "0")
+		require.Equal(t, 100, debeziumStopTimeoutSeconds())
+	})
+
+	t.Run("unparseable value falls back to default", func(t *testing.T) {
+		t.Setenv("DEBEZIUM_STOP_TIMEOUT_SECONDS", "abc")
+		require.Equal(t, 100, debeziumStopTimeoutSeconds())
+	})
+}

--- a/yb-voyager/test/utils/voyager_cmd_runner.go
+++ b/yb-voyager/test/utils/voyager_cmd_runner.go
@@ -266,7 +266,10 @@ func (v *VoyagerCommandRunner) newCmd() {
 
 	v.Cmd.Env = append(os.Environ(),
 		"YB_VOYAGER_SEND_DIAGNOSTICS=false",
-		"DEBEZIUM_SOURCE_YB_LOAD_BALANCE_CONNECTIONS=false")
+		"DEBEZIUM_SOURCE_YB_LOAD_BALANCE_CONNECTIONS=false",
+		// Keep Debezium's SIGTERM->SIGKILL grace short in tests so process teardown
+		// stays well under test process-exit timeouts (de-flakes failpoint/live tests).
+		"DEBEZIUM_STOP_TIMEOUT_SECONDS=20")
 
 	if len(v.testEnvVars) > 0 {
 		v.Cmd.Env = append(v.Cmd.Env, v.testEnvVars...)


### PR DESCRIPTION
## Problem

`TestExportFromTargetStartupFailureAndCutoverResume` (Failpoint: Export job) is **~17% flaky** in CI and **fails on `main` too** — always with:
```
export_data_from_target_failures_test.go:191:
  Error: Received unexpected error: process did not exit after 2m0s — expected a crash
  Messages: Export-from-target should crash via failpoint
```

## Root cause — a two-timeout race (not the test's logic)

The failpoint marker *does* fire; the process just doesn't exit in time. Traced end to end:

1. The test runs `import data` async; after cutover it `syscall.Exec`s (same PID) into `export data from target`.
2. `export data from target` starts the Debezium JVM and registers an atexit hook `dbzm.(*Debezium).Stop()`.
3. The startup failpoint fires **only after Debezium is fully streaming** and returns an *error* (not `os.Exit`).
4. The error unwinds → the process exits via `atexit` → `Stop()` runs: it SIGTERMs the JVM, then blocks on `d.cmd.Wait()`, and only force-kills the JVM after a **hardcoded 100 seconds**.
5. The test polls for process exit for **120 s**, then SIGKILLs and fails.

```
Product Debezium graceful-stop budget:  SIGTERM → wait 100s → SIGKILL
Test "did it crash?" budget:                        wait 120s → give up
                                           └─ only ~20s of slack
```

Under CI load the JVM shutdown drifts and total exit time crosses 120 s → flake. This is also why #3545 (which bumped the test wait 60 s→120 s) reduced but didn't eliminate it: 120 s is only ~20 s above the product's own 100 s Debezium-stop budget.

## Fix

Make the SIGTERM→SIGKILL grace **configurable** and set it low for tests:

- **`dbzm`**: new `debeziumStopTimeoutSeconds()` reads `DEBEZIUM_STOP_TIMEOUT_SECONDS` (**default 100 s — production behavior unchanged**; non-positive / unparseable values fall back to the default). `Stop()` uses it instead of the hardcoded `100`.
- **`test/utils` `VoyagerCommandRunner`**: default `DEBEZIUM_STOP_TIMEOUT_SECONDS=20` in the launched-process env. It propagates to `export data from target` (import-data reaches it via `syscall.Exec(os.Environ())`), so Debezium teardown finishes far inside the test's exit window.

This de-flakes the **whole class** of failpoint/live tests that tear down Debezium, not just this one test, and doesn't widen a window — it removes the near-collision.

## Tests

Container-free `unit` test for `debeziumStopTimeoutSeconds`: unset→100, `"20"`→20, `"0"`→100, `"abc"`→100.

## Verification
```
go build ./...                                                              # ok
go vet -tags unit ./src/dbzm/... ./test/utils/...                            # ok
go test -tags unit ./src/dbzm/... -run TestDebeziumStopTimeoutSeconds        # PASS
```

## Notes
- 20 s is comfortably above a normal Debezium SIGTERM shutdown (a few seconds), so graceful teardown in passing tests is unaffected; the force-kill only triggers if the JVM is genuinely hung.
- The end-to-end confirmation is the Failpoint: Export job on this PR (and reduced flake over repeated runs); the unit test only covers the timeout-selection logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)