### PR TITLE
Upgrade bundled logical YB CDC connector to dz.2.5.2.yb.2026.1

### DIFF
--- a/yb-voyager/versions/yb-cdc-connector-versions.json
+++ b/yb-voyager/versions/yb-cdc-connector-versions.json
@@ -3,6 +3,6 @@
         "tag": "dz.2.5.2.yb.2026.1"
     },
     "grpc_connector": {
-        "tag": "dz.1.9.5.yb.grpc.2024.2.3"
+        "tag": "dz.1.9.5.yb.grpc.2026.1.1"
     }
 }

--- a/yb-voyager/versions/yb-cdc-connector-versions.json
+++ b/yb-voyager/versions/yb-cdc-connector-versions.json
@@ -1,6 +1,6 @@
 {
     "logical_connector": {
-        "tag": "dz.2.5.2.yb.2025.2.3"
+        "tag": "dz.2.5.2.yb.2026.1"
     },
     "grpc_connector": {
         "tag": "dz.1.9.5.yb.grpc.2024.2.3"

--- a/yb-voyager/versions/yb-cdc-connector-versions.json
+++ b/yb-voyager/versions/yb-cdc-connector-versions.json
@@ -3,6 +3,6 @@
         "tag": "dz.2.5.2.yb.2026.1"
     },
     "grpc_connector": {
-        "tag": "dz.1.9.5.yb.grpc.2026.1.1"
+        "tag": "dz.1.9.5.yb.grpc.2024.2.3"
     }
 }


### PR DESCRIPTION
Fixes #3719 / [DB-23021](https://yugabyte.atlassian.net/browse/DB-23021)

### Describe the changes in this pull request

Bumps the bundled logical CDC connector in `yb-voyager/versions/yb-cdc-connector-versions.json` from `dz.2.5.2.yb.2025.2.3` to `dz.2.5.2.yb.2026.1`, the latest GA release in `yugabyte/debezium`. Connector compatibility is per YB series, so this is needed for the 2026.1 series. The gRPC connector is intentionally left as is.

### Describe if there are any user-facing changes

None. A fresh install just ships the 2026.1 connector jar; the installer derives the download URL from this file, so nothing else changed.

### How was this pull request tested?

`TestConnectorLatestStable` (`connector_latest_stable` tag) fails on `main` and passes here — that red check is why this ticket exists. Unit tests for `versions`, `src/dbzm`, `src/ybversion`, `cmd` pass, and the download URL returns 200. Relying on CI migtests for end-to-end validation.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
