### PR TITLE
Make the pr-description skill produce short, plain-language PR descriptions

### DIFF
--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -25,6 +25,9 @@ A PR description is skimmed in under a minute. Optimize for that, always.
 - **Simple language.** Plain words, active voice, present tense. Write "fixes a
   crash when a table has no primary key", not "addresses a suboptimal behavioral
   characteristic in the primary-key-less code path".
+- **One idea per sentence.** Aim for about 20 words. Don't chain facts together
+  with commas, semicolons, or "and". Split them instead — a bullet that needs a
+  semicolon is two bullets. Two plain sentences beat one clause-stacked one.
 - **No filler.** Drop "this PR", "in order to", "it is worth noting that",
   "comprehensive", "robust", "leverage", "various", "as mentioned above".
 - **No diff narration.** The reviewer can see the file list. Don't walk through
@@ -101,9 +104,9 @@ Too long — narrates the diff, pads with filler, explains nothing new:
 Right size — one problem, one fix, one consequence:
 
 > ### Describe the changes in this pull request
-> `handleEvent` silently dropped the error from `WaitUntilNoConflict`, so an
-> import kept applying events after a conflict wait failed. It now propagates the
-> error, and the import fails fast instead of writing bad data.
+> `handleEvent` silently dropped the error from `WaitUntilNoConflict`. An import
+> then kept applying events after a conflict wait had failed. It now propagates
+> the error, so the import fails fast instead of writing bad data.
 
 An example earns its place when a sentence can't show the shape of the change:
 
@@ -118,12 +121,13 @@ A large PR — a lede, then one line per reviewable piece, still scannable:
 > ### Describe the changes in this pull request
 > Adds resumable data export to the fall-back flow.
 >
-> - **Export** — writes a per-tablet checkpoint after each batch; on restart it
->   resumes from the last checkpoint instead of re-exporting the snapshot.
-> - **State** — new `export_checkpoint` table in MetaDB, created lazily on first
->   checkpoint so existing export dirs keep working.
-> - **CLI** — `export data --resume` replaces `--restart-if-interrupted`, which is
->   now a hidden alias.
+> - **Export** — writes a per-tablet checkpoint after each batch.
+> - **Restart** — resumes from the last checkpoint instead of re-exporting the
+>   whole snapshot.
+> - **State** — new `export_checkpoint` table in MetaDB. It is created lazily, so
+>   existing export dirs keep working.
+> - **CLI** — `export data --resume` replaces `--restart-if-interrupted`. The old
+>   flag stays as a hidden alias.
 > - **Not in this PR** — resumption for `export data from target` (DB-1234).
 
 ## Workflow: Create a PR
@@ -213,6 +217,9 @@ When the user asks to update an existing PR description:
   commits or say "in commit X, we did Y".
 - **Simple words**: Explain it the way you would to a teammate in chat. No
   marketing adjectives, no abstract noun where a verb works.
+- **Low density**: One fact per sentence. A reader should never have to unpack a
+  sentence twice. Short sentences are what make a short description readable —
+  cramming the same content into fewer, denser lines defeats the point.
 - **Why over what**: One clause of motivation beats a paragraph of mechanics.
 - **Be specific in testing**: Name actual tests, commands, or scenarios — not
   just "tested manually".
@@ -228,6 +235,9 @@ Before showing any description to the user, delete:
 - any example that only repeats what the prose already said
 - any background the team already knows
 - restated headings ("This section describes the changes...")
+
+Then split: any sentence carrying two facts becomes two sentences, and any bullet
+with a semicolon becomes two bullets.
 
 Then check it against the length budget for this PR's size. If it's over, cut
 again — a large PR is a licence for more bullets, not for padding. Never pad a

--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -17,9 +17,11 @@ Descriptions summarize the **entire PR diff as a whole** — not individual comm
 
 A PR description is skimmed in under a minute. Optimize for that, always.
 
