### PR TITLE
Propagate WaitUntilNoConflict error in streaming conflict detection instead of ignoring it

### DIFF
--- a/yb-voyager/cmd/conflictDetectionCache_test.go
+++ b/yb-voyager/cmd/conflictDetectionCache_test.go
@@ -793,3 +793,22 @@ func TestConflictWithMultipleIndexes(t *testing.T) {
 	assert.Equal(t, "idx_a_b", actualConflicts[0].indexName)
 	assert.Equal(t, "idx_nnd_c_d", actualConflicts[1].indexName)
 }
+
+// An incoming UPDATE with nil BeforeFields (e.g. replica identity not FULL)
+// makes the before-before probe fail; WaitUntilNoConflict must surface that
+// error so handleEvent aborts the import instead of silently skipping
+// conflict detection for the event.
+func TestWaitUntilNoConflictPropagatesBeforeFieldsError(t *testing.T) {
+	cache := newConflictCacheForTest([][]string{{"a", "b"}})
+	incoming := &tgtdb.Event{
+		Vsn:          2,
+		Op:           "u",
+		TableNameTup: testTableTuple(),
+		Key:          map[string]*string{"id": strPtr("2")},
+		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
+		BeforeFields: nil,
+	}
+	err := cache.WaitUntilNoConflict(incoming)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fields are nil")
+}

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -377,7 +377,10 @@ func handleEvent(event *tgtdb.Event,
 				return goerrors.Errorf("error putting event into conflict detection cache: %v", err)
 			}
 		} else { // "i" or "u"
-			conflictDetectionCache.WaitUntilNoConflict(event)
+			err = conflictDetectionCache.WaitUntilNoConflict(event)
+			if err != nil {
+				return goerrors.Errorf("error waiting for conflicts to clear for event vsn(%d): %v", event.Vsn, err)
+			}
 			if event.Op == "u" {
 				// Adding all the update events to the conflict detection cache since we need to check detect the conflicts in cases where
 				// unique key column is not changed in addition to unique key column is actually changed


### PR DESCRIPTION
### Describe the changes in this pull request

During the live-migration streaming phase, `handleEvent` calls `conflictDetectionCache.WaitUntilNoConflict(event)` for every incoming INSERT/UPDATE but discards its error return. `WaitUntilNoConflict` errors when a conflict probe cannot be computed — e.g. an incoming UPDATE with nil `BeforeFields` (source table missing REPLICA IDENTITY FULL) or a failed partition-key computation. With the error ignored, the event proceeded to its channel with **no conflict serialization at all**, silently disabling unique-key conflict detection for that event; a genuine in-flight conflict could then race and either fail the import later with an unexplained `23505` or apply out of order. Inside `findValueConflictLocked` the same error path also throws away before–after conflicts that were already found for the event.

This PR propagates the error so the import fails immediately with a clear message, making the behavior consistent with the DELETE path, which already hard-fails when `Put` cannot cache an event with nil `BeforeFields`. Failing loudly is the correct posture for the conflict-detection subsystem: silently skipping detection converts an operator-visible configuration problem into a potential ordering race.

### Describe if there are any user-facing changes

No user-facing changes in the healthy path. If a migration is running with events whose before-images are missing (replica identity not FULL), import data now exits with `error waiting for conflicts to clear for event vsn(...)` instead of continuing with conflict detection silently disabled for those events.

### How was this pull request tested?

- Added unit test `TestWaitUntilNoConflictPropagatesBeforeFieldsError` in `cmd/conflictDetectionCache_test.go`, asserting `WaitUntilNoConflict` surfaces the probe error for an incoming UPDATE with nil `BeforeFields`.
- Ran the existing conflict-detection unit suite: `go test -tags unit -run 'TestWaitUntilNoConflict...|TestIndexTupleConflicts|TestEventsConf' ./cmd/` — all pass.
- `go vet ./cmd/` clean.
- Existing live-migration UK conflict tests (`failpoint_import`) cover the unchanged happy path; no behavior change there since `WaitUntilNoConflict` only errors on malformed events.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)