### PR TITLE
errcheck 3c: propagate dropped errors in state, validation, and iteration paths

### DIFF
--- a/yb-voyager/cmd/archiveChangesCommand.go
+++ b/yb-voyager/cmd/archiveChangesCommand.go
@@ -83,14 +83,21 @@ func archiveChangesCommandFn(cmd *cobra.Command, args []string) {
 		utils.ErrExit("the streaming phase of export data has not started yet — archive changes can only be run after streaming begins")
 	}
 
-	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+	err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		record.ArchivingEnabled = true
 		record.SegmentCleanupRunning = true
 	})
+	if err != nil {
+		utils.ErrExit("failed to mark archiving enabled in migration status record: %w", err)
+	}
 	resetArchiveChangesRunning := func() {
-		metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 			record.SegmentCleanupRunning = false
 		})
+		if err != nil {
+			// cleanup path: log instead of exiting mid-shutdown
+			log.Errorf("failed to reset SegmentCleanupRunning in migration status record: %v", err)
+		}
 	}
 	defer resetArchiveChangesRunning()
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -193,7 +193,10 @@ func getMappingForTableNameVsTableFileName(dataDirPath string, noWait bool) map[
 	}
 
 	//extracted SQL for setval() and put it into a postexport.sql file
-	os.WriteFile(filepath.Join(dataDirPath, "postdata.sql"), []byte(sequencesPostData.String()), 0644)
+	err = os.WriteFile(filepath.Join(dataDirPath, "postdata.sql"), []byte(sequencesPostData.String()), 0644)
+	if err != nil {
+		utils.ErrExit("failed to write postdata.sql: %w", err)
+	}
 	return tableNameVsFileNameMap
 }
 
@@ -400,7 +403,8 @@ func displayImportedRowCountSnapshot(state *ImportDataState, tasks []*ImportFile
 	}
 
 	keys := make([]sqlname.NameTuple, 0, len(snapshotRowCount.Keys()))