-- **Hard cap: ~150 words** for the whole description (the template's reference
-  table doesn't count). Over budget means cut content, not reformat it.
-- **Every section is 1-3 lines.** Prefer a couple of short bullets to a paragraph.
+- **Match the length to the PR** — see "Length budget" below. Spend the budget on
+  distinct facts, never on longer sentences.
+- **Short answers stay one line.** The callhome and on-disk questions, and the
+  user-facing section when nothing applies, are one line each no matter how large
+  the PR is. Testing is 1-3 lines.
 - **Simple language.** Plain words, active voice, present tense. Write "fixes a
   crash when a table has no primary key", not "addresses a suboptimal behavioral
   characteristic in the primary-key-less code path".
@@ -30,6 +32,25 @@ A PR description is skimmed in under a minute. Optimize for that, always.
 - **Examples only when they earn their place.** One short snippet — a command, a
   config line, a before/after — when it is genuinely clearer than a sentence.
   At most one per PR, at most ~5 lines. Otherwise skip it.
+
+### Length budget
+
+| PR size | "Describe the changes" | Whole description |
+| :-- | :-- | :-- |
+| Small — one fix, 1-3 files | 2-3 bullets, or 2-3 sentences | ~100 words |
+| Typical — one feature or fix, a handful of files | 3-5 bullets | ~200 words |
+| Large — new feature, refactor, or several subsystems | one-sentence lede + one bullet per reviewable piece (usually 6-10) | ~350 words |
+
+**Big PRs get more lines, not longer lines.** For a large PR:
+
+1. Open with one sentence saying what the PR delivers as a whole.
+2. Then one bullet per independently reviewable piece, one line each. A 15-file
+   PR earns 8 bullets; it never earns 8 paragraphs.
+3. Group the bullets under bold labels once there are more than about six.
+4. Name anything deliberately left for a follow-up, in one line.
+
+If a PR genuinely can't be explained in ~350 words, say so and suggest splitting
+it — don't quietly write 800.
 
 ## PR Description Template
 
@@ -42,11 +63,11 @@ your descriptions will automatically stay in sync.
 
 When populating the template, follow these instructions for each section:
 
-- **Describe the changes in this pull request** — **2-4 short bullets, or 2-3
-  sentences.** What was broken or missing, and what the PR does about it. Add the
-  *why* only when it isn't obvious from the *what*. Mention a design decision only
-  if a reviewer would otherwise question the approach. No commit-by-commit
-  breakdown.
+- **Describe the changes in this pull request** — Size it from the length budget
+  above: 2-3 bullets for a small PR, up to ~10 for a large one. Say what was
+  broken or missing and what the PR does about it. Add the *why* only when it
+  isn't obvious from the *what*. Mention a design decision only if a reviewer
+  would otherwise question the approach. No commit-by-commit breakdown.
 
 - **Describe if there are any user-facing changes** — One line per question that
   actually applies (command line, configuration, installation, reports). Show the
@@ -91,6 +112,19 @@ An example earns its place when a sentence can't show the shape of the change:
 > ```
 > --on-conflict-wait-timeout 30s
 > ```
+
+A large PR — a lede, then one line per reviewable piece, still scannable:
+
+> ### Describe the changes in this pull request
+> Adds resumable data export to the fall-back flow.
+>
+> - **Export** — writes a per-tablet checkpoint after each batch; on restart it
+>   resumes from the last checkpoint instead of re-exporting the snapshot.
+> - **State** — new `export_checkpoint` table in MetaDB, created lazily on first
+>   checkpoint so existing export dirs keep working.
+> - **CLI** — `export data --resume` replaces `--restart-if-interrupted`, which is
+>   now a hidden alias.
+> - **Not in this PR** — resumption for `export data from target` (DB-1234).
 
 ## Workflow: Create a PR
 
@@ -195,6 +229,6 @@ Before showing any description to the user, delete:
 - any background the team already knows
 - restated headings ("This section describes the changes...")
 
-Then check: is the whole thing under ~150 words, and is every section 1-3 lines?
-If not, cut again. Never pad a section to look thorough — "No user-facing
-changes." is a complete answer.
+Then check it against the length budget for this PR's size. If it's over, cut
+again — a large PR is a licence for more bullets, not for padding. Never pad a
+section to look thorough: "No user-facing changes." is a complete answer.

--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 This skill creates and updates GitHub PR descriptions for the yb-voyager project.
 Descriptions summarize the **entire PR diff as a whole** — not individual commits.
 
-## the shortest, most pragmatic description that completely explains the change
+## Core rule: the shortest, most pragmatic description that completely explains the change
 
 A PR description is skimmed in under a minute. Optimize for that, always.
 
@@ -247,7 +247,7 @@ When the user asks to update an existing PR description:
 Before showing any description to the user, delete:
 
 - any sentence a reviewer could get from the file list or the diff
-- any word from the filler list in the core rule above
+- any word from the filler list in "Core rule" above
 - any example that only repeats what the prose already said
 - any background the team already knows
 - restated headings ("This section describes the changes...")

--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 This skill creates and updates GitHub PR descriptions for the yb-voyager project.
 Descriptions summarize the **entire PR diff as a whole** — not individual commits.
 
-## Core rule: the shortest, most pragmatic description that completely explains the change
+## the shortest, most pragmatic description that completely explains the change
 
 A PR description is skimmed in under a minute. Optimize for that, always.
 
@@ -247,7 +247,7 @@ When the user asks to update an existing PR description:
 Before showing any description to the user, delete:
 
 - any sentence a reviewer could get from the file list or the diff
-- any word from the filler list in "Core rule" above
+- any word from the filler list in the core rule above
 - any example that only repeats what the prose already said
 - any background the team already knows
 - restated headings ("This section describes the changes...")

--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -212,7 +212,9 @@ When the user asks to update an existing PR description:
    Fall back to the REST API, and check the body afterwards either way:
 
    ```bash
-   gh api -X PATCH repos/yugabyte/yb-voyager/pulls/<number> -F body=@body.md
+   gh api -X PATCH repos/yugabyte/yb-voyager/pulls/<number> -F body=@- <<'EOF'
+   <filled template>
+   EOF
    gh api repos/yugabyte/yb-voyager/pulls/<number> --jq '.body'
    ```
 

--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -207,6 +207,15 @@ When the user asks to update an existing PR description:
    )"
    ```
 
+   `gh pr edit` can fail on this repo with a GraphQL error about Projects
+   (classic) being deprecated. The edit does not go through when that happens.
+   Fall back to the REST API, and check the body afterwards either way:
+
+   ```bash
+   gh api -X PATCH repos/yugabyte/yb-voyager/pulls/<number> -F body=@body.md
+   gh api repos/yugabyte/yb-voyager/pulls/<number> --jq '.body'
+   ```
+
 8. Confirm the update was applied and show the PR URL.
 
 ## Writing Guidelines

--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -13,9 +13,13 @@ description: >-
 This skill creates and updates GitHub PR descriptions for the yb-voyager project.
 Descriptions summarize the **entire PR diff as a whole** — not individual commits.
 
-## Core rule: the shortest description that still explains the change
+## Core rule: the shortest, most pragmatic description that completely explains the change
 
 A PR description is skimmed in under a minute. Optimize for that, always.
+
+Completeness is the floor, not the goal. The description has to cover everything a
+reviewer needs to judge the change. Shortness is how it gets there — cut words,
+never facts.
 
 - **Match the length to the PR** — see "Length budget" below. Spend the budget on
   distinct facts, never on longer sentences.
@@ -222,8 +226,9 @@ When the user asks to update an existing PR description:
 
 ## Writing Guidelines
 
-- **Short beats complete**: A short description that gets read fully is worth more
-  than a thorough one that gets skipped. When in doubt, cut.
+- **Short, not partial**: A short description that gets read fully is worth more
+  than a thorough one that gets skipped. So cut hard — but cut words, filler, and
+  anything the diff already says, never a fact the reviewer needs.
 - **Holistic, not granular**: Describe the PR as one cohesive change. Don't list
   commits or say "in commit X, we did Y".
 - **Simple words**: Explain it the way you would to a teammate in chat. No

--- a/ai/skills/pr-description/SKILL.md
+++ b/ai/skills/pr-description/SKILL.md
@@ -13,6 +13,24 @@ description: >-
 This skill creates and updates GitHub PR descriptions for the yb-voyager project.
 Descriptions summarize the **entire PR diff as a whole** — not individual commits.
 
+## Core rule: the shortest description that still explains the change
+
+A PR description is skimmed in under a minute. Optimize for that, always.
+
+- **Hard cap: ~150 words** for the whole description (the template's reference
+  table doesn't count). Over budget means cut content, not reformat it.
+- **Every section is 1-3 lines.** Prefer a couple of short bullets to a paragraph.
+- **Simple language.** Plain words, active voice, present tense. Write "fixes a
+  crash when a table has no primary key", not "addresses a suboptimal behavioral
+  characteristic in the primary-key-less code path".
+- **No filler.** Drop "this PR", "in order to", "it is worth noting that",
+  "comprehensive", "robust", "leverage", "various", "as mentioned above".
+- **No diff narration.** The reviewer can see the file list. Don't walk through
+  files, functions, or commits.
+- **Examples only when they earn their place.** One short snippet — a command, a
+  config line, a before/after — when it is genuinely clearer than a sentence.
+  At most one per PR, at most ~5 lines. Otherwise skip it.
+
 ## PR Description Template
 
 Use the project's PR template file at `.github/PULL_REQUEST_TEMPLATE` as the base
@@ -24,26 +42,55 @@ your descriptions will automatically stay in sync.
 
 When populating the template, follow these instructions for each section:
 
-- **Describe the changes in this pull request** — Write a concise summary of what
-  the PR does and why (3-8 sentences). Focus on the overall intent, the problem
-  being solved, the approach taken, and key design decisions. Do NOT give a
-  commit-by-commit breakdown.
+- **Describe the changes in this pull request** — **2-4 short bullets, or 2-3
+  sentences.** What was broken or missing, and what the PR does about it. Add the
+  *why* only when it isn't obvious from the *what*. Mention a design decision only
+  if a reviewer would otherwise question the approach. No commit-by-commit
+  breakdown.
 
-- **Describe if there are any user-facing changes** — Answer the questions listed
-  in the template's HTML comments (command line, configuration, installation,
-  reports). If none apply, write "No user-facing changes."
+- **Describe if there are any user-facing changes** — One line per question that
+  actually applies (command line, configuration, installation, reports). Show the
+  new flag or config key literally instead of describing it. If nothing applies,
+  write exactly "No user-facing changes." and nothing more.
 
-- **How was this pull request tested?** — Be specific: mention whether existing
-  tests cover the changes, any new unit tests added, manual testing done, and
-  whether integration tests are needed. Cite actual test names or commands where
-  possible.
+- **How was this pull request tested?** — **1-3 lines.** Name the real tests or
+  commands (`TestFooBar`, `make unit-tests`), and say plainly if something is only
+  manually tested or still uncovered. No prose like "testing was performed to
+  ensure correctness".
 
-- **Does your PR have changes in callhome/yugabyted payloads?** — Answer Yes/No.
-  If yes, confirm the payload version was incremented.
+- **Does your PR have changes in callhome/yugabyted payloads?** — One line: "No."
+  or "Yes — payload version bumped to N."
 
 - **Does your PR have changes to on-disk structures that can cause upgrade issues?**
-  — Answer Yes/No. If yes, list which on-disk structures are affected, using the
-  reference table at the bottom of the template.
+  — One line: "No." or "Yes — <structures>", naming them from the reference table
+  at the bottom of the template.
+
+## Example
+
+Too long — narrates the diff, pads with filler, explains nothing new:
+
+> ### Describe the changes in this pull request
+> This PR introduces a comprehensive set of changes in order to improve the
+> robustness of the CDC event handling code path. In `handleEvent`, we now
+> leverage the error returned by `WaitUntilNoConflict` rather than discarding it.
+> Various call sites in `event_processor.go` were updated accordingly, and the
+> function signature was changed to return an error. It is worth noting that
+> this makes the behavior consistent with the rest of the package.
+
+Right size — one problem, one fix, one consequence:
+
+> ### Describe the changes in this pull request
+> `handleEvent` silently dropped the error from `WaitUntilNoConflict`, so an
+> import kept applying events after a conflict wait failed. It now propagates the
+> error, and the import fails fast instead of writing bad data.
+
+An example earns its place when a sentence can't show the shape of the change:
+
+> ### Describe if there are any user-facing changes
+> New optional flag on `import data`:
+> ```
+> --on-conflict-wait-timeout 30s
+> ```
 
 ## Workflow: Create a PR
 
@@ -59,7 +106,8 @@ When the user asks to create a PR:
    changes as a unified body of work, not as individual commits.
 
 3. **Draft the PR description** using the template above. Fill in each section
-   based on the diff analysis.
+   based on the diff analysis, then run the "Trim pass" checklist below before
+   showing it to anyone.
 
 4. **Draft a concise PR title** — a short imperative sentence summarizing the change
    (e.g., "Add retry logic for failed CDC events").
@@ -94,7 +142,9 @@ When the user asks to update an existing PR description:
 
 4. **Analyze the full PR diff holistically** and draft an updated description
    using the template. The description must reflect the totality of changes
-   in the PR, as if writing it from scratch.
+   in the PR, as if writing it from scratch — length budget included. An update
+   is a rewrite, not an append: never grow a description by tacking the newest
+   changes onto the old text. Run the "Trim pass" checklist before showing it.
 
 5. **Show the user exactly what will change** — present the proposed new description
    clearly, highlighting what's different from the current one. Use a format like:
@@ -123,13 +173,28 @@ When the user asks to update an existing PR description:
 
 ## Writing Guidelines
 
+- **Short beats complete**: A short description that gets read fully is worth more
+  than a thorough one that gets skipped. When in doubt, cut.
 - **Holistic, not granular**: Describe the PR as one cohesive change. Don't list
   commits or say "in commit X, we did Y".
-- **Why over what**: Explain the motivation and design decisions, not just what
-  files changed.
-- **Be specific in testing**: Mention actual test names, commands run, or scenarios
-  verified — not just "tested manually".
-- **Be honest about gaps**: If testing is incomplete, say so. Don't fabricate
-  test coverage.
-- **Keep it concise**: Aim for clarity, not length. Each section should be
-  meaningful, not padded.
+- **Simple words**: Explain it the way you would to a teammate in chat. No
+  marketing adjectives, no abstract noun where a verb works.
+- **Why over what**: One clause of motivation beats a paragraph of mechanics.
+- **Be specific in testing**: Name actual tests, commands, or scenarios — not
+  just "tested manually".
+- **Be honest about gaps**: If testing is incomplete, say so in a few words.
+  Don't fabricate test coverage.
+
+## Trim pass
+
+Before showing any description to the user, delete:
+
+- any sentence a reviewer could get from the file list or the diff
+- any word from the filler list in "Core rule" above
+- any example that only repeats what the prose already said
+- any background the team already knows
+- restated headings ("This section describes the changes...")
+
+Then check: is the whole thing under ~150 words, and is every section 1-3 lines?
+If not, cut again. Never pad a section to look thorough — "No user-facing
+changes." is a complete answer.


### PR DESCRIPTION
### Describe the changes in this pull request

The `pr-description` skill wrote long PR descriptions that narrated the diff. It
allowed 3-8 sentences per section and set no overall limit.

- **Length budget** — scaled to PR size: ~100 words small, ~200 typical, ~350 large.
- **Big PRs** — earn more bullets, not longer ones. One-sentence lede, then one
  line per reviewable piece.
- **Density** — one fact per sentence, about 20 words. A bullet needing a
  semicolon becomes two bullets.
- **Short sections** — one line for each yes/no answer, 1-3 lines for testing.
- **Examples** — optional. One snippet, max ~5 lines, only when prose can't show
  the shape of the change.
- **Trim pass** — a checklist the skill runs before showing any draft. It cuts
  filler words and diff narration, then splits dense sentences.
- **Worked examples** — three of them: too long, right size, and large PR. A word
  count alone doesn't pin down the target.
- **Tooling fix** — `gh pr edit` fails on this repo with a Projects (classic)
  GraphQL error. The update workflow now documents the REST API fallback.

### Describe if there are any user-facing changes

No user-facing changes. This touches documentation for the
`ai/skills/pr-description` skill only.

### How was this pull request tested?

No code changed, so no tests apply. I verified the YAML frontmatter still parses
and every original section heading survived. This description was written under
the new rules.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
