### PR TITLE
migtests: raise fallback-unique-conflict backlog-drain timeout to 1800s

### DIFF
--- a/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
@@ -206,7 +206,7 @@ stages:
   - name: wait_backlog_zero
     action: wait_for
     condition: remaining_events_eq_0
-    timeout_sec: 1200
+    timeout_sec: 1800
 
   # Confirm the conflict-detection cache actually fired on the forward (PG->YB)
   # import, not just that row_count/row_hash matched.


### PR DESCRIPTION
Nightly intermittently timed out around cutover under heavy conflict load. Give the backlog-drain wait (`remaining_events_eq_0` / `wait_backlog_zero`) more room to drain before cutover: 1200s → 1800s. Cutover-to-target wait left at 900s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)