-	snapshotRowCount.IterKV(func(k sqlname.NameTuple, v RowCountPair) (bool, error) {
+	// the callback never returns an error
+	_ = snapshotRowCount.IterKV(func(k sqlname.NameTuple, v RowCountPair) (bool, error) {
 		keys = append(keys, k)
 		return true, nil
 	})
@@ -1937,7 +1941,8 @@ func updateExportSnapshotDataStatsInPayload(exportDataPayload *callhome.ExportDa
 				if err != nil {
 					log.Infof("callhome: error while getting exported snapshot rows map: %v", err)
 				}
-				exportedSnapshotRow.IterKV(func(key sqlname.NameTuple, value int64) (bool, error) {
+				// callhome payload assembly; the callback never returns an error
+				_ = exportedSnapshotRow.IterKV(func(key sqlname.NameTuple, value int64) (bool, error) {
 					exportDataPayload.TotalRows += value
 					if value >= exportDataPayload.LargestTableRows {
 						exportDataPayload.LargestTableRows = value

--- a/yb-voyager/cmd/endMigrationCommand.go
+++ b/yb-voyager/cmd/endMigrationCommand.go
@@ -87,7 +87,10 @@ var endMigrationCmd = &cobra.Command{
 
 		//if parent with iterations
 		//backup the data migration report with detailed report for all iterations
-		saveDataMigrationReportForAllIterationsFn(msr)
+		err = saveDataMigrationReportForAllIterationsFn(msr)
+		if err != nil {
+			utils.ErrExit("failed to save data migration report for all iterations: %w", err)
+		}
 		currMetaDB := metaDB
 		currBackupDir := backupDir
 		currExportDir := exportDir
@@ -1032,11 +1035,15 @@ func stopDataExportCommand(lockFile *lockfile.Lockfile) {
 		return
 	}
 
-	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		// dbzm plugin detects this MSR flag, and stops the data export gracefully
 		// so that the ongoing segment in closed and can be processed -> archived -> deleted
 		record.EndMigrationRequested = true
 	})
+	if err != nil {
+		// if this flag is not persisted, the export never learns it should stop
+		utils.ErrExit("failed to set EndMigrationRequested in migration status record: %w", err)
+	}
 
 	ongoingCmd := lockFile.GetCmdName()
 	ongoingCmdPID, err := lockFile.GetCmdPID()

--- a/yb-voyager/cmd/exportData.go
+++ b/yb-voyager/cmd/exportData.go
@@ -715,7 +715,7 @@ func exportData() bool {
 	finalTableList, tablesColumnList := finalizeTableAndColumnList(finalTableList, partitionsToRootTableMap)
 	handleEmptyTableListForExport(finalTableList)
 
-	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+	err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		switch source.DBType {
 		case POSTGRESQL:
 			record.SourceRenameTablesMap = partitionsToRootTableMap
@@ -728,6 +728,9 @@ func exportData() bool {
 			})
 		}
 	})
+	if err != nil {
+		utils.ErrExit("failed to update rename-tables map in migration status record: %w", err)
+	}
 
 	msr, err = metaDB.GetMigrationStatusRecord()
 	if err != nil {
@@ -943,7 +946,8 @@ func initPGLiveMigrationAndExportSnapshotIfRequired(ctx context.Context, cancel 
 	}
 
 	var sequenceInitValues strings.Builder
-	sequenceValueMap.IterKV(func(seqName sqlname.NameTuple, seqValue int64) (bool, error) {
+	// the callback never returns an error
+	_ = sequenceValueMap.IterKV(func(seqName sqlname.NameTuple, seqValue int64) (bool, error) {
 		sequenceInitValues.WriteString(fmt.Sprintf("%s:%d,", seqName.ForKey(), seqValue))
 		return true, nil
 	})
@@ -1457,13 +1461,16 @@ func fetchTablesNamesFromSourceAndFilterTableList() (map[string]string, []sqlnam
 		isTableListModified = len(sqlname.SetDifferenceNameTuples(nameTupleTableListFromDB, tableListInFirstRun)) != 0
 	}
 	if exporterRole == SOURCE_DB_EXPORTER_ROLE {
-		metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 			if isTableListModified {
 				record.IsExportTableListSet = true
 			} else {
 				record.IsExportTableListSet = false
 			}
 		})
+		if err != nil {
+			utils.ErrExit("failed to update IsExportTableListSet in migration status record: %w", err)
+		}
 	}
 
 	var partitionsToRootTableMap map[string]string
@@ -2317,7 +2324,8 @@ func reportLeafPartitionsWithMismatchedPrimaryKeys(
 		return a.AsQualifiedCatalogName() < b.AsQualifiedCatalogName()
 	}
 	utils.PrintAndLogfInfo("Partitioned tables with inconsistent primary keys across leaf partitions:")
-	mismatches.IterKVSorted(sortFn, func(root sqlname.NameTuple, pks []string) (bool, error) {
+	// display-only iteration right before ErrExit; the callback never returns an error
+	_ = mismatches.IterKVSorted(sortFn, func(root sqlname.NameTuple, pks []string) (bool, error) {
 		utils.PrintAndLogf("- %s: (%s)\n", root.ForOutput(), strings.Join(pks, "), ("))
 		return true, nil
 	})
@@ -2357,7 +2365,8 @@ func handleUnsupportedColumnsInExportData(unsupportedTableColumnsMap *utils.Stru
 
 	var unsupportedColsMsg strings.Builder
 	unsupportedColsMsg.WriteString("The following columns data export is unsupported:\n")
-	unsupportedTableColumnsMap.IterKV(func(k sqlname.NameTuple, v []string) (bool, error) {
+	// message assembly; the callback never returns an error
+	_ = unsupportedTableColumnsMap.IterKV(func(k sqlname.NameTuple, v []string) (bool, error) {
 		if len(v) != 0 {
 			unsupportedColsMsg.WriteString(fmt.Sprintf("%s: %s\n", k.ForOutput(), v))
 		}
@@ -2431,12 +2440,15 @@ func saveSourceDBConfInMSR() {
 	if exporterRole != SOURCE_DB_EXPORTER_ROLE {
 		return
 	}
-	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		// overriding the current value of SourceDBConf
 		record.SourceDBConf = source.Clone()
 		record.SourceDBConf.Password = ""
 		record.SourceDBConf.Uri = ""
 	})
+	if err != nil {
+		utils.ErrExit("failed to save source DB conf in migration status record: %w", err)
+	}
 }
 
 func createSnapshotExportStartedEvent() cp.SnapshotExportStartedEvent {

--- a/yb-voyager/cmd/exportDataDebezium.go
+++ b/yb-voyager/cmd/exportDataDebezium.go
@@ -83,7 +83,8 @@ func prepareDebeziumConfig(partitionsToRootTableMap map[string]string, tableList
 		}
 	}
 
-	tablesColumnList.IterKV(func(k sqlname.NameTuple, v []string) (bool, error) {
+	// column-list assembly for the Debezium config; the callback never returns an error
+	_ = tablesColumnList.IterKV(func(k sqlname.NameTuple, v []string) (bool, error) {
 		for _, column := range v {
 			columnName := fmt.Sprintf("%s.%s", k.AsQualifiedCatalogName(), column)
 			if column == "*" {

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -276,12 +276,15 @@ func getDataMigrationReportCmdFn(msr *metadb.MigrationStatusRecord, donotPrint b
 	for _, nameTup := range tableNameTups {
 
 		row := RowData{}
-		updateExportedSnapshotRowsInTheRow(msr, &row, nameTup, dbzmNameTupToRowCount, exportedPGSnapshotRowsMap)
+		err := updateExportedSnapshotRowsInTheRow(msr, &row, nameTup, dbzmNameTupToRowCount, exportedPGSnapshotRowsMap)
+		if err != nil {
+			utils.ErrExit("error while updating exported snapshot rows in the row for table %q: %w", nameTup.ForOutput(), err)
+		}
 		row.ImportedSnapshotRows = 0
 		row.ErroredImportedSnapshotRows = 0
 		row.TableName = nameTup.ForKey()
 		row.DBType = "source"
-		err := updateExportedEventsCountsInTheRow(&row, nameTup, sourceExportedEventsMap, targetExportedEventsMap) //source OUT counts
+		err = updateExportedEventsCountsInTheRow(&row, nameTup, sourceExportedEventsMap, targetExportedEventsMap) //source OUT counts
 		if err != nil {
 			utils.ErrExit("error while getting exported events counts for source DB: %w\n", err)
 		}

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -528,7 +528,8 @@ func checkPartitionConsistency(msr *metadb.MigrationStatusRecord, importTableLis
 	}
 	// Check each source partition exists on target
 	missingRootToLeafPartitions := utils.NewStructMap[sqlname.NameTuple, []string]()
-	rootToLeafPartitions.IterKV(func(root sqlname.NameTuple, leaves []string) (bool, error) {
+	// the callback never returns an error
+	_ = rootToLeafPartitions.IterKV(func(root sqlname.NameTuple, leaves []string) (bool, error) {
 		if !lo.ContainsBy(importTableList, func(t sqlname.NameTuple) bool {
 			return t.Equals(root)
 		}) {
@@ -565,7 +566,8 @@ func checkPartitionConsistency(msr *metadb.MigrationStatusRecord, importTableLis
 
 func printMissingRootToLeafPartitions(missingRootToLeafPartitions *utils.StructMap[sqlname.NameTuple, []string]) {
 	sortFn := func(a, b sqlname.NameTuple) bool { return a.AsQualifiedCatalogName() < b.AsQualifiedCatalogName() }
-	missingRootToLeafPartitions.IterKVSorted(sortFn, func(root sqlname.NameTuple, leaves []string) (bool, error) {
+	// display-only iteration; the callback never returns an error
+	_ = missingRootToLeafPartitions.IterKVSorted(sortFn, func(root sqlname.NameTuple, leaves []string) (bool, error) {
 		utils.PrintAndLogfInfo("  - %s:", root.ForOutput())
 		sort.Slice(leaves, func(i, j int) bool { return leaves[i] < leaves[j] })
 		utils.PrintAndLogfInfo("    - %s", strings.Join(leaves, ", "))
@@ -1980,7 +1982,8 @@ func packAndSendImportDataToTargetPayload(status string, errorMsg error) {
 	if err != nil {
 		log.Infof("callhome: error in getting the import data: %v", err)
 	} else {
-		importRowsMap.IterKV(func(key sqlname.NameTuple, value RowCountPair) (bool, error) {
+		// callhome payload assembly; the callback never returns an error
+		_ = importRowsMap.IterKV(func(key sqlname.NameTuple, value RowCountPair) (bool, error) {
 			dataMetrics.MigrationSnapshotTotalRows += value.Imported
 			if value.Imported > dataMetrics.MigrationSnapshotLargestTableRows {
 				dataMetrics.MigrationSnapshotLargestTableRows = value.Imported
@@ -2070,10 +2073,13 @@ func fetchAndStoreGeneratedAlwaysIdentityColumnsInMetadb(tables []sqlname.NameTu
 		return fmt.Errorf("failed to get identity(%s) columns for tables: %w", constants.IDENTITY_GENERATION_ALWAYS, err)
 	}
 
-	TableToIdentityColumnNames.IterKV(func(key sqlname.NameTuple, value []string) (bool, error) {
+	err = TableToIdentityColumnNames.IterKV(func(key sqlname.NameTuple, value []string) (bool, error) {
 		tableKeyToIdentityColumnNames[key.ForKey()] = value
 		return true, nil
 	})
+	if err != nil {
+		return fmt.Errorf("failed to iterate identity column names: %w", err)
+	}
 	err = metaDB.InsertJsonObject(nil, identityColumnsMetaDBKey, tableKeyToIdentityColumnNames)
 	if err != nil {
 		return goerrors.Errorf("failed to insert into the key '%s': %v", identityColumnsMetaDBKey, err)
@@ -2451,9 +2457,12 @@ func saveOnPrimaryKeyConflictActionInMSR() {
 		return
 	}
 
-	metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		record.OnPrimaryKeyConflictAction = tconf.OnPrimaryKeyConflictAction
 	})
+	if err != nil {
+		utils.ErrExit("failed to save on-primary-key-conflict action in migration status record: %w", err)
+	}
 }
 
 func clearMigrationStateForImportDataStartClean(state *ImportDataState, importFileTasks []*ImportFileTask, errorHandler importdata.ImportDataErrorHandler) error {

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -267,13 +267,19 @@ func checkDataDirFlag() {
 		utils.ErrExit(`Error required flag "data-dir" not set`)
 	}
 	if strings.HasPrefix(dataDir, "s3://") {
-		s3.ValidateObjectURL(dataDir)
+		if err := s3.ValidateObjectURL(dataDir); err != nil {
+			utils.ErrExit("invalid s3 data-dir %q: %v", dataDir, err)
+		}
 		return
 	} else if strings.HasPrefix(dataDir, "gs://") {
-		gcs.ValidateObjectURL(dataDir)
+		if err := gcs.ValidateObjectURL(dataDir); err != nil {
+			utils.ErrExit("invalid gcs data-dir %q: %v", dataDir, err)
+		}
 		return
 	} else if strings.HasPrefix(dataDir, "https://") {
-		az.ValidateObjectURL(dataDir)
+		if err := az.ValidateObjectURL(dataDir); err != nil {
+			utils.ErrExit("invalid azure data-dir %q: %v", dataDir, err)
+		}
 		return
 	}
 	if !utils.FileOrFolderExists(dataDir) {
@@ -393,7 +399,8 @@ func packAndSendImportDataFilePayload(status string, errorMsg error) {
 	if err != nil {
 		log.Infof("callhome: error in getting the import data: %v", err)
 	} else if importSizeMap != nil {
-		importSizeMap.IterKV(func(key sqlname.NameTuple, value int64) (bool, error) {
+		// callhome payload assembly; the callback never returns an error
+		_ = importSizeMap.IterKV(func(key sqlname.NameTuple, value int64) (bool, error) {
 			dataMetrics.MigrationSnapshotTotalBytes += value
 			if value > dataMetrics.MigrationSnapshotLargestTableBytes {
 				dataMetrics.MigrationSnapshotLargestTableBytes = value

--- a/yb-voyager/cmd/importDataFileTaskPicker.go
+++ b/yb-voyager/cmd/importDataFileTaskPicker.go
@@ -317,10 +317,13 @@ func (c *ColocatedAwareRandomTaskPicker) initializeChooser() error {
 		return goerrors.Errorf("no pending tasks to initialize chooser")
 	}
 	tableNames := make([]sqlname.NameTuple, 0, len(c.tableWisePendingTasks.Keys()))
-	c.tableWisePendingTasks.IterKV(func(k sqlname.NameTuple, v []*ImportFileTask) (bool, error) {
+	err := c.tableWisePendingTasks.IterKV(func(k sqlname.NameTuple, v []*ImportFileTask) (bool, error) {
 		tableNames = append(tableNames, k)
 		return true, nil
 	})
+	if err != nil {
+		return fmt.Errorf("failed to iterate pending tasks: %w", err)
+	}
 
 	colocatedCount := 0
 	for _, tableName := range tableNames {
@@ -351,7 +354,6 @@ func (c *ColocatedAwareRandomTaskPicker) initializeChooser() error {
 		}
 
 	}
-	var err error
 	c.tableChooser, err = weightedrand.NewChooser(choices...)
 	if err != nil {
 		return fmt.Errorf("creating chooser: %w", err)
@@ -377,7 +379,8 @@ func (c *ColocatedAwareRandomTaskPicker) HasMoreTasks() bool {
 	}
 
 	pendingTasks := false
-	c.tableWisePendingTasks.IterKV(func(tableName sqlname.NameTuple, tasks []*ImportFileTask) (bool, error) {
+	// the callback never returns an error
+	_ = c.tableWisePendingTasks.IterKV(func(tableName sqlname.NameTuple, tasks []*ImportFileTask) (bool, error) {
 		if len(tasks) > 0 {
 			pendingTasks = true
 			return false, nil

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -128,7 +128,8 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg error) {
 	if err != nil {
 		log.Infof("callhome: error in getting the import data: %v", err)
 	} else {
-		importRowsMap.IterKV(func(key sqlname.NameTuple, value RowCountPair) (bool, error) {
+		// callhome payload assembly; the callback never returns an error
+		_ = importRowsMap.IterKV(func(key sqlname.NameTuple, value RowCountPair) (bool, error) {
 			dataMetrics.MigrationSnapshotTotalRows += value.Imported
 			if value.Imported > dataMetrics.MigrationSnapshotLargestTableRows {
 				dataMetrics.MigrationSnapshotLargestTableRows = value.Imported

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -291,17 +291,27 @@ func executeSqlStmtWithRetries(tgtConn **ImportSchemaTargetConn, sqlInfo sqlInfo
 		return goerrors.Errorf("error applying session variable: %v", err)
 	}
 
-	defer func(conn *ImportSchemaTargetConn) error {
-		if conn != nil {
+	// NOTE (errcheck): the closure's error return has always been discarded — a
+	// deferred call's return value cannot be observed. Made explicit with `_ =`
+	// below. `(*tgtConn)` MUST stay a defer-time argument (evaluated eagerly,
+	// always non-nil here): reading it at exit time would arm the closure body
+	// on the error paths that set `(*tgtConn) = nil`, nil-dereferencing in
+	// ResetSessionVariables. Pre-existing oddity flagged for a follow-up: the
+	// `conn != nil` early-return means the reset body only ever runs when conn
+	// is nil, so the closure has always been a no-op.
+	defer func(conn *ImportSchemaTargetConn) {
+		_ = func() error {
+			if conn != nil {
+				return nil
+			}
+			// Reset all session variables on the connection for next stmt
+			log.Infof("Resetting all session variables on the connection for next stmt")
+			err = conn.ResetSessionVariables(sessionVariables)
+			if err != nil {
+				return goerrors.Errorf("error resetting all session variables on connection: %v", err)
+			}
 			return nil
-		}
-		// Reset all session variables on the connection for next stmt
-		log.Infof("Resetting all session variables on the connection for next stmt")
-		err = conn.ResetSessionVariables(sessionVariables)
-		if err != nil {
-			return goerrors.Errorf("error resetting all session variables on connection: %v", err)
-		}
-		return nil
+		}()
 	}((*tgtConn))
 
 	for retryCount := 0; retryCount <= DDL_MAX_RETRY_COUNT; retryCount++ {

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -109,7 +109,9 @@ func cutoverInitiatedAndCutoverEventProcessed() (bool, error) {
 }
 
 func streamChanges(state *ImportDataState, tableNames []sqlname.NameTuple, tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string]) error {
-	waitForDebeziumStartIfRequired()
+	if err := waitForDebeziumStartIfRequired(); err != nil {
+		return fmt.Errorf("waiting for debezium to start: %w", err)
+	}
 	importPhase = dbzm.MODE_STREAMING
 	utils.PrintAndLogfInfo("streaming changes to %s...", tconf.TargetDBType)
 	streamingPhaseValueConverter, err := dbzm.NewStreamingPhaseDebeziumValueConverter(tableNames, exportDir, tconf, importerRole, sourceDBType)

--- a/yb-voyager/src/dbzm/valueConverter.go
+++ b/yb-voyager/src/dbzm/valueConverter.go
@@ -267,8 +267,14 @@ func (crp *CsvRowProcessor) ReadRow(row string) ([]string, error) {
 func (crp *CsvRowProcessor) WriteRow(columnValues []string) (string, error) {
 	crp.bufWriter.Reset(crp.wbuf)
 	csvWriter := csv.NewWriter(crp.bufWriter)
-	csvWriter.Write(columnValues)
+	err := csvWriter.Write(columnValues)
+	if err != nil {
+		return "", fmt.Errorf("writing csv row: %w", err)
+	}
 	csvWriter.Flush()
+	if err := csvWriter.Error(); err != nil {
+		return "", fmt.Errorf("flushing csv row: %w", err)
+	}
 	row := strings.TrimSuffix(crp.wbuf.String(), "\n")
 	crp.wbuf.Reset()
 	return row, nil

--- a/yb-voyager/src/namereg/namereg.go
+++ b/yb-voyager/src/namereg/namereg.go
@@ -136,7 +136,10 @@ func (reg *NameRegistry) registerNames() (bool, error) {
 			targetSchema = reg.params.TargetDBSchema[0]
 		}
 		defaultSchema := lo.Ternary(reg.SourceDBType == constants.POSTGRESQL, reg.DefaultSourceDBSchemaName, targetSchema)
-		reg.setDefaultSourceReplicaDBSchemaName(defaultSchema)
+		err := reg.setDefaultSourceReplicaDBSchemaName(defaultSchema)
+		if err != nil {
+			return false, fmt.Errorf("set default source-replica schema name: %w", err)
+		}
 		return true, nil
 	}
 	log.Infof("no name registry update required: mode %q", reg.params.Role)
@@ -148,8 +151,7 @@ func (reg *NameRegistry) UnRegisterYBNames() error {
 	reg.YBTableNames = nil
 	reg.YBSchemaNames = nil
 	reg.DefaultYBSchemaName = ""
-	reg.save()
-	return nil
+	return reg.save()
 }
 
 func (reg *NameRegistry) registerSourceNames() (bool, error) {

--- a/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
+++ b/yb-voyager/src/query/sqltransformer/sqlfiletransformer.go
@@ -158,7 +158,7 @@ func (t *IndexFileTransformer) GetBackupFilePath() string {
 func (t *IndexFileTransformer) writeRemovedRedundantIndexesToFile(removedIndexToStmtMap *utils.StructMap[*sqlname.ObjectNameQualifiedWithTableName, *pg_query.RawStmt]) error {
 	var removedSqlStmts []string
 	var err error
-	removedIndexToStmtMap.IterKV(func(key *sqlname.ObjectNameQualifiedWithTableName, value *pg_query.RawStmt) (bool, error) {
+	err = removedIndexToStmtMap.IterKV(func(key *sqlname.ObjectNameQualifiedWithTableName, value *pg_query.RawStmt) (bool, error) {
 		//Add the existing index ddl in the comments for the individual redundant index
 		stmtStr, err := queryparser.DeparseRawStmt(value)
 		if err != nil {
@@ -171,6 +171,9 @@ func (t *IndexFileTransformer) writeRemovedRedundantIndexesToFile(removedIndexTo
 		removedSqlStmts = append(removedSqlStmts, stmtStr)
 		return true, nil
 	})
+	if err != nil {
+		return fmt.Errorf("failed to collect removed redundant index statements: %w", err)
+	}
 
 	if len(removedSqlStmts) > 0 {
 		// Write the removed indexes to a file

--- a/yb-voyager/src/srcdb/ora2pg_export_data.go
+++ b/yb-voyager/src/srcdb/ora2pg_export_data.go
@@ -45,7 +45,8 @@ func ora2pgExportDataOffline(ctx context.Context, source *Source, exportDir stri
 	conf := getDefaultOra2pgConfig(source)
 	conf.DisablePartition = "1"
 	conf.Allow = fmt.Sprintf("TABLE%v", tableList)
-	tablesColumnList.IterKV(func(tableName sqlname.NameTuple, columnList []string) (bool, error) {
+	// conf assembly; the callback never returns an error
+	_ = tablesColumnList.IterKV(func(tableName sqlname.NameTuple, columnList []string) (bool, error) {
 		_, tname := tableName.ForCatalogQuery()
 		allColumns := "*"
 		if len(columnList) == 1 && columnList[0] == allColumns {
@@ -107,7 +108,10 @@ func extractAlterSequenceStatements(exportDir string) {
 		}
 	}
 
-	os.WriteFile(filepath.Join(exportDir, "data", "postdata.sql"), []byte(requiredLines.String()), 0644)
+	err = os.WriteFile(filepath.Join(exportDir, "data", "postdata.sql"), []byte(requiredLines.String()), 0644)
+	if err != nil {
+		utils.ErrExit("failed to write postdata.sql: %w", err)
+	}
 }
 
 // extract all identity column names from ALTER SEQUENCE IF EXISTS statements in postdata.sql

--- a/yb-voyager/src/srcdb/pg_dump_extract_schema.go
+++ b/yb-voyager/src/srcdb/pg_dump_extract_schema.go
@@ -241,7 +241,10 @@ func parseSchemaFile(exportDir string, schemaDir string, exportObjectTypesList [
 		msg := fmt.Sprintf("\nIMPORTANT NOTE: Please, review and manually import the DDL statements from the %q\n", filePath)
 		color.Red(msg)
 		log.Info(msg)
-		os.WriteFile(filePath, []byte(setSessionVariables.String()+uncategorizedSqls.String()), 0644)
+		err := os.WriteFile(filePath, []byte(setSessionVariables.String()+uncategorizedSqls.String()), 0644)
+		if err != nil {
+			utils.ErrExit("failed to write %q: %w", filePath, err)
+		}
 		return 1
 	}
 

--- a/yb-voyager/src/tgtdb/event.go
+++ b/yb-voyager/src/tgtdb/event.go
@@ -686,7 +686,8 @@ func (eb *EventBatch) GetQueriesToInsertEventStatsByTable(migrationUUID uuid.UUI
 
 func (eb *EventBatch) GetTableNames() []sqlname.NameTuple {
 	tablenames := []sqlname.NameTuple{}
-	eb.EventCountsByTable.IterKV(func(nt sqlname.NameTuple, ec *EventCounter) (bool, error) {
+	// the callback never returns an error
+	_ = eb.EventCountsByTable.IterKV(func(nt sqlname.NameTuple, ec *EventCounter) (bool, error) {
 		tablenames = append(tablenames, nt)
 		return true, nil
 	})

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -827,7 +827,8 @@ func (pg *TargetPostgreSQL) RestoreSequences(sequencesLastVal *utils.StructMap[s
 	log.Infof("restoring sequences on target")
 	batch := pgx.Batch{}
 	restoreStmt := "SELECT pg_catalog.setval('%s', %d, true)"
-	sequencesLastVal.IterKV(func(sequenceTuple sqlname.NameTuple, lastValue int64) (bool, error) {
+	// batch assembly; the callback never returns an error
+	_ = sequencesLastVal.IterKV(func(sequenceTuple sqlname.NameTuple, lastValue int64) (bool, error) {
 		if lastValue == 0 {
 			// TODO: can be valid for cases like cyclic sequences
 			return true, nil
@@ -944,7 +945,7 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 					errorMsg = fmt.Sprintf("error executing stmt for event with vsn(%d) in batch(%s)", batch.Events[i].Vsn, batch.ID())
 				}
 				log.Errorf("%s : %v", errorMsg, err)
-				closeBatch()
+				_ = closeBatch() // best-effort; the original error below takes precedence
 				return false, fmt.Errorf("%s: %w", errorMsg, err)
 			}
 			switch true {

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -1096,7 +1096,8 @@ func (yb *TargetYugabyteDB) RestoreSequences(sequencesLastVal *utils.StructMap[s
 	log.Infof("restoring sequences on target")
 	batch := pgx.Batch{}
 	restoreStmt := "SELECT pg_catalog.setval('%s', %d, true)"
-	sequencesLastVal.IterKV(func(sequenceTuple sqlname.NameTuple, lastValue int64) (bool, error) {
+	// batch assembly; the callback never returns an error
+	_ = sequencesLastVal.IterKV(func(sequenceTuple sqlname.NameTuple, lastValue int64) (bool, error) {
 		if lastValue == 0 {
 			// TODO: can be valid for cases like cyclic sequences
 			log.Infof("sequence %s has last value 0, skipping", sequenceTuple.ForKey())
@@ -1247,7 +1248,7 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 					errorMsg = fmt.Sprintf("error executing stmt for event with vsn(%d) in batch(%s)", batch.Events[i].Vsn, batch.ID())
 				}
 				log.Errorf("%s : %v", errorMsg, err)
-				closeBatch()
+				_ = closeBatch() // best-effort; the original error below takes precedence
 				return false, fmt.Errorf("%s: %w", errorMsg, err)
 			}
 			switch true {


### PR DESCRIPTION
### Describe the changes in this pull request

Third PR of the errcheck stack: check-and-propagate (or `utils.ErrExit`, matching each call path's idiom) for dropped errors whose loss hides real failures.

- `metaDB.UpdateMigrationStatusRecord` ×7: rename-tables map, export table-list flag, source DB conf, on-PK-conflict action, archiving flags, and `EndMigrationRequested` — whose silent loss means data export never learns it should stop.
- `s3/gcs/az.ValidateObjectURL` ×3: **behavior change** — an invalid `--data-dir` bucket URL now fails fast at validation instead of silently passing and failing confusingly later.
- namereg persistence: `setDefaultSourceReplicaDBSchemaName` and `UnRegisterYBNames`' `reg.save()` now propagate.
- A true dropped-error bug: `sqlfiletransformer`'s IterKV callback can genuinely fail (index deparse error) and the outer error was discarded — a failure silently truncated the removed-redundant-indexes file.
- Also: end-migration report backup, per-table exported-snapshot rows in the data-migration report, `waitForDebeziumStartIfRequired`, csv row processor `Write`+`Error()`, `os.WriteFile` of `postdata.sql` (PG and ora2pg) and `uncategorized.sql`, task-picker chooser init, `closeBatch()` on CDC error paths (explicit best-effort; the original batch error takes precedence).
- `StructMap.IterKV` sites whose callbacks provably never return an error (display/message/callhome-payload assembly) are dismissed as `_ =` with a why-comment; they interleave with the checked sites in the same files, so they ride here rather than in the ignores PR.
- The deferred session-variable-reset IIFE in `importSchemaYugabyteDB.go` keeps its (inherently discarded) error, made explicit with `_ =`. Per review, `(*tgtConn)` remains an eagerly-evaluated defer-time argument — wrapping it in an outer closure would move the read to function-exit time, where the error paths set `(*tgtConn) = nil` and the closure's inverted guard would then nil-deref in `ResetSessionVariables`. The pre-existing inverted nil-guard (the reset body only ever runs when conn is nil, i.e. the closure has always been a no-op) is documented for follow-up rather than changed.

### Describe if there are any user-facing changes

Failure behavior only: migration-state persistence failures and invalid cloud-storage `--data-dir` URLs now error out loudly instead of being swallowed.

### How was this pull request tested?

- `go build ./...`, `go test -tags unit ./...` pass (zero failures).
- errcheck production findings: 205 → 164.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No (payload assembly sites only gained explicit `_ =` on never-erroring iterations; no shape or content change).

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
