### PR TITLE
Fix conflict-detection log message content and log conflict resolution

### DIFF
--- a/yb-voyager/cmd/conflictDetectionCache.go
+++ b/yb-voyager/cmd/conflictDetectionCache.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	goerrors "github.com/go-errors/errors"
 	"github.com/samber/lo"
@@ -200,7 +201,7 @@ func (c *ConflictDetectionCache) Put(event *tgtdb.Event) error {
 			return err
 		}
 	}
-	log.Debugf("adding event vsn(%d) to conflict cache for table %s", event.Vsn, event.TableNameTup.ForKey())
+	log.Debugf("adding event vsn(%d) to conflict cache for table %s", event.Vsn, event.TableNameTup.ForOutput())
 	return nil
 }
 
@@ -257,6 +258,7 @@ func (c *ConflictDetectionCache) WaitUntilNoConflict(incomingEvent *tgtdb.Event)
 	c.Lock()
 	defer c.Unlock()
 
+	waitStartTime := time.Now()
 	conflictLogged := false
 	for {
 		conflictInfo, err := c.findConflictLocked(incomingEvent)
@@ -264,7 +266,7 @@ func (c *ConflictDetectionCache) WaitUntilNoConflict(incomingEvent *tgtdb.Event)
 			return err
 		}
 		if len(conflictInfo) == 0 {
-			return nil
+			break
 		}
 
 		// flushing all the batches in channels instead of waiting for MAX_INTERVAL_BETWEEN_BATCHES
@@ -293,8 +295,8 @@ func (c *ConflictDetectionCache) WaitUntilNoConflict(incomingEvent *tgtdb.Event)
 			if isTargetDBExporter(incomingEvent.ExporterRole) {
 				log.Debugf("event(vsn=%d) waiting for in-flight event(s) %v to be applied", incomingEvent.Vsn, cachedVsns)
 			} else if !conflictLogged {
-				log.Infof("conflict detected: event(vsn=%d) on table %s, unique index columns %v with matched value %s (%s conflict) waiting for in-flight event(s) %v to be applied",
-					incomingEvent.Vsn, incomingEvent.TableNameTup.ForKey(), info.indexColumns, info.matchedValue, info.matchType, cachedVsns)
+				log.Infof("conflict detected: event(vsn=%d) on table %s, unique index %s (columns %s) with matched value [%s] (%s conflict) waiting for in-flight event(s) %v to be applied",
+					incomingEvent.Vsn, incomingEvent.TableNameTup.ForOutput(), info.indexName, strings.Join(info.indexColumns, ", "), info.matchedValue, info.matchType, cachedVsns)
 			} else {
 				log.Debugf("still waiting: event(vsn=%d) blocked by in-flight event(s) %v", incomingEvent.Vsn, cachedVsns)
 			}
@@ -306,6 +308,14 @@ func (c *ConflictDetectionCache) WaitUntilNoConflict(incomingEvent *tgtdb.Event)
 		// different times (e.g. a table with several unique indexes).
 		c.cond.Wait()
 	}
+
+	if conflictLogged {
+		// Report how long the event stayed blocked, so that a slow conflict is
+		// distinguishable from one that never clears.
+		log.Infof("conflict cleared: event(vsn=%d) on table %s proceeding after waiting %s",
+			incomingEvent.Vsn, incomingEvent.TableNameTup.ForOutput(), time.Since(waitStartTime).Round(time.Millisecond))
+	}
+	return nil
 }
 
 // Conflict describes the unique-index match that caused a value-path conflict.
@@ -449,8 +459,8 @@ func (c *ConflictDetectionCache) checkBeforeAfterConflict(incomingEvent *tgtdb.E
 		return Conflict{}, nil
 	}
 	for _, cachedEvent := range cachedEvents {
-		log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and after value of incoming-event2(vsn=%d, colVal=%s)",
-			incomingEvent.TableNameTup.ForKey(), index.Columns,
+		log.Debugf("conflict detected for table %s, unique index %s, between before value of cached-event1(vsn=%d, colVal=[%s]) and after value of incoming-event2(vsn=%d, colVal=[%s])",
+			incomingEvent.TableNameTup.ForOutput(), index.String(),
 			cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
 			incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.AfterFields, index.Columns))
 	}
