### PR TITLE
Unhide cdc-partition-key* flags in import data command and add it to live migration config templates

### DIFF
--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -503,15 +503,13 @@ Note that for the cases where a table doesn't have a primary key, this may lead 
 
 	cmd.Flags().StringVar(&cdcPartitionKey, "cdc-partition-key", "auto",
 		`Global strategy for how CDC events are hashed across parallel channels. Supported values: auto, pk, table.
-		\tauto: Automatically pick pk or table per table (expression unique-index tables use table).
-		\tpk: Partition CDC events by primary key.
-		\ttable: Partition CDC events by table (all events for a table share one channel).`)
-	cmd.Flags().MarkHidden("cdc-partition-key")
+		auto: Automatically pick pk or table per table (expression unique-index tables use table).
+		pk: Partition CDC events by primary key.
+		table: Partition CDC events by table (all events for a table share one channel).`)
 
 	cmd.Flags().StringVar(&cdcPartitionKeyOverrides, "cdc-partition-key-overrides", "",
 		`Optional per-table CDC partition-key overrides as schema.table:pk|table pairs, separated by ';'.
 		Example: public.orders:table;sales.events:pk. Unlisted tables keep the global --cdc-partition-key.`)
-	cmd.Flags().MarkHidden("cdc-partition-key-overrides")
 
 	cmd.Flags().IntVar(&prometheusMetricsPort, "prometheus-metrics-port", 0,
 		"Port for Prometheus metrics server (default: 9101)")

--- a/yb-voyager/config-templates/live-migration-with-fall-back.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-back.yaml
@@ -479,6 +479,20 @@ import-data-to-target:
   ### Default - true
   # use-partition-root: true
 
+  ### Global strategy for how CDC events are hashed across parallel channels. Supported values: auto, pk, table.
+  ### auto: Automatically pick pk or table per table (expression unique-index tables use table).
+  ### pk: Partition CDC events by primary key.
+  ### table: Partition CDC events by table (all events for a table share one channel).
+  ### Accepted values: auto, pk, table
+  ### Default - auto
+  # cdc-partition-key: auto
+
+  ### Optional per-table CDC partition-key overrides as schema.table:pk|table pairs, separated by ';'.
+  ### Example: public.orders:table;sales.events:pk. Unlisted tables keep the global --cdc-partition-key.
+  ### Accepted values: schema.table:pk|table pairs, separated by ';'
+  ### Default - empty
+  # cdc-partition-key-overrides: public.orders:table;sales.events:pk
+
 # ---------------------------------------------------------
 # Archive Changes
 # ---------------------------------------------------------

--- a/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
@@ -538,6 +538,20 @@ import-data-to-target:
   ### Default - true
   # use-partition-root: true
 
+  ### Global strategy for how CDC events are hashed across parallel channels. Supported values: auto, pk, table.
+  ### auto: Automatically pick pk or table per table (expression unique-index tables use table).
+  ### pk: Partition CDC events by primary key.
+  ### table: Partition CDC events by table (all events for a table share one channel).
+  ### Accepted values: auto, pk, table
+  ### Default - auto
+  # cdc-partition-key: auto
+
+  ### Optional per-table CDC partition-key overrides as schema.table:pk|table pairs, separated by ';'.
+  ### Example: public.orders:table;sales.events:pk. Unlisted tables keep the global --cdc-partition-key.
+  ### Accepted values: schema.table:pk|table pairs, separated by ';'
+  ### Default - empty
+  # cdc-partition-key-overrides: public.orders:table;sales.events:pk
+
 # ---------------------------------------------------------
 # Import data to source-replica
 # ---------------------------------------------------------

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -487,6 +487,20 @@ import-data-to-target:
   ### Default - true
   # use-partition-root: true
 
+  ### Global strategy for how CDC events are hashed across parallel channels. Supported values: auto, pk, table.
+  ### auto: Automatically pick pk or table per table (expression unique-index tables use table).
+  ### pk: Partition CDC events by primary key.
+  ### table: Partition CDC events by table (all events for a table share one channel).
+  ### Accepted values: auto, pk, table
+  ### Default - auto
+  # cdc-partition-key: auto
+
+  ### Optional per-table CDC partition-key overrides as schema.table:pk|table pairs, separated by ';'.
+  ### Example: public.orders:table;sales.events:pk. Unlisted tables keep the global --cdc-partition-key.
+  ### Accepted values: schema.table:pk|table pairs, separated by ';'
+  ### Default - empty
+  # cdc-partition-key-overrides: public.orders:table;sales.events:pk
+
 # ---------------------------------------------------------
 # Archive Changes
 # ---------------------------------------------------------


### PR DESCRIPTION
https://yugabyte.atlassian.net/browse/DB-22821
### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
