### PR TITLE
Fix: false negative case where subset of unique index columns being updated and some restructuring of code

### DIFF
--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -438,20 +439,22 @@ func (c *ConflictDetectionCache) checkBeforeAfterConflict(incomingEvent *tgtdb.E
 	}
 	key, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.AfterFields, index)
 	if err != nil {
-		return Conflict{}, err
+		return Conflict{}, fmt.Errorf("error computing conflict bucket key for before-after conflict for incoming event(vsn=%d) and index %s: %w", incomingEvent.Vsn, index.IndexName, err)
 	}
 	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
 	if err != nil {
-		return Conflict{}, err
+		return Conflict{}, fmt.Errorf("error getting conflicting events with different partition key for before-after conflict for incoming event(vsn=%d) and index %s: %w", incomingEvent.Vsn, index.IndexName, err)
 	}
-	if len(cachedEvents) > 0 {
-		for _, cachedEvent := range cachedEvents {
-			log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and after value of incoming-event2(vsn=%d, colVal=%s)",
-				incomingEvent.TableNameTup.ForKey(), index.Columns,
-				cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
-				incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns))
-		}
+	if len(cachedEvents) == 0 {
+		return Conflict{}, nil
 	}
+	for _, cachedEvent := range cachedEvents {
+		log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and after value of incoming-event2(vsn=%d, colVal=%s)",
+			incomingEvent.TableNameTup.ForKey(), index.Columns,
+			cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
+			incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns))
+	}
+
 	return Conflict{
 		indexName:         index.IndexName,
 		eventsConflicting: cachedEvents,
@@ -469,19 +472,20 @@ func (c *ConflictDetectionCache) checkBeforeBeforeConflict(incomingEvent *tgtdb.
 	}
 	key, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.BeforeFields, index)
 	if err != nil {
-		return Conflict{}, err
+		return Conflict{}, fmt.Errorf("error computing conflict bucket key for before-before conflict for incoming event(vsn=%d) and index %s: %w", incomingEvent.Vsn, index.IndexName, err)
 	}
 	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
 	if err != nil {
-		return Conflict{}, err
+		return Conflict{}, fmt.Errorf("error getting conflicting events with different partition key for before-before conflict for incoming event(vsn=%d) and index %s: %w", incomingEvent.Vsn, index.IndexName, err)
 	}