@@ -482,8 +492,8 @@ func (c *ConflictDetectionCache) checkBeforeBeforeConflict(incomingEvent *tgtdb.
 		return Conflict{}, nil
 	}
 	for _, cachedEvent := range cachedEvents {
-		log.Debugf("conflict detected for table %s, index columns %v, between before value of cached-event1(vsn=%d, colVal=%s) and before value of incoming-event2(vsn=%d, colVal=%s)",
-			incomingEvent.TableNameTup.ForKey(), index.Columns,
+		log.Debugf("conflict detected for table %s, unique index %s, between before value of cached-event1(vsn=%d, colVal=[%s]) and before value of incoming-event2(vsn=%d, colVal=[%s])",
+			incomingEvent.TableNameTup.ForOutput(), index.String(),
 			cachedEvent.Vsn, formatUniqueIndexColumnValuesForLog(cachedEvent.BeforeFields, index.Columns),
 			incomingEvent.Vsn, formatUniqueIndexColumnValuesForLog(incomingEvent.BeforeFields, index.Columns))
 	}
@@ -769,7 +779,7 @@ func (c *ConflictDetectionCache) eventsConfict(cachedEvent *tgtdb.Event, incomin
 		}
 
 		if conflict {
-			log.Infof("conflict detected for table %s, between event1(vsn=%d) and event2(vsn=%d)", cachedEvent.TableNameTup, cachedEvent.Vsn, incomingEvent.Vsn)
+			log.Infof("conflict detected for table %s, between event1(vsn=%d) and event2(vsn=%d)", cachedEvent.TableNameTup.ForOutput(), cachedEvent.Vsn, incomingEvent.Vsn)
 		}
 		return conflict
 	}
@@ -949,9 +959,14 @@ func uniqueIndexColumnValuesEqual(leftFields, rightFields map[string]*string, in
 	return true
 }
 
