### PR TITLE
Add a POC script for PostgreSQL to YugabyteDB AMP migration assessment

### DIFF
--- a/yb-voyager/scripts/amp/README.md
+++ b/yb-voyager/scripts/amp/README.md
@@ -1,0 +1,202 @@
+# AMP migration assessment (POC)
+
+A minimal migration assessment for a PostgreSQL → YugabyteDB AMP migration.
+
+AMP's compute is PostgreSQL, so none of voyager's YugabyteDB compatibility
+analysis applies. This assessment reports two things: complexity `LOW`, and a
+vCPU recommendation matched to the source database's own capacity. It does not
+analyse the schema — no datatypes, extensions, PL/pgSQL or query constructs.
+
+It writes the same control-plane rows that `yb-voyager assess-migration` writes,
+with a payload shaped like `AssessMigrationPayloadYugabyteD`, so the AMP
+controller can read it unchanged.
+
+> This is throwaway scaffolding for the POC. The real implementation belongs
+> inside `yb-voyager assess-migration --target-db-type yugabytedb-amp`.
+
+## Running it
+
+```
+yb-voyager-amp-assess-migration.sh <pg_connection_string> <schema_list> <output_dir>
+```
+
+| Argument | Meaning |
+| --- | --- |
+| `pg_connection_string` | Source PostgreSQL, e.g. `postgresql://user@host:5432/dbname`. Quote it. |
+| `schema_list` | Pipe-separated, e.g. `public\|sales`. Recorded on the control-plane row; not otherwise used. |
+| `output_dir` | Where the local copy of the report is written. |
+
+| Environment variable | Required | Meaning |
+| --- | --- | --- |
+| `PGPASSWORD` | if the source needs one | Source database password |
+| `YB_VOYAGER_MIGRATION_UUID` | yes | Migration UUID the control-plane rows are keyed by (AMP's `migration.id`) |
+| `CONTROL_PLANE_TYPE` | no | `yugabyted` to write control-plane rows. Anything else, or unset, writes only the local report. |
+| `YUGABYTED_DB_CONN_STRING` | when `CONTROL_PLANE_TYPE=yugabyted` | Control-plane database |
+
+Full run:
+
+```sh
+PGPASSWORD=secret \
+YB_VOYAGER_MIGRATION_UUID=90b8b0b8-1111-2222-3333-444455556666 \
+CONTROL_PLANE_TYPE=yugabyted \
+YUGABYTED_DB_CONN_STRING='postgresql://yugabyte:yugabyte@127.0.0.1:5433' \
+./yb-voyager-amp-assess-migration.sh 'postgresql://user@dbhost:5432/prod' 'public' /tmp/amp-assessment
+```
+
+Local report only, no control plane:
+
+```sh
+YB_VOYAGER_MIGRATION_UUID=90b8b0b8-1111-2222-3333-444455556666 \
+./yb-voyager-amp-assess-migration.sh 'postgresql://user@dbhost:5432/prod' 'public' /tmp/amp-assessment
+```
+
+Requires `psql` on `PATH`. Nothing else — no jq, no python, no voyager install.
+
+### Output
+
+- `<output_dir>/assessment/reports/migration_assessment_report.json`
+- Two rows in `ybvoyager_visualizer.ybvoyager_visualizer_metadata`, if the
+  control plane is enabled.
+
+## Files
+
+| File | Responsibility |
+| --- | --- |
+| `yb-voyager-amp-assess-migration.sh` | Driver. Validates input, sequences the steps, runs the vCPU ladder, assembles the payload. |
+| `amp-source-facts.psql` | Everything cheap from the source, in one round trip. |
+| `amp-source-os-capacity.psql` | The `exact` tier — reads real CPU limits off the source host. |
+| `amp-controlplane-bootstrap.psql` | Control-plane schema DDL, copied verbatim from voyager. |
+
+### Flow
+
+```
+validate args + env
+   │
+   ├─ amp-source-facts.psql ──────────────► 10 fields, one psql round trip
+   │
+   ├─ [if control plane enabled]
+   │     amp-controlplane-bootstrap.psql
+   │     SEQ = MAX(invocation_sequence) + 1
+   │     INSERT seq=SEQ, status='IN PROGRESS', payload=''
+   │
+   ├─ vCPU ladder ────────────────────────► VCPUS, CONFIDENCE, DETECTION_METHOD
+   │
+   ├─ build payload, write local report
+   │
+   └─ [if control plane enabled]
+         INSERT seq=SEQ+1, status='COMPLETED', payload=<json>
+```
+
+The `IN PROGRESS` row is written *before* any detection work, mirroring voyager.
+If detection dies, the control plane shows a started-never-finished assessment
+rather than nothing at all.
+
+### `amp-source-facts.psql`
+
+Always runs, against the source. Emits one pipe-separated row (`psql -tA`) that
+the driver reads positionally — **field order is load-bearing**.
+
+| # | Field | Used for |
+| --- | --- | --- |
+| 1–3 | `is_superuser`, `pg_has_role(pg_read_server_files)`, `has_function_privilege(pg_read_file(...))` | Whether the `exact` tier is attempted |
+| 4–5 | `max_worker_processes`, `max_parallel_workers` | The `high` tier |
+| 6–10 | database name, server version, address, port, `pg_database_size` | Control-plane row columns and `TotalDBSize` |
+
+Its real job is being safe on a locked-down managed instance: every
+`pg_settings` lookup is wrapped in `coalesce(..., '0')` so a missing parameter
+produces a parseable value instead of an empty field that would shift every
+value after it.
+
+Reading `/proc` needs **both** membership in `pg_read_server_files` **and**
+`EXECUTE` on the specific `pg_read_file` overload. Either one alone still fails,
+which is why fields 2 and 3 are separate.
+
+### `amp-source-os-capacity.psql`
+
+Runs against the source, only when the capability probe passed. Four
+pipe-separated fields: cgroup `cpu.max`, `Cpus_allowed_list` from
+`/proc/self/status`, the `/proc/cpuinfo` processor count, and `MemTotal`.
+
+Its job is producing a number that is true *for the database*, not for the
+machine underneath it. Three things it deliberately handles:
+
+- **`/proc` is host-scoped.** A container capped at 1.5 CPUs still reports every
+  host core in `/proc/cpuinfo`, so that field is a last resort, not the primary.
+- **The cgroup path is not `/sys/fs/cgroup/`.** `cpu.max` exists only on non-root
+  cgroups, so the path is rebuilt from the `0::` line of `/proc/self/cgroup`.
+- **cpuset restrictions are invisible to the quota.** `--cpuset-cpus=0-1` leaves
+  `cpu.max` at `max 100000`; only `Cpus_allowed_list` shows the truth. Both are
+  read and the smaller wins.
+
+Every read uses `pg_read_file`'s 4-argument form so `missing_ok` turns an absent
+path into NULL rather than an error — which is what lets the file run harmlessly
+on a non-Linux host and return empty strings. Reads are length-bounded because
+the buffer is `palloc`'d up front.
+
+cgroup **v1 is not handled**. Such hosts fall back to `Cpus_allowed_list`, still
+cpuset-correct, only missing a CFS quota.
+
+### `amp-controlplane-bootstrap.psql`
+
+Pure DDL, no output, run against the control plane. Copied verbatim from
+voyager's `setupDatabase()` (`yb-voyager/src/cp/yugabyted/yugabyted.go`):
+`CREATE SCHEMA IF NOT EXISTS`, the `CREATE TABLE IF NOT EXISTS` with its original
+11 columns, then 7 `ALTER`s adding `host_ip` / `port` / `db_version` /
+`voyager_info` and widening three `VARCHAR(250)`s to `TEXT`.
+
+It is deliberately *not* collapsed into one tidy 15-column `CREATE TABLE`.
+Voyager grew those four columns later, and matching its exact statement sequence
+means a database bootstrapped by this script and one bootstrapped by voyager end
+up identical — same columns, same order, same types — in either order.
+
+## The vCPU ladder
+
+| Confidence | Rule |
+| --- | --- |
+| `exact` | Read the host: `min(Cpus_allowed_list, cgroup cpu.max quota)`, falling back to `/proc/cpuinfo` |
+| `high` | `max_worker_processes > 8 → ÷2`, else `max_parallel_workers > 8 → ×2` |
+| `unknown` | `-1` — the caller decides what to do |
+
+The `> 8` gate is the whole trick. PostgreSQL ships both parameters at exactly
+8, so any larger value means something sized them from the machine, using the
+documented formulas `max_worker_processes = GREATEST(vCPU*2, 8)` and
+`max_parallel_workers = GREATEST(vCPU/2, 8)`.
+
+Two consequences to be aware of:
+
+- The formulas saturate at their floor of 8. `max_parallel_workers` only exceeds
+  8 above 16 vCPU, so small and mid-sized managed instances commonly fall
+  through to `-1` rather than `high`.
+- A parameter that was hand-edited away from its default is indistinguishable
+  from one the platform computed, and produces a confident wrong answer.
+  `DetectionMethod` in the payload records which GUC was inverted.
+
+## Payload
+
+`json_build_object`, not `jsonb_build_object` — jsonb sorts keys, json preserves
+insertion order, so the output matches Go's struct marshal order field for
+field.
+
+Shape is `AssessMigrationPayloadYugabyteD` with `PayloadVersion` `1.8-amp.1`:
+
+- `MigrationComplexity` hard-coded `LOW`
+- `Sizing.SizingRecommendation` with `NumNodes: 1`, the detected `VCPUsPerInstance`,
+  and `MemoryPerInstance` fixed at 16 (AMP provisioning takes vCPU only). Colocated
+  and sharded arrays empty; connection counts and import-time estimates zero.
+- `SourceEnvironment` — an addition, not in voyager's payload: `VCPUs`,
+  `MemoryGiB`, `DetectionMethod`, `Confidence`
+- `SourceSizeDetails` carries `TotalDBSize` only
+- `SchemaSummary`, `ParsedSchemaSummary`, `AssessmentIssues` present but empty
+
+When vCPU is `-1`, `Sizing.FailureReasoning` explains why.
+
+## Gotchas if you edit this
+
+- `psql -c` does **not** interpolate `:'var'`. Variable interpolation only
+  happens for script input, so both parameterised statements are fed on stdin
+  heredocs.
+- There is no `ON CONFLICT` on the control-plane table, matching voyager. The
+  sequence is read fresh from the table each run, so a second run lands at 3 and
+  4 rather than colliding on the primary key.
+- The driver is `#!/bin/bash` and uses `read -ra`, which behaves differently
+  under zsh. Run it with bash.

--- a/yb-voyager/scripts/amp/amp-controlplane-bootstrap.psql
+++ b/yb-voyager/scripts/amp/amp-controlplane-bootstrap.psql
@@ -1,0 +1,32 @@
+-- Control-plane bootstrap, byte-for-byte what voyager's yugabyted control plane
+-- issues in setupDatabase() (yb-voyager/src/cp/yugabyted/yugabyted.go). Kept
+-- identical so a database bootstrapped by this script and one bootstrapped by
+-- voyager are indistinguishable, in either order.
+--
+-- The ALTERs are separate statements that voyager runs after the CREATE TABLE,
+-- which is why host_ip/port/db_version/voyager_info are added rather than being
+-- part of the original column list.
+CREATE SCHEMA IF NOT EXISTS ybvoyager_visualizer;
+
+CREATE TABLE IF NOT EXISTS ybvoyager_visualizer.ybvoyager_visualizer_metadata (
+    migration_uuid UUID,
+    migration_phase INT,
+    invocation_sequence INT,
+    migration_dir VARCHAR(250),
+    database_name VARCHAR(250),
+    schema_name VARCHAR(250),
+    payload TEXT,
+    complexity VARCHAR(30),
+    db_type VARCHAR(30),
+    status VARCHAR(30),
+    invocation_timestamp TIMESTAMPTZ,
+    PRIMARY KEY (migration_uuid, migration_phase, invocation_sequence)
+);
+
+ALTER TABLE ybvoyager_visualizer.ybvoyager_visualizer_metadata ADD COLUMN IF NOT EXISTS host_ip VARCHAR;
+ALTER TABLE ybvoyager_visualizer.ybvoyager_visualizer_metadata ADD COLUMN IF NOT EXISTS port INT;
+ALTER TABLE ybvoyager_visualizer.ybvoyager_visualizer_metadata ADD COLUMN IF NOT EXISTS db_version VARCHAR(250);
+ALTER TABLE ybvoyager_visualizer.ybvoyager_visualizer_metadata ADD COLUMN IF NOT EXISTS voyager_info VARCHAR;
+ALTER TABLE ybvoyager_visualizer.ybvoyager_visualizer_metadata ALTER COLUMN migration_dir TYPE TEXT;
+ALTER TABLE ybvoyager_visualizer.ybvoyager_visualizer_metadata ALTER COLUMN database_name TYPE TEXT;
+ALTER TABLE ybvoyager_visualizer.ybvoyager_visualizer_metadata ALTER COLUMN schema_name TYPE TEXT;

--- a/yb-voyager/scripts/amp/amp-source-facts.psql
+++ b/yb-voyager/scripts/amp/amp-source-facts.psql
@@ -1,0 +1,26 @@
+-- Collects everything the AMP assessment needs from the source PostgreSQL in a
+-- single round trip.
+--
+-- Safe on a locked-down managed instance: every pg_settings lookup is wrapped in
+-- coalesce() so a missing parameter yields a parseable value rather than an
+-- empty field that would shift every value after it.
+--
+-- Emits one pipe-separated row (psql -tA). Field order is load-bearing; the
+-- driver script reads it positionally.
+SELECT
+    -- 1..3  capability probe: reading /proc needs BOTH pg_read_server_files AND
+    --       EXECUTE on the specific pg_read_file overload.
+    current_setting('is_superuser'),
+    pg_has_role(current_user, 'pg_read_server_files', 'USAGE')::text,
+    has_function_privilege(current_user, 'pg_read_file(text,bigint,bigint,boolean)', 'EXECUTE')::text,
+
+    -- 4..5  vCPU-derived GUCs, inverted by the driver's `high` tier
+    coalesce((SELECT setting FROM pg_settings WHERE name = 'max_worker_processes'), '0'),
+    coalesce((SELECT setting FROM pg_settings WHERE name = 'max_parallel_workers'), '0'),
+
+    -- 6..10 identity, for the control-plane row columns and TotalDBSize
+    current_database(),
+    current_setting('server_version'),
+    coalesce(host(inet_server_addr())::text, ''),
+    current_setting('port'),
+    pg_database_size(current_database())::text;

--- a/yb-voyager/scripts/amp/amp-source-os-capacity.psql
+++ b/yb-voyager/scripts/amp/amp-source-os-capacity.psql
@@ -1,0 +1,41 @@
+-- Reads the real CPU count off the source host, for the `exact` confidence tier.
+-- Only run when amp-source-facts.psql reported that both pg_read_server_files
+-- and EXECUTE on pg_read_file are held.
+--
+-- Two things make the naive read wrong:
+--   1. /proc is host-scoped. Inside a container limited to 1.5 CPUs, /proc/cpuinfo
+--      still reports every host core. Cpus_allowed_list and the cgroup quota carry
+--      the truth.
+--   2. cgroup cpu.max is not at /sys/fs/cgroup/ for a process in a non-root
+--      cgroup, so the path is rebuilt from /proc/self/cgroup.
+--
+-- cgroup v1 is not handled; such hosts fall back to Cpus_allowed_list, which is
+-- still cpuset-correct and only misses a CFS quota.
+--
+-- pg_read_file's 4-arg form takes missing_ok, so absent paths return NULL rather
+-- than raising. Reads are length-bounded because the buffer is palloc'd up front.
+--
+-- Emits one pipe-separated row (psql -tA), read positionally by the driver.
+WITH cg AS (
+    SELECT
+        CASE WHEN pg_read_file('/sys/fs/cgroup/cgroup.controllers', 0, 4096, true) IS NOT NULL
+             -- rtrim the trailing slash so a root path does not yield '//cpu.max'
+             THEN rtrim(coalesce((regexp_match(
+                      coalesce(pg_read_file('/proc/self/cgroup', 0, 65536, true), ''),
+                      '(?m)^0::(.*)$'))[1], ''), '/')
+        END AS v2path
+)
+SELECT
+    -- "150000 100000" => 1.5 cores; "max 100000" => no quota
+    btrim(coalesce(pg_read_file('/sys/fs/cgroup' || v2path || '/cpu.max', 0, 128, true), ''), E' \t\n\r'),
+    -- cpuset-aware core list for this backend, e.g. "0-3,8"
+    coalesce((regexp_match(coalesce(pg_read_file('/proc/self/status', 0, 65536, true), ''),
+                           '(?m)^Cpus_allowed_list:\s+(\S+)'))[1], ''),
+    -- host-wide fallback
+    (SELECT count(*)
+       FROM regexp_split_to_table(coalesce(pg_read_file('/proc/cpuinfo', 0, 1048576, true), ''), E'\n') l
+      WHERE l ~ '^processor')::text,
+    -- informational only; the RAM recommendation is a fixed constant
+    coalesce((regexp_match(coalesce(pg_read_file('/proc/meminfo', 0, 65536, true), ''),
+                           'MemTotal:\s+(\d+) kB'))[1], '')
+FROM cg;

--- a/yb-voyager/scripts/amp/yb-voyager-amp-assess-migration.sh
+++ b/yb-voyager/scripts/amp/yb-voyager-amp-assess-migration.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+#   Copyright (c) YugabyteDB, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#	    http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# POC: a minimal migration assessment for a PostgreSQL -> YugabyteDB AMP
+# migration. AMP's compute is PostgreSQL, so none of voyager's YugabyteDB
+# compatibility analysis applies; the assessment reports LOW complexity and a
+# vCPU recommendation matched to the source's own capacity.
+#
+# Writes the same control-plane rows voyager's yugabyted control plane writes
+# for `assess-migration`, with a payload shaped like AssessMigrationPayloadYugabyteD,
+# so the AMP controller can read it without changes.
+#
+# This is throwaway scaffolding. The real implementation belongs inside
+# `yb-voyager assess-migration --target-db-type yugabytedb-amp`.
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE:-$0}" )" &> /dev/null && pwd )
+SCRIPT_NAME=$(basename $0)
+
+PAYLOAD_VERSION="1.8-amp.1"
+VOYAGER_VERSION="amp-assess-poc"
+RECOMMENDED_MEMORY_GB=16   # fixed for now; AMP provisioning takes vCPU only
+
+HELP_TEXT="
+Usage: $SCRIPT_NAME <pg_connection_string> <schema_list> <output_dir>
+
+Arguments:
+  pg_connection_string   Source PostgreSQL connection string, e.g.
+                         'postgresql://username@hostname:port/dbname'
+                         Quote it to avoid shell interpretation.
+
+  schema_list            Pipe-separated schema list, e.g. 'public|sales'.
+                         Recorded on the control-plane row; not otherwise used.
+
+  output_dir             Directory for the local copy of the assessment report.
+
+Environment:
+  PGPASSWORD                  Source database password.
+  YB_VOYAGER_MIGRATION_UUID   Required. The migration UUID the control-plane
+                              rows are keyed by (AMP's migration.id).
+  CONTROL_PLANE_TYPE          'yugabyted' to write control-plane rows. Anything
+                              else (or unset) writes only the local report.
+  YUGABYTED_DB_CONN_STRING    Required when CONTROL_PLANE_TYPE=yugabyted.
+
+Example:
+  PGPASSWORD=secret \\
+  YB_VOYAGER_MIGRATION_UUID=90b8b0b8-1111-2222-3333-444455556666 \\
+  CONTROL_PLANE_TYPE=yugabyted \\
+  YUGABYTED_DB_CONN_STRING='postgresql://yugabyte:yugabyte@127.0.0.1:5433' \\
+  $SCRIPT_NAME 'postgresql://user@dbhost:5432/prod' 'public' /tmp/amp-assessment
+"
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ $# -lt 3 ]; then
+    echo "$HELP_TEXT"
+    [ $# -lt 3 ] && exit 1
+    exit 0
+fi
+
+SOURCE_CONN="$1"
+SCHEMA_LIST="$2"
+OUTPUT_DIR="$3"
+
+if [ -z "$YB_VOYAGER_MIGRATION_UUID" ]; then
+    echo "ERROR: YB_VOYAGER_MIGRATION_UUID must be set." >&2
+    exit 1
+fi
+
+WRITE_CONTROL_PLANE=false
+if [ "$CONTROL_PLANE_TYPE" = "yugabyted" ]; then
+    if [ -z "$YUGABYTED_DB_CONN_STRING" ]; then
+        echo "ERROR: YUGABYTED_DB_CONN_STRING must be set when CONTROL_PLANE_TYPE=yugabyted." >&2
+        exit 1
+    fi
+    WRITE_CONTROL_PLANE=true
+fi
+
+mkdir -p "$OUTPUT_DIR/assessment/reports"
+OUTPUT_DIR=$( cd "$OUTPUT_DIR" && pwd )
+REPORT_PATH="$OUTPUT_DIR/assessment/reports/migration_assessment_report.json"
+
+src()  { psql -X -q -tA "$SOURCE_CONN" "$@"; }
+cp_()  { psql -X -q -tA "$YUGABYTED_DB_CONN_STRING" "$@"; }
+
+# --- source facts -------------------------------------------------------------
+
+echo "Collecting source database facts..."
+FACTS=$(src -v ON_ERROR_STOP=on -f "$SCRIPT_DIR/amp-source-facts.psql")
+IFS='|' read -r IS_SUPERUSER HAS_READ_ROLE HAS_READ_EXEC \
+                MAX_WORKER_PROCESSES MAX_PARALLEL_WORKERS \
+                DB_NAME DB_VERSION SERVER_ADDR SERVER_PORT DB_SIZE <<< "$FACTS"
+
+echo "  database=$DB_NAME version=$DB_VERSION"
+
+# --- control plane: bootstrap and the IN PROGRESS row -------------------------
+
+# Mirrors voyager: the started row is written before any assessment work, and
+# the completed row gets the next invocation_sequence rather than updating it.
+if [ "$WRITE_CONTROL_PLANE" = true ]; then
+    echo "Bootstrapping control-plane schema..."
+    cp_ -v ON_ERROR_STOP=on -f "$SCRIPT_DIR/amp-controlplane-bootstrap.psql" > /dev/null
+
+    SEQ=$(cp_ -v ON_ERROR_STOP=on -c "
+        SELECT coalesce(MAX(invocation_sequence), 0) + 1
+          FROM ybvoyager_visualizer.ybvoyager_visualizer_metadata
+         WHERE migration_uuid = '$YB_VOYAGER_MIGRATION_UUID' AND migration_phase = 1;")
+
+    HOST_IP_JSON="{\"SourceDBIP\":\"${SERVER_ADDR}\"}"
+    LOCAL_IP=$(hostname -i 2>/dev/null | awk '{print $1}')
+    [ -z "$LOCAL_IP" ] && LOCAL_IP="127.0.0.1"
+    DISK_AVAIL=$(df -Pk "$OUTPUT_DIR" | awk 'NR==2 {print $4 * 1024}')
+    VOYAGER_INFO_JSON=$(printf '{"IP":"%s","OperatingSystem":"%s","DiskSpaceAvailable":%s,"ExportDirectory":"%s"}' \
+        "$LOCAL_IP" "$(uname -s | tr 'A-Z' 'a-z')" "$DISK_AVAIL" "$OUTPUT_DIR")
+
+    # psql interpolates :'var' only for script input, never for -c, so the
+    # statement is fed on stdin.
+    insert_cp_row() {   # $1 = invocation_sequence, $2 = status, $3 = payload
+        cp_ -v ON_ERROR_STOP=on \
+            -v uuid="$YB_VOYAGER_MIGRATION_UUID" -v seq="$1" -v status="$2" -v payload="$3" \
+            -v mdir="$OUTPUT_DIR" -v dbname="$DB_NAME" -v schemas="$SCHEMA_LIST" \
+            -v hostip="$HOST_IP_JSON" -v port="$SERVER_PORT" -v dbver="$DB_VERSION" \
+            -v vinfo="$VOYAGER_INFO_JSON" <<'SQL' > /dev/null
+INSERT INTO ybvoyager_visualizer.ybvoyager_visualizer_metadata (
+    migration_uuid, migration_phase, invocation_sequence, migration_dir,
+    database_name, schema_name, host_ip, port, db_version, payload,
+    voyager_info, db_type, status, invocation_timestamp
+) VALUES (
+    :'uuid', 1, :'seq'::int, :'mdir', :'dbname', :'schemas', :'hostip',
+    :'port'::int, :'dbver', :'payload', :'vinfo', 'postgresql', :'status', now()
+);
+SQL
+    }
+
+    echo "Recording assessment start (invocation_sequence=$SEQ)..."
+    insert_cp_row "$SEQ" "IN PROGRESS" ""
+fi
+
+# --- vCPU detection -----------------------------------------------------------
+#
+#   exact  read the source host's real CPU limits through pg_read_file
+#   high   invert a vCPU-derived GUC. PostgreSQL ships max_worker_processes and
+#          max_parallel_workers at exactly 8, so a value above 8 means something
+#          sized them from the machine, using the documented formulas
+#          max_worker_processes = GREATEST(vCPU*2,8) and
+#          max_parallel_workers = GREATEST(vCPU/2,8).
+#   -1     no signal. The caller decides what to do.
+
+VCPUS=-1
+MEMORY_GB=-1
+CONFIDENCE="unknown"
+DETECTION_METHOD="none"
+
+count_cpu_list() {   # "0-3,8,10-11" -> 7
+    local total=0 part lo hi
+    [ -z "$1" ] && { echo 0; return; }
+    IFS=',' read -ra parts <<< "$1"
+    for part in "${parts[@]}"; do
+        if [[ "$part" == *-* ]]; then
+            lo=${part%-*}; hi=${part#*-}
+            total=$(( total + hi - lo + 1 ))
+        else
+            total=$(( total + 1 ))
+        fi
+    done
+    echo "$total"
+}
+
+if [ "$IS_SUPERUSER" = "on" ] || { [ "$HAS_READ_ROLE" = "true" ] && [ "$HAS_READ_EXEC" = "true" ]; }; then
+    echo "Reading source host CPU limits..."
+    if OS_CAPACITY=$(src -v ON_ERROR_STOP=on -f "$SCRIPT_DIR/amp-source-os-capacity.psql" 2>/dev/null); then
+        IFS='|' read -r CPU_MAX CPUS_ALLOWED CPUINFO_COUNT MEMTOTAL_KB <<< "$OS_CAPACITY"
+
+        # cpuset-aware count, falling back to the host-wide core count
+        DETECTED=$(count_cpu_list "$CPUS_ALLOWED")
+        METHOD="Cpus_allowed_list"
+        if [ "$DETECTED" -eq 0 ] && [ -n "$CPUINFO_COUNT" ]; then
+            DETECTED=$CPUINFO_COUNT
+            METHOD="/proc/cpuinfo"
+        fi
+
+        # a CFS quota caps it further; "max 100000" means no quota
+        QUOTA=${CPU_MAX%% *}
+        PERIOD=${CPU_MAX##* }
+        if [ -n "$QUOTA" ] && [ "$QUOTA" != "max" ] && [ "$PERIOD" -gt 0 ] 2>/dev/null; then
+            QUOTA_CPUS=$(( (QUOTA + PERIOD - 1) / PERIOD ))   # round up
+            if [ "$QUOTA_CPUS" -gt 0 ] && [ "$QUOTA_CPUS" -lt "$DETECTED" ]; then
+                DETECTED=$QUOTA_CPUS
+                METHOD="cgroup cpu.max"
+            fi
+        fi
+
+        if [ "$DETECTED" -gt 0 ]; then
+            VCPUS=$DETECTED
+            CONFIDENCE="exact"
+            DETECTION_METHOD="$METHOD"
+            [ -n "$MEMTOTAL_KB" ] && MEMORY_GB=$(( MEMTOTAL_KB / 1048576 ))
+        fi
+    else
+        echo "  host read failed; falling back to parameter inference"
+    fi
+fi
+
+if [ "$VCPUS" -le 0 ]; then
+    if [ "$MAX_WORKER_PROCESSES" -gt 8 ]; then
+        VCPUS=$(( MAX_WORKER_PROCESSES / 2 ))
+        CONFIDENCE="high"
+        DETECTION_METHOD="max_worker_processes/2"
+    elif [ "$MAX_PARALLEL_WORKERS" -gt 8 ]; then
+        VCPUS=$(( MAX_PARALLEL_WORKERS * 2 ))
+        CONFIDENCE="high"
+        DETECTION_METHOD="max_parallel_workers*2"
+    fi
+fi
+
+if [ "$VCPUS" -le 0 ]; then
+    echo "  could not determine source vCPU count; reporting -1"
+else
+    echo "  source vCPUs: $VCPUS (confidence=$CONFIDENCE via $DETECTION_METHOD)"
+fi
+
+# --- payload ------------------------------------------------------------------
+
+# json_build_object, not jsonb_build_object: jsonb reorders keys, json preserves
+# insertion order so the payload matches Go's marshal order field for field.
+if [ "$VCPUS" -gt 0 ]; then
+    SIZING_REASONING="Recommended AMP compute matched to source capacity: ${VCPUS} vCPU (confidence: ${CONFIDENCE}, via ${DETECTION_METHOD})."
+    FAILURE_REASONING=""
+else
+    SIZING_REASONING="Source vCPU count could not be determined; VCPUsPerInstance is reported as -1."
+    FAILURE_REASONING="Unable to determine source vCPU count from the source database."
+fi
+
+echo "Building assessment payload..."
+PAYLOAD=$(src -v ON_ERROR_STOP=on \
+    -v pver="$PAYLOAD_VERSION" -v vver="$VOYAGER_VERSION" \
+    -v vcpus="$VCPUS" -v memgb="$RECOMMENDED_MEMORY_GB" -v srcmem="$MEMORY_GB" \
+    -v conf="$CONFIDENCE" -v method="$DETECTION_METHOD" \
+    -v dbsize="$DB_SIZE" -v reasoning="$SIZING_REASONING" -v failure="$FAILURE_REASONING" \
+    <<'SQL'
+SELECT json_build_object(
+    'PayloadVersion', :'pver',
+    'VoyagerVersion', :'vver',
+    'TargetDBVersion', NULL,
+    'MigrationComplexity', 'LOW',
+    'MigrationComplexityExplanation',
+        'YugabyteDB AMP is a PostgreSQL-compatible compute, so a PostgreSQL source needs no schema conversion. This assessment reports sizing only; it does not analyse the schema for incompatibilities.',
+    'SchemaSummary', json_build_object(),
+    'ParsedSchemaSummary', json_build_object(),
+    'AssessmentIssues', json_build_array(),
+    'SourceSizeDetails', json_build_object(
+        'TotalDBSize', :'dbsize'::bigint,
+        'TotalTableSize', 0,
+        'TotalIndexSize', 0,
+        'TotalTableRowCount', 0),
+    'TargetRecommendations', json_build_object('TotalColocatedSize', 0, 'TotalShardedSize', 0),
+    'ConversionIssues', json_build_array(),
+    'Sizing', json_build_object(
+        'SizingRecommendation', json_build_object(
+            'ColocatedTables', json_build_array(),
+            'ColocatedReasoning', :'reasoning',
+            'ShardedTables', json_build_array(),
+            'NumNodes', 1,
+            'VCPUsPerInstance', :'vcpus'::int,
+            'MemoryPerInstance', :'memgb'::int,
+            'OptimalSelectConnectionsPerNode', 0,
+            'OptimalInsertConnectionsPerNode', 0,
+            'EstimatedTimeInMinForImport', 0,
+            'EstimatedTimeInMinForImportWithoutRedundantIndexes', 0),
+        'FailureReasoning', :'failure'),
+    'TableIndexStats', NULL,
+    'SourceEnvironment', json_build_object(
+        'VCPUs', :'vcpus'::int,
+        'MemoryGiB', :'srcmem'::int,
+        'DetectionMethod', :'method',
+        'Confidence', :'conf'),
+    'GeneralNotes', json_build_array(
+        'Generated by the AMP assessment POC script, not by yb-voyager assess-migration. Schema compatibility, datatypes, extensions and query constructs were not analysed.'),
+    'ColocatedShardedNotes', json_build_array(),
+    'SizingNotes', json_build_array(:'reasoning'),
+    'Notes', json_build_array(:'reasoning')
+);
+SQL
+)
+
+printf '%s\n' "$PAYLOAD" > "$REPORT_PATH"
+echo "Assessment report written to $REPORT_PATH"
+
+# --- control plane: the COMPLETED row -----------------------------------------
+
+if [ "$WRITE_CONTROL_PLANE" = true ]; then
+    echo "Recording assessment completion (invocation_sequence=$(( SEQ + 1 )))..."
+    insert_cp_row "$(( SEQ + 1 ))" "COMPLETED" "$PAYLOAD"
+fi
+
+echo "Done."


### PR DESCRIPTION
### Describe the changes in this pull request

AMP's compute is PostgreSQL, so voyager's YugabyteDB compatibility analysis — unsupported datatypes, PL/pgSQL objects, query constructs, colocation and sharding — does not apply to a PG → AMP migration. This adds a small standalone script that reports only the two things that do matter for that path: complexity `LOW`, and a vCPU recommendation matched to the source database's own capacity.

The script writes the same control-plane rows `assess-migration` writes (phase 1, `IN PROGRESS` at invocation_sequence *n* then `COMPLETED` at *n+1*), carrying a payload shaped like `AssessMigrationPayloadYugabyteD`, so the AMP controller can read it without changes.

Source vCPU is detected in two tiers. `exact` reads the host's real limits through `pg_read_file`, taking the smaller of `Cpus_allowed_list` and the cgroup `cpu.max` quota — both are needed, because `/proc` is host-scoped inside a container and a cpuset restriction leaves the quota reading `max`. `high` inverts a vCPU-derived GUC: PostgreSQL ships `max_worker_processes` and `max_parallel_workers` at exactly 8, so a larger value means the platform sized them from the machine via `GREATEST(vCPU*2,8)` / `GREATEST(vCPU/2,8)`. Neither tier yielding a number reports `-1` and lets the caller decide, rather than inventing one. `MemoryPerInstance` is a fixed 16 — AMP provisioning takes vCPU only.

This is deliberately throwaway scaffolding for the AMP POC. It lives in `yb-voyager/scripts/`, outside the installed tree, and is not wired into any command or the build. The real implementation belongs inside `assess-migration --target-db-type yugabytedb-amp`.

### Describe if there are any user-facing changes

No user-facing changes. No new commands or flags, no configuration changes, no change to the installation process, and no change to any report voyager itself produces. Nothing in `cmd/` or `src/` is touched — the PR is purely additive, five new files under a new `yb-voyager/scripts/amp/` directory.

### How was this pull request tested?

Manual testing only; there are no automated tests, and no existing test tier covers standalone shell scripts. Verified end to end against a local PostgreSQL 17 instance, with a second local database standing in for the control plane (the bootstrap DDL is plain PostgreSQL):

- **No signal → `-1`**: reports `VCPUsPerInstance: -1`, sets `Sizing.FailureReasoning`, still writes the report.
- **`high` tier**: forced `max_parallel_workers=16` via `PGOPTIONS` → 48 vCPU at `max_parallel_workers*2` with `Confidence: high`.
- **Control-plane writes**: bootstrap, then `IN PROGRESS` at seq 1 with an empty payload and `COMPLETED` at seq 2 with the report JSON. A re-run correctly lands at seq 3 and 4 rather than colliding on the primary key. The resulting table is a 15-column match for voyager's effective shape, and `host_ip` / `voyager_info` carry the same JSON-in-a-column format voyager writes.

**Not verified:** the `exact` tier never executed — the dev machine is macOS with no `/proc`, and no Linux container was available. Its two halves were validated separately instead: the SQL regexes against synthetic `/proc/self/status`, `/proc/meminfo`, `/proc/cpuinfo` and `/proc/self/cgroup` content, and the bash cpuset/quota arithmetic against synthetic values (`0-3,8` → 5, `0-3,8,10-11` → 7, `150000 100000` → 2). **This path still needs one run against a containerised PostgreSQL on Linux before the POC is demoed.**

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No changes to voyager's payloads. `ASSESS_MIGRATION_YBD_PAYLOAD_VERSION` and the `AssessMigrationPayloadYugabyteD` struct are untouched.

The script does *write* a yugabyted-shaped payload from outside voyager. It stamps `PayloadVersion` as `1.8-amp.1` — deliberately distinguishable from a genuine `1.8` — and adds one field voyager does not emit, `SourceEnvironment` (`VCPUs`, `MemoryGiB`, `DetectionMethod`, `Confidence`), so a reader can tell how the number was arrived at. `SchemaSummary`, `ParsedSchemaSummary` and `AssessmentIssues` are present but empty; `SourceSizeDetails` carries `TotalDBSize` only.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No schema changes. The script touches **YugabyteD Tables** and **Migration Assessment Report Json** from the reference table, but in both cases it conforms to the existing shape rather than altering it:

- `amp-controlplane-bootstrap.psql` is copied verbatim from `setupDatabase()` in `src/cp/yugabyted/yugabyted.go`, including the original 11-column `CREATE TABLE` followed by the 7 `ALTER`s, so a database bootstrapped by this script and one bootstrapped by voyager end up identical in either order. All statements are `IF NOT EXISTS`.
- The rows written match voyager's column set and value conventions exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)