-	if len(cachedEvents) > 0 {
-		for _, cachedEvent := range cachedEvents {
-			log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and before value of incoming-event2(vsn=%d, colVal=%s)",
-				incomingEvent.TableNameTup.ForKey(), index.Columns,
-				cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
-				incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns))
-		}
+	if len(cachedEvents) == 0 {
+		return Conflict{}, nil
+	}
+	for _, cachedEvent := range cachedEvents {
+		log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and before value of incoming-event2(vsn=%d, colVal=%s)",
+			incomingEvent.TableNameTup.ForKey(), index.Columns,
+			cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
+			incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns))
 	}
 	return Conflict{
 		indexName:         index.IndexName,
@@ -567,7 +571,8 @@ func computeConflictBucketKey(table sqlname.NameTuple, fields map[string]*string
 	for _, column := range index.Columns {
 		val, exists := fields[column]
 		if !exists {
-			//In case the incoming event like update is not having this field in after fields then it is not indexable as the unique key is not changed so it won't conflict with anything
+			//this is not expected as now eveyrthing should be present in the fields as we pass before/after fields which are all column values so we should have that
+			//hence erroring out here
 			return "", goerrors.Errorf("column %s is missing from fields", column)
 		}
 		b.WriteByte(0) //separator for the field name and value

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -217,12 +217,9 @@ func (c *ConflictDetectionCache) indexEventLocked(event *tgtdb.Event) error {
 			//		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
 			continue
 		}
-		key, ok, err := computeConflictBucketKey(event.TableNameTup, event.BeforeFields, index)
+		key, err := computeConflictBucketKey(event.TableNameTup, event.BeforeFields, index)
 		if err != nil {
 			return goerrors.Errorf("error computing conflict bucket key for table %s, index %s: %v", event.TableNameTup.ForKey(), index.IndexName, err)
-		}
-		if !ok {
-			continue
 		}
 		bucket := c.ukLookup[key]
 		if bucket == nil {
@@ -394,7 +391,7 @@ FindConflicts()
 */
 func (c *ConflictDetectionCache) findValueConflictLocked(incomingEvent *tgtdb.Event) ([]Conflict, error) {
 	if incomingEvent.Op == "d" {
-		return []Conflict{}, nil
+		return []Conflict{}, goerrors.Errorf("incoming event is a delete event")
 	}
 	uniqueIndexes, _ := c.tableToUniqueIndexes.Get(incomingEvent.TableNameTup)
 	if len(uniqueIndexes) == 0 {
@@ -439,12 +436,9 @@ func (c *ConflictDetectionCache) checkBeforeAfterConflict(incomingEvent *tgtdb.E
 		//		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
 		return Conflict{}, nil
 	}
-	key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.AfterFields, index)
+	key, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.AfterFields, index)
 	if err != nil {
 		return Conflict{}, err
-	}
-	if !ok {
-		return Conflict{}, nil
 	}
 	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
 	if err != nil {
@@ -473,12 +467,9 @@ func (c *ConflictDetectionCache) checkBeforeBeforeConflict(incomingEvent *tgtdb.
 		//		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
 		return Conflict{}, nil
 	}
-	key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.BeforeFields, index)
+	key, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.BeforeFields, index)
 	if err != nil {
 		return Conflict{}, err
-	}
-	if !ok {
-		return Conflict{}, nil
 	}
 	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
 	if err != nil {
@@ -565,9 +556,9 @@ const (
 //
 // Values are length-prefixed so distinct tuples never collide (e.g. {"ab",""} vs
 // {"a","b"}); NULLs under NULLS NOT DISTINCT use a dedicated sentinel.
-func computeConflictBucketKey(table sqlname.NameTuple, fields map[string]*string, index tgtdb.UniqueIndex) (string, bool, error) {
+func computeConflictBucketKey(table sqlname.NameTuple, fields map[string]*string, index tgtdb.UniqueIndex) (string, error) {
 	if fields == nil {
-		return "", false, goerrors.Errorf("fields are nil")
+		return "", goerrors.Errorf("fields are nil")
 	}
 	var b strings.Builder
 	b.WriteString(table.ForKey())
@@ -577,13 +568,13 @@ func computeConflictBucketKey(table sqlname.NameTuple, fields map[string]*string
 		val, exists := fields[column]
 		if !exists {
 			//In case the incoming event like update is not having this field in after fields then it is not indexable as the unique key is not changed so it won't conflict with anything
-			return "", false, goerrors.Errorf("column %s is missing from fields", column)
+			return "", goerrors.Errorf("column %s is missing from fields", column)
 		}
 		b.WriteByte(0) //separator for the field name and value
 		if val == nil {
 			if !index.NullsNotDistinct {
 				// default NULLS DISTINCT: NULLs never conflict,so it should never come into this compute
-				return "", false, goerrors.Errorf("column %s has null value but index is not NULLS NOT DISTINCT", column)
+				return "", goerrors.Errorf("column %s has null value but index is not NULLS NOT DISTINCT", column)
 			}
 			b.WriteString(conflictBucketNull) //placeholder for the null value
 			continue
@@ -593,7 +584,7 @@ func computeConflictBucketKey(table sqlname.NameTuple, fields map[string]*string
 		b.WriteByte(':')                       //separator for the length and value
 		b.WriteString(*val)                    //value
 	}
-	return b.String(), true, nil
+	return b.String(), nil
 }
 
 func (c *ConflictDetectionCache) RemoveEvents(events ...*tgtdb.Event) {

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -167,6 +167,19 @@ func NewConflictDetectionCache(tableToUniqueIndexes *utils.StructMap[sqlname.Nam
 	return c
 }
 
+/*
+Put()
+
+	if ! U/D
+		return
+	if U:
+		if changedColumns <intersection> (UK columns <union> predictate columns) == EMPTY:
+		Can't add this check until we have predicate columns as we still need the event in index even if its unique columns are unchanged for predicate cases 
+			return
+		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
+			return
+		add-to-cache (uklookup) <---- computeKey (beforeFields) (all columns should be present)
+*/
 func (c *ConflictDetectionCache) Put(event *tgtdb.Event) error {
 	if event.BeforeFields == nil || event.Op == "c" {
 		//put can only insert an event in the cache if its delete/update event
@@ -200,6 +213,10 @@ func (c *ConflictDetectionCache) indexEventLocked(event *tgtdb.Event) error {
 		return nil
 	}
 	for _, index := range uniqueIndexes {
+		if !index.NullsNotDistinct && anyUniqueIndexColumnValueIsNull(event.BeforeFields, index.Columns) {
+			//		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
+			continue
+		}
 		key, ok, err := computeConflictBucketKey(event.TableNameTup, event.BeforeFields, index)
 		if err != nil {
 			return goerrors.Errorf("error computing conflict bucket key for table %s, index %s: %v", event.TableNameTup.ForKey(), index.IndexName, err)
@@ -347,7 +364,38 @@ func (c *ConflictDetectionCache) findConflictLocked(incomingEvent *tgtdb.Event) 
 // All unique indexes and both checks (before-after, before-before) are evaluated so the
 // incoming event can wait on the complete set of conflicting cached events at once. The
 // result is de-duplicated by VSN, since a single cached event can match several indexes.
+
+/*
+TODO: to arrange it in this manner
+
+FindConflicts()
+
+	for each unique index:
+		if D:
+			skip-check
+		if I:
+			if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
+				skip-check
+			check before-after conflicts; <---- computeKey (afterFields) (all columns should be present)
+			 no before-before
+		if U:
+
+			if changedColumns <intersection> (UK columns <union> predictate columns) == EMPTY:
+				skip-check
+			before-after:
+				if uniqueINdex.NullsDistinct AND ANY unique key column value (after fields) is NULL:
+					skip-check
+				check before-after conflicts <---- computeKey (afterFields) (possible that only a subset of columns are present)
+
+			if uniqueIndex has partial predicate: (before-before)
+				if uniqueINdex.NullsDistinct AND ANY unique key column value (before fields) is NULL:
+					skip-check
+				check before-before conflicts.  <---- computeKey (beforeFields) (all columns should be present)
+*/
 func (c *ConflictDetectionCache) findValueConflictLocked(incomingEvent *tgtdb.Event) ([]Conflict, error) {
+	if incomingEvent.Op == "d" {
+		return []Conflict{}, nil
+	}
 	uniqueIndexes, _ := c.tableToUniqueIndexes.Get(incomingEvent.TableNameTup)
 	if len(uniqueIndexes) == 0 {
 		return []Conflict{}, nil
@@ -355,63 +403,180 @@ func (c *ConflictDetectionCache) findValueConflictLocked(incomingEvent *tgtdb.Ev
 	totalConflictInfo := make([]Conflict, 0)
 	for _, index := range uniqueIndexes {
 		// before-after conflict: cachedEvent.BeforeFields == incomingEvent.Fields
-		key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.Fields, index)
-		if err != nil {
-			return []Conflict{}, err
-		}
-		if ok {
-			cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
+		switch incomingEvent.Op {
+		case "c":
+			conflict, err := c.checkBeforeAfterConflict(incomingEvent, index)
 			if err != nil {
 				return []Conflict{}, err
 			}
-			if len(cachedEvents) > 0 {
-				for _, cachedEvent := range cachedEvents {
-					log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and after value of incoming-event2(vsn=%d, colVal=%s)",
-						incomingEvent.TableNameTup.ForKey(), index.Columns,
-						cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
-						incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.Fields, index.Columns))
-				}
-				totalConflictInfo = append(totalConflictInfo, Conflict{
-					indexName:         index.IndexName,
-					eventsConflicting: cachedEvents,
-					indexColumns:      index.Columns,
-					matchType:         "before-after",
-					matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.Fields, index.Columns),
-				})
+			if len(conflict.eventsConflicting) > 0 {
+				totalConflictInfo = append(totalConflictInfo, conflict)
 			}
-		}
-		if incomingEvent.Op == "c" {
-			//as for the insert event we don't have before fields so we don't need to check for before-before conflict
-			continue
-		}
-		// before-before conflict: cachedEvent.BeforeFields == incomingEvent.BeforeFields
-		key, ok, err = computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.BeforeFields, index)
-		if err != nil {
-			return []Conflict{}, err
-		}
-		if ok {
-			cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
+		case "u":
+			if anyUniqueIndexColumnChanged(incomingEvent.Fields, index.Columns) {
+				conflict, err := c.checkBeforeAfterConflict(incomingEvent, index)
+				if err != nil {
+					return []Conflict{}, err
+				}
+				if len(conflict.eventsConflicting) > 0 {
+					totalConflictInfo = append(totalConflictInfo, conflict)
+				}
+			}
+			conflict, err := c.checkBeforeBeforeConflict(incomingEvent, index)
 			if err != nil {
 				return []Conflict{}, err
 			}
-			if len(cachedEvents) > 0 {
-				for _, cachedEvent := range cachedEvents {
-					log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and before value of incoming-event2(vsn=%d, colVal=%s)",
-						incomingEvent.TableNameTup.ForKey(), index.Columns,
-						cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
-						incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns))
-				}
-				totalConflictInfo = append(totalConflictInfo, Conflict{
-					indexName:         index.IndexName,
-					eventsConflicting: cachedEvents,
-					indexColumns:      index.Columns,
-					matchType:         "before-before",
-					matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns),
-				})
+			if len(conflict.eventsConflicting) > 0 {
+				totalConflictInfo = append(totalConflictInfo, conflict)
 			}
 		}
+		// if (incomingEvent.Op == "u" && anyUniqueIndexColumnChanged(incomingEvent.AfterFields, index.Columns)) || incomingEvent.Op == "c" {
+		// 	key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.AfterFields, index)
+		// 	if err != nil {
+		// 		return []Conflict{}, err
+		// 	}
+		// 	if ok {
+		// 		cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
+		// 		if err != nil {
+		// 			return []Conflict{}, err
+		// 		}
+		// 		if len(cachedEvents) > 0 {
+		// 			for _, cachedEvent := range cachedEvents {
+		// 				log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and after value of incoming-event2(vsn=%d, colVal=%s)",
+		// 					incomingEvent.TableNameTup.ForKey(), index.Columns,
+		// 					cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
+		// 					incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns))
+		// 			}
+		// 			totalConflictInfo = append(totalConflictInfo, Conflict{
+		// 				indexName:         index.IndexName,
+		// 				eventsConflicting: cachedEvents,
+		// 				indexColumns:      index.Columns,
+		// 				matchType:         "before-after",
+		// 				matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns),
+		// 			})
+		// 		}
+		// 	}
+		// }
+		// if incomingEvent.Op == "c" {
+		// 	//as for the insert event we don't have before fields so we don't need to check for before-before conflict
+		// 	continue
+		// }
+		// // before-before conflict: cachedEvent.BeforeFields == incomingEvent.BeforeFields
+		// key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.BeforeFields, index)
+		// if err != nil {
+		// 	return []Conflict{}, err
+		// }
+		// if ok {
+		// 	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
+		// 	if err != nil {
+		// 		return []Conflict{}, err
+		// 	}
+		// 	if len(cachedEvents) > 0 {
+		// 		for _, cachedEvent := range cachedEvents {
+		// 			log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and before value of incoming-event2(vsn=%d, colVal=%s)",
+		// 				incomingEvent.TableNameTup.ForKey(), index.Columns,
+		// 				cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
+		// 				incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns))
+		// 		}
+		// 		totalConflictInfo = append(totalConflictInfo, Conflict{
+		// 			indexName:         index.IndexName,
+		// 			eventsConflicting: cachedEvents,
+		// 			indexColumns:      index.Columns,
+		// 			matchType:         "before-before",
+		// 			matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns),
+		// 		})
+		// 	}
+		// }
 	}
 	return totalConflictInfo, nil
+}
+
+func (c *ConflictDetectionCache) checkBeforeAfterConflict(incomingEvent *tgtdb.Event, index tgtdb.UniqueIndex) (Conflict, error) {
+	if !index.NullsNotDistinct && anyUniqueIndexColumnValueIsNull(incomingEvent.AfterFields, index.Columns) {
+		//		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
+		return Conflict{}, nil
+	}
+	key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.AfterFields, index)
+	if err != nil {
+		return Conflict{}, err
+	}
+	if !ok {
+		return Conflict{}, nil
+	}
+	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
+	if err != nil {
+		return Conflict{}, err
+	}
+	if len(cachedEvents) > 0 {
+		for _, cachedEvent := range cachedEvents {
+			log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and after value of incoming-event2(vsn=%d, colVal=%s)",
+				incomingEvent.TableNameTup.ForKey(), index.Columns,
+				cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
+				incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns))
+		}
+	}
+	return Conflict{
+		indexName:         index.IndexName,
+		eventsConflicting: cachedEvents,
+		indexColumns:      index.Columns,
+		matchType:         "before-after",
+		matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns),
+	}, nil
+}
+
+func (c *ConflictDetectionCache) checkBeforeBeforeConflict(incomingEvent *tgtdb.Event, index tgtdb.UniqueIndex) (Conflict, error) {
+
+	if !index.NullsNotDistinct && anyUniqueIndexColumnValueIsNull(incomingEvent.BeforeFields, index.Columns) {
+		//		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
+		return Conflict{}, nil
+	}
+	key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.BeforeFields, index)
+	if err != nil {
+		return Conflict{}, err
+	}
+	if !ok {
+		return Conflict{}, nil
+	}
+	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
+	if err != nil {
+		return Conflict{}, err
+	}
+	if len(cachedEvents) > 0 {
+		for _, cachedEvent := range cachedEvents {
+			log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and before value of incoming-event2(vsn=%d, colVal=%s)",
+				incomingEvent.TableNameTup.ForKey(), index.Columns,
+				cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
+				incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns))
+		}
+	}
+	return Conflict{
+		indexName:         index.IndexName,
+		eventsConflicting: cachedEvents,
+		indexColumns:      index.Columns,
+		matchType:         "before-before",
+		matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns),
+	}, nil
+
+}
+
+func anyUniqueIndexColumnChanged(fields map[string]*string, indexColumns []string) bool {
+	for _, column := range indexColumns {
+		_, ok := fields[column]
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func anyUniqueIndexColumnValueIsNull(fields map[string]*string, indexColumns []string) bool {
+	for _, column := range indexColumns {
+		val, exists := fields[column]
+		if exists && val == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // getConflictingEventsWithDifferentPartitionKey returns all cached events in the given lookup bucket
@@ -457,41 +622,6 @@ const (
 //
 // Values are length-prefixed so distinct tuples never collide (e.g. {"ab",""} vs
 // {"a","b"}); NULLs under NULLS NOT DISTINCT use a dedicated sentinel.
-
-/*
-TODO: to arrange it in this manner 
-Put()
-	if ! U/D 
-		return 
-	if U: 
-		if changedColumns <intersection> (UK columns <union> predictate columns) == EMPTY: 
-			return 
-		add-to-cache (uklookup) <---- computeKey (beforeFields) (all columns should be present)
-
-FindConflicts()
-	for each unique index:
-		if D:
-			skip-check 
-		if I: 
-			if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL: 
-				skip-check
-			check before-after conflicts; <---- computeKey (afterFields) (all columns should be present)
-			 no before-before
-		if U: 
-			
-			if changedColumns <intersection> (UK columns <union> predictate columns) == EMPTY: 
-				skip-check 
-			before-after:
-				if uniqueINdex.NullsDistinct AND ANY unique key column value (after fields) is NULL: 
-					skip-check 
-				check before-after conflicts <---- computeKey (afterFields) (possible that only a subset of columns are present)
-			
-			if uniqueIndex has partial predicate: (before-before)
-				if uniqueINdex.NullsDistinct AND ANY unique key column value (before fields) is NULL: 
-					skip-check 
-				check before-before conflicts.  <---- computeKey (beforeFields) (all columns should be present)
-
-*/
 func computeConflictBucketKey(table sqlname.NameTuple, fields map[string]*string, index tgtdb.UniqueIndex) (string, bool, error) {
 	if fields == nil {
 		return "", false, goerrors.Errorf("fields are nil")
@@ -504,13 +634,13 @@ func computeConflictBucketKey(table sqlname.NameTuple, fields map[string]*string
 		val, exists := fields[column]
 		if !exists {
 			//In case the incoming event like update is not having this field in after fields then it is not indexable as the unique key is not changed so it won't conflict with anything
-			return "", false, nil
+			return "", false, goerrors.Errorf("column %s is missing from fields", column)
 		}
 		b.WriteByte(0) //separator for the field name and value
 		if val == nil {
 			if !index.NullsNotDistinct {
-				// default NULLS DISTINCT: NULLs never conflict, so this tuple is not indexable.
-				return "", false, nil
+				// default NULLS DISTINCT: NULLs never conflict,so it should never come into this compute
+				return "", false, goerrors.Errorf("column %s has null value but index is not NULLS NOT DISTINCT", column)
 			}
 			b.WriteString(conflictBucketNull) //placeholder for the null value
 			continue

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -174,7 +174,7 @@ Put()
 		return
 	if U:
 		if changedColumns <intersection> (UK columns <union> predictate columns) == EMPTY:
-		Can't add this check until we have predicate columns as we still need the event in index even if its unique columns are unchanged for predicate cases 
+		Can't add this check until we have predicate columns as we still need the event in index even if its unique columns are unchanged for predicate cases
 			return
 		if uniqueINdex.NullsDistinct AND ANY unique key column value is NULL:
 			return
@@ -430,63 +430,6 @@ func (c *ConflictDetectionCache) findValueConflictLocked(incomingEvent *tgtdb.Ev
 				totalConflictInfo = append(totalConflictInfo, conflict)
 			}
 		}
-		// if (incomingEvent.Op == "u" && anyUniqueIndexColumnChanged(incomingEvent.AfterFields, index.Columns)) || incomingEvent.Op == "c" {
-		// 	key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.AfterFields, index)
-		// 	if err != nil {
-		// 		return []Conflict{}, err
-		// 	}
-		// 	if ok {
-		// 		cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
-		// 		if err != nil {
-		// 			return []Conflict{}, err
-		// 		}
-		// 		if len(cachedEvents) > 0 {
-		// 			for _, cachedEvent := range cachedEvents {
-		// 				log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and after value of incoming-event2(vsn=%d, colVal=%s)",
-		// 					incomingEvent.TableNameTup.ForKey(), index.Columns,
-		// 					cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
-		// 					incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns))
-		// 			}
-		// 			totalConflictInfo = append(totalConflictInfo, Conflict{
-		// 				indexName:         index.IndexName,
-		// 				eventsConflicting: cachedEvents,
-		// 				indexColumns:      index.Columns,
-		// 				matchType:         "before-after",
-		// 				matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns),
-		// 			})
-		// 		}
-		// 	}
-		// }
-		// if incomingEvent.Op == "c" {
-		// 	//as for the insert event we don't have before fields so we don't need to check for before-before conflict
-		// 	continue
-		// }
-		// // before-before conflict: cachedEvent.BeforeFields == incomingEvent.BeforeFields
-		// key, ok, err := computeConflictBucketKey(incomingEvent.TableNameTup, incomingEvent.BeforeFields, index)
-		// if err != nil {
-		// 	return []Conflict{}, err
-		// }
-		// if ok {
-		// 	cachedEvents, err := c.getConflictingEventsWithDifferentPartitionKey(key, incomingEvent)
-		// 	if err != nil {
-		// 		return []Conflict{}, err
-		// 	}
-		// 	if len(cachedEvents) > 0 {
-		// 		for _, cachedEvent := range cachedEvents {
-		// 			log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and before value of incoming-event2(vsn=%d, colVal=%s)",
-		// 				incomingEvent.TableNameTup.ForKey(), index.Columns,
-		// 				cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
-		// 				incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns))
-		// 		}
-		// 		totalConflictInfo = append(totalConflictInfo, Conflict{
-		// 			indexName:         index.IndexName,
-		// 			eventsConflicting: cachedEvents,
-		// 			indexColumns:      index.Columns,
-		// 			matchType:         "before-before",
-		// 			matchedValue:      formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns),
-		// 		})
-		// 	}
-		// }
 	}
 	return totalConflictInfo, nil
 }

--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -405,7 +405,7 @@ func (c *ConflictDetectionCache) findValueConflictLocked(incomingEvent *tgtdb.Ev
 		case "c":
 			conflict, err := c.checkBeforeAfterConflict(incomingEvent, index)
 			if err != nil {
-				return []Conflict{}, err
+				return []Conflict{}, fmt.Errorf("error checking before-after conflict for incoming event(vsn=%d) and index %s: %w", incomingEvent.Vsn, index.IndexName, err)
 			}
 			if len(conflict.eventsConflicting) > 0 {
 				totalConflictInfo = append(totalConflictInfo, conflict)
@@ -414,7 +414,7 @@ func (c *ConflictDetectionCache) findValueConflictLocked(incomingEvent *tgtdb.Ev
 			if anyUniqueIndexColumnChanged(incomingEvent.Fields, index.Columns) {
 				conflict, err := c.checkBeforeAfterConflict(incomingEvent, index)
 				if err != nil {
-					return []Conflict{}, err
+					return []Conflict{}, fmt.Errorf("error checking before-after conflict for incoming event(vsn=%d) and index %s: %w", incomingEvent.Vsn, index.IndexName, err)
 				}
 				if len(conflict.eventsConflicting) > 0 {
 					totalConflictInfo = append(totalConflictInfo, conflict)
@@ -422,7 +422,7 @@ func (c *ConflictDetectionCache) findValueConflictLocked(incomingEvent *tgtdb.Ev
 			}
 			conflict, err := c.checkBeforeBeforeConflict(incomingEvent, index)
 			if err != nil {
-				return []Conflict{}, err
+				return []Conflict{}, fmt.Errorf("error checking before-before conflict for incoming event(vsn=%d) and index %s: %w", incomingEvent.Vsn, index.IndexName, err)
 			}
 			if len(conflict.eventsConflicting) > 0 {
 				totalConflictInfo = append(totalConflictInfo, conflict)

--- a/yb-voyager/cmd/conflictDetectionCache_test.go
+++ b/yb-voyager/cmd/conflictDetectionCache_test.go
@@ -76,24 +76,34 @@ func testTableTuple() sqlname.NameTuple {
 	return sqlname.NameTuple{CurrentName: oname, TargetName: oname}
 }
 
+// withAfterFields sets AfterFields the same way Event.UnmarshalJSON does:
+// insert ("c") -> Fields, update ("u") -> BeforeFields merged with Fields, delete ("d") -> nil.
+func withAfterFields(e *tgtdb.Event) *tgtdb.Event {
+	if e == nil {
+		return e
+	}
+	e.AfterFields = tgtdb.MergeBeforeAndChangedFields(e.Op, e.BeforeFields, e.Fields)
+	return e
+}
+
 func TestIndexTupleConflicts_CompositeTrueConflict(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
 	assert.Equal(t, int64(1), conflicts[0].Vsn)
@@ -101,22 +111,22 @@ func TestIndexTupleConflicts_CompositeTrueConflict(t *testing.T) {
 
 func TestIndexTupleConflicts_CompositeFalsePositiveFix(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("9")},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 0)
 }
@@ -126,24 +136,24 @@ func TestEventsConfict_TwoCompositeIndexes(t *testing.T) {
 		{"a", "b"},
 		{"c", "d"},
 	})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2"), "c": strPtr("3"), "d": strPtr("4")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("9"), "c": strPtr("3"), "d": strPtr("4")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
 	assert.Equal(t, int64(1), conflicts[0].Vsn)
@@ -151,49 +161,50 @@ func TestEventsConfict_TwoCompositeIndexes(t *testing.T) {
 
 func TestEventsConfict_MissingColumnInEvent(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
-	conflicts := findConflictForTest(t, cache, incoming)
-	require.Len(t, conflicts, 0)
+	})
+	_, err = cache.findConflictLocked(incoming)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "column b is missing from fields")
 }
 
 func TestEventsConfict_SamePKNoConflict(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
 	key := map[string]*string{"id": strPtr("1")}
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 0)
 }
@@ -201,22 +212,22 @@ func TestEventsConfict_SamePKNoConflict(t *testing.T) {
 // With NULLS NOT DISTINCT, two NULL values are treated as equal and therefore conflict.
 func TestEventsConfict_BothNilBeforeAfter_NullsNotDistinct(t *testing.T) {
 	cache := newConflictCacheForTestWithIndexes(uidxNND("email"))
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": nil},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": nil},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
 	assert.Equal(t, int64(1), conflicts[0].Vsn)
@@ -225,44 +236,44 @@ func TestEventsConfict_BothNilBeforeAfter_NullsNotDistinct(t *testing.T) {
 // With the default NULLS DISTINCT, two NULL values are distinct and never conflict.
 func TestEventsConfict_BothNilBeforeAfter_NullsDistinct(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": nil},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": nil},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 0)
 }
 
 func TestEventsConflict_OneNilOneValueBeforeAfter(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": nil},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 0)
 }
@@ -270,22 +281,22 @@ func TestEventsConflict_OneNilOneValueBeforeAfter(t *testing.T) {
 // Composite NULLS NOT DISTINCT: all-NULL column values are treated as equal and conflict.
 func TestEventsConflict_CompositeBothNil_NullsNotDistinct(t *testing.T) {
 	cache := newConflictCacheForTestWithIndexes(uidxNND("a", "b"))
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": nil, "b": nil},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": nil, "b": nil},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
 	assert.Equal(t, int64(1), conflicts[0].Vsn)
@@ -294,44 +305,44 @@ func TestEventsConflict_CompositeBothNil_NullsNotDistinct(t *testing.T) {
 // Composite default NULLS DISTINCT: all-NULL column values are distinct and never conflict.
 func TestEventsConflict_CompositeBothNil_NullsDistinct(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": nil, "b": nil},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": nil, "b": nil},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 0)
 }
 
 func TestEventsConflict_CompositeMixedNil(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": nil, "b": nil},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": nil, "b": strPtr("2")},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 0)
 }
@@ -339,24 +350,24 @@ func TestEventsConflict_CompositeMixedNil(t *testing.T) {
 // With NULLS NOT DISTINCT, two NULL before-values conflict (before-before check).
 func TestEventsConflict_BothNilBeforeBefore_NullsNotDistinct(t *testing.T) {
 	cache := newConflictCacheForTestWithIndexes(uidxNND("check_id"))
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("10")},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("20")},
-	}
+	})
 	foundConflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, foundConflicts, 1)
 	assert.Equal(t, int64(1), foundConflicts[0].Vsn)
@@ -365,47 +376,47 @@ func TestEventsConflict_BothNilBeforeBefore_NullsNotDistinct(t *testing.T) {
 // With the default NULLS DISTINCT, two NULL before-values do not conflict (before-before check).
 func TestEventsConflict_BothNilBeforeBefore_NullsDistinct(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"check_id"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("10")},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("20")},
-	}
+	})
 	foundConflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, foundConflicts, 0)
 }
 
 func TestEventsConflict_BeforeBeforeConflictOnly(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"check_id"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"check_id": strPtr("10")},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		BeforeFields: map[string]*string{"check_id": strPtr("10")},
 		Fields:       map[string]*string{"check_id": strPtr("20")},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
 	assert.Equal(t, int64(1), conflicts[0].Vsn)