+// formatUniqueIndexColumnValuesForLog renders the values of the given index columns
+// as "col1=val1, col2=val2".
 func formatUniqueIndexColumnValuesForLog(fields map[string]*string, indexColumns []string) string {
 	var logStr strings.Builder
-	for _, column := range indexColumns {
+	for i, column := range indexColumns {
+		if i > 0 {
+			logStr.WriteString(", ")
+		}
 		val, ok := fields[column]
 		if !ok {
 			logStr.WriteString(column + "=<missing>")

--- a/yb-voyager/src/tgtdb/postgres.go
+++ b/yb-voyager/src/tgtdb/postgres.go
@@ -466,7 +466,7 @@ func (pg *TargetPostgreSQL) GetPrimaryKeyConstraintNames(table sqlname.NameTuple
 }
 
 func (pg *TargetPostgreSQL) GetTableToUniqueIndexesMap(tableList []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, []UniqueIndex], error) {
-	log.Infof("getting unique indexes from target Postgres for tables: %v", tableList)
+	log.Infof("getting unique indexes from target Postgres for tables: %s", strings.Join(sqlname.NameTupleListToStrings(tableList), ", "))
 	// Unique indexes on a partitioned table are often defined on its leaf partitions
 	// rather than the root (e.g. CREATE UNIQUE INDEX ... ON <leaf> (...)). Since import
 	// events only reference the root table, we discover the unique indexes of every leaf
@@ -508,7 +508,7 @@ func (pg *TargetPostgreSQL) GetTableToUniqueIndexesMap(tableList []sqlname.NameT
 		result.Put(rootTuple, mergeUniqueIndexes(existing, indexes))
 	}
 
-	log.Infof("unique indexes from postgres for tables: %v", result)
+	log.Infof("unique indexes from postgres for tables: %s", formatTableToUniqueIndexesForLog(result))
 	return result, nil
 }
 
@@ -583,6 +583,26 @@ func dedupeUniqueIndexes(indexes []UniqueIndex) []UniqueIndex {
 		result = append(result, idx)
 	}
 	return result
+}
+
+// formatTableToUniqueIndexesForLog renders the unique indexes of each table as
+// "table: index(col1, col2) [nulls not distinct]; table2: ...", sorted by table name.
+func formatTableToUniqueIndexesForLog(tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []UniqueIndex]) string {
+	var tableEntries []string
+	// the callback never returns an error, so IterKVSorted cannot fail here.
+	_ = tableToUniqueIndexes.IterKVSorted(func(a, b sqlname.NameTuple) bool {
+		return a.ForOutput() < b.ForOutput()
+	}, func(table sqlname.NameTuple, indexes []UniqueIndex) (bool, error) {
+		indexEntries := lo.Map(indexes, func(index UniqueIndex, _ int) string {
+			return index.String()
+		})
+		tableEntries = append(tableEntries, fmt.Sprintf("%s: %s", table.ForOutput(), strings.Join(indexEntries, ", ")))
+		return true, nil
+	})
+	if len(tableEntries) == 0 {
+		return "none"
+	}
+	return strings.Join(tableEntries, "; ")
 }
 
 // mergeUniqueIndexes merges two index lists, deduplicating by column signature.

--- a/yb-voyager/src/tgtdb/target_db_interface.go
+++ b/yb-voyager/src/tgtdb/target_db_interface.go
@@ -40,6 +40,16 @@ type UniqueIndex struct {
 	NullsNotDistinct bool
 }
 
+// String renders the index as "index_name(col1, col2)", suffixed with
+// "[nulls not distinct]" when NULLS NOT DISTINCT is set.
+func (u UniqueIndex) String() string {
+	s := fmt.Sprintf("%s(%s)", u.IndexName, strings.Join(u.Columns, ", "))
+	if u.NullsNotDistinct {
+		s += " [nulls not distinct]"
+	}
+	return s
+}
+
 type TargetDB interface {
 	Init() error
 	Finalize()

--- a/yb-voyager/src/tgtdb/yugabytedb.go
+++ b/yb-voyager/src/tgtdb/yugabytedb.go
@@ -608,7 +608,7 @@ func (yb *TargetYugabyteDB) GetPrimaryKeyColumnsForTables(tables []sqlname.NameT
 }
 
 func (yb *TargetYugabyteDB) GetTableToUniqueIndexesMap(tableList []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, []UniqueIndex], error) {
-	log.Infof("getting unique indexes from target for tables: %v", tableList)
+	log.Infof("getting unique indexes from target for tables: %s", strings.Join(sqlname.NameTupleListToStrings(tableList), ", "))
 
 	// Unique indexes on a partitioned table are often defined on its leaf partitions
 	// rather than the root (e.g. CREATE UNIQUE INDEX ... ON <leaf> (...)). Since import
@@ -651,7 +651,7 @@ func (yb *TargetYugabyteDB) GetTableToUniqueIndexesMap(tableList []sqlname.NameT
 		result.Put(rootTuple, mergeUniqueIndexes(existing, indexes))
 	}
 
-	log.Infof("unique indexes from target for tables: %v", result)
+	log.Infof("unique indexes from target for tables: %s", formatTableToUniqueIndexesForLog(result))
 	return result, nil
 }
 


### PR DESCRIPTION
### Describe the changes in this pull request

Log-only changes in the live-migration conflict-detection path (`ConflictDetectionCache` + the two target drivers' unique-index discovery), found while reviewing every log statement in that flow.

**Log-content fixes**

1. `formatUniqueIndexColumnValuesForLog` joined nothing between columns, so a two-column unique index rendered as `c1=abcc2=def` — unreadable, and ambiguous (`{"ab",""}` and `{"a","b"}` rendered identically). Values are now joined with `", "` and bracketed at the call sites.
2. The `conflict detected` log reported the index *columns* but not the index *name*, even though `Conflict.indexName` already carried it. A table can have several unique indexes over overlapping columns, so the name is what identifies the constraint that was serialized on.
3. `eventsConfict` passed the `NameTuple` itself to `%s`, which expands to the verbose `[CurrentName=(..) SourceName=(..) TargetName=(..)]` form.
4. Both target drivers (`TargetYugabyteDB` / `TargetPostgreSQL`) logged the table list as `%v` over `[]sqlname.NameTuple` and the discovered indexes as `%v` over the `*utils.StructMap`. What that actually produced:

   ```
   getting unique indexes from target for tables: [[CurrentName=(users) SourceName=(users) TargetName=(users)] [CurrentName=(orders) ...]]
   unique indexes from target for tables: &{map["public"."users":{0x1400037f2b0 0x1400037f2b0 0x1400037f2b0} "sales"."orders":{0x1400037f380 ...}] map["public"."users":[{users_email_key [email] false} ...]]}
   ```

   The table list is 3x redundant *and* drops the schema; the index map leads with a pointer-address dump of the `StructMap`'s key map (`NameTuple` has `*ObjectName` fields, and `fmt` can't call `String()` through unexported struct fields). Now:

   ```
   getting unique indexes from target for tables: public.users, sales.orders
   unique indexes from target for tables: public.users: users_email_key(email), users_tenant_login_key(tenant_id, login); sales.orders: orders_ref_key(ref) [nulls not distinct]
   ```

   The table list reuses the existing `sqlname.NameTupleListToStrings`; the index map goes through one new `formatTableToUniqueIndexesForLog` in `postgres.go`, alongside the other helpers shared by both PG/YB target drivers.
5. Table names throughout this path are now rendered with `ForOutput()` (`public.users`) rather than `ForKey()` (`"public"."users"`).

**New log: conflict resolution + wait duration**

`WaitUntilNoConflict` now reports when a conflict clears, and how long the event was blocked. Previously the log showed an event getting *blocked* but never showed whether it was released in milliseconds or is still stuck — the difference between a healthy migration and a stalled one. It is emitted only for events that actually waited, so the no-conflict path stays silent.

Before / after, for one blocked event:

```
# before
INFO conflict detected: event(vsn=2) on table "public"."users", unique index columns [tenant_id email] with matched value tenant_id=42email=a@example.com (before-after conflict) waiting for in-flight event(s) [1] to be applied
(nothing further)

# after
INFO conflict detected: event(vsn=2) on table public.users, unique index users_tenant_email_key (columns tenant_id, email) with matched value [tenant_id=42, email=a@example.com] (before-after conflict) waiting for in-flight event(s) [1] to be applied
INFO conflict cleared: event(vsn=2) on table public.users proceeding after waiting 301ms
```

No behavior change outside logging.

This PR deliberately does **not** address the other findings from the same log review (log-level demotions for the per-event DEBUG lines, per-conflict INFO rate-limiting/aggregation, the unreachable `checkUniqueIndex*Conflict` functions and their two dead INFO lines, cache-size/stall WARNs, conflict metrics) — those are follow-ups.

### Describe if there are any user-facing changes

Only the content of the conflict-detection lines in `yb-voyager-import-data*.log`, plus one new INFO line per blocked event when its conflict clears. No CLI, config, installation, or report changes.

### How was this pull request tested?

Existing tests were enough — this is a log-message change with no behavior change, and the existing `cmd` conflict-detection suite already covers the surrounding logic (`go test -tags unit ./cmd/... ./src/tgtdb/...` passes).

Manually verified the rendered lines through a throwaway in-package test (outputs quoted above): the detected/cleared pair for a blocked event, silence for a non-conflicting event, and the current-vs-new rendering of both target-driver logs.

`go vet ./...`, `go vet -tags unit ./...`, `staticcheck ./...`, `staticcheck -tags unit ./...` are all clean; touched files are gofmt-clean.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
