### PR TITLE
migtests: wait for importer to drain queue before cutover in fallback-unique-conflict-test

### DIFF
--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -309,9 +309,7 @@ def importer_caught_up(export_dir: str, leg: str) -> bool:
     backlog_marker_present() only proves the EXPORTER wrote the cutover marker into
     the queue; the importer can still be far behind, and cutover cannot complete
     until it drains. This checks the importer side via queue_segment_meta's
-    per-segment imported flags (mirrors MetaDB.GetPendingSegments). The threshold
-    is <= 1, not 0: voyager finalizes the last open segment only during cutover,
-    so it stays unimported until then.
+    per-segment imported flags (mirrors MetaDB.GetPendingSegments).
     """
     meta_db = os.path.join(export_dir, "metainfo", "meta.db")
     query = (
@@ -322,7 +320,7 @@ def importer_caught_up(export_dir: str, leg: str) -> bool:
     if proc.returncode != 0:
         return False
     try:
-        return int(proc.stdout.strip()) <= 1
+        return int(proc.stdout.strip()) == 0
     except ValueError:
         return False
 

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -293,6 +293,40 @@ def backlog_marker_present(export_dir: str) -> bool:
         return False
 
 
+_IMPORTER_CAUGHT_UP_PREDICATES = {
+    # cutover-to-target waits on the target importer draining source-exported segments
+    "forward": "exporter_role = 'source_db_exporter' AND imported_by_target_db_importer = 0",
+    # cutover-to-source waits on the source importer draining target-exported segments
+    "fallback": "exporter_role LIKE 'target_db_exporter%' AND imported_by_source_db_importer = 0",
+}
+
+
+def importer_caught_up(export_dir: str, leg: str) -> bool:
+    """
+    Return True once the streaming importer for *leg* ("forward" or "fallback") has
+    applied every closed queue segment, i.e. at most one segment is still pending.
+
+    backlog_marker_present() only proves the EXPORTER wrote the cutover marker into
+    the queue; the importer can still be far behind, and cutover cannot complete
+    until it drains. This checks the importer side via queue_segment_meta's
+    per-segment imported flags (mirrors MetaDB.GetPendingSegments). The threshold
+    is <= 1, not 0: voyager finalizes the last open segment only during cutover,
+    so it stays unimported until then.
+    """
+    meta_db = os.path.join(export_dir, "metainfo", "meta.db")
+    query = (
+        "select count(*) from queue_segment_meta "
+        f"where {_IMPORTER_CAUGHT_UP_PREDICATES[leg]};"
+    )
+    proc = subprocess.run(["sqlite3", meta_db, query], capture_output=True, text=True)
+    if proc.returncode != 0:
+        return False
+    try:
+        return int(proc.stdout.strip()) <= 1
+    except ValueError:
+        return False
+
+
 # -------------------------
 # Process utilities
 # -------------------------

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -309,7 +309,9 @@ def importer_caught_up(export_dir: str, leg: str) -> bool:
     backlog_marker_present() only proves the EXPORTER wrote the cutover marker into
     the queue; the importer can still be far behind, and cutover cannot complete
     until it drains. This checks the importer side via queue_segment_meta's
-    per-segment imported flags (mirrors MetaDB.GetPendingSegments).
+    per-segment imported flags (mirrors MetaDB.GetPendingSegments). The threshold
+    is <= 1, not 0: voyager finalizes the last open segment only during cutover,
+    so it stays unimported until then.
     """
     meta_db = os.path.join(export_dir, "metainfo", "meta.db")
     query = (
@@ -320,7 +322,7 @@ def importer_caught_up(export_dir: str, leg: str) -> bool:
     if proc.returncode != 0:
         return False
     try:
-        return int(proc.stdout.strip()) == 0
+        return int(proc.stdout.strip()) <= 1
     except ValueError:
         return False
 

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -304,14 +304,16 @@ _IMPORTER_CAUGHT_UP_PREDICATES = {
 def importer_caught_up(export_dir: str, leg: str) -> bool:
     """
     Return True once the streaming importer for *leg* ("forward" or "fallback") has
-    applied every closed queue segment, i.e. at most one segment is still pending.
+    applied every queue segment, i.e. no segments are left pending.
 
     backlog_marker_present() only proves the EXPORTER wrote the cutover marker into
     the queue; the importer can still be far behind, and cutover cannot complete
     until it drains. This checks the importer side via queue_segment_meta's
-    per-segment imported flags (mirrors MetaDB.GetPendingSegments). The threshold
-    is <= 1, not 0: voyager finalizes the last open segment only during cutover,
-    so it stays unimported until then.
+    per-segment imported flags (mirrors MetaDB.GetPendingSegments).
+
+    Must run AFTER cutover is initiated: a segment is only marked imported once it
+    is closed and fully read, and the final open segment is closed only by cutover.
+    Before cutover the pending count has a floor of 1, so this would never pass.
     """
     meta_db = os.path.join(export_dir, "metainfo", "meta.db")
     query = (
@@ -322,7 +324,7 @@ def importer_caught_up(export_dir: str, leg: str) -> bool:
     if proc.returncode != 0:
         return False
     try:
-        return int(proc.stdout.strip()) <= 1
+        return int(proc.stdout.strip()) == 0
     except ValueError:
         return False
 

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -219,6 +219,16 @@ _WAIT_FOR_CONDITIONS: Dict[str, Dict[str, Any]] = {
         "interval": 5,
         "predicate": lambda ctx: H.backlog_marker_present(ctx.iteration_export_dir),
     },
+    # remaining_events_eq_0 is exporter-side only (marker written to the queue);
+    # these wait for the IMPORTER to drain the queue segments before cutover.
+    "forward_importer_caught_up": {
+        "interval": 5,
+        "predicate": lambda ctx: H.importer_caught_up(ctx.iteration_export_dir, "forward"),
+    },
+    "fallback_importer_caught_up": {
+        "interval": 5,
+        "predicate": lambda ctx: H.importer_caught_up(ctx.iteration_export_dir, "fallback"),
+    },
     "cutover_to_target_status_completed": {
         "interval": 10,
         "predicate": lambda ctx: H.get_cutover_status(ctx.export_dir_base, mode="target") == "COMPLETED",

--- a/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
@@ -208,13 +208,6 @@ stages:
     condition: remaining_events_eq_0
     timeout_sec: 1800
 
-  # wait_backlog_zero only proves the exporter wrote the cutover marker; wait for
-  # the importer to drain the queue too, so cutover completes within its timeout.
-  - name: wait_importer_caught_up
-    action: wait_for
-    condition: forward_importer_caught_up
-    timeout_sec: 1800
-
   # Confirm the conflict-detection cache actually fired on the forward (PG->YB)
   # import, not just that row_count/row_hash matched.
   - name: validate_conflicts_detected
@@ -224,6 +217,15 @@ stages:
 
   - name: cutover_to_target
     action: cutover_to_target
+
+  # wait_backlog_zero only proves the exporter wrote the cutover marker; the
+  # importer can still be far behind. Initiating cutover closes the final queue
+  # segment, so after it every segment (final included) gets marked imported --
+  # wait for that full drain here so the status check below stays fast.
+  - name: wait_importer_caught_up
+    action: wait_for
+    condition: forward_importer_caught_up
+    timeout_sec: 1800
 
   - name: wait_cutover_to_target_completed
     action: wait_for
@@ -327,12 +329,6 @@ stages:
     command: import_to_source
     timeout_sec: 60
 
-  # Same importer-drain wait as the forward leg, for cutover-to-source.
-  - name: wait_fallback_importer_caught_up
-    action: wait_for
-    condition: fallback_importer_caught_up
-    timeout_sec: 1800
-
   # Fallback (YB->PG) import-to-source forces PARTITION_BY_TABLE and skips
   # conflict detection, so its log must record 0 conflicts -- guard that.
   - name: validate_no_conflicts_detected
@@ -342,6 +338,12 @@ stages:
   # Phase 3: cutover back to source and validation
   - name: cutover_to_source
     action: cutover_to_source
+
+  # Same importer-drain wait as the forward leg, after cutover-to-source is initiated.
+  - name: wait_fallback_importer_caught_up
+    action: wait_for
+    condition: fallback_importer_caught_up
+    timeout_sec: 1800
 
   - name: wait_cutover_to_source_completed
     action: wait_for

--- a/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
@@ -208,6 +208,13 @@ stages:
     condition: remaining_events_eq_0
     timeout_sec: 1800
 
+  # wait_backlog_zero only proves the exporter wrote the cutover marker; wait for
+  # the importer to drain the queue too, so cutover completes within its timeout.
+  - name: wait_importer_caught_up
+    action: wait_for
+    condition: forward_importer_caught_up
+    timeout_sec: 1800
+
   # Confirm the conflict-detection cache actually fired on the forward (PG->YB)
   # import, not just that row_count/row_hash matched.
   - name: validate_conflicts_detected
@@ -319,6 +326,12 @@ stages:
     action: voyager_stop_resumptions
     command: import_to_source
     timeout_sec: 60
+
+  # Same importer-drain wait as the forward leg, for cutover-to-source.
+  - name: wait_fallback_importer_caught_up
+    action: wait_for
+    condition: fallback_importer_caught_up
+    timeout_sec: 1800
 
   # Fallback (YB->PG) import-to-source forces PARTITION_BY_TABLE and skips
   # conflict detection, so its log must record 0 conflicts -- guard that.


### PR DESCRIPTION
Nightly hit `TimeoutError: cutover_to_target_status_completed` — `remaining_events_eq_0` only proves the exporter wrote the cutover marker into the queue segments; the importer can still be far behind, so the whole drain was happening inside the 900s cutover wait, which isn't enough under conflict load.

Adds `forward_importer_caught_up` / `fallback_importer_caught_up` wait conditions (checks `queue_segment_meta` per-segment imported flags in metaDB, mirroring `MetaDB.GetPendingSegments`) and a drain-wait stage **after cutover is initiated** on both legs (per review — initiating cutover closes the final open segment, so all segments can reach imported and the condition is `pending == 0`). The cutover status waits stay at 900s and now only cover the status flip, not the drain.

Verified: a pre-cutover `== 0` variant deadlocks by construction (run 1112 — the open tail segment can never be marked imported before cutover); post-initiate placement avoids that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)