### PR TITLE
Fix unhandled and ignored errors surfaced by static-analysis audit

### DIFF
--- a/yb-voyager/cmd/callhome_payload_builder.go
+++ b/yb-voyager/cmd/callhome_payload_builder.go
@@ -479,7 +479,7 @@ func buildCallhomeSchemaOptimizationChanges() []callhome.SchemaOptimizationChang
 		schemaOptimizationChanges = append(schemaOptimizationChanges, callhome.SchemaOptimizationChange{
 			OptimizationType: MVIEW_COLOCATION_RECOMMENDATION_CHANGE_TYPE,
 			IsApplied:        schemaOptimizationReport.MviewColocationRecommendation.IsApplied,
-			Objects:          schemaOptimizationReport.MviewColocationRecommendation.ShardedObjects,
+			Objects:          objects,
 		})
 	}
 	if schemaOptimizationReport.SecondaryIndexToRangeChange != nil {

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -870,14 +870,13 @@ func GetSourceDBTypeFromMSR() string {
 		utils.ErrExit("get migration status record: %v", err)
 	}
 	if msr == nil {
-		// utils.ErrExit is a patchable func variable, so it is not provably terminating; return explicitly.
 		utils.ErrExit("migration status record not found")
-		return ""
 	}
+	//lint:ignore SA5011 utils.ErrExit always exits
 	if msr.SourceDBConf == nil {
 		utils.ErrExit("source DB conf not found in migration status record")
-		return ""
 	}
+	//lint:ignore SA5011 utils.ErrExit always exits
 	return msr.SourceDBConf.DBType
 }
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -870,10 +870,13 @@ func GetSourceDBTypeFromMSR() string {
 		utils.ErrExit("get migration status record: %v", err)
 	}
 	if msr == nil {
+		// utils.ErrExit is a patchable func variable, so it is not provably terminating; return explicitly.
 		utils.ErrExit("migration status record not found")
+		return ""
 	}
 	if msr.SourceDBConf == nil {
 		utils.ErrExit("source DB conf not found in migration status record")
+		return ""
 	}
 	return msr.SourceDBConf.DBType
 }

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -126,7 +126,9 @@ var cutoverToTargetCmd = &cobra.Command{
 			utils.ErrExit("get migration status record: %w", err)
 		}
 		if msr == nil {
+			// utils.ErrExit is a patchable func variable, so it is not provably terminating; return explicitly.
 			utils.ErrExit("migration status record not found")
+			return
 		}
 		// yb-amp supports plain live migration only. Fall-back / fall-forward
 		// require streaming changes *out of* the target via YugabyteDB CDC, which

--- a/yb-voyager/cmd/cutoverToTargetCmd.go
+++ b/yb-voyager/cmd/cutoverToTargetCmd.go
@@ -126,13 +126,12 @@ var cutoverToTargetCmd = &cobra.Command{
 			utils.ErrExit("get migration status record: %w", err)
 		}
 		if msr == nil {
-			// utils.ErrExit is a patchable func variable, so it is not provably terminating; return explicitly.
 			utils.ErrExit("migration status record not found")
-			return
 		}
 		// yb-amp supports plain live migration only. Fall-back / fall-forward
 		// require streaming changes *out of* the target via YugabyteDB CDC, which
 		// a yb-amp compute does not provide. Fail fast with a clear message.
