### PR TITLE
Make yb-voyager log rotation configurable (log-max-size-mb, log-max-backups)

### DIFF
--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -33,7 +33,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -104,8 +103,7 @@ func init() {
 		"assume answer as yes for all questions during migration (default false)")
 	BoolVar(assessMigrationBulkCmd.Flags(), &callhome.SendDiagnostics, "send-diagnostics", true,
 		"enable or disable the 'send-diagnostics' feature that sends analytics data to YugabyteDB.(default true)")
-	assessMigrationBulkCmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
-		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
+	registerLogFlags(assessMigrationBulkCmd)
 
 	const fleetConfigFileHelp = `
 Path to the CSV file with connection parameters for schema(s) to be assessed.
@@ -226,8 +224,8 @@ func buildCommandArguments(dbConfig AssessMigrationDBConfig, exportDirPath strin
 		"--source-db-type", dbConfig.DbType,
 		"--source-db-schema", dbConfig.Schema,
 		"--export-dir", exportDirPath,
-		"--log-level", config.LogLevel,
 	}
+	args = append(args, logSettingsCLIArgs()...)
 
 	if dbConfig.User != "" {
 		args = append(args, "--source-db-user", dbConfig.User)

--- a/yb-voyager/cmd/config.go
+++ b/yb-voyager/cmd/config.go
@@ -52,7 +52,7 @@ var commandsUsingTargetConfig = []string{
 }
 
 var allowedGlobalConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"export-dir", "log-level", "send-diagnostics",
+	"export-dir", "log-level", "log-max-size-mb", "log-max-backups", "send-diagnostics",
 	"profile",
 	// environment variables keys
 	"control-plane-type", "java-home",
@@ -88,7 +88,7 @@ var allowedYBAeonControlPlaneConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedAssessMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"iops-capture-interval", "target-db-version", "assessment-metadata-dir",
 	"invoked-by-export-schema",
 	// environment variables keys
@@ -96,14 +96,14 @@ var allowedAssessMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedAnalyzeSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level",
+	"log-level", "log-max-size-mb", "log-max-backups",
 	"output-format", "target-db-version",
 	// environment variables keys
 	"report-unsupported-plpgsql-objects",
 )
 
 var allowedExportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"use-orafce", "comments-on-objects", "object-type-list", "exclude-object-type-list",
 	"skip-colocation-recommendations", "assessment-report-path",
 	"skip-performance-recommendations",
@@ -113,7 +113,7 @@ var allowedExportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedExportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"disable-pb", "exclude-table-list", "table-list", "exclude-table-list-file-path",
 	"table-list-file-path", "parallel-jobs", "export-type",
 	"allow-oracle-clob-data-export", "metrics-port",
@@ -122,7 +122,7 @@ var allowedExportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedExportDataFromTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level",
+	"log-level", "log-max-size-mb", "log-max-backups",
 	"disable-pb", "exclude-table-list", "table-list", "exclude-table-list-file-path",
 	"table-list-file-path", "transaction-ordering", "metrics-port",
 	// environment variables keys
@@ -130,18 +130,18 @@ var allowedExportDataFromTargetConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportSchemaConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"continue-on-error", "object-type-list", "exclude-object-type-list", "straight-order",
 	"ignore-exist", "enable-orafce",
 )
 
 var allowedFinalizeSchemaPostDataImportConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"continue-on-error", "ignore-exist", "refresh-mviews",
 )
 
 var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"batch-size", "parallel-jobs", "adaptive-parallelism", "adaptive-parallelism-max",
 	"skip-replication-checks",
 	"disable-pb", "max-retries-streaming", "exclude-table-list", "table-list",
@@ -163,7 +163,7 @@ var allowedImportDataConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"parallel-jobs", "disable-pb", "prometheus-metrics-port", "metrics-port", "use-partition-root",
 	// environment variables keys
 	"num-event-channels", "event-channel-size", "max-events-per-batch",
@@ -172,7 +172,7 @@ var allowedImportDataToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
 )
 
 var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level", "run-guardrails-checks",
+	"log-level", "log-max-size-mb", "log-max-backups", "run-guardrails-checks",
 	"batch-size", "parallel-jobs", "truncate-tables", "disable-pb", "max-retries-streaming",
 	"prometheus-metrics-port", "metrics-port",
 	// environment variables keys
@@ -182,7 +182,7 @@ var allowedImportDataToSourceReplicaConfigKeys = mapset.NewThreadUnsafeSet[strin
 )
 
 var allowedImportDataFileConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level",
+	"log-level", "log-max-size-mb", "log-max-backups",
 	"disable-pb", "max-retries-streaming", "enable-upsert", "use-public-ip", "target-endpoints",
 	"batch-size", "parallel-jobs", "adaptive-parallelism", "adaptive-parallelism-max",
 	"format", "delimiter", "data-dir", "file-table-map", "has-header", "escape-char",
@@ -205,12 +205,12 @@ var allowedInitCutoverToSourceConfigKeys = mapset.NewThreadUnsafeSet[string](
 	"restart-data-migration-source-target",
 )
 var allowedArchiveChangesConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level",
+	"log-level", "log-max-size-mb", "log-max-backups",
 	"policy", "archive-dir", "fs-utilization-threshold",
 )
 
 var allowedEndMigrationConfigKeys = mapset.NewThreadUnsafeSet[string](
-	"log-level",
+	"log-level", "log-max-size-mb", "log-max-backups",
 	"backup-schema-files", "backup-data-files", "save-migration-reports", "backup-log-files",
 	"backup-dir",
 )

--- a/yb-voyager/cmd/config_test.go
+++ b/yb-voyager/cmd/config_test.go
@@ -23,11 +23,13 @@ import (
 	"os"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
@@ -4000,4 +4002,157 @@ func TestControlPlane_YBMConfigFileBinding(t *testing.T) {
 
 	// Verify control plane type via environment variable (set by initConfig)
 	assert.Equal(t, "ybm", os.Getenv("CONTROL_PLANE_TYPE"), "Control plane type should be ybm")
+}
+
+////////////////////////////// Log Settings Tests //////////////////////////////
+
+// errLogSettingsHalt stands in for the process exit that ErrExitPreLog would perform.
+const errLogSettingsHalt = "log settings validation halted the command"
+
+// setupLogSettingsContext prepares an analyze-schema run with the given global log
+// settings block, and returns the config file to point the command at.
+func setupLogSettingsContext(t *testing.T, logSettingsYAML string) *testContext {
+	tmpExportDir := setupExportDir(t)
+	t.Cleanup(func() { os.RemoveAll(tmpExportDir) })
+
+	resetCmdAndEnvVars(analyzeSchemaCmd)
+	utils.MonkeyPatchUtilsErrExitToIgnore()
+	origOut, origLevel := log.StandardLogger().Out, log.GetLevel()
+	t.Cleanup(func() {
+		utils.RestoreUtilsErrExit()
+		resetFlags(analyzeSchemaCmd)
+		log.SetOutput(origOut)
+		log.SetLevel(origLevel)
+	})
+
+	configContent := fmt.Sprintf(`
+export-dir: %s
+log-level: info
+%s
+`, tmpExportDir, logSettingsYAML)
+	configFile, configDir := setupConfigFile(t, configContent)
+	t.Cleanup(func() { os.RemoveAll(configDir) })
+
+	return &testContext{tmpExportDir: tmpExportDir, configFile: configFile}
+}
+
+// activeLogRotator returns the lumberjack.Logger that logging was actually initialised
+// with, so tests assert on the real wiring rather than only on the flag variables.
+func activeLogRotator(t *testing.T) *lumberjack.Logger {
+	t.Helper()
+	rotator, ok := log.StandardLogger().Out.(*lumberjack.Logger)
+	require.True(t, ok, "expected logrus output to be a lumberjack.Logger")
+	return rotator
+}
+
+func TestLogSettings_ConfigFileBinding(t *testing.T) {
+	ctx := setupLogSettingsContext(t, "log-max-size-mb: 50\nlog-max-backups: -1")
+
+	rootCmd.SetArgs([]string{"analyze-schema", "--config-file", ctx.configFile})
+	require.NoError(t, rootCmd.Execute())
+
+	assert.Equal(t, 50, config.LogMaxSizeMB, "log-max-size-mb should come from the config file")
+	assert.Equal(t, config.LogMaxBackupsUnlimited, config.LogMaxBackups, "log-max-backups should come from the config file")
+
+	rotator := activeLogRotator(t)
+	assert.Equal(t, 50, rotator.MaxSize)
+	assert.Equal(t, 0, rotator.MaxBackups, "-1 should reach lumberjack as its retain-all value")
+}
+
+func TestLogSettings_CLIOverridesConfigFile(t *testing.T) {
+	ctx := setupLogSettingsContext(t, "log-max-size-mb: 50\nlog-max-backups: 5")
+
+	rootCmd.SetArgs([]string{
+		"analyze-schema",
+		"--config-file", ctx.configFile,
+		"--log-max-size-mb", "10",
+		"--log-max-backups", "-1",
+	})
+	require.NoError(t, rootCmd.Execute())
+
+	assert.Equal(t, 10, config.LogMaxSizeMB, "CLI flag should win over the config file")
+	assert.Equal(t, config.LogMaxBackupsUnlimited, config.LogMaxBackups, "CLI flag should win over the config file")
+
+	rotator := activeLogRotator(t)
+	assert.Equal(t, 10, rotator.MaxSize)
+	assert.Equal(t, 0, rotator.MaxBackups)
+}
+
+// Unset settings must reproduce the values yb-voyager hardcoded before they were
+// configurable, so existing users see no behaviour change.
+func TestLogSettings_DefaultsWhenUnset(t *testing.T) {
+	ctx := setupLogSettingsContext(t, "")
+
+	rootCmd.SetArgs([]string{"analyze-schema", "--config-file", ctx.configFile})
+	require.NoError(t, rootCmd.Execute())
+
+	assert.Equal(t, config.DefaultLogMaxSizeMB, config.LogMaxSizeMB)
+	assert.Equal(t, config.DefaultLogMaxBackups, config.LogMaxBackups)
+
+	rotator := activeLogRotator(t)
+	assert.Equal(t, 200, rotator.MaxSize, "default rotation size should be unchanged")
+	assert.Equal(t, 10, rotator.MaxBackups, "default retained backups should be unchanged")
+}
+
+// The settings are allowed in a command section too, matching log-level.
+func TestLogSettings_CommandSectionBinding(t *testing.T) {
+	ctx := setupLogSettingsContext(t, "analyze-schema:\n  log-max-size-mb: 30\n  log-max-backups: 7")
+
+	rootCmd.SetArgs([]string{"analyze-schema", "--config-file", ctx.configFile})
+	require.NoError(t, rootCmd.Execute())
+
+	assert.Equal(t, 30, config.LogMaxSizeMB)
+	assert.Equal(t, 7, config.LogMaxBackups)
+
+	rotator := activeLogRotator(t)
+	assert.Equal(t, 30, rotator.MaxSize)
+	assert.Equal(t, 7, rotator.MaxBackups)
+}
+
+// An invalid value must halt the command before logging is initialised, i.e. via
+// ErrExitPreLog rather than ErrExit, so the error is not swallowed into a log file.
+func TestLogSettings_InvalidValueHaltsBeforeLoggingInit(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "zero max size",
+			args:    []string{"--log-max-size-mb", "0"},
+			wantErr: "invalid log-max-size-mb: 0",
+		},
+		{
+			// 0 is rejected rather than silently meaning "retain all".
+			name:    "zero max backups",
+			args:    []string{"--log-max-backups", "0"},
+			wantErr: "invalid log-max-backups: 0",
+		},
+		{
+			name:    "negative max backups other than the sentinel",
+			args:    []string{"--log-max-backups", "-2"},
+			wantErr: "invalid log-max-backups: -2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := setupLogSettingsContext(t, "")
+
+			// Capture the message and abort the command the way ErrExitPreLog's
+			// os.Exit would, without killing the test process.
+			var gotMsg string
+			utils.MonkeyPatchUtilsErrExitPreLog(func(formatString string, args ...interface{}) {
+				gotMsg = fmt.Sprintf(formatString, args...)
+				panic(errLogSettingsHalt)
+			})
+			t.Cleanup(utils.RestoreUtilsErrExitPreLog)
+
+			rootCmd.SetArgs(append([]string{"analyze-schema", "--config-file", ctx.configFile}, tt.args...))
+
+			require.PanicsWithValue(t, errLogSettingsHalt, func() { rootCmd.Execute() },
+				"invalid log settings should halt via ErrExitPreLog")
+			assert.Contains(t, gotMsg, tt.wantErr)
+		})
+	}
 }

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/lockfile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
@@ -493,7 +492,8 @@ func saveDataMigrationReport(msr *metadb.MigrationStatusRecord, includeIteration
 		parentExportDir = msr.GetParentExportDir(exportDir)
 	}
 
-	strCmd := fmt.Sprintf("yb-voyager get data-migration-report --export-dir %s --log-level %s --output-format json", parentExportDir, config.LogLevel)
+	strCmd := fmt.Sprintf("yb-voyager get data-migration-report --export-dir %s %s --output-format json",
+		parentExportDir, strings.Join(logSettingsCLIArgs(), " "))
 	if includeIterations {
 		strCmd += " --include-detailed-iterations-stats true"
 	}

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -41,7 +41,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/cp"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
@@ -342,7 +341,7 @@ func startNextIterationImportDataToTarget() {
 			cmd = append(cmd, "--disable-pb=true")
 		}
 		cmd = append(cmd, fmt.Sprintf("--send-diagnostics=%t", callhome.SendDiagnostics))
-		cmd = append(cmd, "--log-level", config.LogLevel)
+		cmd = append(cmd, logSettingsCLIArgs()...)
 		//TODO: see if we can do better, but these params are required for import data to target cmd
 		cmd = append(cmd, "--target-db-name", currentMsr.TargetDBConf.DBName)
 		cmd = append(cmd, "--target-db-user", currentMsr.TargetDBConf.User)
@@ -2143,7 +2142,7 @@ func generateGlobalExportImportArguments() []string {
 		}
 	} else {
 		//else set some overrides for the command
-		arguments = append(arguments, "--log-level", config.LogLevel)
+		arguments = append(arguments, logSettingsCLIArgs()...)
 		arguments = append(arguments, "--export-dir", lo.Ternary(msr.IsParentMigration(), exportDir, msr.ParentExportDir))
 		if bool(disablePb) {
 			arguments = append(arguments, "--disable-pb=true")

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -126,8 +126,12 @@ func prepareDebeziumConfig(partitionsToRootTableMap map[string]string, tableList
 		// dbzm does not support fatal/panic log levels
 		dbzmLogLevel = config.ERROR
 	}
+	// Read before the local `config` variable below shadows the config package.
+	dbzmLogMaxSizeMB, dbzmLogMaxBackups := config.LogMaxSizeMB, config.LogMaxBackups
 	config := &dbzm.Config{
 		LogLevel:           dbzmLogLevel,
+		LogMaxSizeMB:       dbzmLogMaxSizeMB,
+		LogMaxBackups:      dbzmLogMaxBackups,
 		MigrationUUID:      migrationUUID,
 		RunId:              runId,
 		SourceDBType:       source.DBType,

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
@@ -745,8 +744,7 @@ func init() {
 	getCommand.AddCommand(getDataMigrationReportCmd)
 	registerExportDirFlag(getDataMigrationReportCmd)
 	registerConfigFileFlag(getDataMigrationReportCmd)
-	getDataMigrationReportCmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
-		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
+	registerLogFlags(getDataMigrationReportCmd)
 	getDataMigrationReportCmd.Flags().StringVar(&reportOrStatusCmdOutputFormat, "output-format", "table",
 		"format in which report will be generated: (table, json) (default: table)")
 

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/adaptiveparallelism"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/cp"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
@@ -412,7 +411,7 @@ func startExportDataFromSourceOnNextIteration() {
 			cmd = append(cmd, "--disable-pb=true")
 		}
 		cmd = append(cmd, fmt.Sprintf("--send-diagnostics=%t", callhome.SendDiagnostics))
-		cmd = append(cmd, "--log-level", config.LogLevel)
+		cmd = append(cmd, logSettingsCLIArgs()...)
 		cmd = append(cmd, "--export-type", CHANGES_ONLY)
 		//TODO: see if we can do better, but these params are required for import data to target cmd
 		cmd = append(cmd, "--source-db-type", currentMsr.SourceDBConf.DBType)

--- a/yb-voyager/cmd/logging.go
+++ b/yb-voyager/cmd/logging.go
@@ -20,9 +20,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 )
 
 type MyFormatter struct{}
@@ -48,7 +52,7 @@ func (mf *MyFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return []byte(msg), nil
 }
 
-func InitLogging(logDir string, logLevel string, disableLogging bool, cmdName string) error {
+func InitLogging(logDir string, logLevel string, disableLogging bool, cmdName string, logMaxSizeMB int, logMaxBackups int) error {
 	// Redirect log messages to ${logDir}/yb-voyager.log if not a status command.
 	if disableLogging {
 		log.SetOutput(io.Discard)
@@ -59,8 +63,8 @@ func InitLogging(logDir string, logLevel string, disableLogging bool, cmdName st
 	// logRotator handles scenario where "logs" folder, or yb-voyager.log file does not exist.
 	logRotator := &lumberjack.Logger{
 		Filename:   logFileName,
-		MaxSize:    200, // 200 MB log size before rotation
-		MaxBackups: 10,  // Allow upto 10 logs at once before deleting oldest logs.
+		MaxSize:    logMaxSizeMB, // log size in MB before rotation
+		MaxBackups: config.LumberjackMaxBackups(logMaxBackups),
 	}
 	log.SetOutput(logRotator)
 	level, err := log.ParseLevel(logLevel)
@@ -76,6 +80,30 @@ func InitLogging(logDir string, logLevel string, disableLogging bool, cmdName st
 	log.Infof("Args: %v", os.Args)
 	log.Infof("\n%s", getVersionInfo())
 	return nil
+}
+
+// registerLogFlags registers the flags controlling yb-voyager's logging behaviour: level
+// and rotation. Shared by registerCommonGlobalFlags and by the two commands
+// (assess-migration-bulk, get data-migration-report) that do not go through it.
+func registerLogFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
+		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
+	cmd.PersistentFlags().IntVar(&config.LogMaxSizeMB, "log-max-size-mb", config.DefaultLogMaxSizeMB,
+		"maximum size in MB of a yb-voyager log file before it is rotated")
+	cmd.PersistentFlags().IntVar(&config.LogMaxBackups, "log-max-backups", config.DefaultLogMaxBackups,
+		fmt.Sprintf("maximum number of rotated yb-voyager log files to retain (%d to retain all)", config.LogMaxBackupsUnlimited))
+}
+
+// logSettingsCLIArgs returns the resolved log settings as CLI args, for forwarding to a
+// yb-voyager subprocess (the next iteration of an iterative cutover, an assess-migration
+// child, the report spawned by end migration) that is not already inheriting them via a
+// shared config file. Mirrors how --log-level is forwarded at each of those call sites.
+func logSettingsCLIArgs() []string {
+	return []string{
+		"--log-level", config.LogLevel,
+		"--log-max-size-mb", strconv.Itoa(config.LogMaxSizeMB),
+		"--log-max-backups", strconv.Itoa(config.LogMaxBackups),
+	}
 }
 
 func redactPasswordFromArgs() {

--- a/yb-voyager/cmd/logging_test.go
+++ b/yb-voyager/cmd/logging_test.go
@@ -1,0 +1,204 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
+)
+
+// restoreLogOutput restores logrus' global output after a test that calls InitLogging.
+func restoreLogOutput(t *testing.T) {
+	t.Helper()
+	origOut, origLevel := log.StandardLogger().Out, log.GetLevel()
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetLevel(origLevel)
+	})
+}
+
+// withLogSettings sets the resolved log settings for the duration of a test.
+func withLogSettings(t *testing.T, maxSizeMB int, maxBackups int) {
+	t.Helper()
+	origSize, origBackups := config.LogMaxSizeMB, config.LogMaxBackups
+	t.Cleanup(func() { config.LogMaxSizeMB, config.LogMaxBackups = origSize, origBackups })
+	config.LogMaxSizeMB, config.LogMaxBackups = maxSizeMB, maxBackups
+}
+
+func TestInitLogging_RotationSettingsReachLumberjack(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxSizeMB      int
+		maxBackups     int
+		wantMaxSize    int
+		wantMaxBackups int
+	}{
+		{
+			name:           "defaults preserve the previously hardcoded behaviour",
+			maxSizeMB:      config.DefaultLogMaxSizeMB,
+			maxBackups:     config.DefaultLogMaxBackups,
+			wantMaxSize:    200,
+			wantMaxBackups: 10,
+		},
+		{
+			name:           "custom values are passed through",
+			maxSizeMB:      50,
+			maxBackups:     3,
+			wantMaxSize:    50,
+			wantMaxBackups: 3,
+		},
+		{
+			// The whole point of the sentinel: lumberjack retains every rotated file
+			// when MaxBackups is 0 (MaxAge is 0 and compression is off).
+			name:           "unlimited sentinel maps to lumberjack retain-all",
+			maxSizeMB:      config.DefaultLogMaxSizeMB,
+			maxBackups:     config.LogMaxBackupsUnlimited,
+			wantMaxSize:    200,
+			wantMaxBackups: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restoreLogOutput(t)
+			logDir := t.TempDir()
+
+			err := InitLogging(logDir, config.INFO, false, "test-cmd", tt.maxSizeMB, tt.maxBackups)
+			require.NoError(t, err)
+
+			rotator, ok := log.StandardLogger().Out.(*lumberjack.Logger)
+			require.True(t, ok, "expected logrus output to be a lumberjack.Logger")
+			assert.Equal(t, tt.wantMaxSize, rotator.MaxSize)
+			assert.Equal(t, tt.wantMaxBackups, rotator.MaxBackups)
+			assert.Equal(t, filepath.Join(logDir, "logs", "yb-voyager-test-cmd.log"), rotator.Filename)
+			// MaxAge and Compress stay at their zero values, without which
+			// MaxBackups == 0 would not actually retain everything.
+			assert.Zero(t, rotator.MaxAge)
+			assert.False(t, rotator.Compress)
+		})
+	}
+}
+
+// The behavioural guarantee behind --log-max-backups -1: rotated files are actually kept
+// on disk. This exercises the real rotation path rather than only asserting the values
+// handed to lumberjack, so a lumberjack upgrade that changed the meaning of MaxBackups
+// would be caught here.
+func TestInitLogging_UnlimitedBackupsRetainsRotatedFiles(t *testing.T) {
+	countLogFiles := func(t *testing.T, logsDir string) int {
+		t.Helper()
+		entries, err := os.ReadDir(logsDir)
+		require.NoError(t, err)
+		return len(entries)
+	}
+
+	// ~64KB per line, 16 lines per MB, over a 1MB rotation threshold.
+	writeAboutMB := func(mb int) {
+		line := strings.Repeat("x", 64*1024)
+		for i := 0; i < mb*16; i++ {
+			log.Info(line)
+		}
+	}
+
+	t.Run("unlimited retains every rotated file", func(t *testing.T) {
+		restoreLogOutput(t)
+		exportDir := t.TempDir()
+
+		require.NoError(t, InitLogging(exportDir, config.INFO, false, "test-cmd", 1, config.LogMaxBackupsUnlimited))
+		writeAboutMB(5)
+
+		// Nothing is ever deleted, so there is no mill goroutine to race with.
+		assert.Greater(t, countLogFiles(t, filepath.Join(exportDir, "logs")), 4,
+			"every rotated log file should be retained")
+	})
+
+	t.Run("a backup limit still prunes", func(t *testing.T) {
+		restoreLogOutput(t)
+		exportDir := t.TempDir()
+		logsDir := filepath.Join(exportDir, "logs")
+
+		require.NoError(t, InitLogging(exportDir, config.INFO, false, "test-cmd", 1, 2))
+		writeAboutMB(5)
+
+		// lumberjack prunes asynchronously, so allow it to catch up.
+		require.Eventually(t, func() bool { return countLogFiles(t, logsDir) <= 3 }, 10*time.Second, 50*time.Millisecond,
+			"expected at most 2 backups plus the current file")
+	})
+}
+
+func TestInitLogging_DisabledLoggingIgnoresRotation(t *testing.T) {
+	restoreLogOutput(t)
+
+	err := InitLogging(t.TempDir(), config.INFO, true, "status", config.DefaultLogMaxSizeMB, config.DefaultLogMaxBackups)
+	require.NoError(t, err)
+	assert.Equal(t, io.Discard, log.StandardLogger().Out)
+}
+
+func TestInitLogging_InvalidLogLevel(t *testing.T) {
+	restoreLogOutput(t)
+
+	err := InitLogging(t.TempDir(), "verbose", false, "test-cmd", config.DefaultLogMaxSizeMB, config.DefaultLogMaxBackups)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid log level verbose")
+}
+
+func TestLogSettingsCLIArgs(t *testing.T) {
+	origLevel := config.LogLevel
+	t.Cleanup(func() { config.LogLevel = origLevel })
+
+	config.LogLevel = config.DEBUG
+	withLogSettings(t, 50, config.LogMaxBackupsUnlimited)
+
+	assert.Equal(t, []string{
+		"--log-level", "debug",
+		"--log-max-size-mb", "50",
+		"--log-max-backups", "-1",
+	}, logSettingsCLIArgs())
+}
+
+// The two commands below do not go through registerCommonGlobalFlags, so they need
+// registerLogFlags directly. Without it their log settings would stay at Go's zero
+// values and lumberjack would silently fall back to its own 100MB default.
+func TestLogFlagsRegisteredOnCommandsBypassingCommonGlobalFlags(t *testing.T) {
+	cmds := map[string]*cobra.Command{
+		"assess-migration-bulk":     assessMigrationBulkCmd,
+		"get data-migration-report": getDataMigrationReportCmd,
+	}
+
+	for name, cmd := range cmds {
+		t.Run(name, func(t *testing.T) {
+			flags := cmd.PersistentFlags()
+			for _, flagName := range []string{"log-level", "log-max-size-mb", "log-max-backups"} {
+				require.NotNil(t, flags.Lookup(flagName), "%s should register --%s", name, flagName)
+			}
+			assert.Equal(t, "200", flags.Lookup("log-max-size-mb").DefValue)
+			assert.Equal(t, "10", flags.Lookup("log-max-backups").DefValue)
+		})
+	}
+}

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -104,6 +104,12 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 
 		currentCommand = cmd.CommandPath()
 
+		// Validate the logging settings before anything can initialise logging with them:
+		// resolveToActiveIterationIfRequired() below calls InitLogging.
+		if shouldRunPersistentPreRun(cmd) {
+			validateLogFlags()
+		}
+
 		if isLiveMigrationIterationCommand(cmd) {
 			err := resolveToActiveIterationIfRequired(cmd)
 			if err != nil {
@@ -117,17 +123,12 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 
 		if isBulkAssessmentCommand(cmd) {
 			validateBulkAssessmentDirFlag()
-			err := config.ValidateLogLevel()
-			if err != nil {
-				// logging is not initialized yet
-				utils.ErrExitPreLog("ERROR: %v", err)
-			}
 			if shouldLock(cmd) {
 				lockFPath := filepath.Join(bulkAssessmentDir, fmt.Sprintf(".%sLockfile.lck", GetCommandID(cmd)))
 				lockFile = lockfile.NewLockfile(lockFPath)
 				lockFile.Lock()
 			}
-			err = InitLogging(bulkAssessmentDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
+			err := InitLogging(bulkAssessmentDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd), config.LogMaxSizeMB, config.LogMaxBackups)
 			if err != nil {
 				// InitLogging failed, so use ErrExitPreLog to avoid printing twice.
 				utils.ErrExitPreLog("ERROR: Failed to initialize logging: %v", err)
@@ -147,18 +148,13 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 			}
 		} else {
 			validateExportDirFlag()
-			err := config.ValidateLogLevel()
-			if err != nil {
-				// logging is not initialized yet
-				utils.ErrExitPreLog("ERROR: %v", err)
-			}
 			schemaDir = filepath.Join(exportDir, "schema")
 			if shouldLock(cmd) {
 				lockFPath := filepath.Join(exportDir, fmt.Sprintf(".%sLockfile.lck", GetCommandID(cmd)))
 				lockFile = lockfile.NewLockfile(lockFPath)
 				lockFile.Lock()
 			}
-			err = InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
+			err := InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd), config.LogMaxSizeMB, config.LogMaxBackups)
 			if err != nil {
 				// InitLogging failed, so use ErrExitPreLog to avoid printing twice.
 				utils.ErrExitPreLog("ERROR: Failed to initialize logging: %v", err)
@@ -260,7 +256,7 @@ func resolveToActiveIterationIfRequired(cmd *cobra.Command) error {
 		return nil
 	}
 	//this is just for any logs that might be printed before the iteration export dir is resolved
-	err := InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd))
+	err := InitLogging(exportDir, config.LogLevel, cmd.Use == "status", GetCommandID(cmd), config.LogMaxSizeMB, config.LogMaxBackups)
 	if err != nil {
 		// InitLogging failed, so use ErrExitPreLog to avoid printing twice.
 		utils.ErrExitPreLog("ERROR: Failed to initialize logging: %v", err)
@@ -416,6 +412,19 @@ func shouldLock(cmd *cobra.Command) bool {
 	return !slices.Contains(noLockNeededList, cmd.CommandPath())
 }
 
+// validateLogFlags validates the log level and rotation settings resolved from the CLI
+// flags and config file, exiting before logging is initialised if any is invalid.
+func validateLogFlags() {
+	if err := config.ValidateLogLevel(); err != nil {
+		// logging is not initialized yet
+		utils.ErrExitPreLog("ERROR: %v", err)
+	}
+	if err := config.ValidateLogSettings(); err != nil {
+		// logging is not initialized yet
+		utils.ErrExitPreLog("ERROR: %v", err)
+	}
+}
+
 func shouldRunPersistentPreRun(cmd *cobra.Command) bool {
 	return !slices.Contains(noPersistentPreRunNeededList, cmd.CommandPath())
 }
@@ -443,9 +452,8 @@ func registerCommonGlobalFlags(cmd *cobra.Command) {
 	registerConfigFileFlag(cmd)
 	globalFlags = append(globalFlags, "config-file")
 
-	cmd.PersistentFlags().StringVarP(&config.LogLevel, "log-level", "l", "info",
-		"log level for yb-voyager. Accepted values: (trace, debug, info, warn, error, fatal, panic)")
-	globalFlags = append(globalFlags, "log-level")
+	registerLogFlags(cmd)
+	globalFlags = append(globalFlags, "log-level", "log-max-size-mb", "log-max-backups")
 
 	cmd.PersistentFlags().BoolVarP(&utils.DoNotPrompt, "yes", "y", false,
 		"assume answer as yes for all questions during migration (default false)")

--- a/yb-voyager/config-templates/bulk-data-load.yaml
+++ b/yb-voyager/config-templates/bulk-data-load.yaml
@@ -14,6 +14,15 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                                          
 
+### Maximum size (in MB) of a yb-voyager log file before it is rotated
+### Default - 200
+# log-max-size-mb: 200
+
+### Maximum number of rotated yb-voyager log files to retain
+### Use -1 to retain all rotated log files
+### Default - 10
+# log-max-backups: 10
+
 # ---------------------------------------------------------
 # Target Database Configuration
 # ---------------------------------------------------------

--- a/yb-voyager/config-templates/live-migration-with-fall-back.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-back.yaml
@@ -14,6 +14,15 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                  
 
+### Maximum size (in MB) of a yb-voyager log file before it is rotated
+### Default - 200
+# log-max-size-mb: 200
+
+### Maximum number of rotated yb-voyager log files to retain
+### Use -1 to retain all rotated log files
+### Default - 10
+# log-max-backups: 10
+
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
 

--- a/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
+++ b/yb-voyager/config-templates/live-migration-with-fall-forward.yaml
@@ -14,6 +14,15 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                  
 
+### Maximum size (in MB) of a yb-voyager log file before it is rotated
+### Default - 200
+# log-max-size-mb: 200
+
+### Maximum number of rotated yb-voyager log files to retain
+### Use -1 to retain all rotated log files
+### Default - 10
+# log-max-backups: 10
+
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
 

--- a/yb-voyager/config-templates/live-migration.yaml
+++ b/yb-voyager/config-templates/live-migration.yaml
@@ -14,6 +14,15 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                    
 
+### Maximum size (in MB) of a yb-voyager log file before it is rotated
+### Default - 200
+# log-max-size-mb: 200
+
+### Maximum number of rotated yb-voyager log files to retain
+### Use -1 to retain all rotated log files
+### Default - 10
+# log-max-backups: 10
+
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
 

--- a/yb-voyager/config-templates/offline-migration.yaml
+++ b/yb-voyager/config-templates/offline-migration.yaml
@@ -14,6 +14,15 @@ export-dir: <export-dir-path>
 ### Default - info
 log-level: info                  
 
+### Maximum size (in MB) of a yb-voyager log file before it is rotated
+### Default - 200
+# log-max-size-mb: 200
+
+### Maximum number of rotated yb-voyager log files to retain
+### Use -1 to retain all rotated log files
+### Default - 10
+# log-max-backups: 10
+
 ### *********** Control Plane Configuration ************
 ### To see the Voyager migration workflow details in the UI, set the following parameters.
 

--- a/yb-voyager/src/config/config.go
+++ b/yb-voyager/src/config/config.go
@@ -30,10 +30,24 @@ const (
 	ERROR = "error"
 	FATAL = "fatal"
 	PANIC = "panic"
+
+	// DefaultLogMaxSizeMB and DefaultLogMaxBackups are the values yb-voyager used to
+	// hardcode when configuring lumberjack, kept as the defaults now that they are
+	// configurable, so unset behaviour is unchanged.
+	DefaultLogMaxSizeMB  = 200
+	DefaultLogMaxBackups = 10
+
+	// LogMaxBackupsUnlimited is the --log-max-backups sentinel meaning "never delete a
+	// rotated log file". A dedicated sentinel is used rather than accepting 0 because
+	// lumberjack itself treats MaxBackups == 0 as "retain all", which would silently
+	// invert the intent of a user passing 0 to cap disk usage.
+	LogMaxBackupsUnlimited = -1
 )
 
 var (
 	LogLevel       string
+	LogMaxSizeMB   int
+	LogMaxBackups  int
 	validLogLevels = []string{TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC}
 )
 
@@ -43,6 +57,29 @@ func ValidateLogLevel() error {
 		return goerrors.Errorf("invalid log level: %s. Valid log levels = %v", LogLevel, validLogLevels)
 	}
 	return nil
+}
+
+// ValidateLogSettings checks the log rotation settings resolved from the CLI flags and
+// config file. It must run before any code path initialises logging with them.
+func ValidateLogSettings() error {
+	if LogMaxSizeMB <= 0 {
+		return goerrors.Errorf("invalid log-max-size-mb: %d. Must be a positive integer", LogMaxSizeMB)
+	}
+	if LogMaxBackups <= 0 && LogMaxBackups != LogMaxBackupsUnlimited {
+		return goerrors.Errorf("invalid log-max-backups: %d. Must be a positive integer, or %d to retain all rotated log files", LogMaxBackups, LogMaxBackupsUnlimited)
+	}
+	return nil
+}
+
+// LumberjackMaxBackups translates the LogMaxBackupsUnlimited sentinel into the value
+// lumberjack.Logger expects for "retain all rotated files". lumberjack has no sentinel of
+// its own: with MaxBackups and MaxAge both 0 and compression off, it never deletes a
+// rotated file.
+func LumberjackMaxBackups(maxBackups int) int {
+	if maxBackups == LogMaxBackupsUnlimited {
+		return 0
+	}
+	return maxBackups
 }
 
 func IsLogLevelDebugOrBelow() bool {

--- a/yb-voyager/src/config/config_test.go
+++ b/yb-voyager/src/config/config_test.go
@@ -1,0 +1,129 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withLogSettings sets the package-level log settings for the duration of a test and
+// restores them afterwards, so tests do not leak state into each other.
+func withLogSettings(t *testing.T, maxSizeMB int, maxBackups int) {
+	t.Helper()
+	origSize, origBackups := LogMaxSizeMB, LogMaxBackups
+	t.Cleanup(func() { LogMaxSizeMB, LogMaxBackups = origSize, origBackups })
+	LogMaxSizeMB, LogMaxBackups = maxSizeMB, maxBackups
+}
+
+func TestValidateLogSettings(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxSizeMB  int
+		maxBackups int
+		wantErr    string
+	}{
+		{
+			name:       "defaults are valid",
+			maxSizeMB:  DefaultLogMaxSizeMB,
+			maxBackups: DefaultLogMaxBackups,
+		},
+		{
+			name:       "unlimited backups sentinel is valid",
+			maxSizeMB:  DefaultLogMaxSizeMB,
+			maxBackups: LogMaxBackupsUnlimited,
+		},
+		{
+			name:       "smallest valid values",
+			maxSizeMB:  1,
+			maxBackups: 1,
+		},
+		{
+			name:       "zero max size is rejected",
+			maxSizeMB:  0,
+			maxBackups: DefaultLogMaxBackups,
+			wantErr:    "invalid log-max-size-mb: 0. Must be a positive integer",
+		},
+		{
+			name:       "negative max size is rejected",
+			maxSizeMB:  -1,
+			maxBackups: DefaultLogMaxBackups,
+			wantErr:    "invalid log-max-size-mb: -1. Must be a positive integer",
+		},
+		{
+			// 0 is rejected rather than silently meaning "retain all", which is how
+			// lumberjack itself interprets MaxBackups == 0. A user passing 0 to cap
+			// disk usage would otherwise get unbounded growth.
+			name:       "zero max backups is rejected rather than meaning unlimited",
+			maxSizeMB:  DefaultLogMaxSizeMB,
+			maxBackups: 0,
+			wantErr:    "invalid log-max-backups: 0. Must be a positive integer, or -1 to retain all rotated log files",
+		},
+		{
+			name:       "negative max backups other than the sentinel is rejected",
+			maxSizeMB:  DefaultLogMaxSizeMB,
+			maxBackups: -2,
+			wantErr:    "invalid log-max-backups: -2. Must be a positive integer, or -1 to retain all rotated log files",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withLogSettings(t, tt.maxSizeMB, tt.maxBackups)
+
+			err := ValidateLogSettings()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestLumberjackMaxBackups(t *testing.T) {
+	// lumberjack has no sentinel of its own: MaxBackups == 0 (with MaxAge 0 and no
+	// compression) is what makes it retain every rotated file.
+	assert.Equal(t, 0, LumberjackMaxBackups(LogMaxBackupsUnlimited),
+		"unlimited sentinel should map to lumberjack's retain-all value")
+	assert.Equal(t, DefaultLogMaxBackups, LumberjackMaxBackups(DefaultLogMaxBackups))
+	assert.Equal(t, 1, LumberjackMaxBackups(1))
+}
+
+func TestValidateLogLevel(t *testing.T) {
+	origLevel := LogLevel
+	t.Cleanup(func() { LogLevel = origLevel })
+
+	for _, level := range validLogLevels {
+		LogLevel = level
+		require.NoError(t, ValidateLogLevel(), "level %q should be valid", level)
+	}
+
+	// Levels are normalised to lower case rather than rejected.
+	LogLevel = "DEBUG"
+	require.NoError(t, ValidateLogLevel())
+	assert.Equal(t, DEBUG, LogLevel)
+
+	LogLevel = "verbose"
+	err := ValidateLogLevel()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid log level: verbose")
+}

--- a/yb-voyager/src/dbzm/config.go
+++ b/yb-voyager/src/dbzm/config.go
@@ -38,7 +38,12 @@ const (
 )
 
 type Config struct {
-	LogLevel           string
+	LogLevel string
+	// LogMaxSizeMB and LogMaxBackups control rotation of debezium-<role>.log, mirroring
+	// the settings applied to yb-voyager's own log file. LogMaxBackups uses the
+	// config.LogMaxBackupsUnlimited sentinel for "retain all rotated files".
+	LogMaxSizeMB       int
+	LogMaxBackups      int
 	MigrationUUID      uuid.UUID
 	RunId              string
 	SourceDBType       string

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tebeka/atexit"
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -234,8 +235,8 @@ func (d *Debezium) setupLogFile() error {
 
 	logRotator := &lumberjack.Logger{
 		Filename:   logFilePath,
-		MaxSize:    200, // 200 MB log size before rotation
-		MaxBackups: 10,  // Allow upto 10 logs at once before deleting oldest logs.
+		MaxSize:    d.LogMaxSizeMB, // log size in MB before rotation
+		MaxBackups: config.LumberjackMaxBackups(d.LogMaxBackups),
 	}
 	d.cmd.Stdout = logRotator
 	d.cmd.Stderr = logRotator

--- a/yb-voyager/src/dbzm/dbzm_test.go
+++ b/yb-voyager/src/dbzm/dbzm_test.go
@@ -1,0 +1,89 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package dbzm
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
+)
+
+// debezium-<role>.log is rotated by the same settings as yb-voyager's own log file, so a
+// user asking to retain all logs does not silently keep losing the debezium ones.
+func TestSetupLogFile_RotationSettings(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxSizeMB      int
+		maxBackups     int
+		wantMaxSize    int
+		wantMaxBackups int
+	}{
+		{
+			name:           "defaults preserve the previously hardcoded behaviour",
+			maxSizeMB:      config.DefaultLogMaxSizeMB,
+			maxBackups:     config.DefaultLogMaxBackups,
+			wantMaxSize:    200,
+			wantMaxBackups: 10,
+		},
+		{
+			name:           "custom values are passed through",
+			maxSizeMB:      25,
+			maxBackups:     2,
+			wantMaxSize:    25,
+			wantMaxBackups: 2,
+		},
+		{
+			name:           "unlimited sentinel maps to lumberjack retain-all",
+			maxSizeMB:      config.DefaultLogMaxSizeMB,
+			maxBackups:     config.LogMaxBackupsUnlimited,
+			wantMaxSize:    200,
+			wantMaxBackups: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exportDir := t.TempDir()
+			d := NewDebezium(&Config{
+				ExportDir:     exportDir,
+				ExporterRole:  "source_db_exporter",
+				LogMaxSizeMB:  tt.maxSizeMB,
+				LogMaxBackups: tt.maxBackups,
+			})
+			d.cmd = exec.Command("true")
+
+			require.NoError(t, d.setupLogFile())
+
+			rotator, ok := d.cmd.Stdout.(*lumberjack.Logger)
+			require.True(t, ok, "expected debezium stdout to be a lumberjack.Logger")
+			assert.Same(t, rotator, d.cmd.Stderr, "stdout and stderr should share one rotator")
+			assert.Equal(t, tt.wantMaxSize, rotator.MaxSize)
+			assert.Equal(t, tt.wantMaxBackups, rotator.MaxBackups)
+
+			wantPath, err := filepath.Abs(filepath.Join(exportDir, "logs", "debezium-source_db_exporter.log"))
+			require.NoError(t, err)
+			assert.Equal(t, wantPath, rotator.Filename)
+		})
+	}
+}

--- a/yb-voyager/src/utils/logging.go
+++ b/yb-voyager/src/utils/logging.go
@@ -28,6 +28,7 @@ import (
 )
 
 var originalErrExit func(formatString string, args ...interface{})
+var originalErrExitPreLog func(formatString string, args ...interface{})
 
 var ErrExitErr error
 
@@ -240,5 +241,29 @@ func MonkeyPatchUtilsErrExit(newErrExit func(formatString string, args ...interf
 func RestoreUtilsErrExit() {
 	if originalErrExit != nil {
 		ErrExit = originalErrExit
+	}
+}
+
+func MonkeyPatchUtilsErrExitPreLogWithPanic() {
+	MonkeyPatchUtilsErrExitPreLog(func(formatString string, args ...interface{}) {
+		panic("utils.ErrExitPreLog was called with: " + fmt.Sprintf(formatString, args...))
+	})
+}
+
+// MonkeyPatchUtilsErrExitPreLog allows monkey patching of the utils.ErrExitPreLog function
+// for testing purposes. It replaces the original function with a new one provided by the
+// caller. Only the first patch is remembered, so nested patches still restore the real
+// ErrExitPreLog rather than an intermediate one.
+func MonkeyPatchUtilsErrExitPreLog(newErrExitPreLog func(formatString string, args ...interface{})) {
+	if originalErrExitPreLog == nil {
+		originalErrExitPreLog = ErrExitPreLog
+	}
+	ErrExitPreLog = newErrExitPreLog
+}
+
+// RestoreUtilsErrExitPreLog restores the original utils.ErrExitPreLog function after monkey patching.
+func RestoreUtilsErrExitPreLog() {
+	if originalErrExitPreLog != nil {
+		ErrExitPreLog = originalErrExitPreLog
 	}
 }


### PR DESCRIPTION
### Describe the changes in this pull request

Addresses #3679 ("Make log settings configurable").

**Scope reduced from the previous revision of this PR.** `--log-dir` has been dropped
entirely per @ShivanshGahlot's review — there was no user or customer driver behind it, and
it was the source of most of the complexity (log-dir existence/permission checks, concurrent
runs colliding on one file name, `end migration`'s log backup reading the default location,
error messages elsewhere hardcoding `<export-dir>/logs`). If a real need for it appears, it
can be dug into properly in its own PR. The branch was rebuilt from `main` rather than
patched, so what's left is only the part that motivated the issue: not losing log messages
when files wrap around.

Two settings, each available as a CLI flag or a config-file key (global **or** per-command,
matching `log-level`):

| Setting | Default | Notes |
| --- | --- | --- |
| `--log-max-size-mb` | 200 | size threshold before a log file is rotated |
| `--log-max-backups` | 10 | rotated files retained; **`-1` retains all** |

Both default to the exact previously hardcoded values, so nothing changes for anyone not
setting them.

**Why `-1` and not `0` for "retain all":** lumberjack itself treats `MaxBackups == 0` as
"retain all files". Accepting `0` would therefore silently invert the intent of a user
passing it to *cap* disk usage — they'd get unbounded growth of 200 MB files instead. So
`ValidateLogSettings()` rejects `0` for both settings, and `LumberjackMaxBackups()`
translates the `-1` sentinel at the two points where a `lumberjack.Logger` is built.

Also in scope:

- **Debezium logs.** `debezium-<role>.log` carried the same hardcoded 200/10
  (`src/dbzm/dbzm.go`). It now honours these settings too — otherwise "retain all" would
  silently not hold for live migration, the most log-heavy flow. (Raised in review.)
- **Deduplicated** the 3x-copy-pasted `log-level` flag registration into `registerLogFlags()`
  (root.go / assess-migration-bulk / get-data-migration-report).
- **Validation ordering.** Collapsed the two copies of the pre-logging validation into
  `validateLogFlags()` and hoisted it above the iterative-cutover branch, which reaches
  `InitLogging()` via `resolveToActiveIterationIfRequired()` before the old call sites ran.
  (Both raised in review.)
- **Propagation.** The settings are forwarded to every spawned yb-voyager subprocess that
  already forwards `--log-level`: the iterative-cutover re-exec sites,
  `assess-migration-bulk`'s per-schema children, and the report `end migration` spawns
  (`endMigrationCommand.go:493`, raised in review). With `--log-dir` gone there is no
  same-file/two-writer question to reason about, so all of them are forwarded unconditionally.

### Describe if there are any user-facing changes

- Two new CLI flags / config-file keys: `--log-max-size-mb`, `--log-max-backups`. Both
  default to the exact previous behavior.
- Documented in the global section of all 5 `config-templates/*.yaml`, alongside `log-level`.

### How was this pull request tested?

- `src/config/config_test.go` — `ValidateLogSettings` boundaries and exact error messages
  (including that `0` is rejected rather than meaning unlimited), and `LumberjackMaxBackups`
  sentinel translation.
- `cmd/logging_test.go` — the values actually reaching the `lumberjack.Logger` (defaults,
  custom, and the sentinel), disabled logging, invalid level, `logSettingsCLIArgs`, and flag
  registration on the two commands that bypass `registerCommonGlobalFlags`.
  `TestInitLogging_UnlimitedBackupsRetainsRotatedFiles` drives *real* rotation over a 1 MB
  threshold and asserts rotated files are kept on disk (and still pruned when a limit is
  set), so a lumberjack upgrade changing the meaning of `MaxBackups` would be caught here
  rather than in production.
- `src/dbzm/dbzm_test.go` — the same rotation wiring for `debezium-<role>.log`.
- `cmd/config_test.go` — config-file binding, per-command section binding, CLI-overrides-config,
  defaults-when-unset (asserting the live `lumberjack.Logger`, not just the flag vars), and
  invalid values halting via `ErrExitPreLog` before logging is initialised.
- Mutation-checked the new tests: breaking the sentinel translation and loosening the
  validation each fail the suite at every layer (config, cmd, dbzm).
- Manual: built the binary and confirmed the help text, the rejection messages for
  `--log-max-size-mb 0` / `--log-max-backups 0` / `--log-max-backups -2`, and that `-1` is
  accepted. Separately confirmed empirically that lumberjack with `MaxBackups=0` retains
  every rotated file while `MaxBackups=2` keeps 3.
- `go build ./...`, `go vet ./...`, `staticcheck ./...`, `staticcheck -tags unit ./...` and
  `go test -tags unit ./...` all pass across the module, and the diff is gofmt-clean.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No changes to MetaDB, AssessmentDB, or any other serialized/on-disk structure.
