### PR TITLE
Guardrail for cdc-partition-key-overrides to error out properly in case it changes in between the runs

### DIFF
--- a/yb-voyager/cmd/exportDataStatus.go
+++ b/yb-voyager/cmd/exportDataStatus.go
@@ -286,7 +286,7 @@ func startExportPB(progressContainer *mpb.Progress, mapKey string, quitChan chan
 				utils.ErrExit("Error while reading file: %s: %v", tableDataFile.Name(), err)
 			}
 			if isDataLine(line, source.DBType, &insideCopyStmt) {
-				tableMetadata.CountLiveRows += 1 
+				tableMetadata.CountLiveRows += 1
 			}
 			if source.DBType == "postgresql" && strings.HasPrefix(line, "\\.") {
 				break

--- a/yb-voyager/cmd/exportDataStatus.go
+++ b/yb-voyager/cmd/exportDataStatus.go
@@ -286,7 +286,7 @@ func startExportPB(progressContainer *mpb.Progress, mapKey string, quitChan chan
 				utils.ErrExit("Error while reading file: %s: %v", tableDataFile.Name(), err)
 			}
 			if isDataLine(line, source.DBType, &insideCopyStmt) {
-				tableMetadata.CountLiveRows += 1
+				tableMetadata.CountLiveRows += 1 
 			}
 			if source.DBType == "postgresql" && strings.HasPrefix(line, "\\.") {
 				break

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -308,10 +308,11 @@ func validateCdcPartitionKeyFlags(cmd *cobra.Command) error {
 	if cdcPartitionKey != importDataStatus.CdcPartitioningStrategyConfig {
 		return goerrors.Errorf("changing cdc-partition-key is not allowed after the import data has started. Current: %s, new: %s\n Use --start-clean to start a fresh import with the new partition key.", importDataStatus.CdcPartitioningStrategyConfig, cdcPartitionKey)
 	}
-	storedOverrides := importDataStatus.CdcPartitionKeyOverridesConfig //TODO: just checking the string equality is not enough, we might need to compare the overrides by properly
-	if cdcPartitionKeyOverrides != storedOverrides {
-		return goerrors.Errorf("changing cdc-partition-key-overrides is not allowed after the import data has started. Current: %q, new: %q\n Use --start-clean to start a fresh import with the new overrides.", storedOverrides, cdcPartitionKeyOverrides)
-	}
+	// cdc-partition-key-overrides is intentionally NOT compared here as a raw string: two
+	// different strings (ordering, quoting/casing, whitespace) can resolve to the same
+	// effective per-table strategy. The semantic comparison against the persisted per-table
+	// map is done in prepareCdcPartitionKey, which has the import table list + name registry
+	// needed to resolve overrides into effective per-table strategies.
 	log.Infof("cdc-partition-key: %s, cdc-partition-key-overrides: %q", cdcPartitionKey, cdcPartitionKeyOverrides)
 	return nil
 }

--- a/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
+++ b/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	goerrors "github.com/go-errors/errors"
+	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
@@ -320,6 +321,9 @@ func getExpressionUniqueIndexTablesIfRequired(tableNames []sqlname.NameTuple, ov
 		if importDataStatus == nil {
 			return nil, goerrors.Errorf("import data status record not found")
 		}
+		if importDataStatus.CdcExpressionUniqueIndexTables == nil {
+			return nil, goerrors.Errorf("cdc expression unique index tables not found in import data status record")
+		}
 		for _, key := range importDataStatus.CdcExpressionUniqueIndexTables {
 			tuple, err := namereg.NameReg.LookupTableName(key)
 			if err != nil {
@@ -361,11 +365,11 @@ func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, im
 // whose effective strategy changed.
 func diffCdcPartitioningStrategy(resolved *utils.StructMap[sqlname.NameTuple, string], stored map[string]string) error {
 	var changed []string
-	var missing []string
+	var missingInStored []string
 	err := resolved.IterKV(func(t sqlname.NameTuple, strategy string) (bool, error) {
 		storedStrategy, ok := stored[t.ForKey()]
 		if !ok {
-			missing = append(missing, t.ForKey())
+			missingInStored = append(missingInStored, t.ForKey())
 		} else if storedStrategy != strategy {
 			changed = append(changed, fmt.Sprintf("%s (persisted: %q, new: %q)", t.ForOutput(), storedStrategy, strategy))
 		}
@@ -374,13 +378,32 @@ func diffCdcPartitioningStrategy(resolved *utils.StructMap[sqlname.NameTuple, st
 	if err != nil {
 		return err
 	}
-	if len(missing) > 0 {
-		sort.Strings(missing)
-		return goerrors.Errorf("cdc-partition-key-overrides: table %q is not in the import table list", strings.Join(missing, ", "))
+	var missingInResolved []string
+	storedTables := lo.Keys(stored)
+	for _, storedTable := range storedTables {
+		tuple, err := namereg.NameReg.LookupTableName(storedTable)
+		if err != nil {
+			return fmt.Errorf("error looking up table name: %w", err)
+		}
+		if _, ok := resolved.Get(tuple); !ok {
+			missingInResolved = append(missingInResolved, storedTable)
+		}
+	}
+	errorMsg := ""
+	if len(missingInStored) > 0 {
+		sort.Strings(missingInStored)
+		errorMsg += fmt.Sprintf("cdc-partition-key-overrides: table %q is in the current import table list but was not part of the original import; use --start-clean to start a fresh import with the new configuration\n", strings.Join(missingInStored, ", "))
+	}
+	if len(missingInResolved) > 0 {
+		sort.Strings(missingInResolved)
+		errorMsg += fmt.Sprintf("cdc-partition-key-overrides: table %q was part of the original import but is missing from the current import table list; use --start-clean to start a fresh import with the new configuration\n", strings.Join(missingInResolved, ", "))
 	}
 	if len(changed) > 0 {
 		sort.Strings(changed)
-		return goerrors.Errorf("changing cdc-partition-key / cdc-partition-key-overrides is not allowed after the import data has started; effective strategy changed for: %s.\nUse --start-clean to start a fresh import with the new configuration.", strings.Join(changed, "; "))
+		errorMsg += fmt.Sprintf("changing cdc-partition-key / cdc-partition-key-overrides is not allowed after the import data has started; effective strategy changed for: %s.\nUse --start-clean to start a fresh import with the new configuration.", strings.Join(changed, "; "))
+	}
+	if errorMsg != "" {
+		return goerrors.Errorf(errorMsg)
 	}
 	return nil
 }

--- a/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
+++ b/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
@@ -403,7 +403,7 @@ func diffCdcPartitioningStrategy(resolved *utils.StructMap[sqlname.NameTuple, st
 		errorMsg += fmt.Sprintf("changing cdc-partition-key / cdc-partition-key-overrides is not allowed after the import data has started; effective strategy changed for: %s.\nUse --start-clean to start a fresh import with the new configuration.", strings.Join(changed, "; "))
 	}
 	if errorMsg != "" {
-		return goerrors.Errorf(errorMsg)
+		return goerrors.Errorf("change in cdc-partition-key-overrides in between runs detected: %s", errorMsg)
 	}
 	return nil
 }

--- a/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
+++ b/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
@@ -65,7 +65,7 @@ func prepareCdcPartitionKey(tableNames []sqlname.NameTuple) error {
 		return nil
 	}
 
-	_, err = computeAndPersistCdcPartitioningStrategyPerTable(tableNames)
+	_, err = computeAndPersistCdcPartitioningStrategyPerTable(tableNames, importDataStatus)
 	return err
 }
 
@@ -243,44 +243,10 @@ func checkIfNeedsExprUKCheck(cdcPartitionKey string, overrides *utils.StructMap[
 
 // computeAndPersistCdcPartitioningStrategyPerTable resolves global + overrides + auto/expr-UK
 // rules and writes TableToCDCPartitioningStrategyMap to metaDB.
-func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, string], error) {
-	rawOverrides, err := parseCdcPartitionKeyOverrides(cdcPartitionKeyOverrides)
+func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord) (*utils.StructMap[sqlname.NameTuple, string], error) {
+	tableToPartitioningStrategyMap, exprUKKeysForStorage, err := computeCdcPartitioningStrategyPerTable(tableNames, true, importDataStatus)
 	if err != nil {
-		return nil, err
-	}
-	overrides, err := resolveCdcPartitionKeyOverrides(rawOverrides, tableNames)
-	if err != nil {
-		return nil, err
-	}
-
-	needsExprUKCheck, err := checkIfNeedsExprUKCheck(cdcPartitionKey, overrides)
-	if err != nil {
-		return nil, err
-	}
-
-	var expressionUniqueIndexTables []sqlname.NameTuple
-	// nil unless the expression-UK check ran; a non-nil (possibly empty) slice records
-	// that we resolved the set so resume can reuse it without re-querying the target DB.
-	var exprUKKeysForStorage []string
-	if needsExprUKCheck {
-		expressionUniqueIndexTables, err = getExpressionUniqueIndexTables(tableNames)
-		if err != nil {
-			return nil, fmt.Errorf("error getting expression unique index tables: %w", err)
-		}
-		exprUKKeysForStorage = make([]string, 0, len(expressionUniqueIndexTables))
-		for _, t := range expressionUniqueIndexTables {
-			exprUKKeysForStorage = append(exprUKKeysForStorage, t.ForKey())
-		}
-	}
-	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
-	for _, t := range expressionUniqueIndexTables {
-		exprUKSet.Put(t, true)
-	}
-
-	tableToPartitioningStrategyMap, err := resolveEffectiveCdcPartitionKeys(
-		tableNames, cdcPartitionKey, overrides, exprUKSet, tconf.TargetDBType)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error computing cdc partitioning strategy per table: %w", err)
 	}
 
 	metadbMap := make(map[string]string)
@@ -302,6 +268,73 @@ func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameT
 	return tableToPartitioningStrategyMap, nil
 }
 
+func computeCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple, isFirstRun bool, importDataStatus *metadb.ImportDataStatusRecord) (*utils.StructMap[sqlname.NameTuple, string], []string, error) {
+	rawOverrides, err := parseCdcPartitionKeyOverrides(cdcPartitionKeyOverrides)
+	if err != nil {
+		return nil, nil, err
+	}
+	overrides, err := resolveCdcPartitionKeyOverrides(rawOverrides, tableNames)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	exprUKSet, err := getExpressionUniqueIndexTablesIfRequired(tableNames, overrides, cdcPartitionKey, isFirstRun, importDataStatus)
+	if err != nil {
+		return nil, nil, err
+	}
+	tableToPartitioningStrategyMap, err := resolveEffectiveCdcPartitionKeys(tableNames, cdcPartitionKey, overrides, exprUKSet, tconf.TargetDBType)
+
+	if err != nil {
+		return nil, nil, err
+	}
+	exprUKKeysForStorage := make([]string, 0, len(exprUKSet.Keys()))
+	for _, t := range exprUKSet.Keys() {
+		exprUKKeysForStorage = append(exprUKKeysForStorage, t)
+	}
+	return tableToPartitioningStrategyMap, exprUKKeysForStorage, nil
+}
+
+func getExpressionUniqueIndexTablesIfRequired(tableNames []sqlname.NameTuple, overrides *utils.StructMap[sqlname.NameTuple, string], cdcPartitionKey string, isFirstRun bool, importDataStatus *metadb.ImportDataStatusRecord) (*utils.StructMap[sqlname.NameTuple, bool], error) {
+	// Always return a non-nil map: callers call exprUKSet.Keys()/pass it to
+	// resolveEffectiveCdcPartitionKeys, and a nil *StructMap panics on Keys().
+	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
+
+	needsExprUKCheck, err := checkIfNeedsExprUKCheck(cdcPartitionKey, overrides)
+	if err != nil {
+		return nil, err
+	}
+	if !needsExprUKCheck {
+		return exprUKSet, nil
+	}
+
+	var expressionUniqueIndexTables []sqlname.NameTuple
+	if isFirstRun {
+		// First run: query the target DB for the authoritative set of expression-UK tables.
+		expressionUniqueIndexTables, err = getExpressionUniqueIndexTables(tableNames)
+		if err != nil {
+			return nil, fmt.Errorf("error getting expression unique index tables: %w", err)
+		}
+	} else {
+		// Resume: reuse the set captured on the first run (persisted in metaDB) so we do not
+		// re-query the target DB.
+		if importDataStatus == nil {
+			return nil, goerrors.Errorf("import data status record not found")
+		}
+		for _, key := range importDataStatus.CdcExpressionUniqueIndexTables {
+			tuple, err := namereg.NameReg.LookupTableName(key)
+			if err != nil {
+				return nil, fmt.Errorf("error looking up expression-unique-index table %q: %w", key, err)
+			}
+			expressionUniqueIndexTables = append(expressionUniqueIndexTables, tuple)
+		}
+	}
+
+	for _, t := range expressionUniqueIndexTables {
+		exprUKSet.Put(t, true)
+	}
+	return exprUKSet, nil
+}
+
 // validateCdcPartitioningStrategyUnchanged re-resolves the effective per-table CDC
 // partitioning strategy from the current flags and fails if it differs from the map
 // persisted on the first run. It reuses the expression-UK tables captured on the first
@@ -310,42 +343,17 @@ func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameT
 // cdc-partition-key-overrides.
 func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord) error {
 
-	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
-	storedOverrides := importDataStatus.CdcPartitionKeyOverridesConfig
-	if importDataStatus.CdcExpressionUniqueIndexTables == nil {
-		//In case the expression-UK tables were not captured on the first run, then it is only possible that its a resume with upgrade scenario so lets keep it simple
-		//so keeping the old string check for the overrides
-		if storedOverrides != cdcPartitionKeyOverrides {
-			return goerrors.Errorf("changing cdc-partition-key-overrides is not allowed after the import data has started. Current: %q, new: %q\n Use --start-clean to start a fresh import with the new overrides.", storedOverrides, cdcPartitionKeyOverrides)
-		}
-	}
-	if storedOverrides == cdcPartitionKeyOverrides {
+	cdcPartitionKeyOverridesStored := importDataStatus.CdcPartitionKeyOverridesConfig
+	if cdcPartitionKeyOverridesStored == cdcPartitionKeyOverrides {
 		//No changes in the overrides so we can continue
 		return nil
 	}
-	for _, key := range importDataStatus.CdcExpressionUniqueIndexTables {
-		tuple, err := namereg.NameReg.LookupTableName(key)
-		if err != nil {
-			return goerrors.Errorf("error looking up expression-unique-index table %q: %w", key, err)
-		}
-		exprUKSet.Put(tuple, true)
-	}
 
-	rawOverrides, err := parseCdcPartitionKeyOverrides(cdcPartitionKeyOverrides)
+	resolvedTableToPartitioningStrategyMap, _, err := computeCdcPartitioningStrategyPerTable(tableNames, false, importDataStatus)
 	if err != nil {
-		return err
+		return fmt.Errorf("error computing cdc partitioning strategy per table: %w", err)
 	}
-	overrides, err := resolveCdcPartitionKeyOverrides(rawOverrides, tableNames)
-	if err != nil {
-		return err
-	}
-
-	resolved, err := resolveEffectiveCdcPartitionKeys(tableNames, cdcPartitionKey, overrides, exprUKSet, tconf.TargetDBType)
-	if err != nil {
-		return err
-	}
-
-	return diffCdcPartitioningStrategy(resolved, importDataStatus.TableToCDCPartitioningStrategyMap)
+	return diffCdcPartitioningStrategy(resolvedTableToPartitioningStrategyMap, importDataStatus.TableToCDCPartitioningStrategyMap)
 }
 
 // diffCdcPartitioningStrategy compares a freshly-resolved per-table strategy map against
@@ -353,14 +361,22 @@ func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, im
 // whose effective strategy changed.
 func diffCdcPartitioningStrategy(resolved *utils.StructMap[sqlname.NameTuple, string], stored map[string]string) error {
 	var changed []string
+	var missing []string
 	err := resolved.IterKV(func(t sqlname.NameTuple, strategy string) (bool, error) {
-		if storedStrategy, ok := stored[t.ForKey()]; !ok || storedStrategy != strategy {
-			changed = append(changed, fmt.Sprintf("%s (persisted: %q, new: %q)", t.ForOutput(), stored[t.ForKey()], strategy))
+		storedStrategy, ok := stored[t.ForKey()]
+		if !ok {
+			missing = append(missing, t.ForKey())
+		} else if storedStrategy != strategy {
+			changed = append(changed, fmt.Sprintf("%s (persisted: %q, new: %q)", t.ForOutput(), storedStrategy, strategy))
 		}
 		return true, nil
 	})
 	if err != nil {
 		return err
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return goerrors.Errorf("cdc-partition-key-overrides: table %q is not in the import table list", strings.Join(missing, ", "))
 	}
 	if len(changed) > 0 {
 		sort.Strings(changed)

--- a/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
+++ b/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	goerrors "github.com/go-errors/errors"
@@ -50,8 +51,17 @@ func prepareCdcPartitionKey(tableNames []sqlname.NameTuple) error {
 		return goerrors.Errorf("import data status record not found")
 	}
 	if importDataStatus.TableToCDCPartitioningStrategyMap != nil {
-		//TODO: see if we should validation here after computing map again witht he keys and overrides and then check for any mismatch
-		log.Infof("cdc partition key already prepared in metadb; skipping recompute")
+		// On resume the per-table strategy map is already persisted. Rather than trusting
+		// a raw string comparison of the flags (done for the global key in
+		// validateCdcPartitionKeyFlags), re-resolve the effective per-table strategy from
+		// the current flags — reusing the expression-UK tables captured on the first run so
+		// no target-DB re-query is needed — and reject if it differs from what was
+		// persisted. This catches semantically-different overrides that a plain string
+		// compare would miss (ordering, spelling/quoting, whitespace).
+		if err := validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus); err != nil {
+			return err
+		}
+		log.Infof("cdc partition key already prepared in metadb and unchanged; skipping recompute")
 		return nil
 	}
 
@@ -249,10 +259,17 @@ func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameT
 	}
 
 	var expressionUniqueIndexTables []sqlname.NameTuple
+	// nil unless the expression-UK check ran; a non-nil (possibly empty) slice records
+	// that we resolved the set so resume can reuse it without re-querying the target DB.
+	var exprUKKeysForStorage []string
 	if needsExprUKCheck {
 		expressionUniqueIndexTables, err = getExpressionUniqueIndexTables(tableNames)
 		if err != nil {
 			return nil, fmt.Errorf("error getting expression unique index tables: %w", err)
+		}
+		exprUKKeysForStorage = make([]string, 0, len(expressionUniqueIndexTables))
+		for _, t := range expressionUniqueIndexTables {
+			exprUKKeysForStorage = append(exprUKKeysForStorage, t.ForKey())
 		}
 	}
 	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
@@ -276,12 +293,101 @@ func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameT
 	}
 	err = metaDB.UpdateImportDataStatusRecord(func(obj *metadb.ImportDataStatusRecord) {
 		obj.TableToCDCPartitioningStrategyMap = metadbMap
+		obj.CdcExpressionUniqueIndexTables = exprUKKeysForStorage
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error updating cdc partitioning strategy in metadb: %w", err)
 	}
 	log.Infof("updated cdc partitioning strategy in metadb: %v with values: %v", metadb.IMPORT_DATA_STATUS_KEY, metadbMap)
 	return tableToPartitioningStrategyMap, nil
+}
+
+// validateCdcPartitioningStrategyUnchanged re-resolves the effective per-table CDC
+// partitioning strategy from the current flags and fails if it differs from the map
+// persisted on the first run. It reuses the expression-UK tables captured on the first
+// run (falling back to a target-DB lookup only for older records that predate that
+// capture) so resume never silently applies a changed cdc-partition-key /
+// cdc-partition-key-overrides.
+func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord) error {
+	rawOverrides, err := parseCdcPartitionKeyOverrides(cdcPartitionKeyOverrides)
+	if err != nil {
+		return err
+	}
+	overrides, err := resolveCdcPartitionKeyOverrides(rawOverrides, tableNames)
+	if err != nil {
+		return err
+	}
+
+	exprUKSet, err := resolveResumeExprUKSet(tableNames, overrides, importDataStatus)
+	if err != nil {
+		return err
+	}
+
+	resolved, err := resolveEffectiveCdcPartitionKeys(tableNames, cdcPartitionKey, overrides, exprUKSet, tconf.TargetDBType)
+	if err != nil {
+		return err
+	}
+
+	return diffCdcPartitioningStrategy(resolved, importDataStatus.TableToCDCPartitioningStrategyMap)
+}
+
+// resolveResumeExprUKSet returns the set of expression-UK tables to use when re-resolving
+// the strategy on resume. It prefers the set captured on the first run
+// (importDataStatus.CdcExpressionUniqueIndexTables). For older records that never captured
+// it, it re-queries the target DB, but only when the current flags actually need the
+// expression-UK check.
+func resolveResumeExprUKSet(tableNames []sqlname.NameTuple, overrides *utils.StructMap[sqlname.NameTuple, string], importDataStatus *metadb.ImportDataStatusRecord) (*utils.StructMap[sqlname.NameTuple, bool], error) {
+	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
+
+	if importDataStatus.CdcExpressionUniqueIndexTables != nil {
+		for _, key := range importDataStatus.CdcExpressionUniqueIndexTables {
+			tuple, err := namereg.NameReg.LookupTableName(key)
+			if err != nil {
+				return nil, fmt.Errorf("error looking up expression-unique-index table %q: %w", key, err)
+			}
+			exprUKSet.Put(tuple, true)
+		}
+		return exprUKSet, nil
+	}
+
+	// Older record: the map was persisted before the expression-UK set was captured. Only
+	// re-query the target DB when the current flags need the expression-UK check.
+	needsExprUKCheck, err := checkIfNeedsExprUKCheck(cdcPartitionKey, overrides)
+	if err != nil {
+		return nil, err
+	}
+	if !needsExprUKCheck {
+		return exprUKSet, nil
+	}
+	tables, err := getExpressionUniqueIndexTables(tableNames)
+	if err != nil {
+		return nil, fmt.Errorf("error getting expression unique index tables: %w", err)
+	}
+	for _, t := range tables {
+		exprUKSet.Put(t, true)
+	}
+	return exprUKSet, nil
+}
+
+// diffCdcPartitioningStrategy compares a freshly-resolved per-table strategy map against
+// the one persisted on the first run and returns an actionable error listing the tables
+// whose effective strategy changed.
+func diffCdcPartitioningStrategy(resolved *utils.StructMap[sqlname.NameTuple, string], stored map[string]string) error {
+	var changed []string
+	err := resolved.IterKV(func(t sqlname.NameTuple, strategy string) (bool, error) {
+		if storedStrategy, ok := stored[t.ForKey()]; !ok || storedStrategy != strategy {
+			changed = append(changed, fmt.Sprintf("%s (persisted: %q, new: %q)", t.ForOutput(), stored[t.ForKey()], strategy))
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(changed) > 0 {
+		sort.Strings(changed)
+		return goerrors.Errorf("changing cdc-partition-key / cdc-partition-key-overrides is not allowed after the import data has started; effective strategy changed for: %s.\nUse --start-clean to start a fresh import with the new configuration.", strings.Join(changed, "; "))
+	}
+	return nil
 }
 
 func getExpressionUniqueIndexTables(tableNames []sqlname.NameTuple) ([]sqlname.NameTuple, error) {

--- a/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
+++ b/yb-voyager/cmd/live_migration_cdc_partition_strategy.go
@@ -309,16 +309,33 @@ func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameT
 // capture) so resume never silently applies a changed cdc-partition-key /
 // cdc-partition-key-overrides.
 func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord) error {
+
+	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
+	storedOverrides := importDataStatus.CdcPartitionKeyOverridesConfig
+	if importDataStatus.CdcExpressionUniqueIndexTables == nil {
+		//In case the expression-UK tables were not captured on the first run, then it is only possible that its a resume with upgrade scenario so lets keep it simple
+		//so keeping the old string check for the overrides
+		if storedOverrides != cdcPartitionKeyOverrides {
+			return goerrors.Errorf("changing cdc-partition-key-overrides is not allowed after the import data has started. Current: %q, new: %q\n Use --start-clean to start a fresh import with the new overrides.", storedOverrides, cdcPartitionKeyOverrides)
+		}
+	}
+	if storedOverrides == cdcPartitionKeyOverrides {
+		//No changes in the overrides so we can continue
+		return nil
+	}
+	for _, key := range importDataStatus.CdcExpressionUniqueIndexTables {
+		tuple, err := namereg.NameReg.LookupTableName(key)
+		if err != nil {
+			return goerrors.Errorf("error looking up expression-unique-index table %q: %w", key, err)
+		}
+		exprUKSet.Put(tuple, true)
+	}
+
 	rawOverrides, err := parseCdcPartitionKeyOverrides(cdcPartitionKeyOverrides)
 	if err != nil {
 		return err
 	}
 	overrides, err := resolveCdcPartitionKeyOverrides(rawOverrides, tableNames)
-	if err != nil {
-		return err
-	}
-
-	exprUKSet, err := resolveResumeExprUKSet(tableNames, overrides, importDataStatus)
 	if err != nil {
 		return err
 	}
@@ -329,44 +346,6 @@ func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, im
 	}
 
 	return diffCdcPartitioningStrategy(resolved, importDataStatus.TableToCDCPartitioningStrategyMap)
-}
-
-// resolveResumeExprUKSet returns the set of expression-UK tables to use when re-resolving
-// the strategy on resume. It prefers the set captured on the first run
-// (importDataStatus.CdcExpressionUniqueIndexTables). For older records that never captured
-// it, it re-queries the target DB, but only when the current flags actually need the
-// expression-UK check.
-func resolveResumeExprUKSet(tableNames []sqlname.NameTuple, overrides *utils.StructMap[sqlname.NameTuple, string], importDataStatus *metadb.ImportDataStatusRecord) (*utils.StructMap[sqlname.NameTuple, bool], error) {
-	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
-
-	if importDataStatus.CdcExpressionUniqueIndexTables != nil {
-		for _, key := range importDataStatus.CdcExpressionUniqueIndexTables {
-			tuple, err := namereg.NameReg.LookupTableName(key)
-			if err != nil {
-				return nil, fmt.Errorf("error looking up expression-unique-index table %q: %w", key, err)
-			}
-			exprUKSet.Put(tuple, true)
-		}
-		return exprUKSet, nil
-	}
-
-	// Older record: the map was persisted before the expression-UK set was captured. Only
-	// re-query the target DB when the current flags need the expression-UK check.
-	needsExprUKCheck, err := checkIfNeedsExprUKCheck(cdcPartitionKey, overrides)
-	if err != nil {
-		return nil, err
-	}
-	if !needsExprUKCheck {
-		return exprUKSet, nil
-	}
-	tables, err := getExpressionUniqueIndexTables(tableNames)
-	if err != nil {
-		return nil, fmt.Errorf("error getting expression unique index tables: %w", err)
-	}
-	for _, t := range tables {
-		exprUKSet.Put(t, true)
-	}
-	return exprUKSet, nil
 }
 
 // diffCdcPartitioningStrategy compares a freshly-resolved per-table strategy map against

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -522,6 +522,100 @@ func TestResolveCdcPartitionKeyOverrides(t *testing.T) {
 	})
 }
 
+// TestValidateCdcPartitioningStrategyUnchanged covers the semantic resume guard: the
+// current flags are re-resolved into an effective per-table strategy and compared against
+// the map persisted on the first run. Semantically-equivalent overrides (different
+// spelling/quoting/ordering/whitespace) must pass, while any change to the effective
+// per-table strategy must be rejected.
+func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
+	setupCdcOverridesNameRegistry(t)
+
+	origKey := cdcPartitionKey
+	origOverrides := cdcPartitionKeyOverrides
+	origTargetDBType := tconf.TargetDBType
+	t.Cleanup(func() {
+		cdcPartitionKey = origKey
+		cdcPartitionKeyOverrides = origOverrides
+		tconf.TargetDBType = origTargetDBType
+	})
+	tconf.TargetDBType = YUGABYTEDB
+
+	lookup := func(name string) sqlname.NameTuple {
+		nt, err := namereg.NameReg.LookupTableName(name)
+		require.NoError(t, err)
+		return nt
+	}
+	orders := lookup("test_schema.orders")
+	events := lookup("test_schema.events")
+	tableNames := []sqlname.NameTuple{orders, events}
+
+	// First-run config: global pk with an override putting orders on table. No
+	// expression-UK tables (captured as a non-nil empty slice on the first run).
+	firstRun, err := resolveEffectiveCdcPartitionKeys(
+		tableNames, PARTITION_BY_PK,
+		mustResolveOverrides(t, "test_schema.orders:table", tableNames),
+		utils.NewStructMap[sqlname.NameTuple, bool](), YUGABYTEDB)
+	require.NoError(t, err)
+
+	storedMap := make(map[string]string)
+	require.NoError(t, firstRun.IterKV(func(k sqlname.NameTuple, v string) (bool, error) {
+		storedMap[k.ForKey()] = v
+		return true, nil
+	}))
+	importDataStatus := &metadb.ImportDataStatusRecord{
+		ImportDataStarted:                 true,
+		CdcPartitioningStrategyConfig:     PARTITION_BY_PK,
+		CdcPartitionKeyOverridesConfig:    "test_schema.orders:table",
+		TableToCDCPartitioningStrategyMap: storedMap,
+		CdcExpressionUniqueIndexTables:    []string{}, // captured, none
+	}
+
+	t.Run("same config passes", func(t *testing.T) {
+		cdcPartitionKey = PARTITION_BY_PK
+		cdcPartitionKeyOverrides = "test_schema.orders:table"
+		require.NoError(t, validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus))
+	})
+
+	t.Run("semantically-equivalent overrides (quoting) pass", func(t *testing.T) {
+		cdcPartitionKey = PARTITION_BY_PK
+		cdcPartitionKeyOverrides = `"test_schema"."orders":table`
+		require.NoError(t, validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus))
+	})
+
+	t.Run("semantically-equivalent overrides (whitespace) pass", func(t *testing.T) {
+		cdcPartitionKey = PARTITION_BY_PK
+		cdcPartitionKeyOverrides = "  test_schema.orders:table ; "
+		require.NoError(t, validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus))
+	})
+
+	t.Run("changed override target table is rejected", func(t *testing.T) {
+		cdcPartitionKey = PARTITION_BY_PK
+		cdcPartitionKeyOverrides = "test_schema.events:table"
+		err := validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "changing cdc-partition-key")
+		assert.Contains(t, err.Error(), "events")
+	})
+
+	t.Run("removed override is rejected", func(t *testing.T) {
+		cdcPartitionKey = PARTITION_BY_PK
+		cdcPartitionKeyOverrides = ""
+		err := validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "changing cdc-partition-key")
+		assert.Contains(t, err.Error(), "orders")
+	})
+}
+
+func mustResolveOverrides(t *testing.T, raw string, tableNames []sqlname.NameTuple) *utils.StructMap[sqlname.NameTuple, string] {
+	t.Helper()
+	parsed, err := parseCdcPartitionKeyOverrides(raw)
+	require.NoError(t, err)
+	resolved, err := resolveCdcPartitionKeyOverrides(parsed, tableNames)
+	require.NoError(t, err)
+	return resolved
+}
+
 // TestValidateCdcPartitionKeyFlags covers the flag-level guardrails in
 // validateCdcPartitionKeyFlags: context restrictions (target/YB/PG/streaming),
 // value validation, and the resume change-guards (including the positive