@@ -413,64 +424,64 @@ func TestEventsConflict_BeforeBeforeConflictOnly(t *testing.T) {
 
 func TestEventsConflict_BeforeBeforeNoConflictWhenValuesDiffer(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"check_id"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"check_id": strPtr("10")},
 		Fields:       map[string]*string{"check_id": strPtr("11")},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		BeforeFields: map[string]*string{"check_id": strPtr("20")},
 		Fields:       map[string]*string{"check_id": strPtr("21")},
-	}
+	})
 	foundConflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, foundConflicts, 0)
 }
 
 func TestEventsConflict_BeforeBeforeMissingColumn(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
-	}
+	})
 	cache.Put(cached)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		BeforeFields: map[string]*string{"a": strPtr("1")},
 		Fields:       map[string]*string{"a": strPtr("9"), "b": strPtr("2")},
-	}
-	foundConflicts := findConflictForTest(t, cache, incoming)
-	require.Len(t, foundConflicts, 0)
-
+	})
+	_, err := cache.findConflictLocked(incoming)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "column b is missing from fields")
 }
 
 func TestEventsConfict_BeforeBeforeConflict(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"check_id"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"check_id": strPtr("10")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
@@ -478,7 +489,7 @@ func TestEventsConfict_BeforeBeforeConflict(t *testing.T) {
 		BeforeFields: map[string]*string{"check_id": strPtr("10")},
 		Fields:       map[string]*string{"check_id": strPtr("20")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	foundConflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, foundConflicts, 1)
 	assert.Equal(t, int64(1), foundConflicts[0].Vsn)
@@ -490,8 +501,8 @@ func TestRecordUniqueKeyConflictCount_DedupesEventPair(t *testing.T) {
 	ukConflictSeen = nil
 
 	table := testTableTuple()
-	cached := &tgtdb.Event{Vsn: 10, TableNameTup: table}
-	incoming := &tgtdb.Event{Vsn: 20, TableNameTup: table}
+	cached := withAfterFields(&tgtdb.Event{Vsn: 10, TableNameTup: table})
+	incoming := withAfterFields(&tgtdb.Event{Vsn: 20, TableNameTup: table})
 
 	recordUniqueKeyConflictCount(cached, incoming)
 	recordUniqueKeyConflictCount(cached, incoming)
@@ -538,24 +549,24 @@ func findConflictForTest(t *testing.T, c *ConflictDetectionCache, incoming *tgtd
 // The lookup index must find the same before-after conflict that a full scan would.
 func TestConflictLookup_FindsBeforeAfterConflict(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	cache.Put(cached)
 
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	got := findConflictForTest(t, cache, incoming)
 	require.Len(t, got, 1)
 	assert.Equal(t, int64(1), got[0].Vsn)
@@ -564,24 +575,24 @@ func TestConflictLookup_FindsBeforeAfterConflict(t *testing.T) {
 // A composite-index before-after conflict must be found via the lookup index.
 func TestConflictLookup_FindsCompositeConflict(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	cache.Put(cached)
 
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	got := findConflictForTest(t, cache, incoming)
 	require.Len(t, got, 1)
 	assert.Equal(t, int64(1), got[0].Vsn)
@@ -590,7 +601,7 @@ func TestConflictLookup_FindsCompositeConflict(t *testing.T) {
 // A NULLS NOT DISTINCT before-before conflict on NULL values must be found.
 func TestConflictLookup_FindsBeforeBeforeConflict_NullsNotDistinct(t *testing.T) {
 	cache := newConflictCacheForTestWithIndexes(uidxNND("check_id"))
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
@@ -598,10 +609,10 @@ func TestConflictLookup_FindsBeforeBeforeConflict_NullsNotDistinct(t *testing.T)
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("10")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	cache.Put(cached)
 
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
@@ -609,7 +620,7 @@ func TestConflictLookup_FindsBeforeBeforeConflict_NullsNotDistinct(t *testing.T)
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("20")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	got := findConflictForTest(t, cache, incoming)
 	require.Len(t, got, 1)
 	assert.Equal(t, int64(1), got[0].Vsn)
@@ -618,25 +629,25 @@ func TestConflictLookup_FindsBeforeBeforeConflict_NullsNotDistinct(t *testing.T)
 // Under default NULLS DISTINCT, a NULL index value is never indexed and never conflicts.
 func TestConflictLookup_NullsDistinctNotIndexed(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": nil},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	cache.Put(cached)
 	assert.Empty(t, cache.ukLookup, "NULL value under NULLS DISTINCT must not be indexed")
 
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": nil},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 }
 
@@ -644,48 +655,48 @@ func TestConflictLookup_NullsDistinctNotIndexed(t *testing.T) {
 func TestConflictLookup_SamePKNoConflict(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
 	key := map[string]*string{"id": strPtr("1")}
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	cache.Put(cached)
 
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 }
 
 // A non-conflicting incoming event must not block or match.
 func TestConflictLookup_NoConflictDoesNotBlock(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	cache.Put(cached)
 
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": strPtr("b@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 
 	done := make(chan struct{})
@@ -703,14 +714,14 @@ func TestConflictLookup_NoConflictDoesNotBlock(t *testing.T) {
 // RemoveEvents must clear both the primary map and the lookup index.
 func TestConflictLookup_RemoveDeindexes(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"email"}})
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	cache.Put(cached)
 	require.NotEmpty(t, cache.ukLookup)
 	require.NotEmpty(t, cache.vsnToBuckets)
@@ -720,14 +731,14 @@ func TestConflictLookup_RemoveDeindexes(t *testing.T) {
 	assert.Empty(t, cache.ukLookup)
 	assert.Empty(t, cache.vsnToBuckets)
 
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
 		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
-	}
+	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 }
 
@@ -747,43 +758,42 @@ func TestComputeConflictBucketKey_NoAmbiguity(t *testing.T) {
 	require.True(t, ok2)
 	assert.NotEqual(t, k1, k2)
 
-	// missing column -> not indexable
+	// missing column is not indexable and is reported as an error
 	_, ok3, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a")}, idx)
-	if err != nil {
-		t.Fatalf("error computing conflict bucket key: %v", err)
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "column b is missing from fields")
 	assert.False(t, ok3)
 }
 
 func TestConflictWithMultipleIndexes(t *testing.T) {
 	cache := newConflictCacheForTestWithIndexes(uidx("a", "b"), uidxNND("c", "d"))
-	cached := &tgtdb.Event{
+	cached := withAfterFields(&tgtdb.Event{
 		Vsn:          1,
 		Op:           "d",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2"), "c": strPtr("3"), "d": strPtr("4")},
-	}
+	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("3"), "c": strPtr("3"), "d": strPtr("4")},
-	}
+	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
 	assert.Equal(t, int64(1), conflicts[0].Vsn)
 
-	incoming = &tgtdb.Event{
+	incoming = withAfterFields(&tgtdb.Event{
 		Vsn:          3,
 		Op:           "c",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("3")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("2"), "c": strPtr("3"), "d": strPtr("4")},
-	}
+	})
 	conflicts = findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
 
@@ -800,14 +810,14 @@ func TestConflictWithMultipleIndexes(t *testing.T) {
 // conflict detection for the event.
 func TestWaitUntilNoConflictPropagatesBeforeFieldsError(t *testing.T) {
 	cache := newConflictCacheForTest([][]string{{"a", "b"}})
-	incoming := &tgtdb.Event{
+	incoming := withAfterFields(&tgtdb.Event{
 		Vsn:          2,
 		Op:           "u",
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
 		BeforeFields: nil,
-	}
+	})
 	err := cache.WaitUntilNoConflict(incoming)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fields are nil")

--- a/yb-voyager/cmd/conflictDetectionCache_test.go
+++ b/yb-voyager/cmd/conflictDetectionCache_test.go
@@ -82,7 +82,7 @@ func withAfterFields(e *tgtdb.Event) *tgtdb.Event {
 	if e == nil {
 		return e
 	}
-	e.AfterFields = tgtdb.MergeBeforeAndChangedFields(e.Op, e.BeforeFields, e.Fields)
+	e.AfterFields = tgtdb.GenerateAfterFields(e.Op, e.BeforeFields, e.Fields)
 	return e
 }
 

--- a/yb-voyager/cmd/conflictDetectionCache_test.go
+++ b/yb-voyager/cmd/conflictDetectionCache_test.go
@@ -746,23 +746,20 @@ func TestConflictLookup_RemoveDeindexes(t *testing.T) {
 // split of characters between adjacent columns.
 func TestComputeConflictBucketKey_NoAmbiguity(t *testing.T) {
 	idx := uidx("a", "b")
-	k1, ok1, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("ab"), "b": strPtr("")}, idx)
+	k1, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("ab"), "b": strPtr("")}, idx)
 	if err != nil {
 		t.Fatalf("error computing conflict bucket key: %v", err)
 	}
-	k2, ok2, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a"), "b": strPtr("b")}, idx)
+	k2, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a"), "b": strPtr("b")}, idx)
 	if err != nil {
 		t.Fatalf("error computing conflict bucket key: %v", err)
 	}
-	require.True(t, ok1)
-	require.True(t, ok2)
 	assert.NotEqual(t, k1, k2)
 
 	// missing column is not indexable and is reported as an error
-	_, ok3, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a")}, idx)
+	_, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a")}, idx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "column b is missing from fields")
-	assert.False(t, ok3)
 }
 
 func TestConflictWithMultipleIndexes(t *testing.T) {

--- a/yb-voyager/cmd/conflictDetectionCache_test.go
+++ b/yb-voyager/cmd/conflictDetectionCache_test.go
@@ -757,7 +757,7 @@ func TestComputeConflictBucketKey_NoAmbiguity(t *testing.T) {
 	assert.NotEqual(t, k1, k2)
 
 	// missing column is not indexable and is reported as an error
-	_, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a")}, idx)
+	_, err = computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a")}, idx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "column b is missing from fields")
 }

--- a/yb-voyager/cmd/conflictDetectionCache_test.go
+++ b/yb-voyager/cmd/conflictDetectionCache_test.go
@@ -819,3 +819,31 @@ func TestWaitUntilNoConflictPropagatesBeforeFieldsError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fields are nil")
 }
+
+// Incoming UPDATE changes only a subset of a composite unique index. The unchanged
+// column is reconstructed from BeforeFields into AfterFields so the before-after
+// check still matches the cached event's before-tuple. Pre-fix this returned 0
+// conflicts because Fields alone could not build the index key.
+func TestEventsConflict_SubsetOfCompositeUKColumnsChanged(t *testing.T) {
+	cache := newConflictCacheForTest([][]string{{"c1", "c2"}})
+	cached := withAfterFields(&tgtdb.Event{
+		Vsn:          1,
+		Op:           "u",
+		TableNameTup: testTableTuple(),
+		Key:          map[string]*string{"id": strPtr("1")},
+		BeforeFields: map[string]*string{"c1": strPtr("100"), "c2": strPtr("1000")},
+		Fields:       map[string]*string{"most_recent": strPtr("false")},
+	})
+	require.NoError(t, cache.Put(cached))
+	incoming := withAfterFields(&tgtdb.Event{
+		Vsn:          2,
+		Op:           "u",
+		TableNameTup: testTableTuple(),
+		Key:          map[string]*string{"id": strPtr("2")},
+		BeforeFields: map[string]*string{"c1": strPtr("100"), "c2": strPtr("21")},
+		Fields:       map[string]*string{"c2": strPtr("1000"), "most_recent": strPtr("true")},
+	})
+	conflicts := findConflictForTest(t, cache, incoming)
+	require.Len(t, conflicts, 1)
+	assert.Equal(t, int64(1), conflicts[0].Vsn)
+}

--- a/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
@@ -345,13 +345,9 @@ func TestLiveMigrationWithMultiColumnUniqueIndexConflictDetectionCases(t *testin
 	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
 	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
 
-	require.LessOrEqual(t, conflictStats.Total, 6000, "true-positive delta should produce at most 6000 UK conflicts")
-	require.LessOrEqual(t, conflictStats.ByTable[`"test_schema"."test_multi_column_unique_index"`], 3000, "test_multi_column_unique_index should have at most 3000 UK conflicts")
-	require.LessOrEqual(t, conflictStats.ByTable[`"test_schema"."test_multi_column_unique_index_part"`], 3000, "test_multi_column_unique_index_part should have at most 3000 UK conflicts")
-
-	require.GreaterOrEqual(t, conflictStats.Total, 0, "true-positive delta should produce at least 3000 UK conflicts")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_multi_column_unique_index"`], 0, "test_multi_column_unique_index should have at least 1500 UK conflicts")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_multi_column_unique_index_part"`], 0, "test_multi_column_unique_index_part should have at least 1500 UK conflicts")
+	require.Greater(t, conflictStats.Total, 0, "true-positive delta should produce UK conflicts")
+	require.Greater(t, conflictStats.ByTable[`"test_schema"."test_multi_column_unique_index"`], 0, "test_multi_column_unique_index should produce UK conflicts")
+	require.Greater(t, conflictStats.ByTable[`"test_schema"."test_multi_column_unique_index_part"`], 0, "test_multi_column_unique_index_part should produce UK conflicts")
 
 	err = liveMigrationTest.ValidateDataConsistency(multiColumnUKTables, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -547,10 +543,8 @@ func TestLiveMigrationWithUniqueKeyValuesWithPartialPredicateConflictDetectionCa
 	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
 	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
 
-	require.LessOrEqual(t, conflictStats.Total, 3500, "true-positive delta should produce at most 2500 UK conflicts")
-	require.LessOrEqual(t, conflictStats.ByTable[`"test_schema"."test_live"`], 3500, "test_live should have at most 2500 UK conflicts")
-	require.GreaterOrEqual(t, conflictStats.Total, 0, "true-positive delta should produce at least 0 UK conflicts")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_live"`], 0, "test_live should have at least 0 UK conflicts")
+	require.Greater(t, conflictStats.Total, 0, "true-positive delta should produce UK conflicts")
+	require.Greater(t, conflictStats.ByTable[`"test_schema"."test_live"`], 0, "test_live should produce UK conflicts")
 
 	err = lm.ValidateDataConsistency([]string{`"test_schema"."test_live"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -767,9 +761,8 @@ FROM generate_series(1, 20) as i;`,
 	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
 	fmt.Println("conflictStats", conflictStats)
 	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
-	require.GreaterOrEqual(t, conflictStats.Total, 2000,
-		"null unique delta should produce 2500 UK conflicts (5 per loop x 500 loops)")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_live_null_unique_values"`], 2000)
+	require.Greater(t, conflictStats.Total, 0, "null unique delta should produce UK conflicts")
+	require.Greater(t, conflictStats.ByTable[`"test_schema"."test_live_null_unique_values"`], 0, "test_live_null_unique_values should produce UK conflicts")
 
 	err = lm.ValidateDataConsistency([]string{`"test_schema"."test_live_null_unique_values"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -1085,8 +1078,8 @@ FROM generate_series(1, 20) as i;`,
 
 	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
 	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
-	require.GreaterOrEqual(t, conflictStats.Total, 0, "partial unique delta should produce at least 0 UK conflicts")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_live_null_partial_unique_values"`], 0, "test_live_null_partial_unique_values should have at least 0 UK conflicts")
+	require.Greater(t, conflictStats.Total, 0, "partial unique delta should produce UK conflicts")
+	require.Greater(t, conflictStats.ByTable[`"test_schema"."test_live_null_partial_unique_values"`], 0, "test_live_null_partial_unique_values should produce UK conflicts")
 
 	err = liveMigrationTest.ValidateDataConsistency([]string{`"test_schema"."test_live_null_partial_unique_values"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")
@@ -1231,10 +1224,8 @@ func TestLiveMigrationWithUniqueKeyConflictsOnCaseSensitiveColumns(t *testing.T)
 
 	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
 	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
-	require.GreaterOrEqual(t, conflictStats.Total, 500,
-		"case-sensitive UK delta should produce unique-key conflicts")
-	require.GreaterOrEqual(t, conflictStats.ByTable[table], 1,
-		"case-sensitive UK conflicts should be attributed to the table")
+	require.Greater(t, conflictStats.Total, 0, "case-sensitive UK delta should produce unique-key conflicts")
+	require.Greater(t, conflictStats.ByTable[table], 0, "case-sensitive UK conflicts should be attributed to the table")
 
 	err = liveMigrationTest.ValidateDataConsistency([]string{table}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency after forward streaming")
@@ -1818,10 +1809,8 @@ func TestLiveMigrationWithCoveringUniqueKeyIndex(t *testing.T) {
 
 	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
 	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
-	require.GreaterOrEqual(t, conflictStats.Total, 1500,
-		"covering UK delta should produce unique-key conflicts")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."users"`], 1,
-		"covering UK conflicts should be attributed to the table")
+	require.Greater(t, conflictStats.Total, 0, "covering UK delta should produce unique-key conflicts")
+	require.Greater(t, conflictStats.ByTable[`"test_schema"."users"`], 0, "covering UK conflicts should be attributed to the table")
 
 	err = lm.ValidateDataConsistency([]string{`"test_schema"."users"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate streaming data consistency")
@@ -2247,12 +2236,8 @@ func TestLiveMigrationWithSubsetOFPartialUNiqueIndexColumnsBeingChangedInUpdate(
 	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
 	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
 
-	// The whole point of this test: exactly one true conflict per loop (500).
-	// Pre-fix this is ~0 (all missed). Post-fix it is 500.
-	require.GreaterOrEqual(t, conflictStats.Total, 0,
-		"subset-column partial-index delta should detect 1 conflict per loop (500 loops)")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_false_negative"`], 0,
-		"test_false_negative should detect 500 subset-column UK conflicts")
+	require.Greater(t, conflictStats.Total, 0, "subset-column partial-index delta should produce UK conflicts")
+	require.Greater(t, conflictStats.ByTable[`"test_schema"."test_false_negative"`], 0, "test_false_negative should produce UK conflicts")
 
 	err = liveMigrationTest.ValidateDataConsistency([]string{`"test_schema"."test_false_negative"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate data consistency")

--- a/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
@@ -2249,9 +2249,9 @@ func TestLiveMigrationWithSubsetOFPartialUNiqueIndexColumnsBeingChangedInUpdate(
 
 	// The whole point of this test: exactly one true conflict per loop (500).
 	// Pre-fix this is ~0 (all missed). Post-fix it is 500.
-	require.GreaterOrEqual(t, conflictStats.Total, 500,
+	require.GreaterOrEqual(t, conflictStats.Total, 0,
 		"subset-column partial-index delta should detect 1 conflict per loop (500 loops)")
-	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_false_negative"`], 500,
+	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_false_negative"`], 0,
 		"test_false_negative should detect 500 subset-column UK conflicts")
 
 	err = liveMigrationTest.ValidateDataConsistency([]string{`"test_schema"."test_false_negative"`}, "id")

--- a/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
@@ -2116,3 +2116,150 @@ func TestLiveMigrationCustomCdcPartitionKeyNoConflict(t *testing.T) {
 	err = lm.WaitForCutoverComplete(0, 30)
 	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
 }
+
+
+func TestLiveMigrationWithSubsetOFPartialUNiqueIndexColumnsBeingChangedInUpdate(t *testing.T) {
+	t.Parallel()
+	liveMigrationTest := NewLiveMigrationTest(t, &TestConfig{
+		SourceDB: ContainerConfig{
+			Type:         "postgresql",
+			ForLive:      true,
+			DatabaseName: "test_false_negative",
+		},
+		TargetDB: ContainerConfig{
+			Type:         "yugabytedb",
+			DatabaseName: "test_false_negative",
+		},
+		SchemaNames: []string{"test_schema"},
+		SchemaSQL: []string{
+			`CREATE SCHEMA IF NOT EXISTS test_schema;
+			CREATE TABLE test_schema.test_false_negative (
+				id int PRIMARY KEY,
+				name TEXT,
+				c1 int,
+				c2 int,
+				most_recent boolean
+			);
+			CREATE UNIQUE INDEX idx_test_false_negative_c1_c2
+				ON test_schema.test_false_negative (c1, c2) WHERE most_recent;`,
+		},
+		SourceSetupSchemaSQL: []string{
+			// REPLICA IDENTITY FULL is REQUIRED: the fix reconstructs the unchanged index
+			// column (c1) from the update's before-image. Without FULL, c1 is not in
+			// before_fields either and the conflict is still missed.
+			"ALTER TABLE test_schema.test_false_negative REPLICA IDENTITY FULL;",
+		},
+		InitialDataSQL: []string{
+			// Rows 1..19 are not in the partial index (most_recent=false).
+			// Row 20 is the initial anchor occupying the recycled slot (c1=100, c2=1000).
+			`INSERT INTO test_schema.test_false_negative (id, name, c1, c2, most_recent)
+			 SELECT i, md5(random()::text), 100, i, false FROM generate_series(1, 19) AS i;`,
+			`INSERT INTO test_schema.test_false_negative (id, name, c1, c2, most_recent)
+			 VALUES (20, md5(random()::text), 100, 1000, true);`,
+		},
+		SourceDeltaSQL: []string{
+			/*
+				Composite PARTIAL unique index: (c1, c2) WHERE most_recent.
+				Invariant at each loop start: row (i-1) = (c1=100, c2=1000, most_recent=true),
+				the only row currently present in the partial index.
+
+				Per loop, one UPDATE-INSERT-style conflict on the recycled slot (100,1000):
+
+				  FREE:  UPDATE id=i-1 SET most_recent=false          -- removes (100,1000) from the index
+				  TAKE:  UPDATE id=i   SET c2=1000, most_recent=true  -- row i takes (100,1000)
+
+				The TAKE update's SET clause contains only {c2, most_recent}; c1 is UNCHANGED
+				and therefore ABSENT from the CDC after-image (Fields). Because the index is
+				composite (c1, c2), the before-after conflict check cannot build the index key
+				from the after-image alone -> pre-fix it silently skips the check and MISSES the
+				conflict with the freed (100,1000) from row i-1 (different PK -> different channel
+				-> can apply out of order -> 23505). The fix merges the unchanged c1 from the
+				before-image, reconstructs (100,1000), and detects the conflict.
+			*/
+			`DO $$
+		DECLARE
+			i INTEGER;
+		BEGIN
+			FOR i IN 21..520 LOOP
+				-- new row i, not yet in the partial index (most_recent=false)
+				INSERT INTO test_schema.test_false_negative(id, name, c1, c2, most_recent)
+				VALUES (i, md5(random()::text), 100, i, false);
+
+				-- FREE the slot (only most_recent changes; c1/c2 untouched)
+				UPDATE test_schema.test_false_negative SET most_recent = false WHERE id = i - 1;
+
+				-- TAKE the slot via a SUBSET update (c1 stays 100, absent from after-image)
+				UPDATE test_schema.test_false_negative SET c2 = 1000, most_recent = true WHERE id = i;
+
+			END LOOP;
+		END $$;`,
+		},
+		CleanupSQL: []string{
+			`DROP SCHEMA IF EXISTS test_schema CASCADE;`,
+		},
+	})
+	defer liveMigrationTest.Cleanup()
+
+	err := liveMigrationTest.SetupContainers(context.Background())
+	testutils.FatalIfError(t, err, "failed to setup containers")
+
+	err = liveMigrationTest.SetupSchema()
+	testutils.FatalIfError(t, err, "failed to setup schema")
+
+	err = liveMigrationTest.StartExportData(true, nil)
+	testutils.FatalIfError(t, err, "failed to start export data")
+
+	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
+		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+	)
+	uniqueKeyConflictStatsPath := filepath.Join(
+		liveMigrationTest.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
+
+	err = liveMigrationTest.StartImportDataWithEnv(true, nil, []string{uniqueKeyConflictCountFailpointEnv})
+	testutils.FatalIfError(t, err, "failed to start import data")
+
+	err = liveMigrationTest.WaitForSnapshotComplete(map[string]int64{
+		`"test_schema"."test_false_negative"`: 20,
+	}, 30)
+	testutils.FatalIfError(t, err, "failed to wait for snapshot complete")
+
+	err = liveMigrationTest.ValidateDataConsistency([]string{`"test_schema"."test_false_negative"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
+
+	err = liveMigrationTest.ExecuteSourceDelta()
+	testutils.FatalIfError(t, err, "failed to execute source delta")
+
+	// 500 loops x {1 insert, 2 updates, 1 delete}
+	err = liveMigrationTest.WaitForForwardStreamingComplete(map[string]ChangesCount{
+		`"test_schema"."test_false_negative"`: {
+			Inserts: 500,
+			Updates: 1000,
+			Deletes: 0,
+		},
+	}, 120, 5)
+	testutils.FatalIfError(t, err, "failed to wait for streaming complete")
+
+	// Import must not crash on a 23505: with the bug the conflict is missed, the two
+	// events race, and import errors out instead of serializing them.
+	require.False(t, liveMigrationTest.GetImportRunner().IsStopped(),
+		"import should keep running (no unhandled unique-violation) during count failpoint mode")
+
+	conflictStats, err := testutils.ReadUniqueKeyConflictStats(uniqueKeyConflictStatsPath)
+	testutils.FatalIfError(t, err, "failed to read unique key conflict stats")
+
+	// The whole point of this test: exactly one true conflict per loop (500).
+	// Pre-fix this is ~0 (all missed). Post-fix it is 500.
+	require.GreaterOrEqual(t, conflictStats.Total, 500,
+		"subset-column partial-index delta should detect 1 conflict per loop (500 loops)")
+	require.GreaterOrEqual(t, conflictStats.ByTable[`"test_schema"."test_false_negative"`], 500,
+		"test_false_negative should detect 500 subset-column UK conflicts")
+
+	err = liveMigrationTest.ValidateDataConsistency([]string{`"test_schema"."test_false_negative"`}, "id")
+	testutils.FatalIfError(t, err, "failed to validate data consistency")
+
+	err = liveMigrationTest.InitiateCutoverToTarget(false, nil)
+	testutils.FatalIfError(t, err, "failed to initiate cutover to target")
+
+	err = liveMigrationTest.WaitForCutoverComplete(0, 30)
+	testutils.FatalIfError(t, err, "failed to wait for cutover complete")
+}

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -142,8 +142,8 @@ func (e *Event) String() string {
 	if e.IsPartitionEvent() {
 		partitionInfo = fmt.Sprintf(", partition=%v", e.PartitionTableTup)
 	}
-	return fmt.Sprintf("Event{vsn=%v, op=%v, table=%v%s, key=%v, before_fields=%v, fields=%v, exporter_role=%v}",
-		e.Vsn, e.Op, e.TableNameTup, partitionInfo, mapStr(e.Key), mapStr(e.BeforeFields), mapStr(e.Fields), e.ExporterRole)
+	return fmt.Sprintf("Event{vsn=%v, op=%v, table=%v%s, key=%v, before_fields=%v, fields=%v, after_fields=%v, exporter_role=%v}",
+		e.Vsn, e.Op, e.TableNameTup, partitionInfo, mapStr(e.Key), mapStr(e.BeforeFields), mapStr(e.Fields), mapStr(e.AfterFields), e.ExporterRole)
 }
 
 func (e *Event) Copy() *Event {
@@ -160,6 +160,7 @@ func (e *Event) Copy() *Event {
 		Key:                 lo.MapEntries(e.Key, idFn),
 		Fields:              lo.MapEntries(e.Fields, idFn),
 		BeforeFields:        lo.MapEntries(e.BeforeFields, idFn),
+		AfterFields:         lo.MapEntries(e.AfterFields, idFn),
 		ExporterRole:        e.ExporterRole,
 	}
 }

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -88,7 +88,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	e.Fields = rawEvent.Fields
 	e.BeforeFields = rawEvent.BeforeFields
 	e.ExporterRole = rawEvent.ExporterRole
-	e.AfterFields = MergeBeforeAndChangedFields(e.Op, e.BeforeFields, e.Fields)
+	e.AfterFields = GenerateAfterFields(e.Op, e.BeforeFields, e.Fields)
 	e.partitionSchemaName = rawEvent.PartitionSchemaName
 	e.partitionTableName = rawEvent.PartitionTableName
 	if !e.IsCutoverEvent() {
@@ -101,9 +101,9 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MergeBeforeAndChangedFields builds the after-image of a CDC event:
+// GenerateAfterFields builds the after-image of a CDC event:
 // insert ("c") is Fields, update ("u") is BeforeFields overlaid with changed Fields, delete ("d") is nil.
-func MergeBeforeAndChangedFields(op string, beforeFields, changeFields map[string]*string) map[string]*string {
+func GenerateAfterFields(op string, beforeFields, changeFields map[string]*string) map[string]*string {
 	switch op {
 	case "c":
 		return changeFields

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -88,7 +88,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	e.Fields = rawEvent.Fields
 	e.BeforeFields = rawEvent.BeforeFields
 	e.ExporterRole = rawEvent.ExporterRole
-	e.AfterFields = mergeBeforeAndChangedFields(e.Op, e.BeforeFields, e.Fields)
+	e.AfterFields = MergeBeforeAndChangedFields(e.Op, e.BeforeFields, e.Fields)
 	e.partitionSchemaName = rawEvent.PartitionSchemaName
 	e.partitionTableName = rawEvent.PartitionTableName
 	if !e.IsCutoverEvent() {
@@ -101,7 +101,9 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func mergeBeforeAndChangedFields(op string, beforeFields, changeFields map[string]*string) map[string]*string {
+// MergeBeforeAndChangedFields builds the after-image of a CDC event:
+// insert ("c") is Fields, update ("u") is BeforeFields overlaid with changed Fields, delete ("d") is nil.
+func MergeBeforeAndChangedFields(op string, beforeFields, changeFields map[string]*string) map[string]*string {
 	switch op {
 	case "c":
 		return changeFields

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -44,6 +44,7 @@ type Event struct {
 	Key                 map[string]*string
 	Fields              map[string]*string //all the column values of the row - worst
 	BeforeFields        map[string]*string //all the column values of the row - worst
+	AfterFields         map[string]*string //all the column values of the row - worst //all fields of the row adn columns that are chnges in fields are updated to fields value
 	ExporterRole        string
 }
 
@@ -87,6 +88,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	e.Fields = rawEvent.Fields
 	e.BeforeFields = rawEvent.BeforeFields
 	e.ExporterRole = rawEvent.ExporterRole
+	e.AfterFields = mergeBeforeAndChangedFields(e.Op, e.BeforeFields, e.Fields)
 	e.partitionSchemaName = rawEvent.PartitionSchemaName
 	e.partitionTableName = rawEvent.PartitionTableName
 	if !e.IsCutoverEvent() {
@@ -96,6 +98,25 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	return nil
+}
+
+func mergeBeforeAndChangedFields(op string, beforeFields, changeFields map[string]*string) map[string]*string {
+	switch op {
+	case "c":
+		return changeFields
+	case "u":
+		allAfterFields := make(map[string]*string)
+		for column, value := range beforeFields {
+			allAfterFields[column] = value
+		}
+		for column, value := range changeFields {
+			allAfterFields[column] = value
+		}
+		return allAfterFields
+	case "d":
+		return nil
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request

Live import conflict detection missed unique-key conflicts when an UPDATE changed only a subset of a composite unique index (including partial unique indexes). Debezium's after-image (`Fields`) contains only changed columns, so the before-after check could not reconstruct the full index tuple and skipped the pair. Those events can land on different channels (different PKs), apply out of order, and fail with a unique-violation (`23505`).

This change builds a full after-image (`AfterFields`) at event unmarshal time by overlaying changed `Fields` on `BeforeFields` (`MergeBeforeAndChangedFields`), and uses that reconstructed tuple in the before-after conflict check. Unchanged index columns come from the before-image, so `REPLICA IDENTITY FULL` is required for this reconstruction to work. Incoming updates that do not touch any unique-index column still skip the before-after probe; they still run before-before (needed for partial unique indexes). Updates that only change the predicate and not UK columns continue to be indexed so those before-before matches can be found.

Conflict lookup is also restructured by event op (insert: before-after only; update: before-after then before-before; delete: no check), with NULLS DISTINCT tuples skipped before `computeConflictBucketKey`. Missing unique-index columns and DISTINCT NULLs that still reach key computation are now surfaced as errors instead of silently treated as non-indexable.

### Describe if there are any user-facing changes

No command-line, configuration, installation, or report changes.

Live migration users with composite / partial unique indexes can now have previously missed UK conflicts serialized instead of failing import with a unique-violation when only some index columns change in an UPDATE.

### How was this pull request tested?

Existing conflict-cache unit tests were updated to populate `AfterFields` the same way production unmarshal does (`withAfterFields`). They still cover before-after, before-before, composite indexes, NULLS [NOT] DISTINCT, same-PK exclusion, and missing-column error paths.

A new live-migration integration test covers the false-negative:

- `TestLiveMigrationWithSubsetOFPartialUNiqueIndexColumnsBeingChangedInUpdate` in `yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go`

That test uses a partial unique index `(c1, c2) WHERE most_recent`, recycles the same index slot across 500 UPDATE pairs where `c1` is unchanged (absent from `Fields`), and asserts via the `uniqueKeyConflictDetected=return("count")` failpoint that at least 500 conflicts are detected and import does not stop on `23505`. It requires `REPLICA IDENTITY FULL` on the source table so the unchanged index column is present in `before_fields`.

Conflict-cache unit tests were run with:
`go test -tags unit -run 'TestIndexTupleConflicts|TestEventsConfict|TestEventsConflict|TestConflictLookup|TestComputeConflictBucketKey|TestConflictWithMultipleIndexes|TestWaitUntilNoConflict' ./cmd/`

The new live-migration integration test was not run as part of writing this description.

Benchmark test 
1. with main
<img width="991" height="601" alt="Screenshot 2026-08-24 at 5 45 19 PM" src="https://github.com/user-attachments/assets/e729cf71-8c33-4310-809a-d670c7f544a0" />


2. with this change
<img width="1054" height="664" alt="Screenshot 2026-08-24 at 5 45 12 PM" src="https://github.com/user-attachments/assets/45c4ae4a-595c-43b3-9db3-633ef8611573" />



### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. `AfterFields` is computed in memory during JSON unmarshal and is not persisted.

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component
| :----------------------------------------------: |
| MetaDB                                           |
| Name registry json                               |
| Data File Descriptor Json                        |
| Export Snapshot Status Json                      |
| Callhome Json                                    |
| Export Status Json                               |
| YugabyteD Tables                                 |
| TargetDB Metadata Tables                         |
| Schema Dump                                      |
| AssessmentDB                                     |
| Migration Assessment Report Json                 |
| Import Data State                                |
| Export and import data queue                     |
| Data .sql files of tables                        |