+		//lint:ignore SA5011 utils.ErrExit always exits
 		if msr.TargetDBConf != nil && msr.TargetDBConf.TargetDBType == YUGABYTEDB_AMP {
 			if bool(prepareForFallBack) || msr.FallForwardEnabled {
 				utils.ErrExit("fall-back / fall-forward are not supported for --target-db-type %s (yb-amp cannot stream changes out via YugabyteDB CDC). Use plain live migration: re-run cutover with --prepare-for-fall-back no", YUGABYTEDB_AMP)

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -1933,6 +1933,9 @@ func clearMigrationStateIfRequired() {
 			record.TargetRenameTablesMap = nil
 			record.ExportTypeFromSource = ""
 		})
+		if err != nil {
+			utils.ErrExit("Failed to update migration status record: %w", err)
+		}
 
 		err = metadb.TruncateTablesInMetaDb(exportDir, []string{metadb.QUEUE_SEGMENT_META_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_TABLE_NAME, metadb.EXPORTED_EVENTS_STATS_PER_TABLE_TABLE_NAME})
 		if err != nil {

--- a/yb-voyager/cmd/exportSchema.go
+++ b/yb-voyager/cmd/exportSchema.go
@@ -812,9 +812,7 @@ func applyIndexFileTransformations() (*sqltransformer.IndexFileTransformer, erro
 	//fetching redundanant indexes from assessment db
 	//assuming that assessment is run and fetched the redundant indexes
 	//TODO: see if we need to take care of the scenario where assessment is unable to fetch these
-	var err error
-	redundantIndexToResolvedExistingIndex := utils.NewStructMap[*sqlname.ObjectNameQualifiedWithTableName, string]()
-	redundantIndexToResolvedExistingIndex, err = fetchRedundantIndexMapFromAssessmentDB()
+	redundantIndexToResolvedExistingIndex, err := fetchRedundantIndexMapFromAssessmentDB()
 	if err != nil {
 		if skipPerfOptimizations {
 			//this is done to handle errors but if skip is used we need to put the redundant indexes in the schema optimization report

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1825,9 +1825,11 @@ func startMonitoringTargetYBHealth() error {
 			displayMonitoringInformationOnTheConsole(info)
 		})
 
-		// StartMonitoring runs an endless monitoring loop; it returns only on a (non-nil) error.
 		err = monitorTDBHealth.StartMonitoring()
-		log.Errorf("error monitoring the target health: %v", err)
+		//lint:ignore SA4023 StartMonitoring currently only returns on error; keep the conventional check
+		if err != nil {
+			log.Errorf("error monitoring the target health: %v", err)
+		}
 	}()
 	return nil
 }

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1721,7 +1721,8 @@ func getTableTypes(tasks []*ImportFileTask) (*utils.StructMap[sqlname.NameTuple,
 		return nil, fmt.Errorf("checking if db is colocated: %w", err)
 	}
 	for _, task := range tasks {
-		if tableType, ok := tableTypes.Get(task.TableNameTup); !ok {
+		if _, ok := tableTypes.Get(task.TableNameTup); !ok {
+			var tableType string
 			if !isDBColocated {
 				tableType = SHARDED
 			} else {
@@ -1824,10 +1825,9 @@ func startMonitoringTargetYBHealth() error {
 			displayMonitoringInformationOnTheConsole(info)
 		})
 
+		// StartMonitoring runs an endless monitoring loop; it returns only on a (non-nil) error.
 		err = monitorTDBHealth.StartMonitoring()
-		if err != nil {
-			log.Errorf("error monitoring the target health: %v", err)
-		}
+		log.Errorf("error monitoring the target health: %v", err)
 	}()
 	return nil
 }

--- a/yb-voyager/cmd/importDataSequenceRestoration.go
+++ b/yb-voyager/cmd/importDataSequenceRestoration.go
@@ -201,7 +201,6 @@ func fetchSequenceToTableListMap(msr *metadb.MigrationStatusRecord) (*utils.Stru
 		if err != nil {
 			return nil, fmt.Errorf("error looking up sequence name %q: %w", sequenceName, err)
 		}
-		sequenceName = sequenceTuple.ForKey()
 		tableList, ok := sequenceNameToTableMap.Get(sequenceTuple)
 		if ok {
 			tableList = append(tableList, tableNameTuple)

--- a/yb-voyager/src/errs/targetdb.go
+++ b/yb-voyager/src/errs/targetdb.go
@@ -30,6 +30,7 @@ const (
 	IMPORT_BATCH_ERROR_STEP_CHECK_BATCH_ALREADY_IMPORTED = "check_batch_already_imported"
 	IMPORT_BATCH_ERROR_STEP_OPEN_BATCH                   = "open_batch"
 	IMPORT_BATCH_ERROR_STEP_READ_LINE_BATCH              = "read_line_batch"
+	IMPORT_BATCH_ERROR_STEP_SET_TARGET_SCHEMA            = "set_target_schema"
 	IMPORT_BATCH_ERROR_STEP_BEGIN_TXN                    = "begin_txn"
 	IMPORT_BATCH_ERROR_STEP_COMMIT_TXN                   = "commit_txn"
 	IMPORT_BATCH_ERROR_STEP_ROLLBACK_TXN                 = "rollback_txn"

--- a/yb-voyager/src/srcdb/mysql.go
+++ b/yb-voyager/src/srcdb/mysql.go
@@ -59,6 +59,9 @@ func (ms *MySQL) Connect() error {
 	}
 
 	db, err := sql.Open("mysql", ms.getConnectionUri())
+	if err != nil {
+		return fmt.Errorf("open connection to source database: %w", err)
+	}
 	db.SetMaxOpenConns(ms.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	ms.db = db

--- a/yb-voyager/src/srcdb/oracle.go
+++ b/yb-voyager/src/srcdb/oracle.go
@@ -60,6 +60,9 @@ func (ora *Oracle) Connect() error {
 	}
 
 	db, err := sql.Open("godror", ora.getConnectionUri())
+	if err != nil {
+		return fmt.Errorf("open connection to source database: %w", err)
+	}
 	db.SetMaxOpenConns(ora.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	ora.db = db

--- a/yb-voyager/src/srcdb/postgres.go
+++ b/yb-voyager/src/srcdb/postgres.go
@@ -163,6 +163,9 @@ func (pg *PostgreSQL) Connect() error {
 		log.Info("Reconnecting to the source database")
 	}
 	db, err := sql.Open("pgx", pg.getConnectionUri())
+	if err != nil {
+		return fmt.Errorf("open connection to source database: %w", err)
+	}
 	db.SetMaxOpenConns(pg.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	pg.db = db

--- a/yb-voyager/src/srcdb/yugabytedb.go
+++ b/yb-voyager/src/srcdb/yugabytedb.go
@@ -78,6 +78,9 @@ func (yb *YugabyteDB) Connect() error {
 		log.Info("Reconnecting to the source database")
 	}
 	db, err := sql.Open("pgx", yb.getConnectionUri())
+	if err != nil {
+		return fmt.Errorf("open connection to source database: %w", err)
+	}
 	db.SetMaxOpenConns(yb.source.NumConnections)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 	yb.db = db

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -901,7 +901,13 @@ func (yb *TargetYugabyteDB) copyBatchCore(conn *pgx.Conn, batch Batch, args *Imp
 
 	// 2. setting the schema so that COPY command can acesss the table
 	// Q: If we set the schema for this batch on this conn, will it impact others using the same conn from pool later?
-	yb.setTargetSchema(conn)
+	err = yb.setTargetSchema(conn)
+	if err != nil {
+		err = newImportBatchErrorPgYb(err, batch,
+			lo.Ternary(args.ShouldUseFastPath(), errs.IMPORT_BATCH_ERROR_FLOW_COPY_FAST, errs.IMPORT_BATCH_ERROR_FLOW_COPY_NORMAL),
+			errs.IMPORT_BATCH_ERROR_STEP_SET_TARGET_SCHEMA, nil)
+		return 0, err
+	}
 
 	// 3. Check if the split is already imported.
 	alreadyImported, rowsAffected, err := yb.isBatchAlreadyImported(conn, batch)

--- a/yb-voyager/test/containers/mysql_container.go
+++ b/yb-voyager/test/containers/mysql_container.go
@@ -117,12 +117,12 @@ func (ms *MysqlContainer) Stop(ctx context.Context) error {
 }
 
 func (ms *MysqlContainer) Terminate(ctx context.Context) {
-	ms.mutex.Lock()
-	defer ms.mutex.Unlock()
-
 	if ms == nil {
 		return
 	}
+
+	ms.mutex.Lock()
+	defer ms.mutex.Unlock()
 
 	err := ms.container.Terminate(ctx)
 	if err != nil {

--- a/yb-voyager/test/containers/oracle_container.go
+++ b/yb-voyager/test/containers/oracle_container.go
@@ -116,12 +116,12 @@ func (ora *OracleContainer) Stop(ctx context.Context) error {
 }
 
 func (ora *OracleContainer) Terminate(ctx context.Context) {
-	ora.mutex.Lock()
-	defer ora.mutex.Unlock()
-
 	if ora == nil {
 		return
 	}
+
+	ora.mutex.Lock()
+	defer ora.mutex.Unlock()
 
 	err := ora.container.Terminate(ctx)
 	if err != nil {

--- a/yb-voyager/test/containers/postgres_container.go
+++ b/yb-voyager/test/containers/postgres_container.go
@@ -130,12 +130,12 @@ func (pg *PostgresContainer) Stop(ctx context.Context) error {
 }
 
 func (pg *PostgresContainer) Terminate(ctx context.Context) {
-	pg.mutex.Lock()
-	defer pg.mutex.Unlock()
-
 	if pg == nil {
 		return
 	}
+
+	pg.mutex.Lock()
+	defer pg.mutex.Unlock()
 
 	err := pg.container.Terminate(ctx)
 	if err != nil {

--- a/yb-voyager/test/containers/yugabytedb_container.go
+++ b/yb-voyager/test/containers/yugabytedb_container.go
@@ -170,12 +170,12 @@ func (yb *YugabyteDBContainer) Stop(ctx context.Context) error {
 }
 
 func (yb *YugabyteDBContainer) Terminate(ctx context.Context) {
-	yb.mutex.Lock()
-	defer yb.mutex.Unlock()
-
 	if yb == nil {
 		return
 	}
+
+	yb.mutex.Lock()
+	defer yb.mutex.Unlock()
 
 	if yb.external {
 		return


### PR DESCRIPTION
### Describe the changes in this pull request

While auditing why PR #3714's dropped `WaitUntilNoConflict` error got past CI, a static-analysis sweep (errcheck + staticcheck with a working config) surfaced several real bugs of the same family already on main. This PR fixes only the bug-shaped findings; the tooling changes that will prevent recurrence come in a follow-up PR.

- **`copyBatchCore` ignored `setTargetSchema`'s error** (`src/tgtdb/yugabytedb.go`): the check was dropped in PR #2498 when the COPY fast path was extracted. A failure to set the search path now fails the batch (wrapped as an import-batch error with a new `set_target_schema` step) instead of proceeding on a connection with the wrong schema.
- **All four `srcdb` drivers ignored `sql.Open`'s error** in `Connect()` (postgres/mysql/oracle/yugabytedb): on failure `db` is nil and the very next line (`db.SetMaxOpenConns`) panics. Now returns the error.
- **Callhome sent raw materialized-view names instead of the anonymized ones** (`cmd/callhome_payload_builder.go`): the loop anonymized the names into `objects` and then never used it. The mview-colocation payload now sends the anonymized names, matching the table-colocation block above it.
- **Start-clean ignored `UpdateMigrationStatusRecord`'s error** (`cmd/exportData.go`): a failed reset of MSR fields was silently swallowed; now exits with an error like its neighbors.
- **`test/containers` `Terminate()` dereferenced the receiver before its own nil check** (all four containers): the nil guard now comes first.
- `//lint:ignore SA5011 utils.ErrExit always exits` directives on the nil-MSR deref paths (`cmd/common.go`, `cmd/cutoverToTargetCmd.go`): `ErrExit` is a patchable func variable, so staticcheck cannot prove it terminates; the directives assert the production invariant without restructuring the code. `//lint:ignore SA4023` similarly keeps the conventional `if err != nil` after `StartMonitoring` (`cmd/importData.go`), which staticcheck proves is currently always true. If either invariant ever changes, staticcheck flags the directive as unmatched, forcing a revisit.
- Removed dead stores flagged by SA4006/SA4010 (`cmd/exportSchema.go`, `cmd/importData.go`, `cmd/importDataSequenceRestoration.go`).

### Describe if there are any user-facing changes

No CLI, configuration, installation, or report changes. Failure behavior changes in two spots: import batches now fail loudly if setting the target schema on the connection fails, and source `Connect()` returns an error instead of panicking when `sql.Open` fails.

### How was this pull request tested?

- `go build ./...`, `go vet ./...`, and `go test -tags unit ./...` all pass (zero failures).
- Verified with staticcheck 2025.1.1 that all targeted SA4006/SA4010/SA4023/SA5011 findings are resolved.
- The `setTargetSchema` path is exercised by the existing import-data integration tests; no new tests added since the fixes restore error propagation on paths whose happy path is already covered.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

The payload *shape* is unchanged (no version bump needed); the mview-colocation `Objects` field now carries the anonymized names it was always supposed to carry.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
