### PR TITLE
errcheck 3b: handle file close and console flush errors

### DIFF
--- a/yb-voyager/cmd/assessMigrationBulkCommand.go
+++ b/yb-voyager/cmd/assessMigrationBulkCommand.go
@@ -272,7 +272,7 @@ func parseFleetConfigFile(filePath string) ([]AssessMigrationDBConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(filePath, file)
 
 	reader := csv.NewReader(file)
 	header, err := reader.Read()
@@ -428,11 +428,15 @@ func generateBulkAssessmentHtmlReport() error {
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() // backstop; the success path checks Close below
 
 	err = tmpl.Execute(file, bulkAssessmentReport)
 	if err != nil {
 		return fmt.Errorf("failed to execute parsed template file: %w", err)
+	}
+	err = file.Close()
+	if err != nil {
+		return fmt.Errorf("close bulk assessment report %q: %w", reportPath, err)
 	}
 	utils.PrintAndLogf("generated bulk assessment HTML report at: %s", reportPath)
 	return nil
@@ -494,7 +498,7 @@ func validateFleetConfigFile(filePath string) error {
 	if err != nil {
 		return fmt.Errorf("could not open fleet config file: %w", err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(filePath, file)
 
 	// Check if the file is empty
 	stat, err := file.Stat()

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -482,7 +482,8 @@ func reportStreamingProgress(ctx context.Context) {
 		fmt.Fprint(row3Writer, color.GreenString("| %-40s | %30s |\n", "Export Rate(Last 3 min)", strconv.FormatInt(throughputInLast3Min, 10)+"/sec"))
 		fmt.Fprint(row4Writer, color.GreenString("| %-40s | %30s |\n", "Export Rate(Last 10 min)", strconv.FormatInt(throughputInLast10Min, 10)+"/sec"))
 		fmt.Fprint(footerWriter, color.GreenString("| %-40s | %30s |\n", "---------------------------------------", "-----------------------------"))
-		tableWriter.Flush()
+		// console status table redraw; nothing actionable on a flush error
+		_ = tableWriter.Flush()
 		select {
 		case <-ctx.Done():
 			tableWriter.Stop()

--- a/yb-voyager/cmd/exportDataStatus.go
+++ b/yb-voyager/cmd/exportDataStatus.go
@@ -244,7 +244,7 @@ func startExportPB(progressContainer *mpb.Progress, mapKey string, quitChan chan
 		quitChan <- true
 		runtime.Goexit()
 	}
-	defer tableDataFile.Close()
+	defer utils.CloseAndLogOnError(tableDataFileName, tableDataFile)
 
 	reader := bufio.NewReader(tableDataFile)
 

--- a/yb-voyager/cmd/importDataSequentialFileBatchProducer.go
+++ b/yb-voyager/cmd/importDataSequentialFileBatchProducer.go
@@ -317,7 +317,7 @@ func (p *SequentialFileBatchProducer) openDataFileAndReadHeaderIfRequired() (dat
 
 	df, err := datafile.NewDataFile(p.task.FilePath, reader, dataFileDescriptor, 0)
 	if err != nil {
-		reader.Close()
+		_ = reader.Close() // best-effort cleanup on the error path
 		return nil, goerrors.Errorf("open datafile: %q: %v", p.task.FilePath, err)
 	}
 
@@ -356,7 +356,7 @@ func (p *SequentialFileBatchProducer) openDataFileAtByteOffset() error {
 	// format-specific logic (e.g., SQL assuming mid-COPY) is handled internally.
 	dataFile, err := datafile.NewDataFile(p.task.FilePath, reader, dataFileDescriptor, p.lastBatchCumByteOffsetEnd)
 	if err != nil {
-		reader.Close()
+		_ = reader.Close() // best-effort cleanup on the error path
 		return goerrors.Errorf("open datafile after seek: %q: %v", p.task.FilePath, err)
 	}
 	p.dataFile = dataFile

--- a/yb-voyager/cmd/importDataState.go
+++ b/yb-voyager/cmd/importDataState.go
@@ -982,10 +982,14 @@ func (batch *Batch) MarkError(batchErr error, isPartialBatchIngestionPossible bo
 	if err != nil {
 		return goerrors.Errorf("open file for appending error %q: %s", batch.FilePath, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() // backstop; the success path checks Close below
 	_, err = file.WriteString(errorString)
 	if err != nil {
 		return goerrors.Errorf("write error message to %q: %s", batch.FilePath, err)
+	}
+	err = file.Close()
+	if err != nil {
+		return goerrors.Errorf("close %q after appending error: %s", batch.FilePath, err)
 	}
 	return nil
 }

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -208,7 +208,7 @@ func streamChangesFromSegment(
 	if err != nil {
 		return err
 	}
-	defer segment.Close()
+	defer utils.CloseAndLogOnError("event queue segment", segment)
 
 	// start target event channel processors
 	for i := 0; i < NUM_EVENT_CHANNELS; i++ {

--- a/yb-voyager/src/compareperf/comparison.go
+++ b/yb-voyager/src/compareperf/comparison.go
@@ -242,7 +242,7 @@ func (c *QueryPerformanceComparator) generateHTMLReport(exportDir string) error 
 	if err != nil {
 		return fmt.Errorf("failed to create HTML file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() // backstop; the success path checks Close below
 
 	// Sort AllComparisons for HTML display: MATCHED -> TARGET_ONLY -> SOURCE_ONLY, then by call frequency
 	sortedReport := *c.Report // Create a copy
@@ -276,6 +276,10 @@ func (c *QueryPerformanceComparator) generateHTMLReport(exportDir string) error 
 	err = tmpl.Execute(file, &sortedReport)
 	if err != nil {
 		return fmt.Errorf("failed to execute HTML template: %w", err)
+	}
+	err = file.Close()
+	if err != nil {
+		return fmt.Errorf("close HTML report %q: %w", htmlPath, err)
 	}
 
 	utils.PrintAndLogf("HTML report generated at: %s", htmlPath)

--- a/yb-voyager/src/datafile/csvdatafile.go
+++ b/yb-voyager/src/datafile/csvdatafile.go
@@ -67,7 +67,10 @@ func (df *CsvDataFile) NextLine() (string, int64, error) {
 }
 
 func (df *CsvDataFile) Close() {
-	df.reader.Close()
+	err := df.reader.Close()
+	if err != nil {
+		log.Warnf("closing csv data file reader: %v", err)
+	}
 }
 
 func (df *CsvDataFile) GetBytesRead() int64 {

--- a/yb-voyager/src/datafile/sqldatafile.go
+++ b/yb-voyager/src/datafile/sqldatafile.go
@@ -59,7 +59,10 @@ func (df *SqlDataFile) NextLine() (string, int64, error) {
 }
 
 func (df *SqlDataFile) Close() {
-	df.closer.Close()
+	err := df.closer.Close()
+	if err != nil {
+		log.Warnf("closing sql data file reader: %v", err)
+	}
 }
 
 func (df *SqlDataFile) GetBytesRead() int64 {

--- a/yb-voyager/src/datafile/textdatafile.go
+++ b/yb-voyager/src/datafile/textdatafile.go
@@ -62,7 +62,10 @@ func (df *TextDataFile) NextLine() (string, int64, error) {
 }
 
 func (df *TextDataFile) Close() {
-	df.closer.Close()
+	err := df.closer.Close()
+	if err != nil {
+		log.Warnf("closing text data file reader: %v", err)
+	}
 }
 
 func (df *TextDataFile) GetBytesRead() int64 {

--- a/yb-voyager/src/datastore/localDatastore.go
+++ b/yb-voyager/src/datastore/localDatastore.go
@@ -65,7 +65,7 @@ func (ds *LocalDataStore) OpenAt(filePath string, offset int64) (io.ReadCloser, 
 	}
 	_, err = file.Seek(offset, io.SeekStart)
 	if err != nil {
-		file.Close()
+		_ = file.Close() // best-effort cleanup on the error path
 		return nil, err
 	}
 	return file, nil

--- a/yb-voyager/src/dbzm/status.go
+++ b/yb-voyager/src/dbzm/status.go
@@ -61,7 +61,7 @@ func ReadExportStatus(statusFilePath string) (*ExportStatus, error) {
 		}
 		return nil, goerrors.Errorf("failed to open file %s: %v", statusFilePath, err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(statusFilePath, file)
 
 	var status ExportStatus
 	err = json.NewDecoder(file).Decode(&status)

--- a/yb-voyager/src/importdata/errorHandlers.go
+++ b/yb-voyager/src/importdata/errorHandlers.go
@@ -234,7 +234,10 @@ func (handler *ImportDataStashAndContinueHandler) FinalizeRowProcessingErrorsFor
 		return nil
 	}
 	if errorFile != nil {
-		errorFile.Close()
+		err := errorFile.Close()
+		if err != nil {
+			return fmt.Errorf("close error file for batch %d: %w", batchNumber, err)
+		}
 	}
 
 	// Delete old error files potentially left over from previous run.

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -468,7 +468,7 @@ func (adb *AssessmentDB) LoadCSVFileIntoTable(filePath, tableName string) error 
 	if err != nil {
 		return fmt.Errorf("error opening file %s: %w", filePath, err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(filePath, file)
 
 	csvReader := csv.NewReader(file)
 	csvReader.ReuseRecord = true

--- a/yb-voyager/src/pgss/parser.go
+++ b/yb-voyager/src/pgss/parser.go
@@ -37,7 +37,7 @@ func ParseFromCSV(csvPath string) ([]*PgStatStatements, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open PGSS CSV file %s: %w", csvPath, err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(csvPath, file)
 
 	reader := csv.NewReader(file)
 	headers, err := reader.Read()

--- a/yb-voyager/src/reporter/stats/streamImportReporter.go
+++ b/yb-voyager/src/reporter/stats/streamImportReporter.go
@@ -140,7 +140,8 @@ func (s *StreamImportStatsReporter) refreshStats() {
 	if s.displayExtraInfo != "" {
 		fmt.Fprint(displayExtraInfo, color.RedString(s.displayExtraInfo))
 	}
-	s.uitable.Flush()
+	// console status table redraw; nothing actionable on a flush error
+	_ = s.uitable.Flush()
 }
 
 func (s *StreamImportStatsReporter) DisplayInformation(info string) {

--- a/yb-voyager/src/sqlldr/sqlldr.go
+++ b/yb-voyager/src/sqlldr/sqlldr.go
@@ -41,10 +41,14 @@ func CreateSqlldrControlFile(exportDir string, tableNameTup sqlname.NameTuple, s
 	if err != nil {
 		return "", fmt.Errorf("create sqlldr control file %q: %w", sqlldrControlFilePath, err)
 	}
-	defer sqlldrControlFile.Close()
+	defer func() { _ = sqlldrControlFile.Close() }() // backstop; the success path checks Close below
 	_, err = sqlldrControlFile.WriteString(sqlldrConfig)
 	if err != nil {
 		return "", fmt.Errorf("write sqlldr control file %q: %w", sqlldrControlFilePath, err)
+	}
+	err = sqlldrControlFile.Close()
+	if err != nil {
+		return "", fmt.Errorf("close sqlldr control file %q: %w", sqlldrControlFilePath, err)
 	}
 	return sqlldrControlFilePath, nil
 }

--- a/yb-voyager/src/srcdb/common.go
+++ b/yb-voyager/src/srcdb/common.go
@@ -69,13 +69,13 @@ func processImportDirectives(fileName string) error {
 	if err != nil {
 		return fmt.Errorf("create %q: %w", tmpFileName, err)
 	}
-	defer tmpFile.Close()
+	defer func() { _ = tmpFile.Close() }() // backstop; the success path checks Close before the rename below
 	// Open the original file for reading.
 	file, err := os.Open(fileName)
 	if err != nil {
 		return fmt.Errorf("open %q: %w", fileName, err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(fileName, file)
 	// Create a new scanner and read the file line by line.
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -93,7 +93,7 @@ func processImportDirectives(fileName string) error {
 			if err != nil {
 				return fmt.Errorf("open %q: %w", importFileName, err)
 			}
-			defer importFile.Close()
+			defer utils.CloseAndLogOnError(importFileName, importFile)
 			_, err = io.Copy(tmpFile, importFile)
 			if err != nil {
 				return fmt.Errorf("append %q to %q: %w", importFileName, tmpFileName, err)
@@ -109,6 +109,12 @@ func processImportDirectives(fileName string) error {
 	// Check if there were any errors during the scan.
 	if err = scanner.Err(); err != nil {
 		return fmt.Errorf("scan %q: %w", fileName, err)
+	}
+	// Close before the rename replaces the original: a failed close here could
+	// mean incompletely written content silently overwriting the source file.
+	err = tmpFile.Close()
+	if err != nil {
+		return fmt.Errorf("close %q: %w", tmpFileName, err)
 	}
 	// Rename tmpFile to fileName.
 	err = os.Rename(tmpFileName, fileName)

--- a/yb-voyager/src/srcdb/pg_dump_export_data.go
+++ b/yb-voyager/src/srcdb/pg_dump_export_data.go
@@ -126,7 +126,10 @@ func parseAndCreateTocTextFile(dataDirPath string) {
 	if err != nil {
 		utils.ErrExit("flush toc.txt: %w", err)
 	}
-	tocTextFile.Close()
+	err = tocTextFile.Close()
+	if err != nil {
+		utils.ErrExit("close toc.txt: %w", err)
+	}
 }
 
 func createTableListPatterns(tableList []sqlname.NameTuple) string {

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -119,7 +119,7 @@ func readSchemaFile(path string) []string {
 	if err != nil {
 		utils.ErrExit("error in opening schema file: %s: %w", path, err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(path, file)
 	var lines []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -341,7 +341,7 @@ func (tdb *TargetOracleDB) importBatch(conn *sql.Conn, batch Batch, args *Import
 	if err != nil {
 		return 0, fmt.Errorf("open batch file %q: %w", batch.GetFilePath(), err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(batch.GetFilePath(), file)
 
 	//setting the schema so that the table is created in the correct schema
 	tdb.setTargetSchema(conn)
@@ -398,7 +398,7 @@ func (tdb *TargetOracleDB) importBatch(conn *sql.Conn, batch Batch, args *Import
 	if err != nil {
 		return 0, err
 	}
-	defer sqlldrLogFile.Close()
+	defer utils.CloseAndLogOnError(sqlldrLogFilePath, sqlldrLogFile)
 
 	user := tdb.tconf.User
 	password := tdb.tconf.Password

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -726,7 +726,7 @@ func (pg *TargetPostgreSQL) importBatch(conn *pgx.Conn, batch Batch, args *Impor
 	if err != nil {
 		return 0, fmt.Errorf("open file %s: %w", batch.GetFilePath(), err)
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(batch.GetFilePath(), file)
 
 	//setting the schema so that COPY command can acesss the table
 	pg.setTargetSchema(conn)

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -869,7 +869,7 @@ func (yb *TargetYugabyteDB) copyBatchCore(conn *pgx.Conn, batch Batch, args *Imp
 			errs.IMPORT_BATCH_ERROR_STEP_OPEN_BATCH, nil)
 		return 0, err
 	}
-	defer file.Close()
+	defer utils.CloseAndLogOnError(batch.GetFilePath(), file)
 
 	// 2. setting the schema so that COPY command can acesss the table
 	// Q: If we set the schema for this batch on this conn, will it impact others using the same conn from pool later?
@@ -1721,7 +1721,7 @@ func getYBSessionInitScript(tconf *TargetConf) []string {
 		log.Infof("YBSessionInitScript: %v\n", sessionVars)
 		return sessionVars
 	}
-	defer varsFile.Close()
+	defer utils.CloseAndLogOnError(sessionVarsPath, varsFile)
 	fileScanner := bufio.NewScanner(varsFile)
 
 	var curLine string

--- a/yb-voyager/src/utils/az/azutils.go
+++ b/yb-voyager/src/utils/az/azutils.go
@@ -154,7 +154,7 @@ func GetHeadObject(objectURL string) (*blob.Attributes, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening bucket for %q: %w", url, err)
 	}
-	defer bucket.Close()
+	defer utils.CloseAndLogOnError("azure blob bucket", bucket)
 	blobAttributes, err := bucket.Attributes(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("getting attributes of %q: %w", objectURL, err)

--- a/yb-voyager/src/utils/schemareg/schemaRegistry.go
+++ b/yb-voyager/src/utils/schemareg/schemaRegistry.go
@@ -163,7 +163,7 @@ func (sreg *SchemaRegistry) Init() error {
 			return goerrors.Errorf("table %s is not present in the target database", table)
 		}
 		sreg.TableNameToSchema.Put(table, &tableSchema)
-		schemaFile.Close()
+		utils.CloseAndLogOnError(schemaFilePath, schemaFile)
 	}
 	return nil
 }

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -185,7 +185,7 @@ func IsFileEmpty(fpath string) bool {
 		log.Errorf("IsFileEmpty: file open: %v", err)
 		return false
 	}
-	defer file.Close()
+	defer CloseAndLogOnError(fpath, file)
 
 	fileInfo, err := file.Stat()
 	if err != nil {
@@ -289,18 +289,32 @@ func CopyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open source file %q: %w", src, err)
 	}
-	defer srcFile.Close()
+	defer CloseAndLogOnError(src, srcFile)
 	dstFile, err := os.Create(dst)
 	if err != nil {
 		return fmt.Errorf("failed to create destination file %q: %w", dst, err)
 	}
-	defer dstFile.Close()
+	defer func() { _ = dstFile.Close() }() // backstop; the success path checks Close below
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {
 		return fmt.Errorf("failed to copy from %q to %q: %w", src, dst, err)
 	}
 
+	err = dstFile.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close destination file %q: %w", dst, err)
+	}
 	return nil
+}
+
+// CloseAndLogOnError closes c and logs a warning if closing fails. Use it for
+// read-path and teardown closes where the error is not actionable. Write-path
+// closes must be checked explicitly instead — a failed close there can mean
+// lost data.
+func CloseAndLogOnError(what string, c io.Closer) {
+	if err := c.Close(); err != nil {
+		log.Warnf("closing %s: %v", what, err)
+	}
 }
 
 func GetObjectFilePath(schemaDirPath string, objType string) string {
@@ -434,7 +448,7 @@ func WaitForLineInLogFile(filePath string, message string, timeoutDuration time.
 		return goerrors.Errorf("error opening file %s: %v", filePath, err)
 	}
 
-	defer file.Close()
+	defer CloseAndLogOnError(filePath, file)
 
 	for {
 		reader := bufio.NewReader(file)
@@ -555,7 +569,7 @@ func ForEachLineInFile(filePath string, callback func(line string) bool) error {
 	if err != nil {
 		return goerrors.Errorf("error opening file %s: %v", filePath, err)
 	}
-	defer file.Close()
+	defer CloseAndLogOnError(filePath, file)
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -639,7 +653,7 @@ func ReadTableNameListFromFile(filePath string) ([]string, error) {
 	if err != nil {
 		return nil, goerrors.Errorf("error opening file %s: %v", filePath, err)
 	}
-	defer file.Close()
+	defer CloseAndLogOnError(filePath, file)
 	var list []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -745,7 +759,7 @@ func GetFreePort() (int, error) {
 	if err != nil {
 		return 0, goerrors.Errorf("failed to listen on a port: %v", err)
 	}
-	defer listener.Close()
+	defer CloseAndLogOnError("port-probe listener", listener)
 
 	// Retrieve the assigned port
 	addr := listener.Addr().(*net.TCPAddr)

--- a/yb-voyager/test/cdcbench/artifact.go
+++ b/yb-voyager/test/cdcbench/artifact.go
@@ -176,7 +176,7 @@ func generateArtifact(b *testing.B, w Workload, voyagerBin, dir, exportDir strin
 	if err != nil {
 		return artifactManifest{}, err
 	}
-	defer logFile.Close()
+	defer func() { _ = logFile.Close() }() // bench log capture; close error is not actionable
 
 	connStr := func(db string) string {
 		return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=disable", config.User, config.Password, host, port, db)

--- a/yb-voyager/test/cdcbench/cdcbench.go
+++ b/yb-voyager/test/cdcbench/cdcbench.go
@@ -150,7 +150,8 @@ func printSummary(results []workloadResult) {
 			comma(int64(r.depthAvg)), comma(int64(r.depthMax)),
 			r.timePerRun.Round(time.Millisecond))
 	}
-	tw.Flush()
+	// console results table; nothing actionable on a flush error
+	_ = tw.Flush()
 	fmt.Fprintln(os.Stdout)
 }
 
@@ -324,6 +325,6 @@ func runLogDest(b *testing.B, w Workload, run int) (io.Writer, func()) {
 		// point the global logger away from the file before closing it so
 		// later log writes never hit a closed descriptor
 		log.SetOutput(io.Discard)
-		f.Close()
+		_ = f.Close() // bench log capture; close error is not actionable
 	}
 }

--- a/yb-voyager/test/cdcbench/mock.go
+++ b/yb-voyager/test/cdcbench/mock.go
@@ -76,7 +76,7 @@ func (m *MockTargetDB) GetTableToUniqueIndexesMap(tableList []sqlname.NameTuple)
 
 func (m *MockTargetDB) Close() {
 	if m.metadata != nil {
-		m.metadata.Close()
+		_ = m.metadata.Close() // mock teardown; close error is not actionable
 	}
 }
 

--- a/yb-voyager/test/containers/helpers.go
+++ b/yb-voyager/test/containers/helpers.go
@@ -60,7 +60,7 @@ func printContainerLogs(container testcontainers.Container) {
 		log.Printf("Error fetching logs for container %s: %v", containerID, err)
 		return
 	}
-	defer logs.Close()
+	defer func() { _ = logs.Close() }() // read path; close error is not actionable
 
 	// Read the logs
 	logData, err := io.ReadAll(logs)

--- a/yb-voyager/test/containers/mysql_container.go
+++ b/yb-voyager/test/containers/mysql_container.go
@@ -51,7 +51,7 @@ func (ms *MysqlContainer) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temp schema file: %w", err)
 	}
-	defer tmpFile.Close()
+	defer utils.CloseAndLogOnError(tmpFile.Name(), tmpFile)
 
 	if _, err := tmpFile.Write(mysqlInitSchemaFile); err != nil {
 		return fmt.Errorf("failed to write to temp schema file: %w", err)

--- a/yb-voyager/test/containers/oracle_container.go
+++ b/yb-voyager/test/containers/oracle_container.go
@@ -50,7 +50,7 @@ func (ora *OracleContainer) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temp schema file: %w", err)
 	}
-	defer tmpFile.Close()
+	defer utils.CloseAndLogOnError(tmpFile.Name(), tmpFile)
 
 	if _, err := tmpFile.Write(oracleInitSchemaFile); err != nil {
 		return fmt.Errorf("failed to write to temp schema file: %w", err)

--- a/yb-voyager/test/containers/postgres_container.go
+++ b/yb-voyager/test/containers/postgres_container.go
@@ -53,7 +53,7 @@ func (pg *PostgresContainer) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temp schema file: %w", err)
 	}
-	defer tmpFile.Close()
+	defer utils.CloseAndLogOnError(tmpFile.Name(), tmpFile)
 
 	if _, err := tmpFile.Write(postgresInitSchemaFile); err != nil {
 		return fmt.Errorf("failed to write to temp schema file: %w", err)

--- a/yb-voyager/test/containers/yugabytedb_container.go
+++ b/yb-voyager/test/containers/yugabytedb_container.go
@@ -82,7 +82,7 @@ func (yb *YugabyteDBContainer) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temp schema file: %w", err)
 	}
-	defer tmpFile.Close()
+	defer utils.CloseAndLogOnError(tmpFile.Name(), tmpFile)
 
 	if _, err := tmpFile.Write(yugabytedbInitSchemaFile); err != nil {
 		return fmt.Errorf("failed to write to temp schema file: %w", err)

--- a/yb-voyager/test/utils/queue_segment_event_count.go
+++ b/yb-voyager/test/utils/queue_segment_event_count.go
@@ -53,7 +53,7 @@ func countEventsInNDJSONSegmentFile(filePath string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() // read path; close error is not actionable
 
 	scanner := bufio.NewScanner(file)
 	count := 0

--- a/yb-voyager/test/utils/testutils.go
+++ b/yb-voyager/test/utils/testutils.go
@@ -428,6 +428,10 @@ func CreateTempFile(dir string, fileContents string, fileFormat string) (string,
 		return "", err
 	}
 
+	err = file.Close()
+	if err != nil {
+		return "", err
+	}
 	return file.Name(), nil
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request

Second PR of the errcheck stack: resolves every unchecked file `Close()`/`Flush()` in production code (~50 sites). Each site was individually classified **read vs write**, because the correct handling is opposite:

- **Write paths now CHECK `Close()`** — after writing, close is the last chance for the OS to report that data never reached disk; ignoring it is a silent data-loss bug in a migration tool. Pattern: a silent backstop `defer func() { _ = f.Close() }()` plus an explicit checked `Close` on the success path. Sites: bulk-assessment and compare-perf HTML reports, batch error-append files, sqlldr control file, `CopyFile`'s destination, `toc.txt`, error-stash files, `CreateTempFile`.
- **Notable find**: `processImportDirectives` (srcdb) built a tmp file and `os.Rename`d it **over the original schema file** while the tmp file's close was only a bare defer — an incomplete write could silently replace the source file. It now closes-and-checks *before* the rename.
- **Read paths and teardown** use a new `utils.CloseAndLogOnError(what, closer)` (close + warn-level log), so problems stay observable without inventing error paths for non-events: batch files opened for COPY/sqlldr, queue segments, status/config/report/schema reads, container temp schema files.
- Error-path cleanups and bench/mock teardown become explicit `_ = c.Close()` with a why-comment; console table redraws (uilive/tabwriter `Flush` in export/import stats reporters) become `_ = Flush()` — nothing actionable on a console redraw error.

The reviewing question for every hunk is simply: is the read/write classification right?

### Describe if there are any user-facing changes

Failure-behavior change on write paths only: a failed close of a written artifact (report, control file, batch file) now surfaces as an error instead of being swallowed.

### How was this pull request tested?

- `go build ./...`, `go test -tags unit ./...` pass (zero failures).
- errcheck production findings: 254 → 205.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)