### PR TITLE
[cherry-pick] Propagate WaitUntilNoConflict error in handleEvent instead of ignorin…

### DIFF
--- a/yb-voyager/cmd/conflictDetectionCache_test.go
+++ b/yb-voyager/cmd/conflictDetectionCache_test.go
@@ -793,3 +793,22 @@ func TestConflictWithMultipleIndexes(t *testing.T) {
 	assert.Equal(t, "idx_a_b", actualConflicts[0].indexName)
 	assert.Equal(t, "idx_nnd_c_d", actualConflicts[1].indexName)
 }
+
+// An incoming UPDATE with nil BeforeFields (e.g. replica identity not FULL)
+// makes the before-before probe fail; WaitUntilNoConflict must surface that
+// error so handleEvent aborts the import instead of silently skipping
+// conflict detection for the event.
+func TestWaitUntilNoConflictPropagatesBeforeFieldsError(t *testing.T) {
+	cache := newConflictCacheForTest([][]string{{"a", "b"}})
+	incoming := &tgtdb.Event{
+		Vsn:          2,
+		Op:           "u",
+		TableNameTup: testTableTuple(),
+		Key:          map[string]*string{"id": strPtr("2")},
+		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
+		BeforeFields: nil,
+	}
+	err := cache.WaitUntilNoConflict(incoming)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fields are nil")
+}

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -377,7 +377,10 @@ func handleEvent(event *tgtdb.Event,
 				return goerrors.Errorf("error putting event into conflict detection cache: %v", err)
 			}
 		} else { // "i" or "u"
-			conflictDetectionCache.WaitUntilNoConflict(event)
+			err = conflictDetectionCache.WaitUntilNoConflict(event)
+			if err != nil {
+				return goerrors.Errorf("error waiting for conflicts to clear for event vsn(%d): %v", event.Vsn, err)
+			}
 			if event.Op == "u" {
 				// Adding all the update events to the conflict detection cache since we need to check detect the conflicts in cases where
 				// unique key column is not changed in addition to unique key column is actually changed


### PR DESCRIPTION
…g it (#3714)

WaitUntilNoConflict returns an error when a conflict probe cannot be computed (e.g. an incoming UPDATE with nil BeforeFields when the source table lacks REPLICA IDENTITY FULL, or a failed partition-key computation). The call site in handleEvent discarded that error, so the event proceeded without any conflict serialization - silently disabling unique-key conflict detection for that event. Inside findValueConflictLocked the same error path also discards before-after conflicts that were already found.

Propagate the error so the import fails loudly, consistent with how the DELETE path already hard-fails when Put cannot cache an event with nil BeforeFields.

### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
