### PR TITLE
Fix concurrent CREATE/DROP DATABASE failures in migtests on YB 2026.1+

### DIFF
--- a/migtests/scripts/callhome/run-callhome-test.sh
+++ b/migtests/scripts/callhome/run-callhome-test.sh
@@ -143,8 +143,7 @@ main() {
     fi
 
     step "Create target database."
-    ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
-    run_ysql yugabyte "CREATE DATABASE  \"${TARGET_DB_NAME}\" with COLOCATION=TRUE;"
+    create_target_database "${TARGET_DB_NAME}" true
 
     step "Export schema"
     export_schema --send-diagnostics=true

--- a/migtests/scripts/functions.sh
+++ b/migtests/scripts/functions.sh
@@ -93,17 +93,73 @@ run_ysql() {
 	PGPASSWORD="${TARGET_DB_ADMIN_PASSWORD}" psql -P pager=off -h ${TARGET_DB_HOST} -p ${TARGET_DB_PORT} -U ${TARGET_DB_ADMIN_USER} -d ${db_name} -c "${sql}"
 }
 
-# TODO: Remove this helper (and all its call-sites) once the underlying
+# Newer YB versions (2026.1+) no longer support concurrent CREATE DATABASE.
+# When parallel migtests create/drop databases on the same target at once, a
+# concurrent CREATE can partially apply and then abort with "Catalog Version
+# Mismatch", leaving an orphaned keyspace with no pg_database row. A later
+# DROP DATABASE IF EXISTS is then a no-op (nothing in the catalog to drop) and
+# the next CREATE fails with "Keyspace '<name>' already exists" — which retries
+# cannot recover from.
+#
+# So we serialize create/drop with a host-level file lock: only one test does a
+# create-or-drop DATABASE at a time, and the collision never happens. flock only
+# serializes processes that share this lockfile's filesystem (i.e. run on the
+# same agent), which our parallel migtests do. It does NOT serialize whole tests
+# — only the few seconds of create/drop.
+YB_DB_LOCK_FILE="${YB_DB_LOCK_FILE:-/tmp/yb_create_drop_database.lock}"
+
+# TODO: Remove this terminate step (and the DB-14314 note) once the underlying
 # Voyager bug is fixed: https://yugabyte.atlassian.net/browse/DB-14314
-# target-side disconnect() does not close the sql.DB handle, leaving
-# stale sessions that block DROP DATABASE.
-# Once that is fixed, a plain `DROP DATABASE IF EXISTS "<name>";` should
-# suffice and this workaround can be removed.
-ysql_terminate_and_drop_database() {
+# target-side disconnect() does not close the sql.DB handle, leaving stale
+# sessions that block DROP DATABASE. Once fixed, a plain
+# `DROP DATABASE IF EXISTS "<name>";` suffices and the terminate can be removed.
+#
+# Unlocked core: assumes the caller already holds YB_DB_LOCK_FILE.
+_ysql_terminate_and_drop_database_unlocked() {
 	local target_db_to_drop=$1
 	run_ysql yugabyte "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${target_db_to_drop}' AND pid != pg_backend_pid();" || true
 	sleep 1
 	run_ysql yugabyte "DROP DATABASE IF EXISTS \"${target_db_to_drop}\";"
+}
+
+# Public entrypoint for standalone drops (e.g. end-of-test cleanup). Takes the
+# same lock as create_target_database so create and drop are serialized together.
+ysql_terminate_and_drop_database() {
+	(
+		flock 200
+		_ysql_terminate_and_drop_database_unlocked "$1"
+	) 200>"${YB_DB_LOCK_FILE}"
+}
+
+# (Re)create the target database under the same lock. Holds the lock across the
+# drop+create so no other test can create/drop concurrently. Retries stay as a
+# cheap fallback for any residual transient failure (should be rare once
+# create/drop are serialized).
+# Usage: create_target_database <db_name> [colocated]   # colocated defaults to true
+create_target_database() {
+	local target_db=$1
+	local colocated=${2:-true}
+	local create_sql="CREATE DATABASE \"${target_db}\""
+	if [ "${colocated}" = "true" ]; then
+		create_sql="${create_sql} WITH COLOCATION=TRUE"
+	fi
+
+	(
+		flock 200
+		local max_attempts=5
+		local attempt=1
+		while [ ${attempt} -le ${max_attempts} ]; do
+			_ysql_terminate_and_drop_database_unlocked "${target_db}" || true
+			if run_ysql yugabyte "${create_sql}"; then
+				exit 0
+			fi
+			echo "CREATE DATABASE for '${target_db}' failed (attempt ${attempt}/${max_attempts}); retrying in 10s..."
+			sleep 10
+			attempt=$((attempt + 1))
+		done
+		echo "ERROR: CREATE DATABASE for '${target_db}' failed after ${max_attempts} attempts"
+		exit 1
+	) 200>"${YB_DB_LOCK_FILE}"
 }
 
 ysql_import_file() {

--- a/migtests/scripts/live-migration-fallb-run-test.sh
+++ b/migtests/scripts/live-migration-fallb-run-test.sh
@@ -144,11 +144,10 @@ main() {
 	tail -20 ${EXPORT_DIR}/reports/schema_analysis_report.json
 
 	step "Create target database."
-	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
+		create_target_database "${TARGET_DB_NAME}" true
 	else
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\""
+		create_target_database "${TARGET_DB_NAME}" false
 	fi
 
 	step "Import schema."

--- a/migtests/scripts/live-migration-fallf-run-test.sh
+++ b/migtests/scripts/live-migration-fallf-run-test.sh
@@ -141,11 +141,10 @@ main() {
 	tail -20 ${EXPORT_DIR}/reports/schema_analysis_report.json
 
 	step "Create target database."
-	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
+		create_target_database "${TARGET_DB_NAME}" true
 	else
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\""
+		create_target_database "${TARGET_DB_NAME}" false
 	fi
 
 	step "Import schema."

--- a/migtests/scripts/live-migration-run-test.sh
+++ b/migtests/scripts/live-migration-run-test.sh
@@ -134,11 +134,10 @@ main() {
 	tail -20 ${EXPORT_DIR}/reports/schema_analysis_report.json
 
 	step "Create target database."
-	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
+		create_target_database "${TARGET_DB_NAME}" true
 	else
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\""
+		create_target_database "${TARGET_DB_NAME}" false
 	fi
 
 	step "Import schema."

--- a/migtests/scripts/run-schema-migration.sh
+++ b/migtests/scripts/run-schema-migration.sh
@@ -98,8 +98,7 @@ main() {
 	compare_json_reports "${TEST_DIR}/expected_files/expected_schema_analysis_report.json" "${EXPORT_DIR}/reports/schema_analysis_report.json"
 
 	step "Create target database."
-	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
-	run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
+	create_target_database "${TARGET_DB_NAME}" true
 
 	step "Import schema."
 	import_schema --continue-on-error t

--- a/migtests/scripts/run-test.sh
+++ b/migtests/scripts/run-test.sh
@@ -164,11 +164,10 @@ main() {
 	fi
 
 	step "Create target database."
-	ysql_terminate_and_drop_database "${TARGET_DB_NAME}"
 	if [ "${SOURCE_DB_TYPE}" = "postgresql" ] || [ "${SOURCE_DB_TYPE}" = "oracle" ]; then
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\" with COLOCATION=TRUE"
+		create_target_database "${TARGET_DB_NAME}" true
 	else
-		run_ysql yugabyte "CREATE DATABASE \"${TARGET_DB_NAME}\""
+		create_target_database "${TARGET_DB_NAME}" false
 	fi
 
 	step "Import schema."


### PR DESCRIPTION
### Describe the changes in this pull request

Serialize target `CREATE`/`DROP DATABASE` in the migtest harness so parallel tests no longer fail with concurrent-DDL errors on **YB 2026.1+**.

**Problem.** YB 2026.1+ no longer supports concurrent `CREATE DATABASE`. When migtests run in parallel against the same target and create/drop databases at the same time, we see:
- `Restart read required / Catalog Version Mismatch` — a concurrent DDL bumped the catalog version mid-statement.
- `Keyspace '<name>' already exists` — a concurrent `CREATE` partially applied (the DocDB keyspace was created) and then aborted, leaving an **orphaned keyspace with no `pg_database` row**. A later `DROP DATABASE IF EXISTS` is then a no-op (nothing in the catalog to drop), so the next `CREATE` keeps failing. Retries cannot recover this case.

This was clean on 2025.2.3.0-b149 and started failing on 2026.1.0.0-b118. Confirmed with the YB team that concurrent `CREATE DATABASE` is unsupported from 2026.1.

**Fix.** Guard target create/drop with a host-level `flock` (`YB_DB_LOCK_FILE`) so only one test does a create-or-drop `DATABASE` at a time — the collision never happens. This does **not** serialize whole tests, only the few seconds of create/drop. A small retry loop remains as a fallback for any residual transient failure.

- `functions.sh`: add `YB_DB_LOCK_FILE` + `create_target_database` helper; the standalone drop (`ysql_terminate_and_drop_database`) now takes the same lock, so create and drop are serialized together. The DB-14314 terminate-stale-sessions workaround is preserved.
- `run-test.sh`, `live-migration-run-test.sh`, `live-migration-fallb-run-test.sh`, `live-migration-fallf-run-test.sh`, `run-schema-migration.sh`, `callhome/run-callhome-test.sh`: create the target DB via `create_target_database`.

`flock` only serializes processes that share the lockfile's filesystem (i.e. run on the same agent), which the parallel migtests do. `YB_DB_LOCK_FILE` is env-overridable so the path can be pointed at a shared volume if any tests ever run in isolated containers.

Out of scope: the import-file and resumption test frameworks create their target DB directly and are not part of the failing set.

### Describe if there are any user-facing changes

None. Test-harness only (`migtests/scripts/`); no changes to `yb-voyager` itself.

### How was this pull request tested?

- Existing migtests are the coverage; this only changes how they create/drop the target DB.
- Verified the lock logic in isolation (stubbed `run_ysql`): concurrent creates + a standalone drop are fully serialized with no overlap, no self-deadlock (create's internal drop runs on the unlocked core while holding the lock), and return codes propagate.
- To be validated by running both pipelines: passes on the older YB version (no regression) and fixes the failures on 2026.1.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
