### PR TITLE
Stamp generator on-disk output with absolute wall-clock time

### DIFF
--- a/migtests/scripts/event-generator/parallel_generator.py
+++ b/migtests/scripts/event-generator/parallel_generator.py
@@ -300,8 +300,14 @@ def monitor(cursor, worker_procs, run_seconds, monitor_interval_seconds):
             interval = now - last_sample_time
             rate = (cur_sum - last_sum) / interval if interval > 0 else 0.0
             samples.append(rate)
+            # Stamp each sample with an absolute wall-clock time (epoch + UTC
+            # ISO) in addition to the relative t=, so this generator-side series
+            # (machine B) can be joined by timestamp against the monitor CSV and
+            # a Prometheus cdcsdk_flush_lag export (machine A / YB) after the run.
+            now_wall = time.time()
             print(
-                "[monitor] aggregate rate = {:.1f} ev/s (t={:.0f}s, total events so far: {})".format(
+                "[monitor] ts={:.3f} ({}) aggregate rate = {:.1f} ev/s (t={:.0f}s, total events so far: {})".format(
+                    now_wall, time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now_wall)),
                     rate, now - run_start, cur_sum
                 )
             )

--- a/migtests/scripts/event-generator/rate_governor.py
+++ b/migtests/scripts/event-generator/rate_governor.py
@@ -38,7 +38,8 @@ class RateGovernor(object):
     """
 
     def __init__(self, rate_control, *, random_seed=None,
-                 clock=time.monotonic, sleep=time.sleep, log=print):
+                 clock=time.monotonic, sleep=time.sleep, log=print,
+                 wall_clock=time.time):
         self.default_events_per_second = rate_control["default_events_per_second"]
         self.report_interval = rate_control.get("report_interval_seconds", 0) or 0
         self.schedule = rate_control.get("schedule") or []
@@ -55,6 +56,11 @@ class RateGovernor(object):
         self._clock = clock
         self._sleep = sleep
         self._log = log
+        # Wall-clock (real epoch) source, separate from the pacing `clock`
+        # (monotonic). Only used to stamp report lines with an absolute time so
+        # they can be joined against other timestamped series (monitor CSV,
+        # Prometheus cdcsdk_flush_lag, ...) after the run. Injected for tests.
+        self._wall_clock = wall_clock
 
         # Pacing state.
         self.run_start = self._clock()
@@ -167,8 +173,10 @@ class RateGovernor(object):
         if self.report_interval > 0 and now - self.last_report >= self.report_interval:
             elapsed_since_report = now - self.last_report
             achieved = self.report_events / elapsed_since_report if elapsed_since_report > 0 else 0.0
+            wall = self._wall_clock()
             self._log(
-                "[rate_governor] achieved={:.1f} ev/s target={} total_events={}".format(
+                "[rate_governor] ts={:.3f} ({}) achieved={:.1f} ev/s target={} total_events={}".format(
+                    wall, time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(wall)),
                     achieved, self.current_target, self.total_events
                 )
             )


### PR DESCRIPTION
## What

Adds an absolute timestamp (epoch + UTC ISO) to the two generator-side records written to disk during a run:

- `parallel_generator.py` — the per-sample `[monitor] aggregate rate …` line
- `rate_governor.py` — the `[rate_governor] achieved=…` report line, via an injected `wall_clock=time.time` kept separate from the monotonic pacing clock (tests stay deterministic)

## Why

The monitor CSV already has an `epoch` column; the generator side only logged relative `t=…s`. With everything on an absolute clock, three series can be **joined by timestamp** after a run:

1. generator throughput (machine B)
2. monitor export/import/lag CSV (machine A)
3. a Prometheus `cdcsdk_flush_lag` export (YB)

This is the agreed approach for replication lag: pull `cdcsdk_flush_lag` from Prometheus later and map it in by wall-clock, rather than computing lag from byte-LSN math — which is invalid on YugabyteDB (`pg_current_wal_lsn` / `pg_wal_lsn_diff` are unsupported and LSN is not a byte offset, per YB's logical-replication docs).

## Scope

- **Does not touch** the existing `slot_lag_bytes` code on this branch (left as-is per discussion).
- Heads-up @abhinay: that `slot_lag_bytes` byte-LSN calc won't produce a meaningful value on YB for the same reason above — worth revisiting separately (time-based `cdcsdk_flush_lag` / `pg_stat_replication.flush_lag` instead).

## Verification

- `rate_governor` unit suite: 12/12 pass (py3.9).
- Report line now emits `ts=<epoch> (<ISO>Z) achieved=…`.
- `parallel_generator.py` compiles; the edit is an isolated `print` format in `monitor()` (untouched by the pure-function tests, which need psycopg2 that isn't on the local interpreter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)