### PR TITLE
Fix: do not include the columns from the INCLUDE clause of a covering unique index 

### DIFF
--- a/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
@@ -1557,3 +1557,107 @@ func TestLiveMigrationCdcPartitionKeyRejectsPkOnExpressionUniqueIndex(t *testing
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
 }
+
+func TestLiveMigrationWithCoveringUniqueKeyIndex(t *testing.T) {
+	lm := NewLiveMigrationTest(t, &TestConfig{
+		SourceDB: ContainerConfig{
+			Type:         "postgresql",
+			ForLive:      true,
+			DatabaseName: "covering_uk",
+		},
+		TargetDB: ContainerConfig{
+			Type:         "yugabytedb",
+			DatabaseName: "covering_uk",
+		},
+		SchemaNames: []string{"test_schema"},
+		SchemaSQL: []string{
+			`CREATE SCHEMA IF NOT EXISTS test_schema;
+			CREATE TABLE test_schema.users (
+				id int PRIMARY KEY,
+				email TEXT
+			);
+			CREATE UNIQUE INDEX users_lower_email_uidx ON test_schema.users (email) INCLUDE (id);`,
+		},
+		SourceSetupSchemaSQL: []string{
+			`ALTER TABLE test_schema.users REPLICA IDENTITY FULL;`,
+		},
+		InitialDataSQL: []string{
+			`INSERT INTO test_schema.users (id, email) SELECT i, 'user_' || i || '@example.com' FROM generate_series(1, 10) i;`,
+		},
+		SourceDeltaSQL: []string{
+			`
+		  DO $$
+		  BEGIN
+			FOR i IN 11..510 LOOP
+			  UPDATE test_schema.users SET email = 'user_' || i || '@example.com' WHERE id = i-1;
+			  INSERT INTO test_schema.users (id, email) SELECT i, 'user_' || 10 || '@example.com';
+
+			  DELETE FROM test_schema.users WHERE id = i-1;
+			  UPDATE test_schema.users SET email = 'user_' || i || '@example.com' WHERE id = i;
+
+			  INSERT INTO test_schema.users (id, email) SELECT i-1, 'user_' || 10 || '@example.com';
+
+			  DELETE FROM test_schema.users WHERE id = i;
+			  UPDATE test_schema.users SET email = 'user_' || i || '@example.com' WHERE id = i-1;
+			  INSERT INTO test_schema.users (id, email) SELECT i, 'user_' || 10 || '@example.com';
+
+			END LOOP;
+		  END $$;
+		  `,
+		},
+		CleanupSQL: []string{
+			`DROP SCHEMA IF EXISTS test_schema CASCADE;`,
+		},
+	})
+	defer lm.Cleanup()
+
+	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
+		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+	)
+	uniqueKeyConflictStatsPath := filepath.Join(
+		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
+
+	err := lm.SetupContainers(context.Background())
+	testutils.FatalIfError(t, err, "failed to setup containers")
+
+	err = lm.SetupSchema()
+	testutils.FatalIfError(t, err, "failed to setup schema")
+
+	err = lm.StartExportData(true, nil)
+	testutils.FatalIfError(t, err, "failed to start export data")
+
+	err = lm.StartImportDataWithEnv(true, nil, []string{uniqueKeyConflictCountFailpointEnv})
+	testutils.FatalIfError(t, err, "failed to start import data")
+
+	err = lm.WaitForSnapshotComplete(map[string]int64{
+		`"test_schema"."users"`: 10,
+	}, 30)
+	testutils.FatalIfError(t, err, "failed to wait for snapshot complete")
+
+	err = lm.ValidateDataConsistency([]string{`"test_schema"."users"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
+
+	err = lm.ExecuteSourceDelta()
+	testutils.FatalIfError(t, err, "failed to execute source delta")
+
+	err = lm.WaitForForwardStreamingComplete(map[string]ChangesCount{
+		`"test_schema"."users"`: {Inserts: 1500,Updates: 1500, Deletes: 1000},
+	}, 60, 1)
+	testutils.FatalIfError(t, err, "failed to wait for forward streaming complete")
+
+	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
+	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
+	require.GreaterOrEqual(t, conflictStats.Total, 1500,
+		"covering UK delta should produce unique-key conflicts")
+	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."users"`], 1,
+		"covering UK conflicts should be attributed to the table")
+
+	err = lm.ValidateDataConsistency([]string{`"test_schema"."users"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate streaming data consistency")
+
+	err = lm.InitiateCutoverToTarget(false, nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover")
+
+	err = lm.WaitForCutoverComplete(0, 30)
+	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
+}

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -432,6 +432,7 @@ func (pg *TargetPostgreSQL) GetTableToUniqueIndexesMap(tableList []sqlname.NameT
 // (contype 'u'); only primary-key indexes (contype 'p') are excluded.
 // It is used for both PostgreSQL and YugabyteDB targets since YugabyteDB is
 // PG-compatible at the catalog level.
+//Note: this query doesn't include the key columns having expression in it.
 const pgQueryTmplForUniqIndexes = `
 WITH unique_indexes AS (
     SELECT

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -459,6 +459,10 @@ WITH unique_indexes AS (
     WHERE
         ix.indisunique = TRUE
         AND c.contype IS NULL
+        -- indkey (int2vector) is 0-indexed, so array_position returns a 0-based position
+        -- (matching the "+ 1" used for ordinal_position above). Only the first indnkeyatts
+        -- entries are key columns; the rest are INCLUDE (covering) columns, so exclude them.
+        AND array_position(ix.indkey, a.attnum) + 1 <= ix.indnkeyatts
         AND n.nspname = ANY('{%s}')
         AND t.relname = ANY('{%s}')
     GROUP BY

--- a/yb-voyager/src/tgtdb/postgres_test.go
+++ b/yb-voyager/src/tgtdb/postgres_test.go
@@ -268,6 +268,7 @@ func TestPostgresTargetGetTableToUniqueIndexesMap(t *testing.T) {
 		);`,
 		`CREATE UNIQUE INDEX idx_partial_check_id ON test_schema.partial_unique_table (check_id) WHERE most_recent;`,
 		// expression-only unique index has no plain columns, so the table should not appear
+		`CREATE UNIQUE INDEX idx_partial_check_id_include ON test_schema.partial_unique_table ((check_id+id)) INCLUDE (most_recent);`, //this won't reflect in the query results as we don't really fetch indexes properly that have expressions in the key
 		`CREATE TABLE test_schema.expression_unique_table (
 			id SERIAL PRIMARY KEY,
 			email TEXT
@@ -281,6 +282,12 @@ func TestPostgresTargetGetTableToUniqueIndexesMap(t *testing.T) {
 		);`,
 		`CREATE UNIQUE INDEX idx_mixed_expr ON test_schema.mixed_expression_unique_table (lower(email), code);`,
 		`CREATE UNIQUE INDEX idx_including_unique ON test_schema.mixed_expression_unique_table (email) INCLUDE (code);`,
+		`CREATE TABLE test_schema.unique_table_with_include (
+			id SERIAL PRIMARY KEY,
+			email TEXT,
+			code TEXT,
+			UNIQUE (code) INCLUDE (email)
+		);`,
 	)
 	defer testPostgresTarget.ExecuteSqls(
 		`DROP SCHEMA test_schema CASCADE;`,
@@ -298,6 +305,7 @@ func TestPostgresTargetGetTableToUniqueIndexesMap(t *testing.T) {
 		testutils.CreateNameTupleWithTargetName("test_schema.partial_unique_table", "public", POSTGRESQL),
 		testutils.CreateNameTupleWithTargetName("test_schema.expression_unique_table", "public", POSTGRESQL),
 		testutils.CreateNameTupleWithTargetName("test_schema.mixed_expression_unique_table", "public", POSTGRESQL),
+		testutils.CreateNameTupleWithTargetName("test_schema.unique_table_with_include", "public", YUGABYTEDB),
 	}
 
 	actualIndexes, err := testPostgresTarget.GetTableToUniqueIndexesMap(tablesList)
@@ -336,6 +344,9 @@ func TestPostgresTargetGetTableToUniqueIndexesMap(t *testing.T) {
 	expectedIndexesByTable.Put(testutils.CreateNameTupleWithTargetName("test_schema.mixed_expression_unique_table", "public", POSTGRESQL), []UniqueIndex{
 		{Columns: []string{"code"}},
 		{Columns: []string{"email"}},
+	})
+	expectedIndexesByTable.Put(testutils.CreateNameTupleWithTargetName("test_schema.unique_table_with_include", "public", YUGABYTEDB), []UniqueIndex{
+		{Columns: []string{"code"}},
 	})
 
 	assert.Equal(t, len(expectedIndexesByTable.Keys()), len(actualIndexes.Keys()), "Expected number of tables to match")

--- a/yb-voyager/src/tgtdb/postgres_test.go
+++ b/yb-voyager/src/tgtdb/postgres_test.go
@@ -280,6 +280,7 @@ func TestPostgresTargetGetTableToUniqueIndexesMap(t *testing.T) {
 			code TEXT
 		);`,
 		`CREATE UNIQUE INDEX idx_mixed_expr ON test_schema.mixed_expression_unique_table (lower(email), code);`,
+		`CREATE UNIQUE INDEX idx_including_unique ON test_schema.mixed_expression_unique_table (email) INCLUDE (code);`,
 	)
 	defer testPostgresTarget.ExecuteSqls(
 		`DROP SCHEMA test_schema CASCADE;`,
@@ -334,6 +335,7 @@ func TestPostgresTargetGetTableToUniqueIndexesMap(t *testing.T) {
 	})
 	expectedIndexesByTable.Put(testutils.CreateNameTupleWithTargetName("test_schema.mixed_expression_unique_table", "public", POSTGRESQL), []UniqueIndex{
 		{Columns: []string{"code"}},
+		{Columns: []string{"email"}},
 	})
 
 	assert.Equal(t, len(expectedIndexesByTable.Keys()), len(actualIndexes.Keys()), "Expected number of tables to match")

--- a/yb-voyager/src/tgtdb/yugabytedb_test.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_test.go
@@ -387,6 +387,8 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 			code TEXT
 		);`,
 		`CREATE UNIQUE INDEX idx_mixed_expr ON test_schema.mixed_expression_unique_table (lower(email), code);`,
+
+		`CREATE UNIQUE INDEX idx_including_unique ON test_schema.mixed_expression_unique_table (email) INCLUDE (code);`,
 	)
 	defer testYugabyteDBTarget.ExecuteSqls(
 		`DROP SCHEMA test_schema CASCADE;`,
@@ -444,6 +446,7 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 	})
 	expectedIndexesByTable.Put(testutils.CreateNameTupleWithTargetName("test_schema.mixed_expression_unique_table", "public", YUGABYTEDB), []UniqueIndex{
 		{Columns: []string{"code"}},
+		{Columns: []string{"email"}},
 	})
 
 	assert.Equal(t, len(expectedIndexesByTable.Keys()), len(actualIndexes.Keys()), "Expected number of tables to match")

--- a/yb-voyager/src/tgtdb/yugabytedb_test.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_test.go
@@ -392,6 +392,13 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 
 		`CREATE UNIQUE INDEX idx_including_unique ON test_schema.mixed_expression_unique_table (email) INCLUDE (code);`,
 
+		`CREATE TABLE test_schema.unique_table_with_include (
+			id SERIAL PRIMARY KEY,
+			email TEXT,
+			code TEXT,
+			UNIQUE (code) INCLUDE (email)
+		);`,
+
 	)
 	defer testYugabyteDBTarget.ExecuteSqls(
 		`DROP SCHEMA test_schema CASCADE;`,
@@ -409,6 +416,7 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 		testutils.CreateNameTupleWithTargetName("test_schema.partial_unique_table", "public", YUGABYTEDB),
 		testutils.CreateNameTupleWithTargetName("test_schema.expression_unique_table", "public", YUGABYTEDB),
 		testutils.CreateNameTupleWithTargetName("test_schema.mixed_expression_unique_table", "public", YUGABYTEDB),
+		testutils.CreateNameTupleWithTargetName("test_schema.unique_table_with_include", "public", YUGABYTEDB),
 	}
 
 	actualIndexes, err := testYugabyteDBTarget.GetTableToUniqueIndexesMap(tablesList)
@@ -452,6 +460,10 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 		{Columns: []string{"email"}},
 	})
 
+	expectedIndexesByTable.Put(testutils.CreateNameTupleWithTargetName("test_schema.unique_table_with_include", "public", YUGABYTEDB), []UniqueIndex{
+		{Columns: []string{"code"}},
+	})
+
 	assert.Equal(t, len(expectedIndexesByTable.Keys()), len(actualIndexes.Keys()), "Expected number of tables to match")
 
 	expectedIndexesByTable.IterKV(func(table sqlname.NameTuple, expectedIndexes []UniqueIndex) (bool, error) {
@@ -460,6 +472,9 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 			t.Errorf("Expected table %s not found in unique indexes map", table)
 			return true, nil
 		}
+		t.Logf("table: %s", table)
+		t.Logf("expectedIndexes: %v", expectedIndexes)
+		t.Logf("actualIndexesForTable: %v", actualIndexesForTable)
 		assertEqualUniqueIndexes(t, expectedIndexes, actualIndexesForTable)
 		return true, nil
 	})

--- a/yb-voyager/src/tgtdb/yugabytedb_test.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_test.go
@@ -374,6 +374,8 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 			most_recent BOOLEAN
 		);`,
 		`CREATE UNIQUE INDEX idx_partial_check_id ON test_schema.partial_unique_table (check_id) WHERE most_recent;`,
+		`CREATE UNIQUE INDEX idx_partial_check_id_include ON test_schema.partial_unique_table ((check_id+id)) INCLUDE (most_recent);`, //this won't reflect in the query results as we don't really fetch indexes properly that have expressions in the key
+
 		// expression-only unique index has no plain columns, so the table should not appear
 		`CREATE TABLE test_schema.expression_unique_table (
 			id SERIAL PRIMARY KEY,
@@ -389,6 +391,7 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 		`CREATE UNIQUE INDEX idx_mixed_expr ON test_schema.mixed_expression_unique_table (lower(email), code);`,
 
 		`CREATE UNIQUE INDEX idx_including_unique ON test_schema.mixed_expression_unique_table (email) INCLUDE (code);`,
+
 	)
 	defer testYugabyteDBTarget.ExecuteSqls(
 		`DROP SCHEMA test_schema CASCADE;`,

--- a/yb-voyager/src/tgtdb/yugabytedb_test.go
+++ b/yb-voyager/src/tgtdb/yugabytedb_test.go
@@ -472,9 +472,6 @@ func TestYugabyteGetTableToUniqueIndexesMap(t *testing.T) {
 			t.Errorf("Expected table %s not found in unique indexes map", table)
 			return true, nil
 		}
-		t.Logf("table: %s", table)
-		t.Logf("expectedIndexes: %v", expectedIndexes)
-		t.Logf("actualIndexesForTable: %v", actualIndexesForTable)
 		assertEqualUniqueIndexes(t, expectedIndexes, actualIndexesForTable)
 		return true, nil
 	})


### PR DESCRIPTION

### Describe the changes in this pull request

fixes: #3701

The unique-index discovery query (`pgQueryTmplForUniqIndexes` in `tgtdb/postgres.go`), used for unique-key conflict detection during live migration and shared by both the PostgreSQL and YugabyteDB targets, was incorrectly treating the covering columns of a covering unique index (`CREATE UNIQUE INDEX ... (a) INCLUDE (b)` or `UNIQUE (a) INCLUDE (b)`) as part of the uniqueness key. This made conflict detection compare against columns that are not actually part of the unique constraint.

The fix adds the predicate `AND array_position(ix.indkey, a.attnum) + 1 <= ix.indnkeyatts`, which keeps only the first `indnkeyatts` key columns and drops the INCLUDE (covering) columns. The `array_position(ix.indkey, …) + 1` idiom matches the existing 1-based `ordinal_position` computation a few lines above (`indkey` is a 0-indexed `int2vector`), so key columns map to `1..indnkeyatts` and covering columns to `> indnkeyatts` with no off-by-one. Since the template backs both PG and YB targets, this single change fixes both, and expression key entries (`attnum 0`) are unaffected because they don't join to a real `pg_attribute` row.

### Describe if there are any user-facing changes

No user-facing changes. This is an internal correctness fix to unique-key conflict detection during live migration; there are no changes to the command line, configuration, installation, or reports.

### How was this pull request tested?

- **Unit tests** in `tgtdb/postgres_test.go` and `tgtdb/yugabytedb_test.go` (`TestPostgresTargetGetTableToUniqueIndexesMap` / `TestYugabyteGetTableToUniqueIndexesMap`): added covering unique indexes — `... (email) INCLUDE (code)` and a `UNIQUE (code) INCLUDE (email)` table constraint — and assert the discovered columns exclude the INCLUDE column (e.g. `{email}` / `{code}`, not `{email, code}`) on both PG and YB targets. Also added an expression-key covering index case to confirm it is (correctly) not returned.
- **Integration test** `TestLiveMigrationWithCoveringUniqueKeyIndex` in `src/testlivemigration/live_migration_uk_conflict_test.go` (under the `failpoint_import` tag): an end-to-end PG→YB live migration on a table with a covering unique index, running a delta workload of inserts/updates/deletes that provokes unique-key conflicts, asserting conflicts are still detected and attributed to the table, and validating data consistency through cutover.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component |
| :----------------------------------------------: |
| MetaDB |
| Name registry json |
| Data File Descriptor Json |
| Export Snapshot Status Json |
| Callhome Json |
| Export Status Json |
| YugabyteD Tables |
| TargetDB Metadata Tables |
| Schema Dump |
| AssessmentDB |
| Migration Assessment Report Json |
| Import Data State |
| Export and import data queue |
| Data .sql files of tables |