### PR TITLE
Disable sequential scan on live-migration metadata UPDATE queries

### DIFF
--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1290,6 +1290,9 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		}
 
 		updateVsnQuery := batch.GetChannelMetadataUpdateQuery(migrationUUID)
+		if yb.tconf.DisableSequentialScanOnUpdateDeletes {
+			updateVsnQuery = DISABLE_SEQUENTIAL_SCAN_ON_UPDATE_DELETES_HINT + updateVsnQuery
+		}
 		res, err = tx.Exec(context.Background(), updateVsnQuery)
 		if err != nil || res.RowsAffected() == 0 {
 			log.Errorf("error executing stmt for batch(%s): %v, rowsAffected: %v", batch.ID(), err, res.RowsAffected())
@@ -1301,6 +1304,9 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		tableNames := batch.GetTableNames()
 		for _, tableName := range tableNames {
 			updateTableStatsQuery := batch.GetQueriesToUpdateEventStatsByTable(migrationUUID, tableName)
+			if yb.tconf.DisableSequentialScanOnUpdateDeletes {
+				updateTableStatsQuery = DISABLE_SEQUENTIAL_SCAN_ON_UPDATE_DELETES_HINT + updateTableStatsQuery
+			}
 			res, err = tx.Exec(context.Background(), updateTableStatsQuery)
 			if err != nil {
 				log.Errorf("error executing stmt: %v, rowsAffected: %v", err, res.RowsAffected())


### PR DESCRIPTION
### Describe the changes in this pull request

Applies the existing `DISABLE_SEQUENTIAL_SCAN_ON_UPDATE_DELETES_HINT` (`/*+ Set(enable_seqscan off) */`) to the two live-migration metadata `UPDATE` queries in `TargetYugabyteDB.ExecuteBatch` (`yb-voyager/src/tgtdb/yugabytedb.go`):

- the channel-metadata update (`ybvoyager_import_data_event_channels_metainfo`)
- the per-table event-stats update (`ybvoyager_imported_event_count_by_table`)

Both are gated on the existing `tconf.DisableSequentialScanOnUpdateDeletes` flag (CLI `--disable-sequential-scan-on-update-deletes`, default `true`). Previously the hint was applied only to data-table `UPDATE`/`DELETE` events, not to these metadata tables.

**Root cause:** These metadata tables are very small (row count = channels x tables), so YugabyteDB's cost-based optimizer sometimes picks a sequential scan for the `UPDATE`s. Under `REPEATABLE READ` isolation, a sequential scan concurrent with other writes triggers read-restart errors.

**Fix:** Applying the hint forces an index/PK scan for these metadata `UPDATE`s, which avoids the read restarts.

### Describe if there are any user-facing changes

No user-facing changes. The behavior is controlled by the pre-existing `--disable-sequential-scan-on-update-deletes` flag (default `true`); no new commands, configuration, installation, or report changes.

### How was this pull request tested?

The change reuses the existing hint constant and the existing flag gating already covered for data-table events, extending it to the two metadata `UPDATE` queries.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No. There are no changes to callhome or yugabyted payloads.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. This only prepends a query hint to two existing `UPDATE` statements against the TargetDB metadata tables; it does not change any on-disk structure or schema.

---

### Context

Slack thread: https://yugabyte.slack.com/archives/C0BLZN7BWTF/p1785747616392559?thread_ts=1785747284.077929&cid=C0BLZN7BWTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWrxpbXuw4PDdY3b6gS1e2)_