@@ -672,20 +766,9 @@ func TestValidateCdcPartitionKeyFlags(t *testing.T) {
 		assert.Contains(t, err.Error(), "changing cdc-partition-key is not allowed")
 	})
 
-	t.Run("resume rejects changed overrides", func(t *testing.T) {
-		setValidContext()
-		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
-			r.ImportDataStarted = true
-			r.CdcPartitioningStrategyConfig = PARTITION_BY_PK
-			r.CdcPartitionKeyOverridesConfig = ""
-		})
-		cmd := newCmd()
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "test_schema.orders:table"
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "changing cdc-partition-key-overrides is not allowed")
-	})
+	// NOTE: changed cdc-partition-key-overrides is no longer rejected here by a raw string
+	// compare; the semantic per-table comparison is covered by
+	// TestValidateCdcPartitioningStrategyUnchanged.
 
 	t.Run("resume from older version without stored strategy is rejected", func(t *testing.T) {
 		setValidContext()

--- a/yb-voyager/src/metadb/importDataStatus.go
+++ b/yb-voyager/src/metadb/importDataStatus.go
@@ -37,6 +37,14 @@ type ImportDataStatusRecord struct {
 		raw cdc-partition-key-overrides string; empty means no per-table overrides
 	*/
 	CdcPartitionKeyOverridesConfig string `json:"cdcPartitionKeyOverridesConfig"`
+	/*
+		ForKey names of tables that have an expression-based unique index, captured on
+		the first prepare of the cdc partitioning strategy. It lets resume re-resolve the
+		effective per-table strategy (and validate the config is unchanged) without
+		re-querying the target DB. nil means it was not captured (record written by an
+		older voyager, or a first run that did not need the expression-UK check).
+	*/
+	CdcExpressionUniqueIndexTables []string `json:"cdcExpressionUniqueIndexTables"`
 
 	TargetUsePartitionRoot bool `json:"TargetUsePartitionRoot"` // false - use leaf table for partitions, true - use root table for partitions; default is true
 }

--- a/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
@@ -1378,14 +1378,18 @@ func TestLiveMigrationCdcPartitionKeyConfigs(t *testing.T) {
 	err = lm.StopImportData()
 	testutils.FatalIfError(t, err, "failed to stop import data")
 
-	// Resume without start-clean must reject newly introduced overrides.
+	// Resume without start-clean must reject newly introduced overrides. The change is
+	// caught by the semantic per-table comparison in prepareCdcPartitionKey (orders flips
+	// pk -> table), not a raw string compare.
 	_ = lm.ResumeImportData(false, map[string]string{
 		"--cdc-partition-key":           "pk",
 		"--cdc-partition-key-overrides": "test_schema.orders:table",
 	})
+	rejectOutput := lm.GetImportCommandStderr() + lm.GetImportCommandStdout()
 	assert.True(t,
-		strings.Contains(lm.GetImportCommandStderr(), "changing cdc-partition-key-overrides is not allowed"),
-		"expected overrides change-guard error, got: %s", lm.GetImportCommandStderr())
+		strings.Contains(rejectOutput, "changing cdc-partition-key") &&
+			strings.Contains(rejectOutput, "is not allowed"),
+		"expected overrides change-guard error, got: %s", rejectOutput)
 
 	// Case 3: mixed strategies — global pk, override orders to table.
 	mixedOverrides := "test_schema.orders:table;test_schema.events:pk"
@@ -1443,6 +1447,151 @@ func assertStrategyInMap(t *testing.T, strategyMap map[string]string, tableSubst
 		}
 	}
 	t.Fatalf("table %q not found in strategy map: %v", tableSubstring, strategyMap)
+}
+
+// TestLiveMigrationCdcPartitionKeyOverridesEquivalentOnResume verifies the semantic
+// resume guard for cdc-partition-key-overrides: resuming (without --start-clean) with an
+// overrides string written differently (quoting / whitespace) but resolving to the SAME
+// effective per-table strategy must be ACCEPTED. A raw string compare (the old behaviour)
+// would have wrongly rejected it; prepareCdcPartitionKey now compares the resolved
+// per-table map instead.
+func TestLiveMigrationCdcPartitionKeyOverridesEquivalentOnResume(t *testing.T) {
+	lm := NewLiveMigrationTest(t, &TestConfig{
+		SourceDB: ContainerConfig{
+			Type:         "postgresql",
+			ForLive:      true,
+			DatabaseName: "cdc_part_key_equiv",
+		},
+		TargetDB: ContainerConfig{
+			Type:         "yugabytedb",
+			DatabaseName: "cdc_part_key_equiv",
+		},
+		SchemaNames: []string{"test_schema"},
+		SchemaSQL: []string{
+			`CREATE SCHEMA IF NOT EXISTS test_schema;
+			CREATE TABLE test_schema.orders (
+				id SERIAL PRIMARY KEY,
+				name TEXT
+			);
+			CREATE TABLE test_schema.events (
+				id SERIAL PRIMARY KEY,
+				payload TEXT
+			);`,
+		},
+		SourceSetupSchemaSQL: []string{
+			`ALTER TABLE test_schema.orders REPLICA IDENTITY FULL;
+			ALTER TABLE test_schema.events REPLICA IDENTITY FULL;`,
+		},
+		InitialDataSQL: []string{
+			`INSERT INTO test_schema.orders (name) SELECT md5(random()::text) FROM generate_series(1, 10);`,
+			`INSERT INTO test_schema.events (payload) SELECT md5(random()::text) FROM generate_series(1, 10);`,
+		},
+		SourceDeltaSQL: []string{
+			`INSERT INTO test_schema.orders (name) SELECT md5(random()::text) FROM generate_series(1, 5);`,
+			`INSERT INTO test_schema.events (payload) SELECT md5(random()::text) FROM generate_series(1, 5);`,
+		},
+		CleanupSQL: []string{
+			`DROP SCHEMA IF EXISTS test_schema CASCADE;`,
+		},
+	})
+	defer lm.Cleanup()
+
+	err := lm.SetupContainers(context.Background())
+	testutils.FatalIfError(t, err, "failed to setup containers")
+
+	err = lm.SetupSchema()
+	testutils.FatalIfError(t, err, "failed to setup schema")
+
+	err = lm.StartExportData(true, nil)
+	testutils.FatalIfError(t, err, "failed to start export data")
+
+	// First run: global pk, override orders -> table (events keeps pk).
+	err = lm.StartImportData(true, map[string]string{
+		"--cdc-partition-key":           "pk",
+		"--cdc-partition-key-overrides": "test_schema.orders:table",
+	})
+	testutils.FatalIfError(t, err, "failed to start import data")
+
+	err = lm.WaitForSnapshotComplete(map[string]int64{
+		`"test_schema"."orders"`: 10,
+		`"test_schema"."events"`: 10,
+	}, 30)
+	testutils.FatalIfError(t, err, "failed to wait for snapshot complete")
+
+	err = lm.InitMetaDB()
+	testutils.FatalIfError(t, err, "failed to initialize meta db")
+
+	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
+	testutils.FatalIfError(t, err, "failed to get import data status record")
+	assert.Equal(t, "pk", importDataStatus.CdcPartitioningStrategyConfig)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitioningStrategyMap, "orders", cmd.PARTITION_BY_TABLE)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitioningStrategyMap, "events", cmd.PARTITION_BY_PK)
+	// Expression-UK tables are captured on the first run (none here, but non-nil) so the
+	// resume comparison needs no target-DB re-query.
+	require.NotNil(t, importDataStatus.CdcExpressionUniqueIndexTables,
+		"expression-UK tables should be captured on the first prepare")
+
+	err = lm.StopImportData()
+	testutils.FatalIfError(t, err, "failed to stop import data")
+
+	// Case 1 (reject): resume WITHOUT start-clean flipping the strategies
+	// (orders -> pk, events -> table) differs from the persisted map (orders -> table,
+	// events -> pk), so the semantic change-guard must reject it.
+	_ = lm.ResumeImportData(false, map[string]string{
+		"--cdc-partition-key":           "pk",
+		"--cdc-partition-key-overrides": "test_schema.orders:pk;test_schema.events:table",
+	})
+	flipRejectOutput := lm.GetImportCommandStderr() + lm.GetImportCommandStdout()
+	assert.True(t,
+		strings.Contains(flipRejectOutput, "changing cdc-partition-key") &&
+			strings.Contains(flipRejectOutput, "is not allowed"),
+		"flipped strategies must trip the resume change-guard, got: %s", flipRejectOutput)
+
+	// Case 2 (accept): resume WITHOUT start-clean with a differently-written but
+	// semantically-equivalent overrides string (quoted identifiers, reordered, extra
+	// whitespace). Same effective strategy (orders -> table, events -> pk), so it must be
+	// accepted and streaming resumes.
+	equivalentOverrides := ` "test_schema"."events":pk ; "test_schema"."orders":table `
+	err = lm.ResumeImportData(true, map[string]string{
+		"--cdc-partition-key":           "pk",
+		"--cdc-partition-key-overrides": equivalentOverrides,
+	})
+	testutils.FatalIfError(t, err, "resume with semantically-equivalent overrides should succeed")
+
+	// Give the resumed import time to run prepareCdcPartitionKey; it must not trip the
+	// change-guard for an equivalent overrides string.
+	time.Sleep(15 * time.Second)
+	resumeOutput := lm.GetImportCommandStderr() + lm.GetImportCommandStdout()
+	assert.NotContains(t, resumeOutput, "is not allowed",
+		"semantically-equivalent overrides must not trip the resume change-guard, got: %s", resumeOutput)
+
+	// The effective per-table map is preserved across the resume.
+	importDataStatus, err = lm.GetMetaDB().GetImportDataStatusRecord()
+	testutils.FatalIfError(t, err, "failed to get import data status record after resume")
+	assert.Equal(t, "pk", importDataStatus.CdcPartitioningStrategyConfig)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitioningStrategyMap, "orders", cmd.PARTITION_BY_TABLE)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitioningStrategyMap, "events", cmd.PARTITION_BY_PK)
+
+	err = lm.ValidateDataConsistency([]string{`"test_schema"."orders"`, `"test_schema"."events"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate snapshot data consistency after resume")
+
+	err = lm.ExecuteSourceDelta()
+	testutils.FatalIfError(t, err, "failed to execute source delta")
+
+	err = lm.WaitForForwardStreamingComplete(map[string]ChangesCount{
+		`"test_schema"."orders"`: {Inserts: 5},
+		`"test_schema"."events"`: {Inserts: 5},
+	}, 60, 1)
+	testutils.FatalIfError(t, err, "failed to wait for forward streaming complete")
+
+	err = lm.ValidateDataConsistency([]string{`"test_schema"."orders"`, `"test_schema"."events"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate streaming data consistency")
+
+	err = lm.InitiateCutoverToTarget(false, nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover")
+
+	err = lm.WaitForCutoverComplete(0, 30)
+	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 }
 
 // TestLiveMigrationCdcPartitionKeyRejectsPkOnExpressionUniqueIndex verifies the
@@ -1535,6 +1684,27 @@ func TestLiveMigrationCdcPartitionKeyRejectsPkOnExpressionUniqueIndex(t *testing
 	testutils.FatalIfError(t, err, "failed to get import data status record")
 	require.Equal(t, "auto", importDataStatus.CdcPartitioningStrategyConfig)
 	assertStrategyInMap(t, importDataStatus.TableToCDCPartitioningStrategyMap, "users", cmd.PARTITION_BY_TABLE)
+
+	// Resume WITHOUT start-clean trying to switch the expression-UK table from table to pk
+	// must be rejected: pk-partitioning cannot detect unique-key conflicts on an expression
+	// unique index. The expression-UK set captured on the first run (global auto) drives the
+	// same guard on resume, so no target-DB re-query is needed.
+	err = lm.StopImportData()
+	testutils.FatalIfError(t, err, "failed to stop import data before pk-on-expr-UK resume")
+
+	_ = lm.ResumeImportData(false, map[string]string{
+		"--cdc-partition-key-overrides": "test_schema.users:pk",
+	})
+	pkOnExprRejectOutput := lm.GetImportCommandStderr() + lm.GetImportCommandStdout()
+	assert.Contains(t, pkOnExprRejectOutput, "expression-based unique index",
+		"pk on an expression-UK table must be rejected on resume, got: %s", pkOnExprRejectOutput)
+
+	// Resume back to the valid table strategy to continue the migration.
+	err = lm.ResumeImportData(true, map[string]string{
+		"--cdc-partition-key-overrides": "test_schema.users:table",
+	})
+	testutils.FatalIfError(t, err, "failed to resume import data back to table strategy")
+	time.Sleep(15 * time.Second)
 
 	err = lm.ValidateDataConsistency([]string{`"test_schema"."users"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")

--- a/yb-voyager/src/utils/version.go
+++ b/yb-voyager/src/utils/version.go
@@ -20,7 +20,7 @@ const (
 	YB_VOYAGER_VERSION = "main"
 
 	// This constant must be updated after every breaking change.
-	PREVIOUS_BREAKING_CHANGE_VERSION = "2026.7.1"
+	PREVIOUS_BREAKING_CHANGE_VERSION = "2026.8.2"
 
 	// @Refer: https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/
 	GIT_COMMIT_HASH = "$Format:%H$"


### PR DESCRIPTION
### Describe the changes in this pull request

This PR hardens the resume change-guard for `--cdc-partition-key-overrides` during live migration (`import data to target`, PG→YB). Previously the guard compared the raw overrides string on resume, which was fragile: two strings that differ only in ordering, quoting/casing, or whitespace resolve to the same effective per-table strategy but were wrongly rejected (and a genuinely different config could slip through). This addresses the leftover `TODO` from the original feature.

The raw-string comparison for overrides is removed from `validateCdcPartitionKeyFlags` and replaced with a semantic comparison in `prepareCdcPartitionKey` (via the new `validateCdcPartitioningStrategyUnchanged`): on resume the current flags are re-resolved into an effective per-table strategy map and diffed against the map persisted on the first run (`diffCdcPartitioningStrategy`), producing an actionable error that lists exactly which tables changed. To avoid re-querying the target DB for expression-based unique-index tables on every resume, the expression-UK table set is now captured on the first prepare and persisted in a new `ImportDataStatusRecord` field (`CdcExpressionUniqueIndexTables`); resume reuses it. For older records that predate this capture (nil), the code falls back to the previous raw-string check for overrides. The global `--cdc-partition-key` still uses the existing raw-string guard.

### Describe if there are any user-facing changes

- **Command line:** No new or renamed flags. Behavior improvement: on resume (without `--start-clean`), a `--cdc-partition-key-overrides` string that is written differently but resolves to the same per-table strategy (reordered entries, quoted identifiers, extra whitespace) is now accepted instead of being rejected.
- **Error messages:** The resume change-guard error is reworded to `changing cdc-partition-key / cdc-partition-key-overrides is not allowed after the import data has started; effective strategy changed for: <tables>...` and now names the specific tables whose effective strategy changed. Switching an expression-UK table to `pk` on resume is rejected with the expression-UK error.
- **Configuration / installation / reports:** No changes.

### How was this pull request tested?

- **New unit test** `TestValidateCdcPartitioningStrategyUnchanged` in `yb-voyager/cmd/live_migration_test.go`: same config passes; semantically-equivalent overrides (quoting / whitespace) pass; a changed override target table and a removed override are rejected. The old raw-string `resume rejects changed overrides` subtest in `TestValidateCdcPartitionKeyFlags` was removed (superseded by the semantic test).
- **New integration test** `TestLiveMigrationCdcPartitionKeyOverridesEquivalentOnResume` in `src/testlivemigration/live_migration_uk_conflict_test.go`: first run with global `pk` + `orders:table` override; a resume that flips the effective strategies is rejected, while a resume with a differently-written but semantically-equivalent overrides string is accepted and runs through streaming and cutover, asserting the persisted per-table map is preserved and that `CdcExpressionUniqueIndexTables` is captured on the first run.
- **Updated integration tests**: `TestLiveMigrationCdcPartitionKeyConfigs` was updated for the new error wording, and `TestLiveMigrationCdcPartitionKeyRejectsPkOnExpressionUniqueIndex` now also verifies that switching the expression-UK table to `pk` on resume is rejected (reusing the captured expression-UK set, no target-DB re-query).

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

Yes — `ImportDataStatusRecord` (MetaDB / Import Data State) gains a new additive field `CdcExpressionUniqueIndexTables` (`json:"cdcExpressionUniqueIndexTables"`). It is backward compatible: a nil value (records written by an older voyager, or a first run that did not need the expression-UK check) is handled explicitly by falling back to the previous raw-string overrides check. No existing JSON tags are changed.

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component |
| :----------------------------------------------: |
| MetaDB |
| Name registry json |
| Data File Descriptor Json |
| Export Snapshot Status Json |
| Callhome Json |
| Export Status Json |
| YugabyteD Tables |
| TargetDB Metadata Tables |
| Schema Dump |
| AssessmentDB |
| Migration Assessment Report Json |
| Import Data State |
| Export and import data queue |
| Data .sql files of tables |