### PR TITLE
errcheck 3e: fixes surfaced while validating the wider linter set

### DIFF
--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -392,6 +392,9 @@ func fetchObjectUsageStats() ([]*types.ObjectUsageStats, error) {
 		}
 		objectUsagesStats = append(objectUsagesStats, &objectUsage)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating object usage stats: %w", err)
+	}
 	return objectUsagesStats, nil
 }
 
@@ -652,6 +655,9 @@ func fetchRedundantIndexInfoFromAssessmentDB() ([]utils.RedundantIndexesInfo, er
 		redundantIndex.DBType = source.DBType
 		redundantIndexesInfo = append(redundantIndexesInfo, redundantIndex)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating redundant indexes: %w", err)
+	}
 
 	resolvedRedundantIndexes := getResolvedRedundantIndexes(redundantIndexesInfo)
 
@@ -729,6 +735,9 @@ func fetchColumnStatisticsInfo() ([]utils.ColumnStatistics, error) {
 		}
 		stat.DBType = source.DBType
 		columnStats = append(columnStats, stat)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating column statistics: %w", err)
 	}
 	return columnStats, nil
 }

--- a/yb-voyager/cmd/assessMigrationCommand.go
+++ b/yb-voyager/cmd/assessMigrationCommand.go
@@ -379,7 +379,7 @@ func fetchObjectUsageStats() ([]*types.ObjectUsageStats, error) {
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			log.Warnf("error closing rows while fetching object usage stats %v", err)
+			log.Warnf("error closing rows while fetching object usage stats %v", closeErr)
 		}
 	}()
 
@@ -639,7 +639,7 @@ func fetchRedundantIndexInfoFromAssessmentDB() ([]utils.RedundantIndexesInfo, er
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			log.Warnf("error closing rows while fetching redundant indexes %v", err)
+			log.Warnf("error closing rows while fetching redundant indexes %v", closeErr)
 		}
 	}()
 
@@ -722,7 +722,7 @@ func fetchColumnStatisticsInfo() ([]utils.ColumnStatistics, error) {
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			log.Warnf("error closing rows while fetching column statistics %v", err)
+			log.Warnf("error closing rows while fetching column statistics %v", closeErr)
 		}
 	}()
 
@@ -1005,7 +1005,7 @@ func fetchUnsupportedObjectTypes() ([]UnsupportedFeature, error) {
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			log.Warnf("error closing rows while fetching object type mapping metadata: %v", err)
+			log.Warnf("error closing rows while fetching object type mapping metadata: %v", closeErr)
 		}
 	}()
 
@@ -1141,7 +1141,7 @@ func fetchUnsupportedQueryConstructs() ([]utils.UnsupportedQueryConstruct, error
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			log.Warnf("error closing rows while fetching database queries summary metadata: %v", err)
+			log.Warnf("error closing rows while fetching database queries summary metadata: %v", closeErr)
 		}
 	}()
 
@@ -1228,7 +1228,7 @@ func fetchColumnsWithUnsupportedDataTypes() ([]utils.TableColumnsDataTypes, []ut
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			log.Warnf("error closing rows while fetching unsupported datatypes metadata: %v", err)
+			log.Warnf("error closing rows while fetching unsupported datatypes metadata: %v", closeErr)
 		}
 	}()
 

--- a/yb-voyager/cmd/cdc_ingest_bench_test.go
+++ b/yb-voyager/cmd/cdc_ingest_bench_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 	"github.com/yugabyte/yb-voyager/yb-voyager/test/cdcbench"
 )
@@ -114,7 +115,9 @@ func BenchmarkCDCIngest(b *testing.B) {
 		// metadata (answered by the mock's metadata store), conflict cache,
 		// stats reporter, and the segment loop
 		StreamAll: func() error {
-			return streamChanges(run.state, run.tableList)
+			// bench workloads use default pk partitioning; no per-table PK-column
+			// overrides are needed (parameter added for custom partition keys)
+			return streamChanges(run.state, run.tableList, utils.NewStructMap[sqlname.NameTuple, []string]())
 		},
 
 		CacheDepth: func() int {

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -653,7 +653,7 @@ func detectVersionCompatibility(msrVoyagerVersionString string, migrationExportD
 				"Either use a compatible version to continue the migration or start afresh with a new export-dir. ",
 				migrationExportDir, utils.YB_VOYAGER_VERSION, utils.PREVIOUS_BREAKING_CHANGE_VERSION)
 		}
-		utils.ErrExit(userFacingMsg)
+		utils.ErrExit("%s", userFacingMsg)
 	}
 }
 

--- a/yb-voyager/cmd/exportDataStatusCommand.go
+++ b/yb-voyager/cmd/exportDataStatusCommand.go
@@ -54,7 +54,7 @@ var exportDataStatusCmd = &cobra.Command{
 			utils.ErrExit("error while checking streaming mode: %w\n", err)
 		}
 		if streamChanges {
-			utils.ErrExit("\nNote: Run the following command to get the current report of live migration:\n" +
+			utils.ErrExit("%s", "\nNote: Run the following command to get the current report of live migration:\n"+
 				color.CyanString("yb-voyager get data-migration-report --export-dir %q\n", exportDir))
 		}
 		err = InitNameRegistry(exportDir, namereg.SOURCE_DB_EXPORTER_STATUS_ROLE, nil, nil, nil, nil, false)

--- a/yb-voyager/cmd/exportSchemaOptimizationReport.go
+++ b/yb-voyager/cmd/exportSchemaOptimizationReport.go
@@ -116,7 +116,7 @@ func (s *SchemaOptimizationReport) Summary() string {
 	}
 	if s.UKRangeShardingChange != nil {
 		summary += fmt.Sprintf("%d. %s\n", idx, s.UKRangeShardingChange.Summary())
-		// idx deliberately not incremented after the last section; re-add when appending sections
+		idx++ //nolint:ineffassign,staticcheck // kept for uniformity with the sections above; a section appended below will read it
 	}
 	return summary
 }

--- a/yb-voyager/cmd/exportSchemaOptimizationReport.go
+++ b/yb-voyager/cmd/exportSchemaOptimizationReport.go
@@ -116,7 +116,7 @@ func (s *SchemaOptimizationReport) Summary() string {
 	}
 	if s.UKRangeShardingChange != nil {
 		summary += fmt.Sprintf("%d. %s\n", idx, s.UKRangeShardingChange.Summary())
-		idx++
+		// idx deliberately not incremented after the last section; re-add when appending sections
 	}
 	return summary
 }

--- a/yb-voyager/cmd/importDataFileTaskImporterErrorPolicy_test.go
+++ b/yb-voyager/cmd/importDataFileTaskImporterErrorPolicy_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sourcegraph/conc/pool"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
@@ -59,8 +60,8 @@ func assertTableRowCount(t *testing.T, tableName string, expectedCount int64) {
 func assertTableIds(t *testing.T, tableName string, expectedIds []int64) {
 	var ids []int64
 	rows, err := tdb.Query(fmt.Sprintf("SELECT id FROM %s", tableName))
+	require.NoError(t, err) // must halt here: a nil rows would panic in the defer below
 	defer rows.Close()
-	assert.NoError(t, err)
 
 	for rows.Next() {
 		var id int64

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -50,7 +50,7 @@ var importDataStatusCmd = &cobra.Command{
 			utils.ErrExit("error while checking streaming mode: %w\n", err)
 		}
 		if streamChanges {
-			utils.ErrExit("\nNote: Run the following command to get the report of live migration:\n" +
+			utils.ErrExit("%s", "\nNote: Run the following command to get the report of live migration:\n"+
 				color.CyanString("yb-voyager get data-migration-report --export-dir %q\n", exportDir))
 		}
 		dataFileDescriptorPath := filepath.Join(exportDir, datafile.DESCRIPTOR_PATH)

--- a/yb-voyager/cmd/importData_test.go
+++ b/yb-voyager/cmd/importData_test.go
@@ -982,7 +982,7 @@ func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintVi
 	w.Write([]string{
 		fmt.Sprintf("%d", 101),
 		"user101",
-		fmt.Sprintf("user100@gmail.com"), // duplicate email
+		"user100@gmail.com", // duplicate email
 	})
 
 	w.Flush() // flush the writer to ensure all data is written
@@ -1073,7 +1073,7 @@ func TestImportDataFile_FastPath_OnPrimaryKeyConflictAsIgnore_UniqueConstraintVi
 	w.Write([]string{
 		fmt.Sprintf("%d", 100), // duplicate id
 		"user101",
-		fmt.Sprintf("user101@gmail.com"),
+		"user101@gmail.com",
 	})
 
 	w.Flush() // flush the writer to ensure all data is written

--- a/yb-voyager/src/callhome/diagnostics.go
+++ b/yb-voyager/src/callhome/diagnostics.go
@@ -629,12 +629,12 @@ func findInnermostGoError(err error) *goerrors.Error {
 			return
 		}
 
-		if goErr, ok := curr.(*goerrors.Error); ok && depth >= deepestDepth {
+		if goErr, ok := curr.(*goerrors.Error); ok && depth >= deepestDepth { //nolint:errorlint // deliberate per-node check inside a manual unwrap walk
 			deepest = goErr
 			deepestDepth = depth
 		}
 
-		switch unwrapped := curr.(type) {
+		switch unwrapped := curr.(type) { //nolint:errorlint // deliberate per-node traversal of the unwrap tree
 		case interface{ Unwrap() []error }:
 			for _, child := range unwrapped.Unwrap() {
 				walk(child, depth+1)

--- a/yb-voyager/src/cp/yugabyted/yugabyted_test.go
+++ b/yb-voyager/src/cp/yugabyted/yugabyted_test.go
@@ -62,6 +62,7 @@ func TestYugabyteDTableSchema(t *testing.T) {
 	assert.NoError(t, err)
 	// Export the database connection string to env variable YUGABYTED_DB_CONN_STRING
 	err = os.Setenv("YUGABYTED_DB_CONN_STRING", dsn)
+	assert.NoError(t, err)
 
 	exportDir := filepath.Join(os.TempDir(), "yugabyted")
 

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -266,9 +266,9 @@ func (adb *AssessmentDB) BulkInsert(table string, records [][]string) error {
 	}
 
 	defer func() {
-		err = tx.Rollback()
-		if err != nil && errors.Is(err, sql.ErrTxDone) {
-			log.Warnf("error while rollback the BulkInsert txn: %v", err)
+		errRollBack := tx.Rollback()
+		if errRollBack != nil && !errors.Is(errRollBack, sql.ErrTxDone) {
+			log.Warnf("error while rollback the BulkInsert txn: %v", errRollBack)
 		}
 	}()
 

--- a/yb-voyager/src/migassessment/assessmentDB.go
+++ b/yb-voyager/src/migassessment/assessmentDB.go
@@ -280,6 +280,7 @@ func (adb *AssessmentDB) BulkInsert(table string, records [][]string) error {
 	if err != nil {
 		return fmt.Errorf("error preparing statement for bulk insert into %s: %w", table, err)
 	}
+	defer stmt.Close()
 
 	for rowNum := 1; rowNum < len(records); rowNum++ {
 		row := utils.ConvertStringSliceToInterface(records[rowNum])

--- a/yb-voyager/src/migassessment/gather.go
+++ b/yb-voyager/src/migassessment/gather.go
@@ -18,6 +18,7 @@ package migassessment
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -486,7 +487,8 @@ func runGatherAssessmentMetadataScript(
 
 	err = cmd.Wait()
 	if err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
+		var exiterr *exec.ExitError
+		if errors.As(err, &exiterr) {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 				if status.ExitStatus() == 2 {
 					log.Infof("Exit without error as user opted not to continue in the script.")

--- a/yb-voyager/src/monitor/monitor_target_health.go
+++ b/yb-voyager/src/monitor/monitor_target_health.go
@@ -245,7 +245,7 @@ func (m *MonitorTargetYBHealth) monitorReplicationOnTarget() error {
 		return goerrors.Errorf("error fetching logical replication slots for checking if replication enabled - %s", err)
 	}
 	if numOfSlots > 0 {
-		utils.ErrExit(color.RedString("%s Found replication slot(s): %d.", REPLICATION_GUARDRAIL_ALERT_MSG, numOfSlots))
+		utils.ErrExit("%s", color.RedString("%s Found replication slot(s): %d.", REPLICATION_GUARDRAIL_ALERT_MSG, numOfSlots))
 	}
 	if m.loadBalancerEnabled {
 		//No need to do the ybClient check in this load balancer case or deployements where nodes/ports are not accessible e.g. YBM
@@ -256,7 +256,7 @@ func (m *MonitorTargetYBHealth) monitorReplicationOnTarget() error {
 		return goerrors.Errorf("error fetching num of replication streams: %v", err)
 	}
 	if numOfStreams > 0 {
-		utils.ErrExit(color.RedString("%s Found replication stream(s): %d.", REPLICATION_GUARDRAIL_ALERT_MSG, numOfStreams))
+		utils.ErrExit("%s", color.RedString("%s Found replication stream(s): %d.", REPLICATION_GUARDRAIL_ALERT_MSG, numOfStreams))
 	}
 	return nil
 }

--- a/yb-voyager/src/pgss/parser.go
+++ b/yb-voyager/src/pgss/parser.go
@@ -18,6 +18,7 @@ package pgss
 import (
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -49,7 +50,7 @@ func ParseFromCSV(csvPath string) ([]*PgStatStatements, error) {
 	lineNumber := 1 // Header is line 0
 	for {
 		record, err := reader.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return nil, fmt.Errorf("failed to read CSV row at line %d: %w", lineNumber, err)

--- a/yb-voyager/src/query/queryissue/issues_ddl_test.go
+++ b/yb-voyager/src/query/queryissue/issues_ddl_test.go
@@ -1156,6 +1156,7 @@ func testPKandUKONComplexDataType(t *testing.T) {
 	}
 }
 
+//nolint:unused // kept for the disabled extension-support subtest (see the commented t.Run below)
 func testExtensionSupportList(t *testing.T) {
 	conn, err := getConn()
 	assert.NoError(t, err)

--- a/yb-voyager/src/testlivemigration/live_migration_integration_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_integration_test.go
@@ -951,8 +951,8 @@ FROM generate_series(1, 15);`,
 
 	err = lm.WithTargetConn(func(target *sql.DB) error {
 		//Check if always is restored back
-		query := fmt.Sprintf(`SELECT column_name FROM information_schema.columns where table_schema='test_schema' AND
-		table_name='test_live' AND is_identity='YES' AND identity_generation='ALWAYS'`)
+		query := `SELECT column_name FROM information_schema.columns where table_schema='test_schema' AND
+		table_name='test_live' AND is_identity='YES' AND identity_generation='ALWAYS'`
 
 		var col string
 		err = target.QueryRow(query).Scan(&col)
@@ -1031,7 +1031,8 @@ FROM generate_series(1, 10);`,
 	err = lm.StopImportData()
 	testutils.FatalIfError(t, err, "failed to stop import data")
 
-	err = lm.ResumeImportData(false, map[string]string{
+	// the resume is expected to fail; the guardrail message is asserted on stderr below
+	_ = lm.ResumeImportData(false, map[string]string{
 		"--cdc-partition-key": "pk",
 	})
 
@@ -1063,6 +1064,7 @@ FROM generate_series(1, 10);`,
 		}
 		return nil
 	})
+	testutils.FatalIfError(t, err, "failed to recreate table on target")
 
 	err = lm.ResumeImportData(true, map[string]string{
 		"--cdc-partition-key": "pk",
@@ -2746,6 +2748,7 @@ func TestLiveMigrationWithFallbackWithMultipleIterationsWithFailureScenariosDuri
 			Deletes: 0,
 		},
 	}, 30, 1)
+	testutils.FatalIfError(t, err, "failed to wait for fallback streaming to complete")
 
 	// stopping export data from target
 	err = lm.StopExportDataFromTarget()
@@ -2811,6 +2814,7 @@ func TestLiveMigrationWithFallbackWithMultipleIterationsWithFailureScenariosDuri
 	err = lm.InitiateCutoverToSource(map[string]string{
 		"--restart-data-migration-source-target": "true",
 	})
+	testutils.FatalIfError(t, err, "failed to initiate cutover to source")
 
 	err = lm.StartImportDataToSource(true, nil)
 	testutils.FatalIfError(t, err, "failed to start import data to source")

--- a/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_partitions_integrations_test.go
@@ -1236,7 +1236,8 @@ func validatingPartitionConsistencyCheck(lm *LiveMigrationTest) {
 	})
 	testutils.FatalIfError(lm.t, err, "failed to drop table")
 
-	err = lm.StartImportDataWithPromptAnswerNo(false, map[string]string{
+	// the import is expected to abort at the prompt; asserted on stderr below
+	_ = lm.StartImportDataWithPromptAnswerNo(false, map[string]string{
 		"--use-partition-root": "false",
 	})
 

--- a/yb-voyager/src/tgtdb/conn_pool_test.go
+++ b/yb-voyager/src/tgtdb/conn_pool_test.go
@@ -239,7 +239,7 @@ func TestRemoveConnectionsForHosts(t *testing.T) {
 
 	var conn *pgx.Conn
 	for i := 0; i < 4; i++ {
-		conn, _ = <-pool.conns
+		conn = <-pool.conns
 		if conn == nil {
 			conn, err = pool.createNewConnection()
 			testutils.FatalIfError(t, err)
@@ -250,7 +250,7 @@ func TestRemoveConnectionsForHosts(t *testing.T) {
 	}
 
 	for i := 0; i < 2; i++ {
-		conn, _ = <-pool.idleConns
+		conn = <-pool.idleConns
 		if conn == nil {
 			conn, err = pool.createNewConnection()
 			testutils.FatalIfError(t, err)

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -533,7 +534,7 @@ func (tdb *TargetOracleDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBat
 		}
 		defer func() {
 			errRollBack := tx.Rollback()
-			if errRollBack != nil && errRollBack != sql.ErrTxDone {
+			if errRollBack != nil && !errors.Is(errRollBack, sql.ErrTxDone) {
 				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), err)
 			}
 		}()

--- a/yb-voyager/src/tgtdb/oracle.go
+++ b/yb-voyager/src/tgtdb/oracle.go
@@ -535,7 +535,7 @@ func (tdb *TargetOracleDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBat
 		defer func() {
 			errRollBack := tx.Rollback()
 			if errRollBack != nil && !errors.Is(errRollBack, sql.ErrTxDone) {
-				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), err)
+				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), errRollBack)
 			}
 		}()
 		var rowsAffectedInserts, rowsAffectedDeletes, rowsAffectedUpdates int64

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -909,7 +909,7 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		defer func() {
 			errRollBack := tx.Rollback(ctx)
 			if errRollBack != nil && !errors.Is(errRollBack, pgx.ErrTxClosed) {
-				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), err)
+				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), errRollBack)
 			}
 		}()
 

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -908,7 +908,7 @@ func (pg *TargetPostgreSQL) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		}
 		defer func() {
 			errRollBack := tx.Rollback(ctx)
-			if errRollBack != nil && errRollBack != pgx.ErrTxClosed {
+			if errRollBack != nil && !errors.Is(errRollBack, pgx.ErrTxClosed) {
 				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), err)
 			}
 		}()

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -960,7 +960,7 @@ func (yb *TargetYugabyteDB) importBatchFastRecover(conn *pgx.Conn, batch Batch, 
 	}
 	for {
 		line, _, readLinErr := df.NextLine()
-		if readLinErr != nil && readLinErr != io.EOF {
+		if readLinErr != nil && !errors.Is(readLinErr, io.EOF) {
 			return 0, newImportBatchErrorPgYb(err, batch,
 				errs.IMPORT_BATCH_ERROR_FLOW_COPY_RECOVER,
 				errs.IMPORT_BATCH_ERROR_STEP_READ_LINE_BATCH, nil)
@@ -972,7 +972,7 @@ func (yb *TargetYugabyteDB) importBatchFastRecover(conn *pgx.Conn, batch Batch, 
 			2. line!=""(last line) + EOF error
 		*/
 		if line == "" { // handles case 1
-			if readLinErr == io.EOF {
+			if errors.Is(readLinErr, io.EOF) {
 				break
 			} else {
 				// skipping if any empty line (not expected from batch file)
@@ -1197,7 +1197,7 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		}
 		defer func() {
 			errRollBack := tx.Rollback(ctx)
-			if errRollBack != nil && errRollBack != pgx.ErrTxClosed {
+			if errRollBack != nil && !errors.Is(errRollBack, pgx.ErrTxClosed) {
 				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), err)
 			}
 		}()
@@ -1431,7 +1431,7 @@ func (yb *TargetYugabyteDB) GetYBServers() (bool, []*TargetConf, error) {
 						msg = fmt.Sprintf("public ip is not available for host: %s but private ip are available. "+
 							"Either refer to help for how to enable public ip or remove --use-public-up flag and restart the import", host)
 					}
-					utils.ErrExit(msg)
+					utils.ErrExit("%s", msg)
 				}
 			} else {
 				clone.Host = host

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -961,7 +961,7 @@ func (yb *TargetYugabyteDB) importBatchFastRecover(conn *pgx.Conn, batch Batch, 
 	for {
 		line, _, readLinErr := df.NextLine()
 		if readLinErr != nil && !errors.Is(readLinErr, io.EOF) {
-			return 0, newImportBatchErrorPgYb(err, batch,
+			return 0, newImportBatchErrorPgYb(readLinErr, batch,
 				errs.IMPORT_BATCH_ERROR_FLOW_COPY_RECOVER,
 				errs.IMPORT_BATCH_ERROR_STEP_READ_LINE_BATCH, nil)
 		}
@@ -1013,7 +1013,7 @@ func (yb *TargetYugabyteDB) importBatchFastRecover(conn *pgx.Conn, batch Batch, 
 			log.Warnf("Unexpected: COPY command for line=%q in batch %s returned 0 rows affected which is not expected", line, batch.GetFilePath())
 		}
 
-		if readLinErr == io.EOF { // handles case 2
+		if errors.Is(readLinErr, io.EOF) { // handles case 2
 			log.Infof("reached end of file %s", batch.GetFilePath())
 			break
 		}
@@ -1198,7 +1198,7 @@ func (yb *TargetYugabyteDB) ExecuteBatch(migrationUUID uuid.UUID, batch *EventBa
 		defer func() {
 			errRollBack := tx.Rollback(ctx)
 			if errRollBack != nil && !errors.Is(errRollBack, pgx.ErrTxClosed) {
-				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), err)
+				log.Errorf("error rolling back tx for batch id (%s): %v", batch.ID(), errRollBack)
 			}
 		}()
 

--- a/yb-voyager/src/utils/sqlname/sqlname.go
+++ b/yb-voyager/src/utils/sqlname/sqlname.go
@@ -61,22 +61,16 @@ func (i Identifier) CaseInSensitiveMatch(other Identifier) bool {
 }
 
 func (i Identifier) FindBestMatchingIdenitifier(schemaIdenitifiers []Identifier) (bool, Identifier) {
-	var matchedSchema bool
 	for _, schema := range schemaIdenitifiers {
 		if schema.CaseSensitiveMatch(i) {
-			matchedSchema = true
 			return true, schema
 		}
 	}
-	if !matchedSchema {
-		//If not matched with any case sensitive match, then check for in case sensitive match
-		for _, schemaOnDB := range schemaIdenitifiers {
-			if schemaOnDB.CaseInSensitiveMatch(i) {
-				matchedSchema = true
-				return true, schemaOnDB
-			}
+	//If not matched with any case sensitive match, then check for in case sensitive match
+	for _, schemaOnDB := range schemaIdenitifiers {
+		if schemaOnDB.CaseInSensitiveMatch(i) {
+			return true, schemaOnDB
 		}
-
 	}
 	return false, Identifier{}
 }

--- a/yb-voyager/src/utils/utils.go
+++ b/yb-voyager/src/utils/utils.go
@@ -389,7 +389,7 @@ func GetLocalIP() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // udp probe teardown; close error is not actionable
 
 	localAddress := conn.LocalAddr().(*net.UDPAddr)
 	return localAddress.IP.String(), nil

--- a/yb-voyager/test/cdcbench/artifact.go
+++ b/yb-voyager/test/cdcbench/artifact.go
@@ -409,7 +409,11 @@ func pollUntil(timeout, interval time.Duration, procDone <-chan error, cond func
 		}
 		select {
 		case err := <-procDone:
-			return fmt.Errorf("export data exited early: %v", err)
+			if err == nil {
+				// exec.Wait returns nil on a clean exit-0, which is still "too early" here
+				return fmt.Errorf("export data exited early with status 0")
+			}
+			return fmt.Errorf("export data exited early: %w", err)
 		case <-ticker.C:
 		}
 	}

--- a/yb-voyager/test/containers/mysql_container.go
+++ b/yb-voyager/test/containers/mysql_container.go
@@ -227,7 +227,7 @@ func (ms *MysqlContainer) Query(sql string, args ...interface{}) (*sql.Rows, err
 	}
 	defer db.Close()
 
-	rows, err := db.Query(sql, args...)
+	rows, err := db.Query(sql, args...) //nolint:sqlclosecheck // rows are returned to and closed by the caller
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/yb-voyager/test/containers/oracle_container.go
+++ b/yb-voyager/test/containers/oracle_container.go
@@ -226,7 +226,7 @@ func (ora *OracleContainer) Query(sql string, args ...interface{}) (*sql.Rows, e
 	}
 	defer conn.Close()
 
-	rows, err := conn.Query(sql, args...)
+	rows, err := conn.Query(sql, args...) //nolint:sqlclosecheck // rows are returned to and closed by the caller
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/yb-voyager/test/containers/postgres_container.go
+++ b/yb-voyager/test/containers/postgres_container.go
@@ -311,7 +311,7 @@ func (pg *PostgresContainer) Query(sql string, args ...interface{}) (*sql.Rows, 
 		return nil, fmt.Errorf("failed to get connection for postgres query: %w", err)
 	}
 	defer conn.Close()
-	rows, err := conn.Query(sql, args...)
+	rows, err := conn.Query(sql, args...) //nolint:sqlclosecheck // rows are returned to and closed by the caller
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query '%s': %w", sql, err)
 	}

--- a/yb-voyager/test/utils/cmdutils.go
+++ b/yb-voyager/test/utils/cmdutils.go
@@ -58,7 +58,7 @@ func RunVoyagerCommand(container testcontainers.TestContainer,
 		// Gather DB connection info.
 		host, port, err = container.GetHostPort()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get host port for container: %v", err)
+			return nil, fmt.Errorf("failed to get host port for container: %w", err)
 		}
 
 		config = container.GetConfig()

--- a/yb-voyager/test/utils/export_data_failpoint_helpers.go
+++ b/yb-voyager/test/utils/export_data_failpoint_helpers.go
@@ -69,7 +69,7 @@ func verifyNoEventIDDuplicatesInternal(t *testing.T, exportDir string, failOnErr
 			filePath := filepath.Join(queueDir, entry.Name())
 			file, err := os.Open(filePath)
 			require.NoError(t, err, "Failed to open queue segment file")
-			defer file.Close()
+			defer func() { _ = file.Close() }() // read path; close error is not actionable
 
 			scanner := bufio.NewScanner(file)
 			for scanner.Scan() {
@@ -182,10 +182,10 @@ func CollectEventIDsForOffsetCommitTest(exportDir string) (map[string]struct{}, 
 			eventIDs[eventID] = struct{}{}
 		}
 		if err := scanner.Err(); err != nil {
-			f.Close()
+			_ = f.Close() // best-effort cleanup on the error path
 			return nil, err
 		}
-		f.Close()
+		_ = f.Close() // read path; close error is not actionable
 	}
 	return eventIDs, nil
 }
@@ -222,7 +222,7 @@ func CountDedupSkipLogs(exportDir string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read path; close error is not actionable
 
 	count := 0
 	scanner := bufio.NewScanner(f)
@@ -345,7 +345,7 @@ func IsQueueSegmentClosed(filePath string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() // read path; close error is not actionable
 
 	scanner := bufio.NewScanner(file)
 	var lastNonEmpty string

--- a/yb-voyager/test/utils/testutils.go
+++ b/yb-voyager/test/utils/testutils.go
@@ -113,6 +113,9 @@ func CheckTableStructureSqlite(db *sql.DB, tableName string, expectedColumns map
 			Default:    cp.Default,
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating table info for %s: %w", tableName, err)
+	}
 
 	// Compare actual columns with expected columns
 	for colName, expectedProps := range expectedColumns {
@@ -174,6 +177,9 @@ func CheckTableStructurePG(t *testing.T, db *sql.DB, schema, table string, expec
 			t.Fatalf("Failed to scan column metadata: %v", err)
 		}
 		actualColumns[colName] = col
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("Failed iterating column metadata: %v", err)
 	}
 
 	// Compare columns
@@ -239,6 +245,9 @@ func checkPrimaryKeyOfTablePG(t *testing.T, db *sql.DB, schema, table string, ex
 		for _, col := range columns {
 			primaryKeyColumns[col] = true
 		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("Failed iterating primary keys: %v", err)
 	}
 
 	// Check if the primary key columns match the expected primary key columns
@@ -420,7 +429,7 @@ func CreateTempFile(dir string, fileContents string, fileFormat string) (string,
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() // backstop; the success path checks Close below
 
 	// Write some text to the file
 	_, err = file.WriteString(fileContents)

--- a/yb-voyager/test/utils/voyager_cmd_runner.go
+++ b/yb-voyager/test/utils/voyager_cmd_runner.go
@@ -197,7 +197,7 @@ func (v *VoyagerCommandRunner) Prepare() error {
 		// Appending to CmdArgs based on the command type.
 		host, port, err := v.container.GetHostPort()
 		if err != nil {
-			return fmt.Errorf("failed to get host port for container: %v", err)
+			return fmt.Errorf("failed to get host port for container: %w", err)
 		}
 
 		config := v.container.GetConfig()
@@ -360,7 +360,8 @@ func (v *VoyagerCommandRunner) Wait() error {
 		v.logWriter.Flush()
 	}
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			v.exitCode = ExitCode(ee.ExitCode())
 		} else {
 			v.exitCode = ExitCodeFailure


### PR DESCRIPTION
### Describe the changes in this pull request

Fifth PR of the errcheck stack. While validating the gate config, the candidate linters (govet's printf analyzer, per-build-tag staticcheck/ineffassign runs, and the next-wave errorlint/rowserrcheck/sqlclosecheck) surfaced findings beyond errcheck; the real ones are fixed here even though only part of the candidate set gets enabled by the gate PR.

- **govet printf ×5**: `utils.ErrExit(msg)` with a non-constant format string — a message containing `%` verbs would be misrendered; now `ErrExit("%s", msg)`.
- **Missed error checks in tag-gated test code** (same disease as the rest of the stack, but in files no tool had ever linted — they only compile under `integration_live_migration`/`failpoint`/`integration` tags): an SA5001 (`defer rows.Close()` *before* checking the Query error), four genuinely unchecked `err = lm.X(...)` calls in live-migration tests (plus two expected-abort calls made explicitly `_ =` with comments), an unchecked `os.Setenv` in a yugabyted test.
- **errorlint (partial, ahead of enabling it)**: sentinel comparisons → `errors.Is` (`io.EOF`, `sql.ErrTxDone`, `pgx.ErrTxClosed`), error type assertions → `errors.As` (`exec.ExitError`), `%v` → `%w` in test helpers; callhome's manual unwrap-tree walker keeps its deliberate per-node assertions with nolint reasons.
- **rowserrcheck/sqlclosecheck (partial)**: `rows.Err()` checks after scan loops in assess-migration and test utils; a missing `stmt.Close` in assessmentDB bulk insert; container Query helpers annotated (rows are returned to and closed by the caller).
- **ineffassign**: dead `matchedSchema` logic simplified in `sqlname.FindBestMatchingIdenitifier`; the final `idx++` in `SchemaOptimizationReport.Summary()` is kept for uniformity with its sibling sections and suppressed with `//nolint:ineffassign,staticcheck` (golangci flags the never-read increment via both linters; standalone staticcheck does not — same fact-divergence family as the `helpers_protomsg.go` exclusion in the gate config).
- **`-tags cdc_benchmark` does not compile on main**: the bench shim's `streamChanges` call was never updated for the `tableToPKColumns` parameter, and no CI workflow builds that tag. Fixed (caught by linting every tag group).


Adopted from review (round 1):
- `tgtdb/yugabytedb.go`: the twin `== io.EOF` comparison 12 lines below the converted one is now also `errors.Is` (a wrapped EOF would previously have busy-looped `importBatchFastRecover`), and the YB `ExecuteBatch` rollback defer's `pgx.ErrTxClosed` sentinel is converted to match its postgres/oracle siblings.
- `importDataFileTaskImporterErrorPolicy_test.go`: `assert.NoError` → `require.NoError` before `defer rows.Close()` (assert continues on failure; a nil `rows` would panic in the defer).
- `test/cdcbench/artifact.go`: the `%w` on the early-exit error is nil-guarded — `exec.Wait()` returns nil on a clean exit-0, which previously rendered as `%!w(<nil>)`.

Adopted from review (round 2) — pre-existing wrong-variable/inverted-condition bugs on lines adjacent to this PR's conversions, surfaced by review:
- `importBatchFastRecover` now wraps `readLinErr` in the read-failure batch error — the old code wrapped `err`, which is provably nil at that point, so genuine read failures produced an error with no cause. The third `== io.EOF` comparison (case 2, last line + EOF) is also converted to `errors.Is`, completing the loop.
- The `ExecuteBatch` rollback defers in all three target drivers (`yugabytedb.go`, `postgres.go`, `oracle.go`) logged the closure's `err` — the batch error or nil — instead of `errRollBack`; a real rollback failure was logged with the wrong (or no) cause.
- `assessmentDB.BulkInsert`'s rollback warning was fully inverted: it fired only on `sql.ErrTxDone` (the benign, by-design outcome after a successful commit) and never on real rollback failures. Guard flipped to `!errors.Is`, with its own `errRollBack` variable, logging that variable.
- Six `rows.Close()` defers in `assessMigrationCommand.go` (dating to #2549) logged the outer `err` instead of `closeErr`.

### Describe if there are any user-facing changes

None. The `errors.Is`/`errors.As` conversions match wrapped errors where `==`/type-assertions matched only exact values — strictly more correct on the same sentinel/type. Rollback/close failure log lines now carry the actual rollback/close error instead of an unrelated (usually nil) one.

### How was this pull request tested?

- `go build ./...`, full `go test -tags unit ./...` pass; `go vet` clean under every build-tag combination.
- golangci-lint (gate config) verified clean across all 13 tag groups on this branch merged with the gate PR (the two remaining SA4023 findings on this branch alone are at the `StartMonitoring` site whose suppression conversion lands in the gate PR).

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
