### PR TITLE
Set idle_in_transaction_session_timeout on import-data connections

### DIFF
--- a/yb-voyager/src/tgtdb/conn_pool.go
+++ b/yb-voyager/src/tgtdb/conn_pool.go
@@ -32,6 +32,7 @@ import (
 )
 
 var defaultSessionVars = []string{
+	SET_IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
 	"SET client_encoding to 'UTF-8'",
 	"SET session_replication_role to replica",
 }

--- a/yb-voyager/src/tgtdb/idle_in_transaction_timeout_test.go
+++ b/yb-voyager/src/tgtdb/idle_in_transaction_timeout_test.go
@@ -33,9 +33,8 @@ import (
 // transaction for longer than idle_in_transaction_session_timeout.
 const sqlStateIdleInTxnTimeout = "25P03"
 
-// The unit tests cover how the session script is composed; this covers the part
-// that only a real target can show: that a connection handed out by the import
-// pool actually carries the timeout.
+// Covers what only a real target can show: that a connection handed out by the
+// import pool actually carries the timeout.
 func TestPooledConnectionHasIdleInTransactionTimeoutSet(t *testing.T) {
 	yb, ok := testYugabyteDBTarget.TargetDB.(*TargetYugabyteDB)
 	require.True(t, ok, "expected a *TargetYugabyteDB")

--- a/yb-voyager/src/tgtdb/idle_in_transaction_timeout_test.go
+++ b/yb-voyager/src/tgtdb/idle_in_transaction_timeout_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package tgtdb
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SQLSTATE raised when the server terminates a session that sat idle inside a
+// transaction for longer than idle_in_transaction_session_timeout.
+const sqlStateIdleInTxnTimeout = "25P03"
+
+// The unit tests cover how the session script is composed; this covers the part
+// that only a real target can show: that a connection handed out by the import
+// pool actually carries the timeout.
+func TestPooledConnectionHasIdleInTransactionTimeoutSet(t *testing.T) {
+	yb, ok := testYugabyteDBTarget.TargetDB.(*TargetYugabyteDB)
+	require.True(t, ok, "expected a *TargetYugabyteDB")
+
+	// Init() runs during suite setup, which is what populates SessionVars.
+	require.NotEmpty(t, yb.Tconf.SessionVars)
+
+	pool, err := NewConnectionPool(&ConnectionParams{
+		NumConnections:    1,
+		NumMaxConnections: 1,
+		ConnUriList:       []string{testYugabyteDBTarget.GetConnectionString()},
+		SessionInitScript: yb.Tconf.SessionVars,
+	})
+	require.NoError(t, err)
+
+	var timeout string
+	err = pool.WithConn(func(conn *pgx.Conn) (bool, error) {
+		return false, conn.QueryRow(context.Background(),
+			"SHOW idle_in_transaction_session_timeout").Scan(&timeout)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "5min", timeout)
+}
+
+// The whole point of the timeout is that the server kills an orphaned
+// in-transaction session. When that happens to a live pooled connection, the
+// caller must see 25P03 and the pool must recover: WithConn() discards the dead
+// connection and the next caller gets a fresh, usable one.
+func TestPoolRecoversFromIdleInTransactionTermination(t *testing.T) {
+	pool, err := NewConnectionPool(&ConnectionParams{
+		NumConnections:    1,
+		NumMaxConnections: 1,
+		ConnUriList:       []string{testYugabyteDBTarget.GetConnectionString()},
+		// Deliberately tiny so the test does not wait out the real 5min default.
+		SessionInitScript: []string{"SET idle_in_transaction_session_timeout = '1s'"},
+	})
+	require.NoError(t, err)
+
+	// WHEN: a transaction sits idle past the timeout.
+	err = pool.WithConn(func(conn *pgx.Conn) (bool, error) {
+		ctx := context.Background()
+		if _, err := conn.Exec(ctx, "BEGIN"); err != nil {
+			return false, err
+		}
+		time.Sleep(3 * time.Second)
+		_, err := conn.Exec(ctx, "SELECT 1")
+		return false, err
+	})
+
+	// THEN: the server terminated it, and the error says why.
+	require.Error(t, err)
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "expected a *pgconn.PgError, got %v", err)
+	assert.Equal(t, sqlStateIdleInTxnTimeout, pgErr.Code)
+
+	// AND: the pool replaced the dead connection, so it is usable again.
+	var one int
+	err = pool.WithConn(func(conn *pgx.Conn) (bool, error) {
+		return false, conn.QueryRow(context.Background(), "SELECT 1").Scan(&one)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, one)
+}

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1668,11 +1668,20 @@ const (
 	SET_YB_FAST_PATH_FOR_COLOCATED_COPY   = "SET yb_fast_path_for_colocated_copy=true"
 	// The "SELECT 1" workaround introduced in ExecuteBatch does not work if isolation level is read_committed. Therefore, for now, we are forcing REPEATABLE READ.
 	SET_DEFAULT_ISOLATION_LEVEL_REPEATABLE_READ = "SET default_transaction_isolation = 'repeatable read'"
-	ERROR_MSG_PERMISSION_DENIED                 = "permission denied"
+	// If voyager exits abruptly mid-transaction, the target backend keeps holding that
+	// transaction's locks until TCP keepalive reaps it (~2h), wedging later imports. Bound it
+	// so voyager's own sessions are self-limiting; 5min is far above any gap voyager can
+	// produce inside a transaction. Override via /etc/yb-voyager/ybSessionVariables.sql.
+	SET_IDLE_IN_TRANSACTION_SESSION_TIMEOUT = "SET idle_in_transaction_session_timeout = '5min'"
+	ERROR_MSG_PERMISSION_DENIED             = "permission denied"
 )
 
 func getPGSessionInitScript(tconf *TargetConf) []string {
 	var sessionVars []string
+	// first, so a permission-denied error on a later var cannot make initSession() skip it
+	if checkSessionVariableSupport(tconf, SET_IDLE_IN_TRANSACTION_SESSION_TIMEOUT) {
+		sessionVars = append(sessionVars, SET_IDLE_IN_TRANSACTION_SESSION_TIMEOUT)
+	}
 	if checkSessionVariableSupport(tconf, SET_CLIENT_ENCODING_TO_UTF8) {
 		sessionVars = append(sessionVars, SET_CLIENT_ENCODING_TO_UTF8)
 	}
@@ -1684,6 +1693,10 @@ func getPGSessionInitScript(tconf *TargetConf) []string {
 
 func getYBSessionInitScript(tconf *TargetConf) []string {
 	var sessionVars []string
+	// first, so a permission-denied error on a later var cannot make initSession() skip it
+	if checkSessionVariableSupport(tconf, SET_IDLE_IN_TRANSACTION_SESSION_TIMEOUT) {
+		sessionVars = append(sessionVars, SET_IDLE_IN_TRANSACTION_SESSION_TIMEOUT)
+	}
 	if checkSessionVariableSupport(tconf, SET_CLIENT_ENCODING_TO_UTF8) {
 		sessionVars = append(sessionVars, SET_CLIENT_ENCODING_TO_UTF8)
 	}


### PR DESCRIPTION
### Describe the changes in this pull request

Sets `idle_in_transaction_session_timeout = '5min'` on voyager's import-data connections.

**The problem.** If voyager exits abruptly (`kill -9`, OOM, container eviction) while one of its pooled connections is inside a transaction, the target backend does not notice the client is gone. The session stays `idle in transaction` and keeps holding its locks until TCP keepalive reaps it — roughly two hours by default. A later import that touches those rows wedges behind the orphan. This has been observed in the field: CDC apply wedged on a lock held by a stale connection left behind by a voyager restart.

**Why voyager has to set it.** YSQL defaults this GUC to `0` (off), so nothing bounds it today. Setting it server-side via `ysql_pg_conf_csv` or `ALTER DATABASE`/`ALTER ROLE` is not reliable either — a session-level value overrides the cluster default, and we have seen exactly that happen. Setting it on voyager's own sessions is what makes it stick.

**Scope.** Applied to the import-data connection pool for YugabyteDB and PostgreSQL targets, via `getYBSessionInitScript` / `getPGSessionInitScript`. Since `InitConnPool` is only ever called from `cmd/importData.go`, one change covers offline, live, changes-only, and iterative-cutover flows; fall-back / fall-forward to PG go through the PG builder.

Deliberately **not** applied to:
- **Export paths** — they legitimately hold long `pg_dump` snapshot transactions and must not be capped.
- **Oracle targets** — `TargetOracleDB.InitConnPool` does not use `SessionInitScript`, and Oracle has no equivalent GUC. Genuine no-op.
- **The single ad-hoc target connection** (`yb.conn_` / `pg.conn_`) — `connect()` does not run `initSession`; it serves metadata/DDL, not the apply path this addresses.

**Why 5min is safe.** Every gap voyager can produce *inside* a transaction is a single round trip — `importBatch`/`copyBatchCore` is BEGIN → open file → set schema → dedupe check → `CopyFrom` → record → COMMIT, and `ExecuteBatch` builds all statements before entering `WithConn`. During `COPY` the backend state is `active`, not `idle in transaction`, so a slow COPY is never a target. The one genuinely slow wait, `WaitUntilNoConflict`, runs in `handleEvent` outside any transaction. 5min is orders of magnitude above any real gap.

**Ordering.** The new statement is deliberately **first** in the session script. `ConnectionPool.initSession` returns early on a permission-denied error, silently skipping every remaining variable, and `session_replication_role` is the privileged one. Ordering this ahead of it means it can never be the one dropped. (The early-return itself is pre-existing and left alone here.)

The diff is intentionally minimal: one new constant, one gated append in each of the two session-script builders, and one entry in `defaultSessionVars` (the fallback the pool uses when no script is supplied).

### Describe if there are any user-facing changes

No CLI, config, installation, or report changes.

Behavioural change worth knowing about: import-data sessions now self-terminate after 5 minutes idle **inside a transaction**, surfacing as `FATAL: 25P03: terminating connection due to idle-in-transaction timeout`. The connection pool already handles this — `WithConn` discards the failed connection, clears its prepared-statement cache, and the next caller reconnects with the session script re-applied.

An operator who needs a different value, or `0` to disable, can append a `SET` to `/etc/yb-voyager/ybSessionVariables.sql`; those entries are applied after the built-ins and the last `SET` wins. Note this file is read on the YB path only.

The effective value is visible in the logs via the existing `YBSessionInitScript: ...` line, which is useful for support.

### How was this pull request tested?

**New integration tests** (`src/tgtdb/idle_in_transaction_timeout_test.go`, `-tags integration`, 2 tests):
- A connection handed out by the import pool actually reports `5min`.
- With a 1s timeout, an idle transaction is terminated, the caller sees SQLSTATE `25P03`, and the *next* `WithConn` succeeds on a fresh connection — exercising the pool's discard-and-reconnect path.

**Please note:** these two tests compile and vet cleanly but **I could not execute them locally** — this package's shared `TestMain` starts PostgreSQL, Oracle, a single-node YB and a 3-node YB cluster before any test runs, and the Oracle container failed on my machine (`ORA-12547: TNS:lost contact`) with ~8GB of Docker memory. They will run for the first time in the `integration` CI job. Reviewers may want to confirm that job goes green before merging, since these are the only tests covering the runtime behaviour.

**No unit tests.** `getYBSessionInitScript` / `getPGSessionInitScript` call `checkSessionVariableSupport`, which opens a real connection, so the script composition is not unit-testable without injecting that dependency. I had done exactly that in an earlier revision and reverted it as out of scope for this change — the refactor was larger than the fix it enabled. Coverage therefore lives entirely in the integration tier.

Existing tests were otherwise sufficient: full `-tags unit` suite passes (29 packages), `go build ./...`, `go vet ./...` and `go vet -tags integration ./src/tgtdb/` all clean, gofmt clean.

No manual end-to-end migration run was performed.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No changes to callhome or yugabyted payloads.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. Nothing in the table below is touched. The change only adds a `SET` statement to the in-memory session script applied to import connections; `TargetConf.SessionVars` is an internal cache and is not persisted to the MSR or any on-disk structure.
