### PR TITLE
Document metrics-port in config templates

### DIFF
--- a/yb-voyager/config-templates/bulk-data-load.yaml
+++ b/yb-voyager/config-templates/bulk-data-load.yaml
@@ -185,6 +185,10 @@ import-data-file:
   ### Default - false
   disable-pb: false
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9102
+
 # ---------------------------------------------------------
 # End Migration Configuration
 # ---------------------------------------------------------

--- a/yb-voyager/config-templates/live-migration-with-fall-back.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-back.yaml
@@ -370,6 +370,10 @@ export-data-from-source:
   ### Default - info
   # log-level: info                                            
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9105
+
 # ---------------------------------------------------------
 # Import Data Configuration
 # ---------------------------------------------------------
@@ -493,6 +497,10 @@ import-data-to-target:
   ### Default - empty
   # cdc-partition-key-overrides: public.orders:table;sales.events:pk
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9101
+
 # ---------------------------------------------------------
 # Archive Changes
 # ---------------------------------------------------------
@@ -613,6 +621,10 @@ export-data-from-target:
   ### Default - info
   # log-level: info 
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9106
+
 # ---------------------------------------------------------
 # Import data to source
 # ---------------------------------------------------------
@@ -656,6 +668,10 @@ import-data-to-source:
   ### Accepted values (true, false, yes, no, 1, 0)
   ### Default - true
   # use-partition-root: true
+
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9104
 
 # ---------------------------------------------------------
 # initiate cutover to source configuration

--- a/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
@@ -430,6 +430,10 @@ export-data-from-source:
   ### Default - info
   # log-level: info                                           
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9105
+
 # ---------------------------------------------------------
 # Import Data Configuration
 # ---------------------------------------------------------
@@ -552,6 +556,10 @@ import-data-to-target:
   ### Default - empty
   # cdc-partition-key-overrides: public.orders:table;sales.events:pk
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9101
+
 # ---------------------------------------------------------
 # Import data to source-replica
 # ---------------------------------------------------------
@@ -598,6 +606,10 @@ import-data-to-source-replica:
   ### Note: This overrides the value of the number of retries to happen for streaming phase 
   ## Accepted value - <integer>, default - 15
   # max-retries-streaming: 15
+
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9103
 
 # ---------------------------------------------------------
 # Archive Changes
@@ -718,6 +730,10 @@ export-data-from-target:
   ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
   ### Default - info
   # log-level: info 
+
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9106
 
 # ---------------------------------------------------------
 # End Migration Configuration

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -376,6 +376,10 @@ export-data-from-source:
   ### Default - info
   # log-level: info                                              
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9105
+
 # ---------------------------------------------------------
 # Import Data Configuration
 # ---------------------------------------------------------
@@ -500,6 +504,10 @@ import-data-to-target:
   ### Accepted values: schema.table:pk|table pairs, separated by ';'
   ### Default - empty
   # cdc-partition-key-overrides: public.orders:table;sales.events:pk
+
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9101
 
 # ---------------------------------------------------------
 # Archive Changes

--- a/yb-voyager/config-templates/offline-migration.yaml
+++ b/yb-voyager/config-templates/offline-migration.yaml
@@ -378,6 +378,10 @@ export-data:
   ### Default - false
   # allow-oracle-clob-data-export: true
 
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9105
+
 # ---------------------------------------------------------
 # Import Data Configuration
 # ---------------------------------------------------------
@@ -488,6 +492,10 @@ import-data:
   ### Accepted values - (trace, debug, info, warn, error, fatal, panic) 
   ### Default - info
   # log-level: info                                                                 
+
+  ### Port to expose Prometheus metrics on (0 disables). Serves GET /metrics.
+  ### Default - 0
+  # metrics-port: 9101
 
 # ---------------------------------------------------------
 # Finalize Schema Post Data Import Configuration


### PR DESCRIPTION
### Describe the changes in this pull request

`--metrics-port` is config-bindable for every export/import data section (allow-listed in `cmd/config.go`), but it was missing from all shipped YAML config templates under `config-templates/`. This adds a commented `metrics-port` block, following the existing template convention, to every export/import data section that accepts it: `export-data`/`export-data-from-source`, `export-data-from-target`, `import-data`/`import-data-to-target`, `import-data-to-source`, `import-data-to-source-replica`, and `import-data-file`. Each section uses a distinct example port so a config running multiple commands concurrently doesn't collide on the same port.

The deprecated `prometheus-metrics-port` alias is intentionally left undocumented since it's a hidden, deprecated flag.

### Describe if there are any user-facing changes

No behavioral changes. Documentation-only: adds commented example config to the shipped templates. No changes to the command line, configuration semantics, installation, or reports.

### How was this pull request tested?

Verified each edited template still parses as valid YAML (`yq e '.' <file>`), and confirmed via `git diff` that every change is a pure addition with no unrelated lines touched. Cross-checked the added `metrics-port` key against the allow-lists in `cmd/config.go` for each section.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.