### PR TITLE
errcheck 3d: explicitly dismiss best-effort and teardown errors

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -313,7 +313,7 @@ func assessMigration() (err error) {
 	parserIssueDetector.PopulateObjectUsages(objectUsagesStats)
 
 	// Stage 2: Assessing migration
-	tracker.StartStage("Assessing migration", 0, nil)
+	_ = tracker.StartStage("Assessing migration", 0, nil) // console progress UX; nothing actionable on error
 	err = runAssessment()
 	if err != nil {
 		tracker.FailStage()
@@ -322,7 +322,7 @@ func assessMigration() (err error) {
 	tracker.CompleteStage()
 
 	// Stage 3: Generate report
-	tracker.StartStage("Generating report", 0, nil)
+	_ = tracker.StartStage("Generating report", 0, nil) // console progress UX; nothing actionable on error
 	err = generateAssessmentReport(replicaDiscoveryInfoForCallhome)
 	if err != nil {
 		tracker.FailStage()

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -1002,7 +1002,7 @@ func waitForProcessToExit(pid int, forceShutdownAfterSeconds int) {
 		}
 		if forceShutdownAfterSeconds > 0 && secondsWaited > forceShutdownAfterSeconds {
 			log.Infof("force shutting down pid %d", pid)
-			process.Signal(syscall.SIGKILL)
+			_ = process.Signal(syscall.SIGKILL) // best-effort kill; the process may already be gone
 		}
 	}
 }

--- a/yb-voyager/cmd/importSchemaYugabyteDB.go
+++ b/yb-voyager/cmd/importSchemaYugabyteDB.go
@@ -173,7 +173,7 @@ func executeSqlFile(file string, objType string, skipFn func(string, string) boo
 
 	defer func() {
 		if tgtConn != nil {
-			tgtConn.Close(context.Background())
+			_ = tgtConn.Close(context.Background()) // teardown; close error is not actionable
 		}
 	}()
 
@@ -324,7 +324,7 @@ func executeSqlStmtWithRetries(tgtConn **ImportSchemaTargetConn, sqlInfo sqlInfo
 		if bool(flagPostSnapshotImport) && strings.Contains(objType, "INDEX") {
 			err = beforeIndexCreation(sqlInfo, (*tgtConn).GetConn(), objType)
 			if err != nil {
-				(*tgtConn).Close(context.Background())
+				_ = (*tgtConn).Close(context.Background()) // conn is being discarded
 				(*tgtConn) = nil
 				return fmt.Errorf("before index creation: %w", err)
 			}
@@ -339,19 +339,19 @@ func executeSqlStmtWithRetries(tgtConn **ImportSchemaTargetConn, sqlInfo sqlInfo
 		log.Errorf("DDL Execution Failed for %q: %s", sqlInfo.formattedStmt, err)
 		if strings.Contains(strings.ToLower(err.Error()), "conflicts with higher priority transaction") {
 			// creating fresh connection
-			(*tgtConn).Close(context.Background())
+			_ = (*tgtConn).Close(context.Background()) // conn is being discarded
 			(*tgtConn) = newTargetConn()
 			continue
 		} else if strings.Contains(strings.ToLower(err.Error()), strings.ToLower(SCHEMA_VERSION_MISMATCH_ERR)) &&
 			(objType == "INDEX" || objType == "PARTITION_INDEX") { // retriable error
 			// creating fresh connection
-			(*tgtConn).Close(context.Background())
+			_ = (*tgtConn).Close(context.Background()) // conn is being discarded
 			(*tgtConn) = newTargetConn()
 
 			// Extract the schema name and add to the index name
 			fullyQualifiedObjName, err := getIndexName(sqlInfo.stmt, sqlInfo.objName)
 			if err != nil {
-				(*tgtConn).Close(context.Background())
+				_ = (*tgtConn).Close(context.Background()) // conn is being discarded
 				(*tgtConn) = nil
 				return goerrors.Errorf("extract qualified index name from DDL [%v]: %v", sqlInfo.stmt, err)
 			}
@@ -360,7 +360,7 @@ func executeSqlStmtWithRetries(tgtConn **ImportSchemaTargetConn, sqlInfo sqlInfo
 			// `err` is already being used for retries, so using `err2`
 			err2 := dropIdx((*tgtConn).GetConn(), fullyQualifiedObjName)
 			if err2 != nil {
-				(*tgtConn).Close(context.Background())
+				_ = (*tgtConn).Close(context.Background()) // conn is being discarded
 				(*tgtConn) = nil
 				return fmt.Errorf("drop invalid index %q: %w", fullyQualifiedObjName, err2)
 			}
@@ -382,7 +382,7 @@ func executeSqlStmtWithRetries(tgtConn **ImportSchemaTargetConn, sqlInfo sqlInfo
 		break // no more iteration in case of non retriable error
 	}
 	if err != nil {
-		(*tgtConn).Close(context.Background())
+		_ = (*tgtConn).Close(context.Background()) // conn is being discarded
 		(*tgtConn) = nil
 		if missingRequiredSchemaObject(err) || isPercentTypeResolutionError(err) {
 			// Do nothing for deferred case

--- a/yb-voyager/cmd/root.go
+++ b/yb-voyager/cmd/root.go
@@ -224,7 +224,7 @@ Refer to docs (https://docs.yugabyte.com/preview/migrate/) for more details like
 
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cmd.Help()
+			_ = cmd.Help() // help printing; nothing actionable on error
 			os.Exit(0)
 		}
 	},

--- a/yb-voyager/src/dbzm/dbzm.go
+++ b/yb-voyager/src/dbzm/dbzm.go
@@ -287,7 +287,7 @@ func (d *Debezium) Stop() error {
 				}
 			}
 		}()
-		d.cmd.Wait()
+		_ = d.cmd.Wait() // reaping after a deliberate stop; a non-zero exit is expected here
 		d.done = true
 		log.Info("Stopped debezium.")
 	}

--- a/yb-voyager/test/cdcbench/artifact.go
+++ b/yb-voyager/test/cdcbench/artifact.go
@@ -111,7 +111,7 @@ func EnsureArtifact(b *testing.B, w Workload) (string, artifactManifest) {
 	}
 	manifest, err := generateArtifact(b, w, voyagerBin, dir, exportDir)
 	if err != nil {
-		os.RemoveAll(dir) // don't leave a half-built artifact behind
+		_ = os.RemoveAll(dir) // best-effort: don't leave a half-built artifact behind
 		b.Fatalf("cdcbench: generating artifact for workload %q: %v", w.Name, err)
 	}
 	return exportDir, manifest

--- a/yb-voyager/test/cdcbench/cdcbench.go
+++ b/yb-voyager/test/cdcbench/cdcbench.go
@@ -278,7 +278,7 @@ func runWorkload(b *testing.B, w Workload, hooks Hooks) workloadResult {
 			depthAvgSum += int64(sum / len(samples))
 		}
 
-		os.RemoveAll(runDir)
+		_ = os.RemoveAll(runDir) // best-effort bench-run cleanup
 	}
 
 	// benchstat-compatible metrics: totals normalized per iteration ("op" =


### PR DESCRIPTION
### Describe the changes in this pull request

Fourth PR of the errcheck stack: the remaining production sites where ignoring the error IS the correct behavior, converted from bare calls to explicit `_ = call()` with a why-comment each. The point: errcheck distinguishes "author consciously discarded" (`_ =`) from "author possibly forgot" (bare call) — the #3714 bug was indistinguishable from intentional ignoring precisely because the codebase used bare calls for both. After this PR, a bare error-dropping call can only mean a mistake, which is what lets the gate (next PRs) flag it.

Sites: best-effort `SIGKILL` on a possibly-already-gone process, console progress stages in assess-migration, `cmd.Help()`, reaping Debezium after a deliberate stop (non-zero exit expected), `ImportSchemaTargetConn.Close` ×8 in import-schema retry/teardown paths (voyager-owned type, so the config-level pgx/sql exclusions do not cover it; the connection is being discarded in every case), and cdcbench best-effort directory cleanup.

After this PR every remaining production errcheck finding (150) is covered by the gate's documented `exclude-functions` policy list.

### Describe if there are any user-facing changes

No user-facing changes; no behavior changes at all (`_ =` is semantically identical to the bare call).

### How was this pull request tested?

- `go build ./...`, targeted unit tests pass.
- errcheck production findings: 164 → 150, all 150 exclusion-covered.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)