### PR TITLE
Fix: false negative case where subset of unique index columns being changed in update

### DIFF
--- a/.github/workflows/failpoint-tests.yml
+++ b/.github/workflows/failpoint-tests.yml
@@ -2,7 +2,7 @@ name: Failpoint Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [2026.7.1-dev]
   push:
     branches: [ main, '*.*-dev', '*.*.*-dev' ]
 

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -374,18 +374,31 @@ func (c *ConflictDetectionCache) uniqueIndexConflicts(cachedEvent *tgtdb.Event, 
 	return false
 }
 
+func anyIndexColumnsChanged(fields map[string]*string, indexColumns []string) bool {
+	for _, column := range indexColumns {
+		if fields[column] != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *ConflictDetectionCache) checkUniqueIndexBeforeAfterConflict(cachedEvent *tgtdb.Event, incomingEvent *tgtdb.Event, indexColumns []string) bool {
-	// Check conflict: cachedEvent.BeforeFields[index columns] == incomingEvent.Fields[index columns]
-	if !uniqueIndexColumnsExistInBothFields(cachedEvent.BeforeFields, incomingEvent.Fields, indexColumns) {
+	if incomingEvent.Op == "u" && !anyIndexColumnsChanged(incomingEvent.Fields, indexColumns) {
 		return false
 	}
-	if !uniqueIndexColumnValuesEqual(cachedEvent.BeforeFields, incomingEvent.Fields, indexColumns) {
+
+	// Check conflict: cachedEvent.BeforeFields[index columns] == incomingEvent.Fields[index columns]
+	if !uniqueIndexColumnsExistInBothFields(cachedEvent.BeforeFields, incomingEvent.AfterFields, indexColumns) {
+		return false
+	}
+	if !uniqueIndexColumnValuesEqual(cachedEvent.BeforeFields, incomingEvent.AfterFields, indexColumns) {
 		return false
 	}
 
 	//for logging purposes
 	cachedEventBeforeVal := formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, indexColumns)
-	incomingEventAfterVal := formatUniqueIndexColumnValuesForLog(incomingEvent.Fields, indexColumns)
+	incomingEventAfterVal := formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, indexColumns)
 	/*
 		If uk column is changes then it is a pure conflict
 		Handles all cases of UPDATE-UPDATE, UPDATE-INSERT, DELETE-INSERT, DELETE-UPDATE

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -376,7 +376,8 @@ func (c *ConflictDetectionCache) uniqueIndexConflicts(cachedEvent *tgtdb.Event, 
 
 func anyIndexColumnsChanged(fields map[string]*string, indexColumns []string) bool {
 	for _, column := range indexColumns {
-		if fields[column] != nil {
+		_, ok := fields[column]
+		if ok {
 			return true
 		}
 	}

--- a/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
@@ -1096,3 +1096,149 @@ FROM generate_series(1, 20) as i;`,
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 
 }
+
+func TestLiveMigrationWithSubsetOFPartialUNiqueIndexColumnsBeingChangedInUpdate(t *testing.T) {
+	t.Parallel()
+	liveMigrationTest := NewLiveMigrationTest(t, &TestConfig{
+		SourceDB: ContainerConfig{
+			Type:         "postgresql",
+			ForLive:      true,
+			DatabaseName: "test_false_negative",
+		},
+		TargetDB: ContainerConfig{
+			Type:         "yugabytedb",
+			DatabaseName: "test_false_negative",
+		},
+		SchemaNames: []string{"test_schema"},
+		SchemaSQL: []string{
+			`CREATE SCHEMA IF NOT EXISTS test_schema;
+			CREATE TABLE test_schema.test_false_negative (
+				id int PRIMARY KEY,
+				name TEXT,
+				c1 int,
+				c2 int,
+				most_recent boolean
+			);
+			CREATE UNIQUE INDEX idx_test_false_negative_c1_c2
+				ON test_schema.test_false_negative (c1, c2) WHERE most_recent;`,
+		},
+		SourceSetupSchemaSQL: []string{
+			// REPLICA IDENTITY FULL is REQUIRED: the fix reconstructs the unchanged index
+			// column (c1) from the update's before-image. Without FULL, c1 is not in
+			// before_fields either and the conflict is still missed.
+			"ALTER TABLE test_schema.test_false_negative REPLICA IDENTITY FULL;",
+		},
+		InitialDataSQL: []string{
+			// Rows 1..19 are not in the partial index (most_recent=false).
+			// Row 20 is the initial anchor occupying the recycled slot (c1=100, c2=1000).
+			`INSERT INTO test_schema.test_false_negative (id, name, c1, c2, most_recent)
+			 SELECT i, md5(random()::text), 100, i, false FROM generate_series(1, 19) AS i;`,
+			`INSERT INTO test_schema.test_false_negative (id, name, c1, c2, most_recent)
+			 VALUES (20, md5(random()::text), 100, 1000, true);`,
+		},
+		SourceDeltaSQL: []string{
+			/*
+				Composite PARTIAL unique index: (c1, c2) WHERE most_recent.
+				Invariant at each loop start: row (i-1) = (c1=100, c2=1000, most_recent=true),
+				the only row currently present in the partial index.
+
+				Per loop, one UPDATE-INSERT-style conflict on the recycled slot (100,1000):
+
+				  FREE:  UPDATE id=i-1 SET most_recent=false          -- removes (100,1000) from the index
+				  TAKE:  UPDATE id=i   SET c2=1000, most_recent=true  -- row i takes (100,1000)
+
+				The TAKE update's SET clause contains only {c2, most_recent}; c1 is UNCHANGED
+				and therefore ABSENT from the CDC after-image (Fields). Because the index is
+				composite (c1, c2), the before-after conflict check cannot build the index key
+				from the after-image alone -> pre-fix it silently skips the check and MISSES the
+				conflict with the freed (100,1000) from row i-1 (different PK -> different channel
+				-> can apply out of order -> 23505). The fix merges the unchanged c1 from the
+				before-image, reconstructs (100,1000), and detects the conflict.
+			*/
+			`DO $$
+		DECLARE
+			i INTEGER;
+		BEGIN
+			FOR i IN 21..520 LOOP
+				-- new row i, not yet in the partial index (most_recent=false)
+				INSERT INTO test_schema.test_false_negative(id, name, c1, c2, most_recent)
+				VALUES (i, md5(random()::text), 100, i, false);
+
+				-- FREE the slot (only most_recent changes; c1/c2 untouched)
+				UPDATE test_schema.test_false_negative SET most_recent = false WHERE id = i - 1;
+
+				-- TAKE the slot via a SUBSET update (c1 stays 100, absent from after-image)
+				UPDATE test_schema.test_false_negative SET c2 = 1000, most_recent = true WHERE id = i;
+
+			END LOOP;
+		END $$;`,
+		},
+		CleanupSQL: []string{
+			`DROP SCHEMA IF EXISTS test_schema CASCADE;`,
+		},
+	})
+	defer liveMigrationTest.Cleanup()
+
+	err := liveMigrationTest.SetupContainers(context.Background())
+	testutils.FatalIfError(t, err, "failed to setup containers")
+
+	err = liveMigrationTest.SetupSchema()
+	testutils.FatalIfError(t, err, "failed to setup schema")
+
+	err = liveMigrationTest.StartExportData(true, nil)
+	testutils.FatalIfError(t, err, "failed to start export data")
+
+	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
+		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+	)
+	uniqueKeyConflictStatsPath := filepath.Join(
+		liveMigrationTest.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
+
+	err = liveMigrationTest.StartImportDataWithEnv(true, nil, []string{uniqueKeyConflictCountFailpointEnv})
+	testutils.FatalIfError(t, err, "failed to start import data")
+
+	err = liveMigrationTest.WaitForSnapshotComplete(map[string]int64{
+		`"test_schema"."test_false_negative"`: 20,
+	}, 30)
+	testutils.FatalIfError(t, err, "failed to wait for snapshot complete")
+
+	err = liveMigrationTest.ValidateDataConsistency([]string{`"test_schema"."test_false_negative"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
+
+	err = liveMigrationTest.ExecuteSourceDelta()
+	testutils.FatalIfError(t, err, "failed to execute source delta")
+
+	// 500 loops x {1 insert, 2 updates, 1 delete}
+	err = liveMigrationTest.WaitForForwardStreamingComplete(map[string]ChangesCount{
+		`"test_schema"."test_false_negative"`: {
+			Inserts: 500,
+			Updates: 1000,
+			Deletes: 0,
+		},
+	}, 120, 5)
+	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+
+	// Import must not crash on a 23505: with the bug the conflict is missed, the two
+	// events race, and import errors out instead of serializing them.
+	require.False(t, liveMigrationTest.GetImportRunner().IsStopped(),
+		"import should keep running (no unhandled unique-violation) during count failpoint mode")
+
+	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
+	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
+
+	// The whole point of this test: exactly one true conflict per loop (500).
+	// Pre-fix this is ~0 (all missed). Post-fix it is 500.
+	require.GreaterOrEqual(t, conflictStats.Total, 500,
+		"subset-column partial-index delta should detect 1 conflict per loop (500 loops)")
+	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_false_negative"`], 500,
+		"test_false_negative should detect 500 subset-column UK conflicts")
+
+	err = liveMigrationTest.ValidateDataConsistency([]string{`"test_schema"."test_false_negative"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
+
+	err = liveMigrationTest.InitiateCutoverToTarget(false, nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover to target")
+
+	err = liveMigrationTest.WaitForCutoverComplete(0, 30)
+	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
+}

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -88,7 +88,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	e.Fields = rawEvent.Fields
 	e.BeforeFields = rawEvent.BeforeFields
 	e.ExporterRole = rawEvent.ExporterRole
-	e.AfterFields = mergeBeforeAndAfterFields(e.BeforeFields, e.Fields)
+	e.AfterFields = mergeBeforeAndChangedFields(e.Op, e.BeforeFields, e.Fields)
 	e.partitionSchemaName = rawEvent.PartitionSchemaName
 	e.partitionTableName = rawEvent.PartitionTableName
 	if !e.IsCutoverEvent() {
@@ -101,15 +101,23 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func mergeBeforeAndAfterFields(beforeFields, afterFields map[string]*string) map[string]*string {
-	fullFields := make(map[string]*string)
-	for column, value := range beforeFields {
-		fullFields[column] = value
+func mergeBeforeAndChangedFields(op string, beforeFields, changeFields map[string]*string) map[string]*string {
+	switch op {
+	case "c":
+		return changeFields
+	case "u":
+		allAfterFields := make(map[string]*string)
+		for column, value := range beforeFields {
+			allAfterFields[column] = value
+		}
+		for column, value := range changeFields {
+			allAfterFields[column] = value
+		}
+		return allAfterFields
+	case "d":
+		return nil
 	}
-	for column, value := range afterFields {
-		fullFields[column] = value
-	}
-	return fullFields
+	return nil
 }
 
 var cachePreparedStmt = sync.Map{}

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -44,6 +44,7 @@ type Event struct {
 	Key                 map[string]*string
 	Fields              map[string]*string //all the column values of the row - worst
 	BeforeFields        map[string]*string //all the column values of the row - worst
+	AfterFields         map[string]*string //all the column values of the row - worst //all fields of the row adn columns that are chnges in fields are updated to fields value
 	ExporterRole        string
 }
 
@@ -87,6 +88,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	e.Fields = rawEvent.Fields
 	e.BeforeFields = rawEvent.BeforeFields
 	e.ExporterRole = rawEvent.ExporterRole
+	e.AfterFields = mergeBeforeAndAfterFields(e.BeforeFields, e.Fields)
 	e.partitionSchemaName = rawEvent.PartitionSchemaName
 	e.partitionTableName = rawEvent.PartitionTableName
 	if !e.IsCutoverEvent() {
@@ -97,6 +99,17 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+func mergeBeforeAndAfterFields(beforeFields, afterFields map[string]*string) map[string]*string {
+	fullFields := make(map[string]*string)
+	for column, value := range beforeFields {
+		fullFields[column] = value
+	}
+	for column, value := range afterFields {
+		fullFields[column] = value
+	}
+	return fullFields
 }
 
 var cachePreparedStmt = sync.Map{}


### PR DESCRIPTION
The write-up covers the false-negative: Debezium’s after-image only has changed columns, so a composite/partial unique-index UPDATE that touches a subset of columns never reconstructed the full index tuple. Import now merges BeforeFields + Fields into AfterFields and uses that in the before-after check. Testing called out is TestLiveMigrationWithSubsetOFPartialUNiqueIndexColumnsBeingChangedInUpdate.


### Describe the changes in this pull request


### Describe if there are any user-facing changes
<!--
Clarify any changes to the user experience. For instance,
  1. Were there any changes to the command line? 
  2. Were there any changes to the configuration?
  3. Has the installation process changed? 
  4. Were there any changes to the reports? 
-->

### How was this pull request tested?
<!--
Mention if the existing tests were enough
Mention the new unit tests added 
Was any manual testing needed? If yes, is there a need to add integration tests for that?
-->

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

### Does your PR have changes to on-disk structures that can cause upgrade issues? 

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component        
| :----------------------------------------------: | 
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |
