### PR TITLE
errcheck 3f: adopt golangci-lint as the CI lint gate

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -69,17 +69,4 @@ jobs:
         cd yb-voyager
         go test -v ./... -tags 'unit'
         
-    # Run vet/staticcheck both without tags (the shipped build) and with -tags unit
-    # (unit-tagged test and helper files are otherwise never analyzed).
-    - name: Vet
-      run: |
-        cd yb-voyager
-        go vet ./...
-        go vet -tags unit ./...
-
-    - name: Run staticcheck
-      run: |
-        cd yb-voyager
-        go install honnef.co/go/tools/cmd/staticcheck@${{ needs.prepare-versions.outputs.staticcheck_version }}
-        staticcheck ./...
-        staticcheck -tags unit ./...
+    # Vet and staticcheck now run inside golangci-lint — see lint.yml.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,89 @@
+name: Lint
+
+on:
+  push:
+    branches: ['main', '*.*-dev', '*.*.*-dev']
+  pull_request:
+    branches: [main]
+
+jobs:
+  prepare-versions:
+    uses: ./.github/workflows/prepare-versions.yml
+
+  # golangci-lint (config: yb-voyager/.golangci.yml) runs errcheck, govet,
+  # staticcheck, ineffassign, and unused in one invocation.
+  #
+  # One step per build-tag group: the groups cannot be combined into a single
+  # run because test files of different tags redeclare symbols (e.g. TestMain)
+  # within the same package, so a combined-tags build does not compile.
+  # `if: ${{ !cancelled() }}` lets every group report even when an earlier one
+  # fails (the job still fails). golangci-lint's per-package cache makes the
+  # later steps incremental.
+  lint:
+    name: golangci-lint
+    needs: prepare-versions
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: yb-voyager
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ needs.prepare-versions.outputs.go_version }}
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" ${{ needs.prepare-versions.outputs.golangci_lint_version }}
+
+      - name: Lint (no build tags)
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...
+
+      - name: Lint (unit)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags unit ./...
+
+      - name: Lint (integration)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags integration ./...
+
+      - name: Lint (integration_voyager_command)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags integration_voyager_command ./...
+
+      - name: Lint (integration_live_migration)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags integration_live_migration ./...
+
+      - name: Lint (issues_integration)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags issues_integration ./...
+
+      - name: Lint (failpoint_export)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags failpoint_export ./...
+
+      - name: Lint (failpoint_import)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags failpoint_import ./...
+
+      - name: Lint (failpoint_cutover)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags failpoint_cutover ./...
+
+      - name: Lint (cdc_benchmark)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags cdc_benchmark ./...
+
+      - name: Lint (manual)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags manual ./...
+
+      - name: Lint (yb_version_latest_stable)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags yb_version_latest_stable ./...
+
+      - name: Lint (connector_latest_stable)
+        if: ${{ !cancelled() }}
+        run: golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --build-tags connector_latest_stable ./...

--- a/.github/workflows/prepare-versions.yml
+++ b/.github/workflows/prepare-versions.yml
@@ -15,9 +15,9 @@ on:
       java_version:
         description: "Java version from ci-config.json"
         value: ${{ jobs.prepare-versions.outputs.java_version }}
-      staticcheck_version:
-        description: "Staticcheck version from ci-config.json"
-        value: ${{ jobs.prepare-versions.outputs.staticcheck_version }}
+      golangci_lint_version:
+        description: "golangci-lint version from ci-config.json"
+        value: ${{ jobs.prepare-versions.outputs.golangci_lint_version }}
 
 jobs:
   prepare-versions:
@@ -27,7 +27,7 @@ jobs:
       yb_latest_stable: ${{ steps.extract-versions.outputs.yb_latest_stable }}
       go_version: ${{ steps.extract-versions.outputs.go_version }}
       java_version: ${{ steps.extract-versions.outputs.java_version }}
-      staticcheck_version: ${{ steps.extract-versions.outputs.staticcheck_version }}
+      golangci_lint_version: ${{ steps.extract-versions.outputs.golangci_lint_version }}
     steps:
       - uses: actions/checkout@v4
       - name: Extracting versions from central registry
@@ -57,15 +57,15 @@ jobs:
           # Extract CI versions from ci-config.json
           go_version=$(jq -r '.versions.go' yb-voyager/versions/ci-config.json)
           java_version=$(jq -r '.versions.java' yb-voyager/versions/ci-config.json)
-          staticcheck_version=$(jq -r '.versions.staticcheck' yb-voyager/versions/ci-config.json)
+          golangci_lint_version=$(jq -r '.versions.golangci_lint' yb-voyager/versions/ci-config.json)
           
           echo "Go Version: $go_version"
           echo "Java Version: $java_version"
-          echo "Staticcheck Version: $staticcheck_version"
+          echo "golangci-lint Version: $golangci_lint_version"
           
           echo "go_version=$go_version" >> $GITHUB_OUTPUT
           echo "java_version=$java_version" >> $GITHUB_OUTPUT
-          echo "staticcheck_version=$staticcheck_version" >> $GITHUB_OUTPUT
+          echo "golangci_lint_version=$golangci_lint_version" >> $GITHUB_OUTPUT
       
       - name: Validate Go Version Consistency
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ The Go module uses build tags to separate test tiers. From `yb-voyager/`:
 
 Single test: `go test -tags unit -run TestName ./yb-voyager/cmd/...`
 
-Lint (from `yb-voyager/`), matching CI (`go.yml`): `go vet ./...`, `go vet -tags unit ./...`, `staticcheck ./...`, and `staticcheck -tags unit ./...` (pin the staticcheck version from `versions/ci-config.json`). `staticcheck.conf` disables `S1008` (explicit boolean returns) and `ST1005` (user-facing error strings are deliberately capitalized/punctuated) — when editing it, keep `"inherit"` as the first entry or every check is silently disabled. Also keep the tree `gofmt`-clean.
+Lint: `bash yb-voyager/scripts/lint.sh` runs golangci-lint over every build-tag group, exactly mirroring CI (`.github/workflows/lint.yml`); a single group is `golangci-lint run --build-tags unit ./...` from `yb-voyager/`. Config lives in `yb-voyager/.golangci.yml` (errcheck + govet + staticcheck + ineffassign + unused; the errcheck `exclude-functions` list is deliberate policy — read the comments before touching it), version pin in `versions/ci-config.json` (`golangci_lint`). `staticcheck.conf` remains for running standalone staticcheck and must stay in sync with the yaml's staticcheck checks — keep `"inherit"` as its first entry or every check is silently disabled. Keep new/edited files `gofmt`-clean (the tree still has legacy drift; a sweep is planned).
 
 End-to-end migtests are invoked outside Go: `bash migtests/scripts/run-test.sh <test-name> [env.sh]`. They build/use the installed `yb-voyager` binary and a real source DB + YugabyteDB target.
 

--- a/ai/skills/update-yb-latest-stable/SKILL.md
+++ b/ai/skills/update-yb-latest-stable/SKILL.md
@@ -197,7 +197,8 @@ Use the `babysit` skill to fix CI failures in a loop (do not weaken workflows to
 
 | Workflow | What it exercises |
 |----------|-------------------|
-| `Go` | Unit tests, staticcheck |
+| `Go` | Unit tests |
+| `Lint` | golangci-lint (errcheck, govet, staticcheck, ineffassign, unused) per build-tag group |
 | `Build Voyager` | Installer / build |
 | `Integration Tests` | Live migration @ `yb_latest_stable` |
 | `Failpoint Tests` | Failpoint flows @ `yb_latest_stable` |

--- a/yb-voyager/.golangci.yml
+++ b/yb-voyager/.golangci.yml
@@ -1,21 +1,43 @@
 # golangci-lint v2 configuration — the single lint entry point for this module.
-# CI runs it once per build-tag group (see .github/workflows/lint.yml); the tag
-# groups cannot be combined because test files of different tags redeclare
-# symbols (e.g. TestMain) in the same package.
+# The binary is pinned in versions/ci-config.json (`golangci_lint`).
+#
+# CI (.github/workflows/lint.yml) and scripts/lint.sh run it once per build-tag
+# group; the tag groups cannot be combined into one run because test files of
+# different tags redeclare symbols (e.g. TestMain) in the same package, so a
+# combined-tags build does not compile. The union of the groups covers every Go
+# file in the module.
 #
 # The errcheck exclude-functions list below is deliberate policy, not noise
 # suppression: an entry means "this method's error is safely ignorable at every
 # call site", with the rationale alongside. Anything not listed must handle its
 # error explicitly (check it, or `_ =` with a why-comment).
+
+# Config schema version for the golangci-lint v2.x binary (a v1 config is
+# rejected at startup).
 version: "2"
 
 linters:
+  # Deny-by-default: `none` plus an explicit enable list means upgrading
+  # golangci-lint can never silently add or remove linters from the gate.
+  # The gate is exactly the set below until someone edits this file.
   default: none
   enable:
+    # A bare call statement that drops an error return (the PR #3714 bug
+    # class) is caught by no other tool. Also makes void->error signature
+    # widenings unlandable without updating every call site.
     - errcheck
+    # Previously go.yml's standalone `go vet` step; runs inside the gate now.
     - govet
+    # Ineffectual assignments; overlaps staticcheck's SA4006 but catches
+    # shapes it misses, and is essentially free.
     - ineffassign
+    # The SA bug class (incl. SA4006 "err assigned, never read"). Replaces
+    # the standalone staticcheck CI step; check selection is under
+    # settings.staticcheck below.
     - staticcheck
+    # Dead-code detection (U1000). Standalone staticcheck bundles this in its
+    # default run, but golangci splits it into a separate linter — enabling
+    # staticcheck alone would silently narrow the gate vs. the standalone tool.
     - unused
     # TODO(lint): enable the next-wave linters, one PR each, after sweeping
     # that linter's remaining findings (measured Aug 2026: errorlint ~15,
@@ -26,30 +48,50 @@ linters:
     # - sqlclosecheck
   settings:
     staticcheck:
-      # Mirrors staticcheck's defaults (all minus the default ST excludes), plus:
-      # -S1008:  allow explicit boolean returns.
-      # -ST1005: user-facing CLI error strings are deliberately capitalized/punctuated.
+      # Goal: parity with the standalone staticcheck gate this replaces —
+      # neither wider nor narrower. golangci's default check selection for
+      # staticcheck differs from the standalone tool's defaults, so the list
+      # is spelled out explicitly.
       checks:
         - all
+        # ST1000/ST1003/ST1016/ST1020/ST1021/ST1022/ST1023 are default-OFF in
+        # standalone staticcheck 2025.1.1 (ST1023 verified empirically: a
+        # pre-existing violation sits on a staticcheck-green main). Excluded
+        # here to keep parity. Note SA4023 is deliberately NOT excluded — it
+        # is default-ON in the standalone tool.
         - -ST1000
         - -ST1003
+        # ST1005 and S1008 (below) are the project's two pre-existing
+        # opt-outs, carried over from staticcheck.conf:
+        # -ST1005: user-facing CLI error strings are deliberately
+        #          capitalized/punctuated.
         - -ST1005
         - -ST1016
         - -ST1020
         - -ST1021
         - -ST1022
         - -ST1023
+        # -S1008: explicit boolean returns are allowed for readability.
         - -S1008
         # QF* (quickfix) checks are not shipped by standalone staticcheck
-        # 2025.1.1 at all; excluded defensively for future golangci-bundled
-        # versions. ST1000/1003/1016/1020/1021/1022/1023 above mirror the
-        # standalone default set (ST1023 verified default-off in 2025.1.1);
-        # ST1005/S1008 are the project's pre-existing opt-outs.
+        # 2025.1.1 at all; excluded defensively so a future golangci-bundled
+        # staticcheck version cannot add checks the project never opted into.
         - -QF*
     errcheck:
+      # The bar for an entry here: the error must be safely ignorable at
+      # EVERY possible call site, not just the current ones. Deliberately NOT
+      # excluded (each call site handles these on its merits instead):
+      #   - (*os.File).Close — a write-path close error is a data-loss bug in
+      #     a migration tool; read-path defers use explicit `_ =`.
+      #   - cobra MarkFlagRequired/MarkHidden/MarkDeprecated — a typo'd flag
+      #     name must not silently no-op; see the mustMarkFlag* helpers.
+      #   - os.WriteFile / os.Remove / os.RemoveAll and similar — checked or
+      #     explicitly dismissed per site.
       exclude-functions:
         # Read-path/teardown closes: real failures surface via rows.Err()/Scan,
-        # which are checked; nothing actionable on close.
+        # which are checked; nothing actionable on close. Exclusions match on
+        # the exact receiver type, which is why pgx v4, pgx v5, and pgconn are
+        # all listed — the codebase uses all three.
         - (*database/sql.Rows).Close
         - (*database/sql.DB).Close
         - (*database/sql.Conn).Close
@@ -79,17 +121,22 @@ linters:
         - (hash.Hash).Write
         - (hash.Hash32).Write
   exclusions:
+    # Each rule below is scoped as narrowly as possible: to specific paths,
+    # to a single linter, and (where supported) to a message text — so the
+    # excluded check stays enforced everywhere else.
     rules:
       # TEMPORARY (removed by the test-modernization PR): test files carry
       # ~380 legacy errcheck findings, dominated by os.Setenv / os.RemoveAll
       # patterns that will become t.Setenv / t.TempDir. Production code is
-      # fully enforced.
+      # fully enforced, and staticcheck/govet/ineffassign/unused still run on
+      # test files — only errcheck is deferred.
       - path: _test\.go
         linters:
           - errcheck
       # Shared test helpers consumed by tests of DIFFERENT build tags; under
       # any single tag some helpers legitimately look unused, so `unused`
-      # cannot evaluate these files meaningfully in a per-tag lint run.
+      # cannot evaluate these files meaningfully in a per-tag lint run. All
+      # other linters still apply to them.
       - path: cmd/importData(Integration)?TestUtils\.go
         linters:
           - unused

--- a/yb-voyager/.golangci.yml
+++ b/yb-voyager/.golangci.yml
@@ -1,97 +1,89 @@
-# golangci-lint v2 configuration — the single lint entry point for this module.
-# The binary is pinned in versions/ci-config.json (`golangci_lint`).
+# golangci-lint v2 config — the single lint entry point for this module.
+# Binary pinned in versions/ci-config.json (`golangci_lint`).
 #
-# CI (.github/workflows/lint.yml) and scripts/lint.sh run it once per build-tag
-# group; the tag groups cannot be combined into one run because test files of
-# different tags redeclare symbols (e.g. TestMain) in the same package, so a
-# combined-tags build does not compile. The union of the groups covers every Go
-# file in the module.
-#
-# The errcheck exclude-functions list below is deliberate policy, not noise
-# suppression: an entry means "this method's error is safely ignorable at every
-# call site", with the rationale alongside. Anything not listed must handle its
-# error explicitly (check it, or `_ =` with a why-comment).
+# CI (.github/workflows/lint.yml) and scripts/lint.sh run this once per
+# build-tag group: tag groups cannot be combined (test files of different
+# tags redeclare symbols, e.g. TestMain), and the union of groups covers
+# every Go file in the module.
 
-# Config schema version for the golangci-lint v2.x binary (a v1 config is
-# rejected at startup).
+# Config schema for the v2.x binary (v1 configs are rejected).
 version: "2"
 
 linters:
-  # Deny-by-default: `none` plus an explicit enable list means upgrading
-  # golangci-lint can never silently add or remove linters from the gate.
-  # The gate is exactly the set below until someone edits this file.
+  # Deny-by-default: an upgrade of golangci-lint can never silently change
+  # the linter set; every addition/removal is an edit to this file.
   default: none
   enable:
-    # A bare call statement that drops an error return (the PR #3714 bug
-    # class) is caught by no other tool. Also makes void->error signature
-    # widenings unlandable without updating every call site.
+    # Bare dropped error returns (the PR #3714 bug class) — caught by no
+    # other tool.
     - errcheck
-    # Previously go.yml's standalone `go vet` step; runs inside the gate now.
+    # Was go.yml's standalone `go vet` step.
     - govet
-    # Ineffectual assignments; overlaps staticcheck's SA4006 but catches
-    # shapes it misses, and is essentially free.
+    # Ineffectual assignments; overlaps SA4006 but catches more shapes.
     - ineffassign
-    # The SA bug class (incl. SA4006 "err assigned, never read"). Replaces
-    # the standalone staticcheck CI step; check selection is under
-    # settings.staticcheck below.
+    # The SA bug class; replaces the standalone staticcheck CI step.
     - staticcheck
-    # Dead-code detection (U1000). Standalone staticcheck bundles this in its
-    # default run, but golangci splits it into a separate linter — enabling
-    # staticcheck alone would silently narrow the gate vs. the standalone tool.
+    # Dead code (U1000). Standalone staticcheck bundles this check; golangci
+    # splits it into its own linter, so it must be enabled for parity.
     - unused
-    # TODO(lint): enable the next-wave linters, one PR each, after sweeping
-    # that linter's remaining findings (measured Aug 2026: errorlint ~15,
-    # rowserrcheck ~40, sqlclosecheck ~8). Nothing prevents enabling them
-    # today except that the gate must be green the day a linter turns on.
+    # TODO(lint): next-wave linters, one enable-and-sweep PR each (findings
+    # measured Aug 2026: errorlint ~15, rowserrcheck ~40, sqlclosecheck ~8).
     # - errorlint
     # - rowserrcheck
     # - sqlclosecheck
   settings:
     staticcheck:
-      # Goal: parity with the standalone staticcheck gate this replaces —
-      # neither wider nor narrower. golangci's default check selection for
-      # staticcheck differs from the standalone tool's defaults, so the list
-      # is spelled out explicitly.
+      # Parity with the standalone staticcheck gate this replaces: golangci's
+      # default selection differs from the standalone tool's, so every
+      # deviation from `all` is listed explicitly. SA4023 is deliberately not
+      # excluded (default-on in the standalone tool).
       checks:
         - all
-        # ST1000/ST1003/ST1016/ST1020/ST1021/ST1022/ST1023 are default-OFF in
-        # standalone staticcheck 2025.1.1 (ST1023 verified empirically: a
-        # pre-existing violation sits on a staticcheck-green main). Excluded
-        # here to keep parity. Note SA4023 is deliberately NOT excluded — it
-        # is default-ON in the standalone tool.
+        # Missing/malformed package comment. Default-off in standalone
+        # staticcheck; the tree has no package-doc convention.
         - -ST1000
+        # Identifier naming style (initialisms, underscores). Default-off in
+        # standalone; enforcing it would rename exported legacy identifiers.
         - -ST1003
-        # ST1005 and S1008 (below) are the project's two pre-existing
-        # opt-outs, carried over from staticcheck.conf:
-        # -ST1005: user-facing CLI error strings are deliberately
-        #          capitalized/punctuated.
+        # Error-string capitalization/punctuation. Project opt-out (carried
+        # from staticcheck.conf): user-facing CLI errors are deliberately
+        # capitalized and punctuated.
         - -ST1005
+        # Inconsistent method-receiver names across a type. Default-off in
+        # standalone.
         - -ST1016
+        # Exported-function comment must start with the function name.
+        # Default-off in standalone.
         - -ST1020
+        # Exported-type comment must start with the type name. Default-off in
+        # standalone.
         - -ST1021
+        # Exported var/const comment must start with the identifier name.
+        # Default-off in standalone.
         - -ST1022
+        # Redundant type or default value in declarations. Default-off in
+        # standalone 2025.1.1 (verified: a violation sits on a green main).
         - -ST1023
-        # -S1008: explicit boolean returns are allowed for readability.
+        # "if cond { return true }; return false" simplification. Project
+        # opt-out (carried from staticcheck.conf): explicit boolean returns
+        # are allowed for readability.
         - -S1008
-        # QF* (quickfix) checks are not shipped by standalone staticcheck
-        # 2025.1.1 at all; excluded defensively so a future golangci-bundled
-        # staticcheck version cannot add checks the project never opted into.
+        # Editor quickfix suggestions; not shipped by standalone 2025.1.1 —
+        # excluded so a future golangci-bundled version cannot add checks the
+        # project never opted into.
         - -QF*
     errcheck:
-      # The bar for an entry here: the error must be safely ignorable at
-      # EVERY possible call site, not just the current ones. Deliberately NOT
-      # excluded (each call site handles these on its merits instead):
-      #   - (*os.File).Close — a write-path close error is a data-loss bug in
-      #     a migration tool; read-path defers use explicit `_ =`.
-      #   - cobra MarkFlagRequired/MarkHidden/MarkDeprecated — a typo'd flag
-      #     name must not silently no-op; see the mustMarkFlag* helpers.
-      #   - os.WriteFile / os.Remove / os.RemoveAll and similar — checked or
-      #     explicitly dismissed per site.
+      # Bar for an entry: the error must be safely ignorable at EVERY
+      # possible call site, with the reason alongside. Deliberately NOT
+      # excluded, handled per call site instead: (*os.File).Close (a
+      # write-path close error is a data-loss bug), cobra Mark* (a typo'd
+      # flag must not silently no-op — see the mustMarkFlag* helpers), and
+      # os.WriteFile/Remove/RemoveAll.
       exclude-functions:
-        # Read-path/teardown closes: real failures surface via rows.Err()/Scan,
-        # which are checked; nothing actionable on close. Exclusions match on
-        # the exact receiver type, which is why pgx v4, pgx v5, and pgconn are
-        # all listed — the codebase uses all three.
+        # sql/pgx teardown closes, matched by exact receiver type (pgx v4,
+        # v5, and pgconn are all in use). Close releases resources and never
+        # flushes user writes: SQL writes are durable at Exec/Commit (both
+        # checked), and read failures surface via rows.Err()/Scan.
         - (*database/sql.Rows).Close
         - (*database/sql.DB).Close
         - (*database/sql.Conn).Close
@@ -104,50 +96,43 @@ linters:
         - (*database/sql.Tx).Rollback
         # resp.Body and similar read-only bodies.
         - (io.ReadCloser).Close
-        # Console report/status rendering (verified: every production use
-        # writes to tabwriter/uilive buffers or stderr); buffered errors
-        # surface at Flush, which is handled at the call sites.
+        # Console report/status rendering to tabwriter/uilive buffers or
+        # stderr (verified for every production use); buffered errors surface
+        # at Flush, which is checked at the call sites.
         - fmt.Fprint
         - fmt.Fprintf
         - fmt.Fprintln
-        # Console UX color printers (fatih/color, incl. the ux package aliases).
+        # Console UX color printers (fatih/color, incl. the ux aliases).
         - (*github.com/fatih/color.Color).Print
         - (*github.com/fatih/color.Color).Printf
         - (*github.com/fatih/color.Color).Println
         - (*github.com/fatih/color.Color).Fprint
         - (*github.com/fatih/color.Color).Fprintf
         - (*github.com/fatih/color.Color).Fprintln
-        # Documented to never return an error.
-        - (hash.Hash).Write
-        - (hash.Hash32).Write
   exclusions:
-    # Each rule below is scoped as narrowly as possible: to specific paths,
-    # to a single linter, and (where supported) to a message text — so the
-    # excluded check stays enforced everywhere else.
+    # Each rule is scoped as narrowly as possible (path, single linter, and
+    # message text where supported) so the check stays enforced elsewhere.
     rules:
       # TEMPORARY (removed by the test-modernization PR): test files carry
-      # ~380 legacy errcheck findings, dominated by os.Setenv / os.RemoveAll
-      # patterns that will become t.Setenv / t.TempDir. Production code is
-      # fully enforced, and staticcheck/govet/ineffassign/unused still run on
-      # test files — only errcheck is deferred.
+      # ~380 legacy errcheck findings, mostly os.Setenv / os.RemoveAll that
+      # will become t.Setenv / t.TempDir. Only errcheck is deferred — the
+      # other linters still run on test files.
       - path: _test\.go
         linters:
           - errcheck
-      # Shared test helpers consumed by tests of DIFFERENT build tags; under
-      # any single tag some helpers legitimately look unused, so `unused`
-      # cannot evaluate these files meaningfully in a per-tag lint run. All
-      # other linters still apply to them.
+      # Test helpers shared across build-tag families: under any single tag
+      # some helpers legitimately look unused, so `unused` cannot evaluate
+      # these files in a per-tag run.
       - path: cmd/importData(Integration)?TestUtils\.go
         linters:
           - unused
       - path: src/testlivemigration/live_migration_test_helpers\.go
         linters:
           - unused
-      # golangci's staticcheck integration computes interprocedural facts
-      # differently from the standalone tool and flags these five defensive
-      # protoreflect nil-checks as SA4023 ("never true"); standalone
-      # staticcheck 2025.1.1 is clean on the identical code. Scoped to this
-      # file + check so SA4023 stays enforced everywhere else.
+      # golangci's staticcheck computes interprocedural facts differently
+      # from the standalone tool and flags these defensive protoreflect
+      # nil-checks as SA4023 ("never true"); standalone 2025.1.1 is clean on
+      # identical code.
       - path: src/query/queryparser/helpers_protomsg\.go
         text: "SA4023"
         linters:

--- a/yb-voyager/.golangci.yml
+++ b/yb-voyager/.golangci.yml
@@ -1,0 +1,107 @@
+# golangci-lint v2 configuration — the single lint entry point for this module.
+# CI runs it once per build-tag group (see .github/workflows/lint.yml); the tag
+# groups cannot be combined because test files of different tags redeclare
+# symbols (e.g. TestMain) in the same package.
+#
+# The errcheck exclude-functions list below is deliberate policy, not noise
+# suppression: an entry means "this method's error is safely ignorable at every
+# call site", with the rationale alongside. Anything not listed must handle its
+# error explicitly (check it, or `_ =` with a why-comment).
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    # TODO(lint): enable the next-wave linters, one PR each, after sweeping
+    # that linter's remaining findings (measured Aug 2026: errorlint ~15,
+    # rowserrcheck ~40, sqlclosecheck ~8). Nothing prevents enabling them
+    # today except that the gate must be green the day a linter turns on.
+    # - errorlint
+    # - rowserrcheck
+    # - sqlclosecheck
+  settings:
+    staticcheck:
+      # Mirrors staticcheck's defaults (all minus the default ST excludes), plus:
+      # -S1008:  allow explicit boolean returns.
+      # -ST1005: user-facing CLI error strings are deliberately capitalized/punctuated.
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1005
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        - -ST1023
+        - -S1008
+        # QF* (quickfix) checks are not shipped by standalone staticcheck
+        # 2025.1.1 at all; excluded defensively for future golangci-bundled
+        # versions. ST1000/1003/1016/1020/1021/1022/1023 above mirror the
+        # standalone default set (ST1023 verified default-off in 2025.1.1);
+        # ST1005/S1008 are the project's pre-existing opt-outs.
+        - -QF*
+    errcheck:
+      exclude-functions:
+        # Read-path/teardown closes: real failures surface via rows.Err()/Scan,
+        # which are checked; nothing actionable on close.
+        - (*database/sql.Rows).Close
+        - (*database/sql.DB).Close
+        - (*database/sql.Conn).Close
+        - (*database/sql.Stmt).Close
+        - (*github.com/jackc/pgx/v4.Conn).Close
+        - (*github.com/jackc/pgx/v5.Conn).Close
+        - (*github.com/jackc/pgx/v5/pgconn.PgConn).Close
+        # Deferred rollback-after-commit idiom: returns sql.ErrTxDone on the
+        # success path by design.
+        - (*database/sql.Tx).Rollback
+        # resp.Body and similar read-only bodies.
+        - (io.ReadCloser).Close
+        # Console report/status rendering (verified: every production use
+        # writes to tabwriter/uilive buffers or stderr); buffered errors
+        # surface at Flush, which is handled at the call sites.
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        # Console UX color printers (fatih/color, incl. the ux package aliases).
+        - (*github.com/fatih/color.Color).Print
+        - (*github.com/fatih/color.Color).Printf
+        - (*github.com/fatih/color.Color).Println
+        - (*github.com/fatih/color.Color).Fprint
+        - (*github.com/fatih/color.Color).Fprintf
+        - (*github.com/fatih/color.Color).Fprintln
+        # Documented to never return an error.
+        - (hash.Hash).Write
+        - (hash.Hash32).Write
+  exclusions:
+    rules:
+      # TEMPORARY (removed by the test-modernization PR): test files carry
+      # ~380 legacy errcheck findings, dominated by os.Setenv / os.RemoveAll
+      # patterns that will become t.Setenv / t.TempDir. Production code is
+      # fully enforced.
+      - path: _test\.go
+        linters:
+          - errcheck
+      # Shared test helpers consumed by tests of DIFFERENT build tags; under
+      # any single tag some helpers legitimately look unused, so `unused`
+      # cannot evaluate these files meaningfully in a per-tag lint run.
+      - path: cmd/importData(Integration)?TestUtils\.go
+        linters:
+          - unused
+      - path: src/testlivemigration/live_migration_test_helpers\.go
+        linters:
+          - unused
+      # golangci's staticcheck integration computes interprocedural facts
+      # differently from the standalone tool and flags these five defensive
+      # protoreflect nil-checks as SA4023 ("never true"); standalone
+      # staticcheck 2025.1.1 is clean on the identical code. Scoped to this
+      # file + check so SA4023 stays enforced everywhere else.
+      - path: src/query/queryparser/helpers_protomsg\.go
+        text: "SA4023"
+        linters:
+          - staticcheck

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -1876,9 +1876,9 @@ func startMonitoringTargetYBHealth() error {
 			displayMonitoringInformationOnTheConsole(info)
 		})
 
-		err = monitorTDBHealth.StartMonitoring()
-		//lint:ignore SA4023 StartMonitoring currently only returns on error; keep the conventional check
-		if err != nil {
+		// SA4023: StartMonitoring currently only returns on error; keep the conventional check anyway.
+		err = monitorTDBHealth.StartMonitoring() //nolint:staticcheck
+		if err != nil {                          //nolint:staticcheck
 			log.Errorf("error monitoring the target health: %v", err)
 		}
 	}()

--- a/yb-voyager/scripts/lint.sh
+++ b/yb-voyager/scripts/lint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Runs golangci-lint over every build-tag group, mirroring .github/workflows/lint.yml.
+# Run from anywhere; lints the yb-voyager module. Requires golangci-lint on PATH
+# (pin: versions/ci-config.json -> golangci_lint). Install:
+#   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+#     | sh -s -- -b "$(go env GOPATH)/bin" "$(jq -r .versions.golangci_lint versions/ci-config.json)"
+set -u
+
+cd "$(dirname "$0")/.."
+
+TAG_GROUPS=(
+  ""
+  "unit"
+  "integration"
+  "integration_voyager_command"
+  "integration_live_migration"
+  "issues_integration"
+  "failpoint_export"
+  "failpoint_import"
+  "failpoint_cutover"
+  "cdc_benchmark"
+  "manual"
+  "yb_version_latest_stable"
+  "connector_latest_stable"
+)
+
+failed=0
+for tags in "${TAG_GROUPS[@]}"; do
+  echo "==> golangci-lint run ${tags:+--build-tags $tags}"
+  golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ${tags:+--build-tags "$tags"} ./... || failed=1
+done
+
+exit $failed

--- a/yb-voyager/versions/ci-config.json
+++ b/yb-voyager/versions/ci-config.json
@@ -2,7 +2,7 @@
   "versions": {
     "go": "1.24.2",
     "java": "17",
-    "staticcheck": "2025.1.1"
+    "golangci_lint": "v2.13.2"
   },
   "runner": {
     "ubuntu": "ubuntu-22.04"

--- a/yb-voyager/versions/versions.go
+++ b/yb-voyager/versions/versions.go
@@ -77,9 +77,9 @@ var ciConfigJSON []byte
 // CIConfigData represents the structure of ci-config.json
 type CIConfigData struct {
 	Versions struct {
-		Go          string `json:"go"`
-		Java        string `json:"java"`
-		Staticcheck string `json:"staticcheck"`
+		Go           string `json:"go"`
+		Java         string `json:"java"`
+		GolangciLint string `json:"golangci_lint"`
 	} `json:"versions"`
 	Runner struct {
 		Ubuntu string `json:"ubuntu"`
@@ -108,10 +108,10 @@ func GetJavaVersion() string {
 	return config.Versions.Java
 }
 
-// GetStaticcheckVersion returns the Staticcheck version from ci-config.json
-func GetStaticcheckVersion() string {
+// GetGolangciLintVersion returns the golangci-lint version from ci-config.json
+func GetGolangciLintVersion() string {
 	config := LoadCIConfig()
-	return config.Versions.Staticcheck
+	return config.Versions.GolangciLint
 }
 
 // =============================== Connector Versions ===============================


### PR DESCRIPTION
### Describe the changes in this pull request

Top of the errcheck stack: the gate itself. golangci-lint runs **errcheck, govet, staticcheck, ineffassign, and unused** in one invocation with one config. errcheck is the piece that closes the PR #3714 bug class end to end: a bare call statement dropping an error return is caught by no other tool, and signature-widening refactors (void → error) become unlandable without updating every call site.

**`yb-voyager/.golangci.yml`:**
- staticcheck check list mirrors the standalone default gate exactly: all minus staticcheck's default ST excludes (incl. `ST1023`, verified default-off in 2025.1.1 both by a scratch-module test and by a pre-existing violation on staticcheck-green main), minus the project's pre-existing `-S1008`/`-ST1005` opt-outs, minus `-QF*` (2025.1.1 ships no QF checks; excluded defensively for future golangci-bundled versions). **`SA4023` is enforced** — it is part of the standalone default set, so excluding it would have weakened the gate (fixed per review). Two accompaniments: the deliberate always-true `err != nil` after `StartMonitoring` carries two `//nolint:staticcheck` markers with one explanatory comment (golangci emits two diagnostics for one SA4023 — the finding at the `if` and the related-information position at the call — and each needs its own suppression; the old `//lint:ignore` was dropped for simplicity, so bare standalone staticcheck flags this one site while golangci, the actual gate, is clean), and `helpers_protomsg.go` gets a path+check-scoped exclusion for five defensive protoreflect nil-checks that golangci's fact computation flags but standalone staticcheck provably does not on identical code.
- The errcheck `exclude-functions` list is deliberate policy with per-entry rationale in the file: sql/pgx connection + rows teardown closes (pgx **v4, v5, and pgconn** — the codebase uses all three), deferred `Tx.Rollback` (returns `ErrTxDone` on the success path by design), `resp.Body.Close`, console `fmt.Fprint*`/color printers. Anything not listed must handle its error explicitly. Per review, every excluded staticcheck check now carries its own one-line rationale in the file, and the `hash.Write` entries were dropped as provably inert: under the pinned golangci v2.13.2, errcheck produces no finding for the fnv call site even with an empty exclude-functions list. Post-merge follow-up (agreed in review): replace the Close/Rollback exclusions with explicit `utils.CloseAndLogOnError`-style handling at the ~90 call sites, shrinking exclude-functions to the console printers only.
- Temporary rule: `_test.go` files skip **errcheck only** (~380 legacy findings, dominated by `os.Setenv`/`os.RemoveAll` → `t.Setenv`/`t.TempDir`; removed by the planned test-modernization PR). Cross-tag shared test-helper files skip **unused only** (no single-tag lint run can see all their consumers).
- TODO(lint) documents the next wave — errorlint (~15 remaining findings), rowserrcheck (~40), sqlclosecheck (~8) — each to be enabled by its own sweep-then-enable PR.

**`.github/workflows/lint.yml`:** a single job, one golangci-lint install (pinned via `versions/ci-config.json` → `golangci_lint`, replacing the staticcheck pin end to end: `versions.go`, `prepare-versions.yml`), then **one named step per build-tag group** (13 groups). The groups cannot be combined into one run — test files of different tags redeclare symbols (e.g. `TestMain`) in the same package, so a combined-tags build does not compile. `if: !cancelled()` lets every group report even when an earlier one fails. go.yml's Vet and staticcheck steps are removed (both now run inside golangci-lint). `scripts/lint.sh` mirrors the CI steps for local runs; AGENTS.md and the update-yb-latest-stable skill doc are updated.

### Describe if there are any user-facing changes

No user-facing changes (CI/tooling only).

### How was this pull request tested?

- `golangci-lint run` (v2.13.2, uncapped output) verified **0 issues across all 13 build-tag groups** locally, on this exact stack.
- `go build ./...` and full `go test -tags unit ./...` pass.
- The negative test of the gate: reverting the #3714 one-line fix makes errcheck fail the lint run, which no previous CI configuration could do.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
