### PR TITLE
Add custom-cdc-partition-key-test for --cdc-partition-key-overrides live migration

### DIFF
--- a/migtests/scripts/event-generator/generator.py
+++ b/migtests/scripts/event-generator/generator.py
@@ -71,6 +71,10 @@ INDEX_EVENTS_INTERVAL = GEN.get("index_events_interval", 5)
 
 # Column overrides for partition-aware value generation
 COLUMN_OVERRIDES = GEN.get("column_overrides", {})
+
+# Columns that must never appear in an UPDATE's SET list, per table (e.g. a
+# custom cdc-partition-key column, which the importer requires to be immutable).
+EXCLUDE_COLUMNS_FROM_UPDATE = GEN.get("exclude_columns_from_update", {})
 # ---------------------------------
 
 # Deterministic seeds from YAML
@@ -189,14 +193,15 @@ try:
                     continue
 
                 pk_set = set(primary_key) if isinstance(primary_key, list) else {primary_key}
+                excluded_columns = pk_set | set(EXCLUDE_COLUMNS_FROM_UPDATE.get(table_name, []))
 
                 for _ in range(UPDATE_MAX_RETRIES):
                     columns = table_schemas[table_name]["columns"]
 
-                    if len(columns) <= len(pk_set):
+                    if len(columns) <= len(excluded_columns):
                         break
 
-                    updateable_columns = [col for col in columns if col not in pk_set]
+                    updateable_columns = [col for col in columns if col not in excluded_columns]
 
                     if not updateable_columns:
                         print(f"No updateable columns found for table {table_name}. Retrying...")

--- a/migtests/scripts/event-generator/utils.py
+++ b/migtests/scripts/event-generator/utils.py
@@ -54,6 +54,7 @@ CONFIG_SCHEMA: Dict[str, Dict[str, Any]] = {
         "enable_index_create_drop": bool,
         "index_events_interval": int,
         "column_overrides": dict,
+        "exclude_columns_from_update": dict,
     },
 }
 
@@ -75,7 +76,7 @@ def load_yaml_file(path: str) -> Dict[str, Any]:
 
 def validate_section(section: Dict[str, Any], schema: Dict[str, Any], section_name: str) -> None:
     # Optional fields that don't need to be present (for backward compatibility)
-    optional_fields = {"enable_index_create_drop","index_events_interval","column_overrides","min_col_size_bytes"}
+    optional_fields = {"enable_index_create_drop","index_events_interval","column_overrides","min_col_size_bytes","exclude_columns_from_update"}
     
     for key, expected_type in schema.items():
         if key not in section:

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -54,7 +54,7 @@ class Context:
         self.archive_changes_policy: str | None = None
         self.prev_archive_file_count: int = 0
         # Set by the `pick_random_custom_key` orchestrator action; consumed by
-        # `validate_no_conflicts_for_picked_custom_key`.
+        # `validate_picked_custom_key_conflicts`.
         self.picked_custom_key: Dict[str, Any] | None = None
 
 

--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -53,6 +53,9 @@ class Context:
         self.iteration_export_dir: str = self.export_dir_base
         self.archive_changes_policy: str | None = None
         self.prev_archive_file_count: int = 0
+        # Set by the `pick_random_custom_key` orchestrator action; consumed by
+        # `validate_no_conflicts_for_picked_custom_key`.
+        self.picked_custom_key: Dict[str, Any] | None = None
 
 
 def apply_effective_export_dir(ctx: Context) -> None:

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -387,15 +387,24 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
     orchestrator plumbing changes are needed for the pick to take effect.
 
     Required stage key:
-      - candidates: list of {table: "schema.table", columns: [col, ...],
-        expect_conflicts: bool (optional, default false)}. Every candidate's
-        conflict DML must already be safe to route by those columns (i.e.
-        never appears in an UPDATE for that table) -- this action only
-        performs the pick and the wiring, not that verification.
+      - candidates: list of {table: "schema.table", expect_conflicts: bool
+        (optional, default false)} with EITHER:
+          - columns: [col, ...] -- a fixed custom key, OR
+          - random_columns_pool: [col, ...] -- the key's columns are ALSO
+            randomized: 1..2 columns (or min_columns..max_columns) are sampled
+            from the pool, in random order, so successive runs route the same
+            table by different columns and column counts.
+        Every fixed column and every pool column must already be safe to route
+        by (never appears in an UPDATE for that table in the conflict DML, and
+        its value must be identical across the rows of each conflict pair --
+        e.g. a DML-churned key column, or a column the DML leaves at a
+        transaction-constant default) -- this action only performs the pick
+        and the wiring, not that verification.
         `expect_conflicts: true` marks a candidate whose DML deliberately
         creates conflicts that MUST still be detected when it is picked (e.g.
         a PK-recycle pattern); `validate_picked_custom_key_conflicts` uses it
-        to decide which assertion to run.
+        to decide which assertion to run. Such candidates should use fixed
+        `columns` -- their assertion depends on the specific key.
 
     Optional stage key:
       - generator_key: which generator config block to inject
@@ -419,12 +428,22 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
 
     choice = random.choice(candidates)
     table = choice["table"]
-    columns = choice["columns"]
+    pool = choice.get("random_columns_pool")
+    if pool:
+        if choice.get("columns"):
+            raise ValueError(f"pick_random_custom_key: candidate {table} must not set both 'columns' and 'random_columns_pool'")
+        min_cols = int(choice.get("min_columns", 1))
+        max_cols = min(int(choice.get("max_columns", 2)), len(pool))
+        num_cols = random.randint(min_cols, max_cols)
+        columns = random.sample(pool, num_cols)
+    else:
+        columns = choice["columns"]
     expect_conflicts = bool(choice.get("expect_conflicts", False))
     ctx.picked_custom_key = {"table": table, "columns": columns, "expect_conflicts": expect_conflicts}
     H.log(
         f"pick_random_custom_key: selected table={table} columns={columns} "
-        f"expect_conflicts={expect_conflicts} (out of {len(candidates)} candidates)"
+        f"expect_conflicts={expect_conflicts} "
+        f"({'sampled from pool of ' + str(len(pool)) if pool else 'fixed'}; out of {len(candidates)} candidates)"
     )
 
     override = f"{table}:({','.join(columns)})"

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -372,9 +372,9 @@ def validate_no_conflicts_detected_action(stage: Dict[str, Any], ctx: Any) -> No
 
 @action("pick_random_custom_key")
 def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
-    """Randomly select one table/column(s) to route by `--cdc-partition-key-overrides`
-    instead of the hardcoded default, and wire that pick through everywhere it
-    needs to land:
+    """Randomly select ONE table/column(s) to route by `--cdc-partition-key-overrides`
+    this run -- mirroring how a real user opts specific tables into custom-key
+    routing -- and wire that pick through everywhere it needs to land:
 
       - appends to `voyager.import_data.flags.cdc-partition-key-overrides`.
       - adds the picked column(s) to the named generator's
@@ -386,17 +386,22 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
     orchestrator plumbing changes are needed for the pick to take effect.
 
     Required stage key:
-      - candidates: list of {table: "schema.table", columns: [col, ...]}. Every
-        candidate's conflict DML must already be safe to route by those
-        columns (i.e. never appears in an UPDATE for that table) -- this
-        action only performs the pick and the wiring, not that verification.
+      - candidates: list of {table: "schema.table", columns: [col, ...],
+        expect_conflicts: bool (optional, default false)}. Every candidate's
+        conflict DML must already be safe to route by those columns (i.e.
+        never appears in an UPDATE for that table) -- this action only
+        performs the pick and the wiring, not that verification.
+        `expect_conflicts: true` marks a candidate whose DML deliberately
+        creates conflicts that MUST still be detected when it is picked (e.g.
+        a PK-recycle pattern); `validate_picked_custom_key_conflicts` uses it
+        to decide which assertion to run.
 
     Optional stage key:
       - generator_key: which generator config block to inject
         exclude_columns_from_update into (default: "generator").
 
-    The pick is stored on `ctx.picked_custom_key` (`{"table", "columns"}`) for
-    `validate_no_conflicts_for_picked_custom_key` to consume later.
+    The pick is stored on `ctx.picked_custom_key` for
+    `validate_picked_custom_key_conflicts` to consume later.
     """
     if ctx.picked_custom_key is not None:
         raise RuntimeError(
@@ -414,8 +419,12 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
     choice = random.choice(candidates)
     table = choice["table"]
     columns = choice["columns"]
-    ctx.picked_custom_key = {"table": table, "columns": columns}
-    H.log(f"pick_random_custom_key: selected table={table} columns={columns} (out of {len(candidates)} candidates)")
+    expect_conflicts = bool(choice.get("expect_conflicts", False))
+    ctx.picked_custom_key = {"table": table, "columns": columns, "expect_conflicts": expect_conflicts}
+    H.log(
+        f"pick_random_custom_key: selected table={table} columns={columns} "
+        f"expect_conflicts={expect_conflicts} (out of {len(candidates)} candidates)"
+    )
 
     override = f"{table}:({','.join(columns)})"
     flags = ctx.cfg.setdefault("voyager", {}).setdefault("import_data", {}).setdefault("flags", {})
@@ -438,22 +447,31 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
             excluded_for_table.append(col)
 
 
-@action("validate_no_conflicts_for_picked_custom_key")
-def validate_no_conflicts_for_picked_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
-    """`validate_no_conflicts_detected`, scoped to whatever table
-    `pick_random_custom_key` selected earlier in this run -- lets the scenario
-    assert 0 conflicts for the picked table without knowing in advance which
-    one that will be.
+@action("validate_picked_custom_key_conflicts")
+def validate_picked_custom_key_conflicts_action(stage: Dict[str, Any], ctx: Any) -> None:
+    """Run the right conflict assertion for whatever table `pick_random_custom_key`
+    selected earlier in this run:
+
+      - expect_conflicts false (the usual case): the picked table's conflicts all
+        share its custom key's value, so they land on one channel already and the
+        conflict-detection cache must never fire for it -- assert 0.
+      - expect_conflicts true (e.g. a PK-recycle candidate, where the SAME PK is
+        reused with a DIFFERENT custom-key value -- a real cross-channel race
+        custom-key routing does not eliminate): the synthetic-PK guard must still
+        catch it -- assert >= min_count (default 1).
     """
     picked = ctx.picked_custom_key
     if not picked:
         raise RuntimeError(
-            "validate_no_conflicts_for_picked_custom_key: ctx.picked_custom_key is unset "
+            "validate_picked_custom_key_conflicts: ctx.picked_custom_key is unset "
             "-- run 'pick_random_custom_key' earlier in this scenario"
         )
     scoped_stage = dict(stage)
     scoped_stage["table"] = picked["table"]
-    validate_no_conflicts_detected_action(scoped_stage, ctx)
+    if picked["expect_conflicts"]:
+        validate_conflicts_detected_action(scoped_stage, ctx)
+    else:
+        validate_no_conflicts_detected_action(scoped_stage, ctx)
 
 
 @action("start_resumptions")

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -4,6 +4,7 @@ import os
 import sys
 import glob
 import argparse
+import copy
 import random
 import subprocess
 import time
@@ -472,6 +473,58 @@ def validate_picked_custom_key_conflicts_action(stage: Dict[str, Any], ctx: Any)
         validate_conflicts_detected_action(scoped_stage, ctx)
     else:
         validate_no_conflicts_detected_action(scoped_stage, ctx)
+
+
+@action("voyager_import_start_expect_fail")
+def voyager_import_start_expect_fail_action(stage: Dict[str, Any], ctx: Any) -> None:
+    """Run `import data` in the foreground with the scenario's flags plus the
+    stage's `flags` on top, and require it to FAIL with `error_contains` in its
+    output -- used to verify resume guardrails at the real CLI level (e.g.
+    changing cdc-partition-key / cdc-partition-key-overrides between runs must
+    be rejected). The running importer must be stopped first
+    (voyager_stop_command), or this run fails on the export-dir lock instead.
+
+    Stage keys:
+      - flags (required): flag overrides merged over voyager.import_data.flags
+        for this one invocation only (ctx.cfg is not mutated). The placeholder
+        "{picked_table}" in a value is replaced with the table
+        pick_random_custom_key selected.
+      - error_contains (required): substring that must appear in the failed
+        run's stdout/stderr.
+      - timeout_sec (optional, default 120): how long the invocation may run
+        before being killed and the stage failed.
+    """
+    error_contains = stage.get("error_contains")
+    if not error_contains:
+        raise ValueError("voyager_import_start_expect_fail: 'error_contains' stage key is required")
+    extra_flags = dict(stage.get("flags") or {})
+    if not extra_flags:
+        raise ValueError("voyager_import_start_expect_fail: 'flags' stage key is required and must be non-empty")
+    for k, v in extra_flags.items():
+        if isinstance(v, str) and "{picked_table}" in v:
+            if not ctx.picked_custom_key:
+                raise RuntimeError(
+                    "voyager_import_start_expect_fail: '{picked_table}' used but no custom key was picked "
+                    "-- run 'pick_random_custom_key' earlier in this scenario"
+                )
+            extra_flags[k] = v.replace("{picked_table}", ctx.picked_custom_key["table"])
+
+    cfg = copy.deepcopy(ctx.cfg)
+    flags = cfg.setdefault("voyager", {}).setdefault("import_data", {}).setdefault("flags", {})
+    flags.update(extra_flags)
+    cmd = H.build_import_data_cmd(cfg)
+    timeout = int(stage.get("timeout_sec", 120))
+    H.log(f"voyager_import_start_expect_fail: running import data expecting failure with {extra_flags}")
+    proc = subprocess.run(cmd, env=ctx.env, capture_output=True, text=True, timeout=timeout)
+    output = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode == 0:
+        raise RuntimeError(f"voyager_import_start_expect_fail: import unexpectedly SUCCEEDED with flags {extra_flags}")
+    if error_contains not in output:
+        raise RuntimeError(
+            f"voyager_import_start_expect_fail: import failed (exit {proc.returncode}) but the expected "
+            f"error text was not found.\nexpected substring: {error_contains}\noutput (tail):\n{output[-3000:]}"
+        )
+    H.log(f"voyager_import_start_expect_fail: import correctly rejected (exit {proc.returncode})")
 
 
 @action("start_resumptions")

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -289,6 +289,31 @@ def row_hash_validations_action(stage: Dict[str, Any], ctx: Any) -> None:
     H.run_segment_hash_validations(ctx, left_role, right_role)
 
 
+def _conflict_log_table_marker(table: str | None) -> str | None:
+    """Build the substring that identifies `table` in a "conflict detected" log
+    line, e.g. "public.orders" -> 'table "public"."orders"' (conflictDetectionCache.go
+    renders TableNameTup.ForKey() with each identifier quoted)."""
+    if table is None:
+        return None
+    schema, sep, name = table.partition(".")
+    if not sep:
+        raise ValueError(f"_conflict_log_table_marker: 'table' must be schema-qualified (e.g. 'public.orders'), got {table!r}")
+    return f'table "{schema}"."{name}"'
+
+
+def _count_conflict_log_lines(log_dir: str, name: str, table: str | None) -> int:
+    """Count "conflict detected" lines in `log_dir`/`name`* log files, optionally
+    scoped to one table (see `_conflict_log_table_marker`)."""
+    table_marker = _conflict_log_table_marker(table)
+    count = 0
+    for p in glob.glob(os.path.join(log_dir, name + "*")):
+        with open(p, errors="ignore") as f:
+            for line in f:
+                if "conflict detected" in line and (table_marker is None or table_marker in line):
+                    count += 1
+    return count
+
+
 @action("validate_conflicts_detected")
 def validate_conflicts_detected_action(stage: Dict[str, Any], ctx: Any) -> None:
     """Assert the import-data log recorded unique-key conflict detections.
@@ -298,20 +323,25 @@ def validate_conflicts_detected_action(stage: Dict[str, Any], ctx: Any) -> None:
     without ever exercising it. Meaningful on the forward leg
     (yb-voyager-import-data.log); the fallback leg's import-to-source forces
     PARTITION_BY_TABLE and logs 0 conflicts by design, so don't assert there.
+
+    Optional stage key:
+      - table: schema-qualified table name (e.g. "public.orders"); when set,
+        only counts lines also mentioning that table -- lets a run that mixes
+        custom-cdc-partition-key tables (expected to log 0 conflicts) with
+        normally-routed tables (expected to keep logging some) assert both
+        against the same log file.
     """
     log_dir = os.path.join(ctx.iteration_export_dir, "logs")
     name = stage.get("log", "yb-voyager-import-data.log")
     min_count = int(stage.get("min_count", 1))
-    count = 0
-    for p in glob.glob(os.path.join(log_dir, name + "*")):
-        with open(p, errors="ignore") as f:
-            count += sum(1 for line in f if "conflict detected" in line)
+    table = stage.get("table")
+    count = _count_conflict_log_lines(log_dir, name, table)
     if count < min_count:
         raise RuntimeError(
             f"validate_conflicts_detected: expected >= {min_count} 'conflict detected' "
-            f"in {name}, found {count} (dir={log_dir})"
+            f"in {name}{f' for table {table}' if table else ''}, found {count} (dir={log_dir})"
         )
-    H.log(f"validate_conflicts_detected: {count} conflicts detected in {name}")
+    H.log(f"validate_conflicts_detected: {count} conflicts detected in {name}" + (f" for table {table}" if table else ""))
 
 
 @action("validate_no_conflicts_detected")
@@ -321,19 +351,109 @@ def validate_no_conflicts_detected_action(stage: Dict[str, Any], ctx: Any) -> No
     Used on the fallback leg (yb-voyager-import-data-to-source.log): the
     source-importer forces PARTITION_BY_TABLE and skips conflict detection, so
     the log must have 0 'conflict detected' -- this guards that the skip holds.
+
+    Optional stage key:
+      - table: schema-qualified table name (e.g. "public.orders"); when set,
+        only counts lines also mentioning that table -- lets this assert 0
+        conflicts for one table (e.g. a custom-cdc-partition-key table)
+        within a log that also has real conflicts logged for other tables.
     """
     log_dir = os.path.join(ctx.iteration_export_dir, "logs")
     name = stage.get("log", "yb-voyager-import-data-to-source.log")
-    count = 0
-    for p in glob.glob(os.path.join(log_dir, name + "*")):
-        with open(p, errors="ignore") as f:
-            count += sum(1 for line in f if "conflict detected" in line)
+    table = stage.get("table")
+    count = _count_conflict_log_lines(log_dir, name, table)
     if count != 0:
         raise RuntimeError(
             f"validate_no_conflicts_detected: expected 0 'conflict detected' "
-            f"in {name}, found {count} (dir={log_dir})"
+            f"in {name}{f' for table {table}' if table else ''}, found {count} (dir={log_dir})"
         )
-    H.log(f"validate_no_conflicts_detected: 0 conflicts detected in {name} (as expected)")
+    H.log(f"validate_no_conflicts_detected: 0 conflicts detected in {name}" + (f" for table {table}" if table else "") + " (as expected)")
+
+
+@action("pick_random_custom_key")
+def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
+    """Randomly select one table/column(s) to route by `--cdc-partition-key-overrides`
+    instead of the hardcoded default, and wire that pick through everywhere it
+    needs to land:
+
+      - appends to `voyager.import_data.flags.cdc-partition-key-overrides`.
+      - adds the picked column(s) to the named generator's
+        `exclude_columns_from_update[table]`, so the random generator never
+        updates them (the importer requires custom key columns to be immutable).
+
+    Must run before `start_event_generator`/`start_importer` -- both read
+    `ctx.cfg` at start time, so mutating it here beforehand is sufficient; no
+    orchestrator plumbing changes are needed for the pick to take effect.
+
+    Required stage key:
+      - candidates: list of {table: "schema.table", columns: [col, ...]}. Every
+        candidate's conflict DML must already be safe to route by those
+        columns (i.e. never appears in an UPDATE for that table) -- this
+        action only performs the pick and the wiring, not that verification.
+
+    Optional stage key:
+      - generator_key: which generator config block to inject
+        exclude_columns_from_update into (default: "generator").
+
+    The pick is stored on `ctx.picked_custom_key` (`{"table", "columns"}`) for
+    `validate_no_conflicts_for_picked_custom_key` to consume later.
+    """
+    if ctx.picked_custom_key is not None:
+        raise RuntimeError(
+            "pick_random_custom_key: ctx.picked_custom_key is already set "
+            f"(previous pick: {ctx.picked_custom_key}) -- this action does not support "
+            "running more than once per scenario (e.g. inside a loop_start/loop_end block), "
+            "since a second pick would silently stack onto cdc-partition-key-overrides via "
+            "';' while ctx.picked_custom_key would only reflect the newest pick."
+        )
+
+    candidates = stage.get("candidates")
+    if not candidates:
+        raise ValueError("pick_random_custom_key: 'candidates' stage key is required and must be non-empty")
+
+    choice = random.choice(candidates)
+    table = choice["table"]
+    columns = choice["columns"]
+    ctx.picked_custom_key = {"table": table, "columns": columns}
+    H.log(f"pick_random_custom_key: selected table={table} columns={columns} (out of {len(candidates)} candidates)")
+
+    override = f"{table}:({','.join(columns)})"
+    flags = ctx.cfg.setdefault("voyager", {}).setdefault("import_data", {}).setdefault("flags", {})
+    existing = flags.get("cdc-partition-key-overrides")
+    flags["cdc-partition-key-overrides"] = f"{existing};{override}" if existing else override
+
+    generator_key = stage.get("generator_key", "generator")
+    _, _, bare_table = table.partition(".")
+    gen_cfg_block = ctx.cfg[generator_key]
+    if "config_inline" not in gen_cfg_block:
+        raise ValueError(
+            f"pick_random_custom_key: generator block '{generator_key}' must use 'config_inline' "
+            "(not 'config_path') -- a config_path generator loads a static file this action cannot mutate at run time"
+        )
+    gen_section = gen_cfg_block["config_inline"]["generator"]
+    exclude_map = gen_section.setdefault("exclude_columns_from_update", {})
+    excluded_for_table = exclude_map.setdefault(bare_table, [])
+    for col in columns:
+        if col not in excluded_for_table:
+            excluded_for_table.append(col)
+
+
+@action("validate_no_conflicts_for_picked_custom_key")
+def validate_no_conflicts_for_picked_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
+    """`validate_no_conflicts_detected`, scoped to whatever table
+    `pick_random_custom_key` selected earlier in this run -- lets the scenario
+    assert 0 conflicts for the picked table without knowing in advance which
+    one that will be.
+    """
+    picked = ctx.picked_custom_key
+    if not picked:
+        raise RuntimeError(
+            "validate_no_conflicts_for_picked_custom_key: ctx.picked_custom_key is unset "
+            "-- run 'pick_random_custom_key' earlier in this scenario"
+        )
+    scoped_stage = dict(stage)
+    scoped_stage["table"] = picked["table"]
+    validate_no_conflicts_detected_action(scoped_stage, ctx)
 
 
 @action("start_resumptions")

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -290,27 +290,33 @@ def row_hash_validations_action(stage: Dict[str, Any], ctx: Any) -> None:
     H.run_segment_hash_validations(ctx, left_role, right_role)
 
 
-def _conflict_log_table_marker(table: str | None) -> str | None:
-    """Build the substring that identifies `table` in a "conflict detected" log
-    line, e.g. "public.orders" -> 'table "public"."orders"' (conflictDetectionCache.go
-    renders TableNameTup.ForKey() with each identifier quoted)."""
+def _conflict_log_table_markers(table: str | None) -> list[str] | None:
+    """Build the substrings that identify `table` in a "conflict detected" log
+    line. conflictDetectionCache.go renders the table via TableNameTup.ForKey()
+    (each identifier quoted: 'table "public"."orders"') in some messages and
+    TableNameTup.ForOutput() (minimally quoted: 'table public.orders' for
+    lowercase identifiers) in others, so a line matches if it carries either
+    form."""
     if table is None:
         return None
     schema, sep, name = table.partition(".")
     if not sep:
-        raise ValueError(f"_conflict_log_table_marker: 'table' must be schema-qualified (e.g. 'public.orders'), got {table!r}")
-    return f'table "{schema}"."{name}"'
+        raise ValueError(f"_conflict_log_table_markers: 'table' must be schema-qualified (e.g. 'public.orders'), got {table!r}")
+    # every message renders a comma right after the table name; the trailing
+    # comma on the unquoted form keeps 'public.single_unique_index' from also
+    # matching 'public.single_unique_index_nulls_distinct'.
+    return [f'table "{schema}"."{name}"', f'table {schema}.{name},']
 
 
 def _count_conflict_log_lines(log_dir: str, name: str, table: str | None) -> int:
     """Count "conflict detected" lines in `log_dir`/`name`* log files, optionally
-    scoped to one table (see `_conflict_log_table_marker`)."""
-    table_marker = _conflict_log_table_marker(table)
+    scoped to one table (see `_conflict_log_table_markers`)."""
+    table_markers = _conflict_log_table_markers(table)
     count = 0
     for p in glob.glob(os.path.join(log_dir, name + "*")):
         with open(p, errors="ignore") as f:
             for line in f:
-                if "conflict detected" in line and (table_marker is None or table_marker in line):
+                if "conflict detected" in line and (table_markers is None or any(m in line for m in table_markers)):
                     count += 1
     return count
 

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -393,24 +393,31 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
     orchestrator plumbing changes are needed for the pick to take effect.
 
     Required stage key:
-      - candidates: list of {table: "schema.table", expect_conflicts: bool
-        (optional, default false)} with EITHER:
-          - columns: [col, ...] -- a fixed custom key, OR
-          - random_columns_pool: [col, ...] -- the key's columns are ALSO
-            randomized: 1..2 columns (or min_columns..max_columns) are sampled
-            from the pool, in random order, so successive runs route the same
-            table by different columns and column counts.
-        Every fixed column and every pool column must already be safe to route
-        by (never appears in an UPDATE for that table in the conflict DML, and
-        its value must be identical across the rows of each conflict pair --
-        e.g. a DML-churned key column, or a column the DML leaves at a
-        transaction-constant default) -- this action only performs the pick
-        and the wiring, not that verification.
-        `expect_conflicts: true` marks a candidate whose DML deliberately
-        creates conflicts that MUST still be detected when it is picked (e.g.
-        a PK-recycle pattern); `validate_picked_custom_key_conflicts` uses it
-        to decide which assertion to run. Such candidates should use fixed
-        `columns` -- their assertion depends on the specific key.
+      - candidates: list of {table: "schema.table", columns: [col, ...]} plus
+        the optional keys below.
+          - columns (required): the table's natural custom key -- its
+            unique-index column(s). Used as-is when no pool is given, and as
+            the "natural" branch when one is.
+          - random_columns_pool: [col, ...] -- when given, the key's columns are
+            ALSO randomized: with probability 1 - natural_key_probability
+            (default 0.5) 1..2 columns (or min_columns..max_columns) are
+            sampled from the pool in random order, otherwise `columns` is
+            used -- so successive runs route the same table by different
+            columns, column counts and datatypes while still regularly
+            exercising the natural key.
+          - unique_index_columns: [[col, ...], ...] -- every unique index on
+            the table (default: [columns]). Zero conflicts is asserted for the
+            picked table only when the sampled key is a subset of EVERY listed
+            index (see the comment in the code for why that is the structural
+            condition); otherwise conflicts on it are legitimate and only
+            reported.
+          - expect_conflicts: bool (default false) -- marks a candidate whose
+            DML deliberately creates conflicts that MUST still be detected when
+            it is picked (e.g. a PK-recycle pattern); such candidates should
+            not set a pool -- their assertion depends on the specific key.
+        Every column in `columns` and in a pool must be immutability-safe:
+        never appears in an UPDATE for that table in the conflict DML -- this
+        action only performs the pick and the wiring, not that verification.
 
     Optional stage key:
       - generator_key: which generator config block to inject
@@ -434,22 +441,38 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
 
     choice = random.choice(candidates)
     table = choice["table"]
+    natural_columns = choice["columns"]
     pool = choice.get("random_columns_pool")
-    if pool:
-        if choice.get("columns"):
-            raise ValueError(f"pick_random_custom_key: candidate {table} must not set both 'columns' and 'random_columns_pool'")
+    unique_index_columns = choice.get("unique_index_columns") or [natural_columns]
+    if pool and random.random() >= float(choice.get("natural_key_probability", 0.5)):
         min_cols = int(choice.get("min_columns", 1))
         max_cols = min(int(choice.get("max_columns", 2)), len(pool))
-        num_cols = random.randint(min_cols, max_cols)
-        columns = random.sample(pool, num_cols)
+        columns = random.sample(pool, random.randint(min_cols, max_cols))
+        how = f"sampled from pool of {len(pool)}"
     else:
-        columns = choice["columns"]
+        columns = natural_columns
+        how = "natural unique-key columns"
     expect_conflicts = bool(choice.get("expect_conflicts", False))
-    ctx.picked_custom_key = {"table": table, "columns": columns, "expect_conflicts": expect_conflicts}
+    # Two rows that collide on a unique index are equal on every column of that
+    # index; if the custom key uses only such columns they are equal on the key
+    # too, so they share a channel and the conflict cache never has to serialize
+    # them -- structurally, for any traffic (deterministic DML or the random
+    # generator). Any other key can legitimately see cross-channel collisions
+    # (e.g. two rows with the same check_id but different status), which the
+    # cache MUST serialize -- so zero conflicts is only asserted in the first
+    # case. The synthetic PK index the importer adds for custom-key tables is
+    # deliberately not part of this check: nothing but the expect_conflicts
+    # PK-recycle candidate ever reuses a primary key.
+    zero_conflicts_guaranteed = all(set(columns) <= set(idx) for idx in unique_index_columns)
+    ctx.picked_custom_key = {
+        "table": table,
+        "columns": columns,
+        "expect_conflicts": expect_conflicts,
+        "zero_conflicts_guaranteed": zero_conflicts_guaranteed,
+    }
     H.log(
-        f"pick_random_custom_key: selected table={table} columns={columns} "
-        f"expect_conflicts={expect_conflicts} "
-        f"({'sampled from pool of ' + str(len(pool)) if pool else 'fixed'}; out of {len(candidates)} candidates)"
+        f"pick_random_custom_key: selected table={table} columns={columns} ({how}; out of {len(candidates)} candidates) "
+        f"expect_conflicts={expect_conflicts} zero_conflicts_guaranteed={zero_conflicts_guaranteed}"
     )
 
     override = f"{table}:({','.join(columns)})"
@@ -478,13 +501,19 @@ def validate_picked_custom_key_conflicts_action(stage: Dict[str, Any], ctx: Any)
     """Run the right conflict assertion for whatever table `pick_random_custom_key`
     selected earlier in this run:
 
-      - expect_conflicts false (the usual case): the picked table's conflicts all
-        share its custom key's value, so they land on one channel already and the
-        conflict-detection cache must never fire for it -- assert 0.
       - expect_conflicts true (e.g. a PK-recycle candidate, where the SAME PK is
         reused with a DIFFERENT custom-key value -- a real cross-channel race
         custom-key routing does not eliminate): the synthetic-PK guard must still
         catch it -- assert >= min_count (default 1).
+      - zero_conflicts_guaranteed (the key is a subset of every unique index on
+        the table): any two rows colliding on a unique index are equal on the
+        key, so they share a channel and the cache must never fire for the
+        table -- assert 0, for any traffic source.
+      - otherwise (an arbitrary sampled key): rows colliding on a unique index
+        can carry different key values and land on different channels, so the
+        cache serializing them is correct behavior, not a failure -- only report
+        the count. Such runs still verify routing, the immutability guard, and
+        end-to-end correctness via the row-hash validations.
     """
     picked = ctx.picked_custom_key
     if not picked:
@@ -496,8 +525,17 @@ def validate_picked_custom_key_conflicts_action(stage: Dict[str, Any], ctx: Any)
     scoped_stage["table"] = picked["table"]
     if picked["expect_conflicts"]:
         validate_conflicts_detected_action(scoped_stage, ctx)
-    else:
+    elif picked["zero_conflicts_guaranteed"]:
         validate_no_conflicts_detected_action(scoped_stage, ctx)
+    else:
+        log_dir = os.path.join(ctx.iteration_export_dir, "logs")
+        name = stage.get("log", "yb-voyager-import-data.log")
+        count = _count_conflict_log_lines(log_dir, name, picked["table"])
+        H.log(
+            f"validate_picked_custom_key_conflicts: key {picked['columns']} is not a subset of every "
+            f"unique index on {picked['table']}, so cross-channel collisions are legitimate -- "
+            f"{count} conflicts detected in {name} (informational, not asserted)"
+        )
 
 
 @action("voyager_import_start_expect_fail")

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -393,13 +393,12 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
     `ctx.cfg` at start time, so mutating it here beforehand is sufficient.
 
     Required stage key:
-      - candidates: list of {table: "schema.table", ...} with EITHER
-          - random_columns_pool: [col, ...] -- 1..2 columns (or
-            min_columns..max_columns) are sampled in random order, so successive
-            runs route the same table by different columns, counts and
-            datatypes; OR
-          - columns: [col, ...] -- a fixed key, for candidates whose assertion
-            depends on a specific key (see expect_conflicts).
+      - candidates: list of {table: "schema.table", random_columns_pool:
+        [col, ...]} -- 1..2 columns (or min_columns..max_columns) are sampled
+        from the pool in random order, so successive runs route the same table
+        by different columns, counts and datatypes. A single-column pool pins
+        the key for candidates whose assertion depends on it (see
+        expect_conflicts).
         Optional per candidate:
           - partitions: [bare_table, ...] -- leaf partitions of a partitioned
             table; the generator exclusion is applied to them too.
@@ -407,7 +406,7 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
             deliberately creates conflicts that MUST still be detected when it
             is picked (e.g. a PK-recycle pattern); used by
             `validate_picked_custom_key_conflicts`.
-        Every pool/fixed column must be immutability-safe (never appears in an
+        Every pool column must be immutability-safe (never appears in an
         UPDATE for that table in the conflict DML) -- this action only performs
         the pick and the wiring, not that verification.
 
@@ -432,21 +431,15 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
 
     choice = random.choice(candidates)
     table = choice["table"]
-    pool = choice.get("random_columns_pool")
-    if pool:
-        if choice.get("columns"):
-            raise ValueError(f"pick_random_custom_key: candidate {table} must not set both 'columns' and 'random_columns_pool'")
-        min_cols = int(choice.get("min_columns", 1))
-        max_cols = min(int(choice.get("max_columns", 2)), len(pool))
-        columns = random.sample(pool, random.randint(min_cols, max_cols))
-        how = f"sampled from pool of {len(pool)}"
-    else:
-        columns = choice["columns"]
-        how = "fixed"
+    pool = choice["random_columns_pool"]
+    min_cols = int(choice.get("min_columns", 1))
+    max_cols = min(int(choice.get("max_columns", 2)), len(pool))
+    columns = random.sample(pool, random.randint(min_cols, max_cols))
     expect_conflicts = bool(choice.get("expect_conflicts", False))
     ctx.picked_custom_key = {"table": table, "columns": columns, "expect_conflicts": expect_conflicts}
     H.log(
-        f"pick_random_custom_key: selected table={table} columns={columns} ({how}; out of {len(candidates)} candidates) "
+        f"pick_random_custom_key: selected table={table} columns={columns} "
+        f"(sampled from a pool of {len(pool)}; out of {len(candidates)} candidates) "
         f"expect_conflicts={expect_conflicts}"
     )
 

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -4,7 +4,6 @@ import os
 import sys
 import glob
 import argparse
-import copy
 import random
 import subprocess
 import time
@@ -379,52 +378,44 @@ def validate_no_conflicts_detected_action(stage: Dict[str, Any], ctx: Any) -> No
 
 @action("pick_random_custom_key")
 def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
-    """Randomly select ONE table/column(s) to route by `--cdc-partition-key-overrides`
-    this run -- mirroring how a real user opts specific tables into custom-key
-    routing -- and wire that pick through everywhere it needs to land:
+    """Randomly select ONE table to route by `--cdc-partition-key-overrides` this
+    run, then sample WHICH of its columns form the custom key, and wire that pick
+    through everywhere it needs to land:
 
       - appends to `voyager.import_data.flags.cdc-partition-key-overrides`.
       - adds the picked column(s) to the named generator's
-        `exclude_columns_from_update[table]`, so the random generator never
-        updates them (the importer requires custom key columns to be immutable).
+        `exclude_columns_from_update` for the table and each of its declared
+        partitions, so the random generator never updates them (the importer
+        requires custom key columns to be immutable, and events on a leaf
+        partition are renamed to the root before that check runs).
 
     Must run before `start_event_generator`/`start_importer` -- both read
-    `ctx.cfg` at start time, so mutating it here beforehand is sufficient; no
-    orchestrator plumbing changes are needed for the pick to take effect.
+    `ctx.cfg` at start time, so mutating it here beforehand is sufficient.
 
     Required stage key:
-      - candidates: list of {table: "schema.table", columns: [col, ...]} plus
-        the optional keys below.
-          - columns (required): the table's natural custom key -- its
-            unique-index column(s). Used as-is when no pool is given, and as
-            the "natural" branch when one is.
-          - random_columns_pool: [col, ...] -- when given, the key's columns are
-            ALSO randomized: with probability 1 - natural_key_probability
-            (default 0.5) 1..2 columns (or min_columns..max_columns) are
-            sampled from the pool in random order, otherwise `columns` is
-            used -- so successive runs route the same table by different
-            columns, column counts and datatypes while still regularly
-            exercising the natural key.
-          - unique_index_columns: [[col, ...], ...] -- every unique index on
-            the table (default: [columns]). Zero conflicts is asserted for the
-            picked table only when the sampled key is a subset of EVERY listed
-            index (see the comment in the code for why that is the structural
-            condition); otherwise conflicts on it are legitimate and only
-            reported.
-          - expect_conflicts: bool (default false) -- marks a candidate whose
-            DML deliberately creates conflicts that MUST still be detected when
-            it is picked (e.g. a PK-recycle pattern); such candidates should
-            not set a pool -- their assertion depends on the specific key.
-        Every column in `columns` and in a pool must be immutability-safe:
-        never appears in an UPDATE for that table in the conflict DML -- this
-        action only performs the pick and the wiring, not that verification.
+      - candidates: list of {table: "schema.table", ...} with EITHER
+          - random_columns_pool: [col, ...] -- 1..2 columns (or
+            min_columns..max_columns) are sampled in random order, so successive
+            runs route the same table by different columns, counts and
+            datatypes; OR
+          - columns: [col, ...] -- a fixed key, for candidates whose assertion
+            depends on a specific key (see expect_conflicts).
+        Optional per candidate:
+          - partitions: [bare_table, ...] -- leaf partitions of a partitioned
+            table; the generator exclusion is applied to them too.
+          - expect_conflicts: bool (default false) -- the candidate's DML
+            deliberately creates conflicts that MUST still be detected when it
+            is picked (e.g. a PK-recycle pattern); used by
+            `validate_picked_custom_key_conflicts`.
+        Every pool/fixed column must be immutability-safe (never appears in an
+        UPDATE for that table in the conflict DML) -- this action only performs
+        the pick and the wiring, not that verification.
 
     Optional stage key:
       - generator_key: which generator config block to inject
         exclude_columns_from_update into (default: "generator").
 
-    The pick is stored on `ctx.picked_custom_key` for
-    `validate_picked_custom_key_conflicts` to consume later.
+    The pick is stored on `ctx.picked_custom_key`.
     """
     if ctx.picked_custom_key is not None:
         raise RuntimeError(
@@ -441,38 +432,22 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
 
     choice = random.choice(candidates)
     table = choice["table"]
-    natural_columns = choice["columns"]
     pool = choice.get("random_columns_pool")
-    unique_index_columns = choice.get("unique_index_columns") or [natural_columns]
-    if pool and random.random() >= float(choice.get("natural_key_probability", 0.5)):
+    if pool:
+        if choice.get("columns"):
+            raise ValueError(f"pick_random_custom_key: candidate {table} must not set both 'columns' and 'random_columns_pool'")
         min_cols = int(choice.get("min_columns", 1))
         max_cols = min(int(choice.get("max_columns", 2)), len(pool))
         columns = random.sample(pool, random.randint(min_cols, max_cols))
         how = f"sampled from pool of {len(pool)}"
     else:
-        columns = natural_columns
-        how = "natural unique-key columns"
+        columns = choice["columns"]
+        how = "fixed"
     expect_conflicts = bool(choice.get("expect_conflicts", False))
-    # Two rows that collide on a unique index are equal on every column of that
-    # index; if the custom key uses only such columns they are equal on the key
-    # too, so they share a channel and the conflict cache never has to serialize
-    # them -- structurally, for any traffic (deterministic DML or the random
-    # generator). Any other key can legitimately see cross-channel collisions
-    # (e.g. two rows with the same check_id but different status), which the
-    # cache MUST serialize -- so zero conflicts is only asserted in the first
-    # case. The synthetic PK index the importer adds for custom-key tables is
-    # deliberately not part of this check: nothing but the expect_conflicts
-    # PK-recycle candidate ever reuses a primary key.
-    zero_conflicts_guaranteed = all(set(columns) <= set(idx) for idx in unique_index_columns)
-    ctx.picked_custom_key = {
-        "table": table,
-        "columns": columns,
-        "expect_conflicts": expect_conflicts,
-        "zero_conflicts_guaranteed": zero_conflicts_guaranteed,
-    }
+    ctx.picked_custom_key = {"table": table, "columns": columns, "expect_conflicts": expect_conflicts}
     H.log(
         f"pick_random_custom_key: selected table={table} columns={columns} ({how}; out of {len(candidates)} candidates) "
-        f"expect_conflicts={expect_conflicts} zero_conflicts_guaranteed={zero_conflicts_guaranteed}"
+        f"expect_conflicts={expect_conflicts}"
     )
 
     override = f"{table}:({','.join(columns)})"
@@ -481,7 +456,6 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
     flags["cdc-partition-key-overrides"] = f"{existing};{override}" if existing else override
 
     generator_key = stage.get("generator_key", "generator")
-    _, _, bare_table = table.partition(".")
     gen_cfg_block = ctx.cfg[generator_key]
     if "config_inline" not in gen_cfg_block:
         raise ValueError(
@@ -490,30 +464,30 @@ def pick_random_custom_key_action(stage: Dict[str, Any], ctx: Any) -> None:
         )
     gen_section = gen_cfg_block["config_inline"]["generator"]
     exclude_map = gen_section.setdefault("exclude_columns_from_update", {})
-    excluded_for_table = exclude_map.setdefault(bare_table, [])
-    for col in columns:
-        if col not in excluded_for_table:
-            excluded_for_table.append(col)
+    _, _, bare_table = table.partition(".")
+    for gen_table in [bare_table] + list(choice.get("partitions") or []):
+        excluded_for_table = exclude_map.setdefault(gen_table, [])
+        for col in columns:
+            if col not in excluded_for_table:
+                excluded_for_table.append(col)
 
 
 @action("validate_picked_custom_key_conflicts")
 def validate_picked_custom_key_conflicts_action(stage: Dict[str, Any], ctx: Any) -> None:
-    """Run the right conflict assertion for whatever table `pick_random_custom_key`
-    selected earlier in this run:
+    """For the table `pick_random_custom_key` selected this run:
 
-      - expect_conflicts true (e.g. a PK-recycle candidate, where the SAME PK is
-        reused with a DIFFERENT custom-key value -- a real cross-channel race
-        custom-key routing does not eliminate): the synthetic-PK guard must still
-        catch it -- assert >= min_count (default 1).
-      - zero_conflicts_guaranteed (the key is a subset of every unique index on
-        the table): any two rows colliding on a unique index are equal on the
-        key, so they share a channel and the cache must never fire for the
-        table -- assert 0, for any traffic source.
-      - otherwise (an arbitrary sampled key): rows colliding on a unique index
-        can carry different key values and land on different channels, so the
-        cache serializing them is correct behavior, not a failure -- only report
-        the count. Such runs still verify routing, the immutability guard, and
-        end-to-end correctness via the row-hash validations.
+      - expect_conflicts true (the PK-recycle candidate: the SAME PK is reused
+        with a DIFFERENT custom-key value -- a real cross-channel race custom-key
+        routing does not eliminate): the synthetic-PK guard must still catch
+        it -- assert >= min_count (default 1).
+      - otherwise: report the conflict count for the table. With an arbitrary
+        sampled key, rows colliding on a unique index can carry different key
+        values and land on different channels, so the cache serializing them is
+        correct behavior, not a failure; the same-channel property for a key
+        that IS the index column is asserted by the Go-side
+        TestLiveMigrationCustomCdcPartitionKeyNoConflict. These runs verify
+        routing, the immutability guard and end-to-end correctness via the
+        row-hash validations.
     """
     picked = ctx.picked_custom_key
     if not picked:
@@ -521,73 +495,18 @@ def validate_picked_custom_key_conflicts_action(stage: Dict[str, Any], ctx: Any)
             "validate_picked_custom_key_conflicts: ctx.picked_custom_key is unset "
             "-- run 'pick_random_custom_key' earlier in this scenario"
         )
-    scoped_stage = dict(stage)
-    scoped_stage["table"] = picked["table"]
     if picked["expect_conflicts"]:
+        scoped_stage = dict(stage)
+        scoped_stage["table"] = picked["table"]
         validate_conflicts_detected_action(scoped_stage, ctx)
-    elif picked["zero_conflicts_guaranteed"]:
-        validate_no_conflicts_detected_action(scoped_stage, ctx)
-    else:
-        log_dir = os.path.join(ctx.iteration_export_dir, "logs")
-        name = stage.get("log", "yb-voyager-import-data.log")
-        count = _count_conflict_log_lines(log_dir, name, picked["table"])
-        H.log(
-            f"validate_picked_custom_key_conflicts: key {picked['columns']} is not a subset of every "
-            f"unique index on {picked['table']}, so cross-channel collisions are legitimate -- "
-            f"{count} conflicts detected in {name} (informational, not asserted)"
-        )
-
-
-@action("voyager_import_start_expect_fail")
-def voyager_import_start_expect_fail_action(stage: Dict[str, Any], ctx: Any) -> None:
-    """Run `import data` in the foreground with the scenario's flags plus the
-    stage's `flags` on top, and require it to FAIL with `error_contains` in its
-    output -- used to verify resume guardrails at the real CLI level (e.g.
-    changing cdc-partition-key / cdc-partition-key-overrides between runs must
-    be rejected). The running importer must be stopped first
-    (voyager_stop_command), or this run fails on the export-dir lock instead.
-
-    Stage keys:
-      - flags (required): flag overrides merged over voyager.import_data.flags
-        for this one invocation only (ctx.cfg is not mutated). The placeholder
-        "{picked_table}" in a value is replaced with the table
-        pick_random_custom_key selected.
-      - error_contains (required): substring that must appear in the failed
-        run's stdout/stderr.
-      - timeout_sec (optional, default 120): how long the invocation may run
-        before being killed and the stage failed.
-    """
-    error_contains = stage.get("error_contains")
-    if not error_contains:
-        raise ValueError("voyager_import_start_expect_fail: 'error_contains' stage key is required")
-    extra_flags = dict(stage.get("flags") or {})
-    if not extra_flags:
-        raise ValueError("voyager_import_start_expect_fail: 'flags' stage key is required and must be non-empty")
-    for k, v in extra_flags.items():
-        if isinstance(v, str) and "{picked_table}" in v:
-            if not ctx.picked_custom_key:
-                raise RuntimeError(
-                    "voyager_import_start_expect_fail: '{picked_table}' used but no custom key was picked "
-                    "-- run 'pick_random_custom_key' earlier in this scenario"
-                )
-            extra_flags[k] = v.replace("{picked_table}", ctx.picked_custom_key["table"])
-
-    cfg = copy.deepcopy(ctx.cfg)
-    flags = cfg.setdefault("voyager", {}).setdefault("import_data", {}).setdefault("flags", {})
-    flags.update(extra_flags)
-    cmd = H.build_import_data_cmd(cfg)
-    timeout = int(stage.get("timeout_sec", 120))
-    H.log(f"voyager_import_start_expect_fail: running import data expecting failure with {extra_flags}")
-    proc = subprocess.run(cmd, env=ctx.env, capture_output=True, text=True, timeout=timeout)
-    output = (proc.stdout or "") + (proc.stderr or "")
-    if proc.returncode == 0:
-        raise RuntimeError(f"voyager_import_start_expect_fail: import unexpectedly SUCCEEDED with flags {extra_flags}")
-    if error_contains not in output:
-        raise RuntimeError(
-            f"voyager_import_start_expect_fail: import failed (exit {proc.returncode}) but the expected "
-            f"error text was not found.\nexpected substring: {error_contains}\noutput (tail):\n{output[-3000:]}"
-        )
-    H.log(f"voyager_import_start_expect_fail: import correctly rejected (exit {proc.returncode})")
+        return
+    log_dir = os.path.join(ctx.iteration_export_dir, "logs")
+    name = stage.get("log", "yb-voyager-import-data.log")
+    count = _count_conflict_log_lines(log_dir, name, picked["table"])
+    H.log(
+        f"validate_picked_custom_key_conflicts: {count} conflicts detected in {name} for {picked['table']} "
+        f"routed by {picked['columns']} (informational, not asserted)"
+    )
 
 
 @action("start_resumptions")

--- a/migtests/tests/resumption/live-migration/common-sql/verify_sequence_restored_after_cutover.sql
+++ b/migtests/tests/resumption/live-migration/common-sql/verify_sequence_restored_after_cutover.sql
@@ -1,0 +1,6 @@
+-- Honest insert: relies on cutover_table's SERIAL default (nextval) instead of
+-- supplying an id. If the cutover did not restore the sequence past the migrated
+-- rows, nextval returns an already-used id and this fails with a duplicate-key
+-- error, surfacing the missed sequence bump. Run against the DB just cut over to.
+INSERT INTO public.cutover_table(status)
+VALUES ('verify sequence restored after cutover');

--- a/migtests/tests/resumption/live-migration/common-sql/verify_sequence_restored_after_cutover.sql
+++ b/migtests/tests/resumption/live-migration/common-sql/verify_sequence_restored_after_cutover.sql
@@ -1,6 +1,0 @@
--- Honest insert: relies on cutover_table's SERIAL default (nextval) instead of
--- supplying an id. If the cutover did not restore the sequence past the migrated
--- rows, nextval returns an already-used id and this fails with a duplicate-key
--- error, surfacing the missed sequence bump. Run against the DB just cut over to.
-INSERT INTO public.cutover_table(status)
-VALUES ('verify sequence restored after cutover');

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
@@ -1,12 +1,34 @@
--- Schema for the live-migration unique-conflict resumption test.
--- Tables are copied from migtests/tests/pg/unique-key-conflicts-test/snapshot_schema.sql
--- and cover every unique-key shape the streaming-phase conflict-detection cache
--- (yb-voyager/cmd/conflictDetectionCache.go) reasons about.
+-- Schema for the custom-cdc-partition-key live-migration resumption test.
+-- Unique-key shapes are copied from fallback-unique-conflict-test/init.sql
+-- (originally migtests/tests/pg/unique-key-conflicts-test/snapshot_schema.sql)
+-- and cover every unique-key shape the streaming-phase conflict-detection
+-- cache (yb-voyager/cmd/conflictDetectionCache.go) reasons about.
+--
+-- Each table carries 13-14 columns shaped like a production table: an audit
+-- backbone (created_at/updated_at NOT NULL, nullable deleted_at) plus a
+-- realistic mix of business columns -- varchar/text/timestamp-heavy, with
+-- boolean, int, bigint, smallint, date, numeric(38,6), jsonb, uuid, arrays
+-- and double precision spread across the tables. NOT NULL columns get a
+-- DEFAULT so the deterministic conflict DML (source_dml.sql), which names
+-- only the key columns, works unchanged. numeric stays bounded -- unbounded
+-- numeric loses trailing zeros through live CDC and breaks row-hash
+-- validation.
 
 -- Table with Single Column Unique Constraint
 CREATE TABLE single_unique_constraint (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255) UNIQUE
+    email VARCHAR(255) UNIQUE,
+    description text NOT NULL DEFAULT '',
+    notes text NOT NULL DEFAULT '',
+    failure_reason text NOT NULL DEFAULT '',
+    remarks text NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    address_line text NOT NULL DEFAULT '',
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    deleted_at timestamp
 );
 
 -- Table with Multiple Column Unique Constraint
@@ -14,13 +36,34 @@ CREATE TABLE multi_unique_constraint (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
     last_name VARCHAR(100),
+    status varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    metadata jsonb NOT NULL DEFAULT '{}',
+    description text NOT NULL DEFAULT '',
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    is_verified boolean,
+    notes text,
+    deleted_at timestamp,
     CONSTRAINT unique_name UNIQUE (first_name, last_name)
 );
 
 -- Table with Single Column Unique Index
 CREATE TABLE single_unique_index (
     id SERIAL PRIMARY KEY,
-    "Ssn" VARCHAR(100)
+    "Ssn" VARCHAR(100),
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    status varchar NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    is_active boolean NOT NULL DEFAULT false,
+    currency varchar NOT NULL DEFAULT '',
+    is_verified boolean NOT NULL DEFAULT false,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    notes text,
+    seq_no bigint
 );
 CREATE UNIQUE INDEX idx_ssn_unique ON single_unique_index ("Ssn");
 
@@ -28,14 +71,36 @@ CREATE UNIQUE INDEX idx_ssn_unique ON single_unique_index ("Ssn");
 CREATE TABLE multi_unique_index (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
-    last_name VARCHAR(100)
+    last_name VARCHAR(100),
+    description text,
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    metadata jsonb NOT NULL DEFAULT '{}',
+    created_at timestamp,
+    updated_at timestamp,
+    notes text,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    failure_reason text,
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_name_unique ON multi_unique_index (first_name, last_name);
 
 -- Table with Unique Constraint and Unique Index on the Same Column
 CREATE TABLE same_column_unique_constraint_and_index (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255) UNIQUE
+    email VARCHAR(255) UNIQUE,
+    status varchar NOT NULL DEFAULT '',
+    external_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    currency varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    attempt_count int NOT NULL DEFAULT 0,
+    tags varchar[] NOT NULL DEFAULT '{}',
+    processed_at timestamp,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    reference_code varchar NOT NULL DEFAULT '',
+    org_unit varchar NOT NULL DEFAULT ''
 );
 CREATE UNIQUE INDEX idx_email_unique ON same_column_unique_constraint_and_index (email);
 
@@ -43,7 +108,17 @@ CREATE UNIQUE INDEX idx_email_unique ON same_column_unique_constraint_and_index 
 CREATE TABLE different_columns_unique_constraint_and_index (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255) UNIQUE,
-    phone_number VARCHAR(20)
+    phone_number VARCHAR(20),
+    status varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    metadata jsonb NOT NULL DEFAULT '{}',
+    description text NOT NULL DEFAULT '',
+    notes text,
+    failure_reason text,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_phone_unique ON different_columns_unique_constraint_and_index (phone_number);
 
@@ -52,7 +127,17 @@ CREATE TABLE subset_columns_unique_constraint_and_index (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
     last_name VARCHAR(100),
-    phone_number VARCHAR(20)
+    phone_number VARCHAR(20),
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    priority smallint NOT NULL DEFAULT 0,
+    processed_at timestamp,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    is_active boolean NOT NULL DEFAULT false,
+    retry_count int NOT NULL DEFAULT 0,
+    attempt_count int NOT NULL DEFAULT 0
 );
 
 -- Unique constraint on first_name and last_name
@@ -64,14 +149,36 @@ CREATE UNIQUE INDEX idx_name_phone_unique ON subset_columns_unique_constraint_an
 
 CREATE TABLE expression_based_unique_index (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255)
+    email VARCHAR(255),
+    description text NOT NULL DEFAULT '',
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    status varchar NOT NULL DEFAULT '',
+    is_active boolean NOT NULL DEFAULT false,
+    deleted_at timestamp,
+    amount numeric(38,6),
+    notes text,
+    failure_reason text,
+    remarks text,
+    address_line text
 );
 CREATE UNIQUE INDEX idx_email_unique_expression ON expression_based_unique_index (LOWER(email));
 
 CREATE TABLE test_partial_unique_index (
     id SERIAL PRIMARY KEY,
     check_id int,
-    most_recent boolean
+    most_recent boolean,
+    status varchar NOT NULL DEFAULT '',
+    metadata jsonb,
+    retry_count int NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    currency varchar NOT NULL DEFAULT '',
+    reference_code varchar NOT NULL DEFAULT '',
+    org_unit varchar,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    deleted_at timestamp
 );
 
 CREATE UNIQUE INDEX idx_test_partial_unique_index ON test_partial_unique_index (check_id) WHERE most_recent;
@@ -80,7 +187,19 @@ CREATE UNIQUE INDEX idx_test_partial_unique_index ON test_partial_unique_index (
 -- equal, so a NULL free->reuse across different PKs is a real conflict.
 CREATE TABLE single_unique_index_nulls_not_distinct (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255)
+    email VARCHAR(255),
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    reference_code varchar NOT NULL DEFAULT '',
+    org_unit varchar NOT NULL DEFAULT '',
+    seq_no bigint NOT NULL DEFAULT 0,
+    amount numeric(38,6),
+    is_active boolean NOT NULL DEFAULT false,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    channel varchar
 );
 CREATE UNIQUE INDEX idx_email_nnd ON single_unique_index_nulls_not_distinct (email) NULLS NOT DISTINCT;
 
@@ -88,7 +207,18 @@ CREATE UNIQUE INDEX idx_email_nnd ON single_unique_index_nulls_not_distinct (ema
 CREATE TABLE multi_unique_index_nulls_not_distinct (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
-    last_name VARCHAR(100)
+    last_name VARCHAR(100),
+    description text NOT NULL DEFAULT '',
+    notes text NOT NULL DEFAULT '',
+    failure_reason text,
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    status varchar NOT NULL DEFAULT '',
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    remarks text,
+    deleted_at timestamp,
+    is_active boolean,
+    address_line text
 );
 CREATE UNIQUE INDEX idx_name_nnd ON multi_unique_index_nulls_not_distinct (first_name, last_name) NULLS NOT DISTINCT;
 
@@ -98,7 +228,18 @@ CREATE UNIQUE INDEX idx_name_nnd ON multi_unique_index_nulls_not_distinct (first
 -- NULLS DISTINCT branch of the per-index conflict handling.
 CREATE TABLE single_unique_index_nulls_distinct (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255)
+    email VARCHAR(255),
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    processed_at timestamp,
+    expires_at timestamp,
+    description text,
+    external_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    reference_code varchar,
+    org_unit varchar NOT NULL DEFAULT '',
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now()
 );
 CREATE UNIQUE INDEX idx_email_nd ON single_unique_index_nulls_distinct (email);
 
@@ -108,6 +249,17 @@ CREATE TABLE partitioned_unique_conflict (
     id INT,
     region VARCHAR(50),
     email VARCHAR(255),
+    description text NOT NULL DEFAULT '',
+    status varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    currency varchar,
+    reference_code varchar,
+    attempt_count int NOT NULL DEFAULT 0,
+    score double precision,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    due_date date,
+    deleted_at timestamp,
     PRIMARY KEY (id, region)
 ) PARTITION BY LIST (region);
 CREATE TABLE partitioned_unique_conflict_east PARTITION OF partitioned_unique_conflict FOR VALUES IN ('east');

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
@@ -1,0 +1,116 @@
+-- Schema for the live-migration unique-conflict resumption test.
+-- Tables are copied from migtests/tests/pg/unique-key-conflicts-test/snapshot_schema.sql
+-- and cover every unique-key shape the streaming-phase conflict-detection cache
+-- (yb-voyager/cmd/conflictDetectionCache.go) reasons about.
+
+-- Table with Single Column Unique Constraint
+CREATE TABLE single_unique_constraint (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE
+);
+
+-- Table with Multiple Column Unique Constraint
+CREATE TABLE multi_unique_constraint (
+    id SERIAL PRIMARY KEY,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    CONSTRAINT unique_name UNIQUE (first_name, last_name)
+);
+
+-- Table with Single Column Unique Index
+CREATE TABLE single_unique_index (
+    id SERIAL PRIMARY KEY,
+    "Ssn" VARCHAR(100)
+);
+CREATE UNIQUE INDEX idx_ssn_unique ON single_unique_index ("Ssn");
+
+-- Table with Multiple Column Unique Index
+CREATE TABLE multi_unique_index (
+    id SERIAL PRIMARY KEY,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100)
+);
+CREATE UNIQUE INDEX idx_name_unique ON multi_unique_index (first_name, last_name);
+
+-- Table with Unique Constraint and Unique Index on the Same Column
+CREATE TABLE same_column_unique_constraint_and_index (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE
+);
+CREATE UNIQUE INDEX idx_email_unique ON same_column_unique_constraint_and_index (email);
+
+-- Table with Unique Constraint and Unique Index on Different Columns
+CREATE TABLE different_columns_unique_constraint_and_index (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE,
+    phone_number VARCHAR(20)
+);
+CREATE UNIQUE INDEX idx_phone_unique ON different_columns_unique_constraint_and_index (phone_number);
+
+-- Table with Unique Constraint and Unique Index, having Subset of Columns Overlapping
+CREATE TABLE subset_columns_unique_constraint_and_index (
+    id SERIAL PRIMARY KEY,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    phone_number VARCHAR(20)
+);
+
+-- Unique constraint on first_name and last_name
+ALTER TABLE subset_columns_unique_constraint_and_index ADD CONSTRAINT unique_name_constraint UNIQUE (first_name, last_name);
+
+-- Unique index on first_name, last_name, and phone_number (superset of columns)
+CREATE UNIQUE INDEX idx_name_phone_unique ON subset_columns_unique_constraint_and_index (first_name, last_name, phone_number);
+
+
+CREATE TABLE expression_based_unique_index (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255)
+);
+CREATE UNIQUE INDEX idx_email_unique_expression ON expression_based_unique_index (LOWER(email));
+
+CREATE TABLE test_partial_unique_index (
+    id SERIAL PRIMARY KEY,
+    check_id int,
+    most_recent boolean
+);
+
+CREATE UNIQUE INDEX idx_test_partial_unique_index ON test_partial_unique_index (check_id) WHERE most_recent;
+
+-- Single-column unique index with NULLS NOT DISTINCT: two NULLs are treated as
+-- equal, so a NULL free->reuse across different PKs is a real conflict.
+CREATE TABLE single_unique_index_nulls_not_distinct (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255)
+);
+CREATE UNIQUE INDEX idx_email_nnd ON single_unique_index_nulls_not_distinct (email) NULLS NOT DISTINCT;
+
+-- Multi-column unique index with NULLS NOT DISTINCT.
+CREATE TABLE multi_unique_index_nulls_not_distinct (
+    id SERIAL PRIMARY KEY,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100)
+);
+CREATE UNIQUE INDEX idx_name_nnd ON multi_unique_index_nulls_not_distinct (first_name, last_name) NULLS NOT DISTINCT;
+
+-- Single-column unique index with the default NULLS DISTINCT: NULLs are all
+-- distinct, so multiple NULL rows coexist and a NULL free->reuse is NOT a conflict
+-- (contrast with single_unique_index_nulls_not_distinct above). Exercises the
+-- NULLS DISTINCT branch of the per-index conflict handling.
+CREATE TABLE single_unique_index_nulls_distinct (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255)
+);
+CREATE UNIQUE INDEX idx_email_nd ON single_unique_index_nulls_distinct (email);
+
+-- Partitioned table with a unique index. A unique key on a partitioned table
+-- must include the partition-key column, so the key is (email, region).
+CREATE TABLE partitioned_unique_conflict (
+    id INT,
+    region VARCHAR(50),
+    email VARCHAR(255),
+    PRIMARY KEY (id, region)
+) PARTITION BY LIST (region);
+CREATE TABLE partitioned_unique_conflict_east PARTITION OF partitioned_unique_conflict FOR VALUES IN ('east');
+CREATE TABLE partitioned_unique_conflict_west PARTITION OF partitioned_unique_conflict FOR VALUES IN ('west');
+CREATE TABLE partitioned_unique_conflict_default PARTITION OF partitioned_unique_conflict DEFAULT;
+CREATE UNIQUE INDEX idx_partitioned_unique_email ON partitioned_unique_conflict (email, region);

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
@@ -10,12 +10,12 @@
 -- text, amount numeric(38,6), due_date date, seq_no bigint, is_active
 -- boolean), with the rarer types (jsonb, smallint, double precision, uuid,
 -- varchar[], int, text) rotated across tables so each appears on several.
--- NOT NULL columns get a DEFAULT so the deterministic conflict DML
--- (source_dml.sql / target_dml.sql), which names only the key columns, works
--- unchanged; uuid/array/jsonb columns are nullable so they are also valid
--- random custom-key choices (their value is NULL, hence identical, on every
--- DML row). numeric stays bounded -- unbounded numeric loses trailing zeros
--- through live CDC and breaks row-hash validation.
+-- source_dml.sql names every column explicitly and gives the two rows of a
+-- free/reuse pair different values, so whichever column is sampled as this
+-- run's custom key still routes the pair to different channels. target_dml.sql
+-- names only the key columns and relies on the DEFAULTs, since custom keys do
+-- not apply on the fallback leg. numeric stays bounded -- unbounded numeric
+-- loses trailing zeros through live CDC and breaks row-hash validation.
 
 -- Table with Single Column Unique Constraint
 CREATE TABLE single_unique_constraint (

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
@@ -5,27 +5,30 @@
 -- cache (yb-voyager/cmd/conflictDetectionCache.go) reasons about.
 --
 -- Each table carries 13-14 columns shaped like a production table: an audit
--- backbone (created_at/updated_at NOT NULL, nullable deleted_at) plus a
--- realistic mix of business columns -- varchar/text/timestamp-heavy, with
--- boolean, int, bigint, smallint, date, numeric(38,6), jsonb, uuid, arrays
--- and double precision spread across the tables. NOT NULL columns get a
--- DEFAULT so the deterministic conflict DML (source_dml.sql), which names
--- only the key columns, works unchanged. numeric stays bounded -- unbounded
--- numeric loses trailing zeros through live CDC and breaks row-hash
--- validation.
+-- backbone (created_at/updated_at NOT NULL, nullable deleted_at) plus the
+-- same core business spread on every table (status varchar, description
+-- text, amount numeric(38,6), due_date date, seq_no bigint, is_active
+-- boolean), with the rarer types (jsonb, smallint, double precision, uuid,
+-- varchar[], int, text) rotated across tables so each appears on several.
+-- NOT NULL columns get a DEFAULT so the deterministic conflict DML
+-- (source_dml.sql / target_dml.sql), which names only the key columns, works
+-- unchanged; uuid/array/jsonb columns are nullable so they are also valid
+-- random custom-key choices (their value is NULL, hence identical, on every
+-- DML row). numeric stays bounded -- unbounded numeric loses trailing zeros
+-- through live CDC and breaks row-hash validation.
 
 -- Table with Single Column Unique Constraint
 CREATE TABLE single_unique_constraint (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255) UNIQUE,
+    status varchar NOT NULL DEFAULT '',
     description text NOT NULL DEFAULT '',
-    notes text NOT NULL DEFAULT '',
-    failure_reason text NOT NULL DEFAULT '',
-    remarks text NOT NULL DEFAULT '',
-    retry_count int NOT NULL DEFAULT 0,
     amount numeric(38,6) NOT NULL DEFAULT 0,
-    address_line text NOT NULL DEFAULT '',
     due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    metadata jsonb,
+    priority smallint NOT NULL DEFAULT 0,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
     deleted_at timestamp
@@ -37,14 +40,14 @@ CREATE TABLE multi_unique_constraint (
     first_name VARCHAR(100),
     last_name VARCHAR(100),
     status varchar NOT NULL DEFAULT '',
-    retry_count int NOT NULL DEFAULT 0,
+    metadata jsonb,
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
     is_active boolean NOT NULL DEFAULT false,
-    metadata jsonb NOT NULL DEFAULT '{}',
-    description text NOT NULL DEFAULT '',
+    priority smallint NOT NULL DEFAULT 0,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    is_verified boolean,
-    notes text,
     deleted_at timestamp,
     CONSTRAINT unique_name UNIQUE (first_name, last_name)
 );
@@ -53,17 +56,17 @@ CREATE TABLE multi_unique_constraint (
 CREATE TABLE single_unique_index (
     id SERIAL PRIMARY KEY,
     "Ssn" VARCHAR(100),
-    due_date date NOT NULL DEFAULT CURRENT_DATE,
     status varchar NOT NULL DEFAULT '',
     description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
     is_active boolean NOT NULL DEFAULT false,
-    currency varchar NOT NULL DEFAULT '',
-    is_verified boolean NOT NULL DEFAULT false,
-    deleted_at timestamp,
+    score double precision,
+    external_ref uuid,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    notes text,
-    seq_no bigint
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_ssn_unique ON single_unique_index ("Ssn");
 
@@ -72,15 +75,15 @@ CREATE TABLE multi_unique_index (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
     last_name VARCHAR(100),
-    description text,
     status varchar NOT NULL DEFAULT '',
-    currency varchar NOT NULL DEFAULT '',
-    metadata jsonb NOT NULL DEFAULT '{}',
-    created_at timestamp,
-    updated_at timestamp,
-    notes text,
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
     due_date date NOT NULL DEFAULT CURRENT_DATE,
-    failure_reason text,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    external_ref uuid,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
     deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_name_unique ON multi_unique_index (first_name, last_name);
@@ -90,17 +93,17 @@ CREATE TABLE same_column_unique_constraint_and_index (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255) UNIQUE,
     status varchar NOT NULL DEFAULT '',
-    external_id uuid NOT NULL DEFAULT gen_random_uuid(),
-    currency varchar NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    tags varchar[],
     retry_count int NOT NULL DEFAULT 0,
-    attempt_count int NOT NULL DEFAULT 0,
-    tags varchar[] NOT NULL DEFAULT '{}',
-    processed_at timestamp,
-    deleted_at timestamp,
+    metadata jsonb,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    reference_code varchar NOT NULL DEFAULT '',
-    org_unit varchar NOT NULL DEFAULT ''
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_email_unique ON same_column_unique_constraint_and_index (email);
 
@@ -110,12 +113,12 @@ CREATE TABLE different_columns_unique_constraint_and_index (
     email VARCHAR(255) UNIQUE,
     phone_number VARCHAR(20),
     status varchar NOT NULL DEFAULT '',
-    retry_count int NOT NULL DEFAULT 0,
+    metadata jsonb,
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
     is_active boolean NOT NULL DEFAULT false,
-    metadata jsonb NOT NULL DEFAULT '{}',
-    description text NOT NULL DEFAULT '',
-    notes text,
-    failure_reason text,
+    retry_count int NOT NULL DEFAULT 0,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
     deleted_at timestamp
@@ -129,15 +132,15 @@ CREATE TABLE subset_columns_unique_constraint_and_index (
     last_name VARCHAR(100),
     phone_number VARCHAR(20),
     status varchar NOT NULL DEFAULT '',
-    currency varchar NOT NULL DEFAULT '',
-    priority smallint NOT NULL DEFAULT 0,
-    processed_at timestamp,
-    deleted_at timestamp,
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    metadata jsonb,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    is_active boolean NOT NULL DEFAULT false,
-    retry_count int NOT NULL DEFAULT 0,
-    attempt_count int NOT NULL DEFAULT 0
+    deleted_at timestamp
 );
 
 -- Unique constraint on first_name and last_name
@@ -146,22 +149,21 @@ ALTER TABLE subset_columns_unique_constraint_and_index ADD CONSTRAINT unique_nam
 -- Unique index on first_name, last_name, and phone_number (superset of columns)
 CREATE UNIQUE INDEX idx_name_phone_unique ON subset_columns_unique_constraint_and_index (first_name, last_name, phone_number);
 
-
 CREATE TABLE expression_based_unique_index (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255),
+    status varchar NOT NULL DEFAULT '',
     description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
     due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    notes text,
+    metadata jsonb,
+    priority smallint NOT NULL DEFAULT 0,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    status varchar NOT NULL DEFAULT '',
-    is_active boolean NOT NULL DEFAULT false,
-    deleted_at timestamp,
-    amount numeric(38,6),
-    notes text,
-    failure_reason text,
-    remarks text,
-    address_line text
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_email_unique_expression ON expression_based_unique_index (LOWER(email));
 
@@ -170,12 +172,12 @@ CREATE TABLE test_partial_unique_index (
     check_id int,
     most_recent boolean,
     status varchar NOT NULL DEFAULT '',
-    metadata jsonb,
-    retry_count int NOT NULL DEFAULT 0,
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
     is_active boolean NOT NULL DEFAULT false,
-    currency varchar NOT NULL DEFAULT '',
-    reference_code varchar NOT NULL DEFAULT '',
-    org_unit varchar,
+    metadata jsonb,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
     deleted_at timestamp
@@ -189,17 +191,17 @@ CREATE TABLE single_unique_index_nulls_not_distinct (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255),
     status varchar NOT NULL DEFAULT '',
-    currency varchar NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
     due_date date NOT NULL DEFAULT CURRENT_DATE,
-    reference_code varchar NOT NULL DEFAULT '',
-    org_unit varchar NOT NULL DEFAULT '',
     seq_no bigint NOT NULL DEFAULT 0,
-    amount numeric(38,6),
     is_active boolean NOT NULL DEFAULT false,
-    deleted_at timestamp,
+    priority smallint NOT NULL DEFAULT 0,
+    score double precision,
+    external_ref uuid,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    channel varchar
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_email_nnd ON single_unique_index_nulls_not_distinct (email) NULLS NOT DISTINCT;
 
@@ -208,17 +210,17 @@ CREATE TABLE multi_unique_index_nulls_not_distinct (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
     last_name VARCHAR(100),
-    description text NOT NULL DEFAULT '',
-    notes text NOT NULL DEFAULT '',
-    failure_reason text,
-    amount numeric(38,6) NOT NULL DEFAULT 0,
     status varchar NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    score double precision,
+    external_ref uuid,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    remarks text,
-    deleted_at timestamp,
-    is_active boolean,
-    address_line text
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_name_nnd ON multi_unique_index_nulls_not_distinct (first_name, last_name) NULLS NOT DISTINCT;
 
@@ -230,16 +232,16 @@ CREATE TABLE single_unique_index_nulls_distinct (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255),
     status varchar NOT NULL DEFAULT '',
-    currency varchar NOT NULL DEFAULT '',
-    processed_at timestamp,
-    expires_at timestamp,
-    description text,
-    external_id uuid NOT NULL DEFAULT gen_random_uuid(),
-    reference_code varchar,
-    org_unit varchar NOT NULL DEFAULT '',
-    deleted_at timestamp,
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    external_ref uuid,
+    tags varchar[],
     created_at timestamp NOT NULL DEFAULT now(),
-    updated_at timestamp NOT NULL DEFAULT now()
+    updated_at timestamp NOT NULL DEFAULT now(),
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_email_nd ON single_unique_index_nulls_distinct (email);
 
@@ -249,16 +251,16 @@ CREATE TABLE partitioned_unique_conflict (
     id INT,
     region VARCHAR(50),
     email VARCHAR(255),
-    description text NOT NULL DEFAULT '',
     status varchar NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    seq_no bigint NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    tags varchar[],
     retry_count int NOT NULL DEFAULT 0,
-    currency varchar,
-    reference_code varchar,
-    attempt_count int NOT NULL DEFAULT 0,
-    score double precision,
     created_at timestamp NOT NULL DEFAULT now(),
     updated_at timestamp NOT NULL DEFAULT now(),
-    due_date date,
     deleted_at timestamp,
     PRIMARY KEY (id, region)
 ) PARTITION BY LIST (region);

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -34,7 +34,7 @@ target:
 # key below gets added to exclude_columns_from_update at run time, so the
 # generator never updates that custom key column (the importer requires it to
 # be immutable) while still touching that table's other columns normally.
-generator:
+generator_source:
   config_inline:
     connection:
       host: 127.0.0.1
@@ -62,16 +62,55 @@ generator:
 
 # Deterministic unique-conflict DML (same file as fallback-unique-conflict-test),
 # re-applied on a loop throughout streaming in parallel with the random generator.
-conflict_generator:
+conflict_generator_source:
   config_inline:
     conflict:
       sql_path: ./source_dml.sql
       interval_seconds: 10
 
+# Fallback (target) event generator: random traffic on target during fallback.
+generator_target:
+  config_inline:
+    connection:
+      host: ${TARGET_DB_HOST}
+      port: ${TARGET_DB_PORT}
+      database: test_db
+      user: ${TARGET_DB_USER}
+      password: ${TARGET_DB_PASSWORD}
+
+    generator:
+      schema_name: public
+      manual_table_list: []
+      exclude_table_list: [cutover_table]
+      num_iterations: -1
+      wait_after_operations: 1000
+      wait_duration_seconds: 1
+      table_weights: {}
+      operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
+      random_seed: 456
+      faker_seed: 456
+      insert_rows: 3
+      update_rows: 2
+      delete_rows: 1
+      insert_max_retries: 5
+      update_max_retries: 1
+
+# Fallback (target) conflict generator: re-applies the deterministic
+# unique-conflict DML on the target on a loop, in parallel with
+# generator_target. Custom keys do not apply on the fallback leg (import to
+# source forces table routing), so target_dml.sql keeps the full four
+# conflict types with no immutability restrictions.
+conflict_generator_target:
+  config_inline:
+    conflict:
+      sql_path: ./target_dml.sql
+      interval_seconds: 10
+
+
 voyager:
   cutover_to_target:
     flags:
-      prepare-for-fall-back: false
+      prepare-for-fall-back: true
 
 stages:
   - name: create_source_and_target_dbs
@@ -89,6 +128,7 @@ stages:
 
   - name: grant_source_permissions
     action: grant_source_permissions
+    is_live_migration_fall_back: 1
 
   # Randomly select ONE (table, columns) pair to route by
   # --cdc-partition-key-overrides this run -- mirroring how a real user opts a
@@ -101,6 +141,7 @@ stages:
   # detected (expect_conflicts: true) -- every other candidate must show none.
   - name: pick_random_custom_key
     action: pick_random_custom_key
+    generator_key: generator_source
     candidates:
       - table: public.single_unique_constraint
         columns: [email]
@@ -138,6 +179,7 @@ stages:
 
   - name: start_event_generator
     action: generator_start
+    generator_key: generator_source
 
   - name: load_snapshot
     action: sleep
@@ -161,6 +203,7 @@ stages:
   # streaming, in parallel with the random event generator.
   - name: start_conflict_generator
     action: conflict_generator_start
+    generator_key: conflict_generator_source
 
   - name: start_import_resumptions
     action: start_resumptions
@@ -193,10 +236,12 @@ stages:
 
   - name: stop_conflict_generator
     action: conflict_generator_stop
+    generator_key: conflict_generator_source
     graceful_timeout_sec: 60
 
   - name: stop_event_generator
     action: generator_stop
+    generator_key: generator_source
     graceful_timeout_sec: 60
 
   - name: insert_backlog_marker
@@ -238,6 +283,31 @@ stages:
     log: yb-voyager-import-data.log
     min_count: 1
 
+  # Resume guardrail: changing cdc-partition-key / cdc-partition-key-overrides
+  # between runs must be rejected (diffCdcPartitioningStrategy). Stop the
+  # importer, try to resume twice with a changed config -- once changing the
+  # global default, once changing the picked table's override to pk -- assert
+  # both are refused, then resume with the original flags.
+  - name: stop_importer_for_guardrail_check
+    action: voyager_stop_command
+    command: import_data
+    timeout_sec: 60
+
+  - name: guardrail_reject_global_default_change
+    action: voyager_import_start_expect_fail
+    flags:
+      cdc-partition-key: table
+    error_contains: "not allowed after the import data has started"
+
+  - name: guardrail_reject_picked_override_change
+    action: voyager_import_start_expect_fail
+    flags:
+      cdc-partition-key-overrides: "{picked_table}:pk"
+    error_contains: "not allowed after the import data has started"
+
+  - name: restart_importer_after_guardrail_check
+    action: voyager_import_start
+
   - name: cutover_to_target
     action: cutover_to_target
 
@@ -246,11 +316,128 @@ stages:
     condition: cutover_to_target_status_completed
     timeout_sec: 900
 
+  # Honest (nextval) insert on the DB just cut over to: fails with a duplicate key
+  # if its sequence was not restored past the migrated rows. Runs after validations
+  # since it adds a row on one side only.
+  - name: verify_target_sequence_restored_after_cutover
+    action: run_sql
+    target: target
+    sql_path: ../common-sql/verify_sequence_restored_after_cutover.sql
+
+  - name: stop_forward_exporter
+    action: voyager_stop_command
+    command: export_data
+    graceful_timeout_sec: 60
+
+  - name: stop_forward_importer
+    action: voyager_stop_command
+    command: import_data
+    graceful_timeout_sec: 60
+
+  - name: start_fallback_exporter_from_target
+    action: voyager_export_from_target_start
+
+  - name: start_fallback_importer_to_source
+    action: voyager_import_to_source_start
+
+  # Deterministic unique-conflict DML applied once up-front on the target for
+  # an immediate burst as fallback streaming starts. Custom keys do not apply
+  # on this leg (import to source forces table routing), so the fallback
+  # importer must log ZERO conflicts even with conflict-prone DML flowing.
+  - name: run_target_dml
+    action: run_sql
+    target: target
+    sql_path: ./target_dml.sql
+    use_admin: true
+
+  - name: start_target_conflict_generator
+    action: conflict_generator_start
+    generator_key: conflict_generator_target
+
+  - name: start_target_event_generator
+    action: generator_start
+    generator_key: generator_target
+
+  - name: start_fallback_resumptions
+    action: start_resumptions
+    resumption:
+      export_from_target:
+        max_restarts: 100
+        min_interrupt_seconds: 15
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 5
+        max_restart_wait_seconds: 30
+
+  - name: start_import_to_source_resumptions
+    action: start_resumptions
+    resumption:
+      import_to_source:
+        max_restarts: 100
+        min_interrupt_seconds: 15
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 5
+        max_restart_wait_seconds: 30
+
+  - name: soak_fallback_with_resumptions
+    action: sleep
+    seconds: 3000
+
+  - name: stop_target_conflict_generator
+    action: conflict_generator_stop
+    generator_key: conflict_generator_target
+    graceful_timeout_sec: 60
+
+  - name: stop_target_event_generator
+    action: generator_stop
+    generator_key: generator_target
+    graceful_timeout_sec: 60
+
+  - name: insert_backlog_marker_on_target
+    action: run_sql
+    target: target
+    sql_path: ../common-sql/insert_marker.sql
+
+  - name: wait_backlog_zero_after_fallback
+    action: wait_for
+    condition: remaining_events_eq_0
+    timeout_sec: 6000
+
+  - name: stop_fallback_export_resumptions
+    action: voyager_stop_resumptions
+    command: export_from_target
+    timeout_sec: 60
+
+  - name: stop_fallback_import_resumptions
+    action: voyager_stop_resumptions
+    command: import_to_source
+    timeout_sec: 60
+
+  # The fallback importer forces PARTITION_BY_TABLE (custom keys are rejected
+  # outside import-data-to-target), so conflict detection must never fire on
+  # this leg -- also proves the forward leg's custom-key config doesn't leak
+  # into or break the fallback.
+  - name: validate_no_conflicts_on_fallback
+    action: validate_no_conflicts_detected
+    log: yb-voyager-import-data-to-source.log
+
+  - name: cutover_to_source
+    action: cutover_to_source
+
+  - name: wait_cutover_to_source_completed
+    action: wait_for
+    condition: cutover_to_source_status_completed
+    timeout_sec: 900
+
   - name: row_count_validations
     action: row_count_validations
 
   - name: row_hash_validations
     action: row_hash_validations
+
+  - name: verify_source_sequence_restored_after_cutover
+    action: run_sql
+    target: source
+    sql_path: ../common-sql/verify_sequence_restored_after_cutover.sql
 
   - name: cleanup_source
     action: run_sql

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -130,46 +130,51 @@ stages:
     action: grant_source_permissions
     is_live_migration_fall_back: 1
 
-  # Randomly select ONE (table, columns) pair to route by
-  # --cdc-partition-key-overrides this run -- mirroring how a real user opts a
-  # specific table into custom-key routing. Every candidate's conflict DML
-  # (source_dml.sql) is already immutability-safe for whichever one gets
-  # picked. Also injects the pick into the generator's
-  # exclude_columns_from_update so the random generator respects it too.
-  # single_unique_constraint's DML is a deliberate PK-recycle pattern (see
-  # source_dml.sql section 1), so when IT is picked, conflicts MUST still be
-  # detected (expect_conflicts: true) -- every other candidate must show none.
+  # Randomly select ONE table to route by --cdc-partition-key-overrides this
+  # run, then randomly sample WHICH of its columns (1-2, random order) form
+  # the custom key from that table's random_columns_pool -- so successive runs
+  # exercise a variety of key columns, column counts and datatypes, mirroring
+  # how a real user opts a specific table into custom-key routing. Pools hold
+  # only columns that are immutability-safe (never UPDATEd by source_dml.sql)
+  # and whose value is identical across each conflict pair's rows (DML-churned
+  # key columns, or columns the DML leaves at transaction-constant defaults);
+  # PK columns and uuid-default columns are excluded. The pick is also
+  # injected into the generator's exclude_columns_from_update so the random
+  # generator respects it. single_unique_constraint's DML is a deliberate
+  # PK-recycle pattern (see source_dml.sql section 1), so when IT is picked,
+  # conflicts MUST still be detected (expect_conflicts: true) -- every other
+  # candidate must show none.
   - name: pick_random_custom_key
     action: pick_random_custom_key
     generator_key: generator_source
     candidates:
+      # PK-recycle candidate: fixed key -- its expect_conflicts assertion
+      # depends on the key being the churned email column specifically.
       - table: public.single_unique_constraint
         columns: [email]
         expect_conflicts: true
       - table: public.multi_unique_constraint
-        columns: [first_name, last_name]
+        random_columns_pool: [first_name, last_name, status, retry_count, is_active, metadata, description, created_at, updated_at, is_verified, notes, deleted_at]
       - table: public.same_column_unique_constraint_and_index
-        columns: [email]
+        random_columns_pool: [email, status, currency, retry_count, attempt_count, tags, processed_at, deleted_at, created_at, updated_at, reference_code, org_unit]
       - table: public.single_unique_index
-        columns: ["Ssn"]
+        random_columns_pool: ["Ssn", due_date, status, description, is_active, currency, is_verified, deleted_at, created_at, updated_at, notes, seq_no]
       - table: public.multi_unique_index
-        columns: [first_name, last_name]
+        random_columns_pool: [first_name, last_name, description, status, currency, metadata, created_at, updated_at, notes, due_date, failure_reason, deleted_at]
       - table: public.different_columns_unique_constraint_and_index
-        columns: [email]
-      - table: public.different_columns_unique_constraint_and_index
-        columns: [phone_number]
+        random_columns_pool: [email, phone_number, status, retry_count, is_active, metadata, description, notes, failure_reason, created_at, updated_at, deleted_at]
       - table: public.subset_columns_unique_constraint_and_index
-        columns: [first_name, last_name]
+        random_columns_pool: [first_name, last_name, phone_number, status, currency, priority, processed_at, deleted_at, created_at, updated_at, is_active, retry_count, attempt_count]
       - table: public.test_partial_unique_index
-        columns: [check_id]
+        random_columns_pool: [check_id, status, metadata, retry_count, is_active, currency, reference_code, org_unit, created_at, updated_at, deleted_at]
       - table: public.partitioned_unique_conflict
-        columns: [region]
+        random_columns_pool: [region, description, status, retry_count, currency, reference_code, attempt_count, score, created_at, updated_at, due_date, deleted_at]
       - table: public.single_unique_index_nulls_not_distinct
-        columns: [email]
+        random_columns_pool: [email, status, currency, due_date, reference_code, org_unit, seq_no, amount, is_active, deleted_at, created_at, updated_at, channel]
       - table: public.multi_unique_index_nulls_not_distinct
-        columns: [first_name, last_name]
+        random_columns_pool: [first_name, last_name, description, notes, failure_reason, amount, status, created_at, updated_at, remarks, deleted_at, is_active, address_line]
       - table: public.single_unique_index_nulls_distinct
-        columns: [email]
+        random_columns_pool: [email, status, currency, processed_at, expires_at, description, reference_code, org_unit, deleted_at, created_at, updated_at]
 
   - name: export_schema_from_source
     action: voyager_export_schema

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -1,0 +1,254 @@
+name: custom-cdc-partition-key-test
+
+env:
+  LOG_LEVEL: info
+  QUEUE_SEGMENT_MAX_BYTES: 10485760
+
+export_dir: ./export-dir
+artifacts_dir: ./artifacts
+
+source:
+  type: postgresql
+  host: 127.0.0.1
+  port: 5432
+  database: test_db
+  user: ybvoyager
+  password: Test@123#$%^&*()!
+  schema: public
+  admin:
+    user: postgres
+    password: postgres
+
+target:
+  type: yugabytedb
+  host: ${TARGET_DB_HOST}
+  port: ${TARGET_DB_PORT}
+  database: test_db
+  user: ${TARGET_DB_USER}
+  password: ${TARGET_DB_PASSWORD}
+  admin:
+    user: ${TARGET_DB_ADMIN_USER}
+    password: ${TARGET_DB_ADMIN_PASSWORD}
+
+# Random event generator. Whichever table/column(s) pick_random_custom_key
+# selects below gets added to exclude_columns_from_update at run time, so the
+# generator never updates that custom key column (the importer requires it to
+# be immutable) while still touching that table's other columns normally.
+generator:
+  config_inline:
+    connection:
+      host: 127.0.0.1
+      port: 5432
+      database: test_db
+      user: postgres
+      password: postgres
+
+    generator:
+      schema_name: public
+      manual_table_list: []
+      exclude_table_list: [cutover_table]
+      num_iterations: -1
+      wait_after_operations: 1000
+      wait_duration_seconds: 1
+      table_weights: {}
+      operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
+      random_seed: 123
+      faker_seed: 123
+      insert_rows: 3
+      update_rows: 2
+      delete_rows: 1
+      insert_max_retries: 5
+      update_max_retries: 1
+
+# Deterministic unique-conflict DML (same file as fallback-unique-conflict-test),
+# re-applied on a loop throughout streaming in parallel with the random generator.
+conflict_generator:
+  config_inline:
+    conflict:
+      sql_path: ./source_dml.sql
+      interval_seconds: 10
+
+voyager:
+  cutover_to_target:
+    flags:
+      prepare-for-fall-back: false
+
+stages:
+  - name: create_source_and_target_dbs
+    action: reset_databases
+    targets: [source, target]
+
+  - name: create_source_schema
+    action: run_sql
+    sql_path: ./init.sql
+    use_admin: true
+
+  - name: create_cutover_table
+    action: create_cutover_table
+    target: [source]
+
+  - name: grant_source_permissions
+    action: grant_source_permissions
+
+  # Randomly select one (table, columns) pair to route by
+  # --cdc-partition-key-overrides for this run, instead of a fixed pair --
+  # every candidate's conflict DML (source_dml.sql) is already immutability-safe
+  # for whichever one gets picked. Also injects the pick into the generator's
+  # exclude_columns_from_update so the random generator respects it too.
+  - name: pick_random_custom_key
+    action: pick_random_custom_key
+    candidates:
+      - table: public.single_unique_constraint
+        columns: [email]
+      - table: public.multi_unique_constraint
+        columns: [first_name, last_name]
+      - table: public.same_column_unique_constraint_and_index
+        columns: [email]
+      - table: public.single_unique_index
+        columns: ["Ssn"]
+      - table: public.multi_unique_index
+        columns: [first_name, last_name]
+      - table: public.different_columns_unique_constraint_and_index
+        columns: [email]
+      - table: public.different_columns_unique_constraint_and_index
+        columns: [phone_number]
+      - table: public.subset_columns_unique_constraint_and_index
+        columns: [first_name, last_name]
+      - table: public.test_partial_unique_index
+        columns: [check_id]
+      - table: public.partitioned_unique_conflict
+        columns: [region]
+      - table: public.single_unique_index_nulls_not_distinct
+        columns: [email]
+      - table: public.multi_unique_index_nulls_not_distinct
+        columns: [first_name, last_name]
+      - table: public.single_unique_index_nulls_distinct
+        columns: [email]
+
+  - name: export_schema_from_source
+    action: voyager_export_schema
+
+  - name: import_schema_on_target
+    action: voyager_import_schema
+
+  - name: start_event_generator
+    action: generator_start
+
+  - name: load_snapshot
+    action: sleep
+    seconds: 120
+
+  - name: start_exporter
+    action: voyager_export_start
+
+  - name: start_importer
+    action: voyager_import_start
+
+  # Deterministic unique-conflict DML applied once up-front for an immediate
+  # conflict burst as soon as streaming starts.
+  - name: run_source_dml
+    action: run_sql
+    target: source
+    sql_path: ./source_dml.sql
+    use_admin: true
+
+  # Conflict generator: then re-applies source_dml.sql continuously throughout
+  # streaming, in parallel with the random event generator.
+  - name: start_conflict_generator
+    action: conflict_generator_start
+
+  - name: start_import_resumptions
+    action: start_resumptions
+    resumption:
+      import_data:
+        max_restarts: 100
+        min_interrupt_seconds: 15
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 5
+        max_restart_wait_seconds: 30
+
+  - name: wait_exporter_streaming
+    action: wait_for
+    condition: exporter_in_streaming_phase
+    timeout_sec: 600
+
+  - name: start_export_resumptions
+    action: start_resumptions
+    resumption:
+      export_data:
+        max_restarts: 100
+        min_interrupt_seconds: 15
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 5
+        max_restart_wait_seconds: 30
+
+  - name: soak_with_resumptions
+    action: sleep
+    seconds: 3000
+
+  - name: stop_conflict_generator
+    action: conflict_generator_stop
+    graceful_timeout_sec: 60
+
+  - name: stop_event_generator
+    action: generator_stop
+    graceful_timeout_sec: 60
+
+  - name: insert_backlog_marker
+    action: run_sql
+    target: source
+    sql_path: ../common-sql/insert_marker.sql
+
+  - name: wait_backlog_zero
+    action: wait_for
+    condition: remaining_events_eq_0
+    timeout_sec: 1800
+
+  - name: stop_export_resumptions
+    action: voyager_stop_resumptions
+    command: export_data
+    timeout_sec: 60
+
+  - name: stop_import_resumptions
+    action: voyager_stop_resumptions
+    command: import_data
+    timeout_sec: 60
+
+  # The table pick_random_custom_key selected is routed by its custom key, and
+  # source_dml.sql's conflicts on that table always share that key's value --
+  # so those events land on the same channel already and the conflict-detection
+  # cache must never need to serialize them.
+  - name: validate_no_conflicts_for_picked_custom_key
+    action: validate_no_conflicts_for_picked_custom_key
+    log: yb-voyager-import-data.log
+
+  # The other tables are still PK-routed, so conflict detection must keep
+  # firing normally for them -- confirms custom-cdc-partition-key doesn't
+  # disable the cache wholesale.
+  - name: validate_conflicts_still_detected_elsewhere
+    action: validate_conflicts_detected
+    log: yb-voyager-import-data.log
+    min_count: 1
+
+  - name: cutover_to_target
+    action: cutover_to_target
+
+  - name: wait_cutover_completed
+    action: wait_for
+    condition: cutover_to_target_status_completed
+    timeout_sec: 900
+
+  - name: row_count_validations
+    action: row_count_validations
+
+  - name: row_hash_validations
+    action: row_hash_validations
+
+  - name: cleanup_source
+    action: run_sql
+    sql_path: ../common-sql/cleanup.sql
+
+  - name: cleanup_target
+    action: run_sql
+    target: target
+    sql_path: ../common-sql/cleanup.sql

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -30,8 +30,8 @@ target:
     user: ${TARGET_DB_ADMIN_USER}
     password: ${TARGET_DB_ADMIN_PASSWORD}
 
-# Random event generator. Whichever table/column(s) pick_random_custom_key
-# selects below gets added to exclude_columns_from_update at run time, so the
+# Random event generator. Every table select_custom_keys routes by a custom
+# key below gets added to exclude_columns_from_update at run time, so the
 # generator never updates that custom key column (the importer requires it to
 # be immutable) while still touching that table's other columns normally.
 generator:
@@ -90,16 +90,21 @@ stages:
   - name: grant_source_permissions
     action: grant_source_permissions
 
-  # Randomly select one (table, columns) pair to route by
-  # --cdc-partition-key-overrides for this run, instead of a fixed pair --
-  # every candidate's conflict DML (source_dml.sql) is already immutability-safe
-  # for whichever one gets picked. Also injects the pick into the generator's
+  # Randomly select ONE (table, columns) pair to route by
+  # --cdc-partition-key-overrides this run -- mirroring how a real user opts a
+  # specific table into custom-key routing. Every candidate's conflict DML
+  # (source_dml.sql) is already immutability-safe for whichever one gets
+  # picked. Also injects the pick into the generator's
   # exclude_columns_from_update so the random generator respects it too.
+  # single_unique_constraint's DML is a deliberate PK-recycle pattern (see
+  # source_dml.sql section 1), so when IT is picked, conflicts MUST still be
+  # detected (expect_conflicts: true) -- every other candidate must show none.
   - name: pick_random_custom_key
     action: pick_random_custom_key
     candidates:
       - table: public.single_unique_constraint
         columns: [email]
+        expect_conflicts: true
       - table: public.multi_unique_constraint
         columns: [first_name, last_name]
       - table: public.same_column_unique_constraint_and_index
@@ -214,12 +219,15 @@ stages:
     command: import_data
     timeout_sec: 60
 
-  # The table pick_random_custom_key selected is routed by its custom key, and
-  # source_dml.sql's conflicts on that table always share that key's value --
-  # so those events land on the same channel already and the conflict-detection
-  # cache must never need to serialize them.
-  - name: validate_no_conflicts_for_picked_custom_key
-    action: validate_no_conflicts_for_picked_custom_key
+  # For the picked table: if it's a normal candidate, its conflicts always
+  # share its custom key's value, so those events land on the same channel
+  # already and the conflict-detection cache must never fire for it (assert
+  # 0). If it's the PK-recycle candidate (expect_conflicts: true), the SAME PK
+  # is reused with a DIFFERENT custom-key value -- a real cross-channel race
+  # custom-key routing does NOT eliminate -- so the synthetic-PK guard added
+  # for custom-key tables (PR #3746) must still catch it (assert >= 1).
+  - name: validate_picked_custom_key_conflicts
+    action: validate_picked_custom_key_conflicts
     log: yb-voyager-import-data.log
 
   # The other tables are still PK-routed, so conflict detection must keep

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -132,19 +132,16 @@ stages:
 
   # Randomly select ONE table to route by --cdc-partition-key-overrides this
   # run -- mirroring how a real user opts a specific table into custom-key
-  # routing -- then, 50/50, either use its natural unique-key columns or
-  # sample 1-2 arbitrary columns (random order) from its random_columns_pool,
-  # so successive runs exercise a variety of key columns, counts and datatypes.
-  # Pools hold only immutability-safe columns (never UPDATEd by
-  # source_dml.sql); PK columns and uuid-default columns are excluded. The pick
-  # is also injected into the generator's exclude_columns_from_update so the
-  # random generator respects it. Zero conflicts is asserted for the picked
-  # table only when the key is a subset of every unique index on it
-  # (unique_index_columns) -- then colliding rows provably share a channel;
-  # for any other key, cross-channel collisions are legitimate and the count
-  # is only reported. single_unique_constraint's DML is a deliberate PK-recycle
-  # pattern (see source_dml.sql section 1), so when IT is picked, conflicts
-  # MUST still be detected (expect_conflicts: true).
+  # routing -- then sample 1-2 of its columns (random order) from
+  # random_columns_pool, so successive runs exercise a variety of key columns,
+  # counts and datatypes. Pools hold only immutability-safe columns (never
+  # UPDATEd by source_dml.sql); PK columns and uuid-default columns are
+  # excluded. The pick is injected into the generator's
+  # exclude_columns_from_update for the table and its leaf partitions (leaf
+  # events are renamed to the root before the importer's immutability check).
+  # single_unique_constraint's DML is a deliberate PK-recycle pattern (see
+  # source_dml.sql section 1): a fixed (email) key, and when IT is picked,
+  # conflicts MUST still be detected (expect_conflicts: true).
   - name: pick_random_custom_key
     action: pick_random_custom_key
     generator_key: generator_source
@@ -155,48 +152,27 @@ stages:
         columns: [email]
         expect_conflicts: true
       - table: public.multi_unique_constraint
-        columns: [first_name, last_name]
-        unique_index_columns: [[first_name, last_name]]
         random_columns_pool: [first_name, last_name, status, metadata, amount, due_date, seq_no, is_active, priority, created_at, updated_at, deleted_at]
       - table: public.same_column_unique_constraint_and_index
-        columns: [email]
-        unique_index_columns: [[email]]
         random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, metadata, created_at, updated_at, deleted_at]
       - table: public.single_unique_index
-        columns: ["Ssn"]
-        unique_index_columns: [["Ssn"]]
         random_columns_pool: ["Ssn", status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.multi_unique_index
-        columns: [first_name, last_name]
-        unique_index_columns: [[first_name, last_name]]
         random_columns_pool: [first_name, last_name, status, description, amount, due_date, seq_no, is_active, external_ref, created_at, updated_at, deleted_at]
       - table: public.different_columns_unique_constraint_and_index
-        columns: [email]
-        unique_index_columns: [[email], [phone_number]]
         random_columns_pool: [email, phone_number, status, metadata, amount, due_date, seq_no, is_active, retry_count, created_at, updated_at, deleted_at]
       - table: public.subset_columns_unique_constraint_and_index
-        columns: [first_name, last_name]
-        unique_index_columns: [[first_name, last_name], [first_name, last_name, phone_number]]
         random_columns_pool: [first_name, last_name, phone_number, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at]
       - table: public.test_partial_unique_index
-        columns: [check_id]
-        unique_index_columns: [[check_id]]
         random_columns_pool: [check_id, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at]
       - table: public.partitioned_unique_conflict
-        columns: [region]
-        unique_index_columns: [[email, region]]
+        partitions: [partitioned_unique_conflict_east, partitioned_unique_conflict_west, partitioned_unique_conflict_default]
         random_columns_pool: [region, status, description, amount, due_date, seq_no, is_active, tags, retry_count, created_at, updated_at, deleted_at]
       - table: public.single_unique_index_nulls_not_distinct
-        columns: [email]
-        unique_index_columns: [[email]]
         random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, priority, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.multi_unique_index_nulls_not_distinct
-        columns: [first_name, last_name]
-        unique_index_columns: [[first_name, last_name]]
         random_columns_pool: [first_name, last_name, status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.single_unique_index_nulls_distinct
-        columns: [email]
-        unique_index_columns: [[email]]
         random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, external_ref, tags, created_at, updated_at, deleted_at]
 
   - name: export_schema_from_source
@@ -292,13 +268,14 @@ stages:
     command: import_data
     timeout_sec: 60
 
-  # For the picked table: if it's a normal candidate, its conflicts always
-  # share its custom key's value, so those events land on the same channel
-  # already and the conflict-detection cache must never fire for it (assert
-  # 0). If it's the PK-recycle candidate (expect_conflicts: true), the SAME PK
-  # is reused with a DIFFERENT custom-key value -- a real cross-channel race
-  # custom-key routing does NOT eliminate -- so the synthetic-PK guard added
-  # for custom-key tables (PR #3746) must still catch it (assert >= 1).
+  # For the picked table: the PK-recycle candidate (expect_conflicts: true)
+  # must show conflicts detected -- the SAME PK is reused with a DIFFERENT
+  # custom-key value, a cross-channel race the synthetic-PK guard (PR #3746)
+  # must still catch. For any other pick the count is only reported: with an
+  # arbitrary sampled key, rows colliding on a unique index can carry different
+  # key values and be serialized by the cache -- correct behavior, not a
+  # failure (the same-channel property for an index-column key is asserted by
+  # the Go-side TestLiveMigrationCustomCdcPartitionKeyNoConflict).
   - name: validate_picked_custom_key_conflicts
     action: validate_picked_custom_key_conflicts
     log: yb-voyager-import-data.log
@@ -311,31 +288,6 @@ stages:
     log: yb-voyager-import-data.log
     min_count: 1
 
-  # Resume guardrail: changing cdc-partition-key / cdc-partition-key-overrides
-  # between runs must be rejected (diffCdcPartitioningStrategy). Stop the
-  # importer, try to resume twice with a changed config -- once changing the
-  # global default, once changing the picked table's override to pk -- assert
-  # both are refused, then resume with the original flags.
-  - name: stop_importer_for_guardrail_check
-    action: voyager_stop_command
-    command: import_data
-    timeout_sec: 60
-
-  - name: guardrail_reject_global_default_change
-    action: voyager_import_start_expect_fail
-    flags:
-      cdc-partition-key: table
-    error_contains: "not allowed after the import data has started"
-
-  - name: guardrail_reject_picked_override_change
-    action: voyager_import_start_expect_fail
-    flags:
-      cdc-partition-key-overrides: "{picked_table}:pk"
-    error_contains: "not allowed after the import data has started"
-
-  - name: restart_importer_after_guardrail_check
-    action: voyager_import_start
-
   - name: cutover_to_target
     action: cutover_to_target
 
@@ -347,11 +299,6 @@ stages:
   # Honest (nextval) insert on the DB just cut over to: fails with a duplicate key
   # if its sequence was not restored past the migrated rows. Runs after validations
   # since it adds a row on one side only.
-  - name: verify_target_sequence_restored_after_cutover
-    action: run_sql
-    target: target
-    sql_path: ../common-sql/verify_sequence_restored_after_cutover.sql
-
   - name: stop_forward_exporter
     action: voyager_stop_command
     command: export_data
@@ -461,11 +408,6 @@ stages:
 
   - name: row_hash_validations
     action: row_hash_validations
-
-  - name: verify_source_sequence_restored_after_cutover
-    action: run_sql
-    target: source
-    sql_path: ../common-sql/verify_sequence_restored_after_cutover.sql
 
   - name: cleanup_source
     action: run_sql

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -59,6 +59,18 @@ generator_source:
       delete_rows: 1
       insert_max_retries: 5
       update_max_retries: 1
+      # region is the LIST partition key of partitioned_unique_conflict, and the
+      # generator treats the root and each leaf as an independent table, so
+      # every one of them needs values its own partition constraint accepts.
+      column_overrides:
+        partitioned_unique_conflict:
+          region: {type: choice, values: [east, west]}
+        partitioned_unique_conflict_east:
+          region: {type: choice, values: [east]}
+        partitioned_unique_conflict_west:
+          region: {type: choice, values: [west]}
+        partitioned_unique_conflict_default:
+          region: {type: choice, values: [north, south]}
 
 # Deterministic unique-conflict DML (same file as fallback-unique-conflict-test),
 # re-applied on a loop throughout streaming in parallel with the random generator.
@@ -94,6 +106,18 @@ generator_target:
       delete_rows: 1
       insert_max_retries: 5
       update_max_retries: 1
+      # region is the LIST partition key of partitioned_unique_conflict, and the
+      # generator treats the root and each leaf as an independent table, so
+      # every one of them needs values its own partition constraint accepts.
+      column_overrides:
+        partitioned_unique_conflict:
+          region: {type: choice, values: [east, west]}
+        partitioned_unique_conflict_east:
+          region: {type: choice, values: [east]}
+        partitioned_unique_conflict_west:
+          region: {type: choice, values: [west]}
+        partitioned_unique_conflict_default:
+          region: {type: choice, values: [north, south]}
 
 # Fallback (target) conflict generator: re-applies the deterministic
 # unique-conflict DML on the target on a loop, in parallel with
@@ -135,21 +159,22 @@ stages:
   # routing -- then sample 1-2 of its columns (random order) from
   # random_columns_pool, so successive runs exercise a variety of key columns,
   # counts and datatypes. Pools hold only immutability-safe columns (never
-  # UPDATEd by source_dml.sql); PK columns and uuid-default columns are
-  # excluded. The pick is injected into the generator's
+  # UPDATEd by source_dml.sql), and source_dml.sql gives each of them a
+  # different value on the two rows of a conflicting pair so the sampled key
+  # actually splits them across channels. The pick is injected into the generator's
   # exclude_columns_from_update for the table and its leaf partitions (leaf
   # events are renamed to the root before the importer's immutability check).
   # single_unique_constraint's DML is a deliberate PK-recycle pattern (see
-  # source_dml.sql section 1): a fixed (email) key, and when IT is picked,
+  # source_dml.sql section 1): its pool is just (email), and when IT is picked,
   # conflicts MUST still be detected (expect_conflicts: true).
   - name: pick_random_custom_key
     action: pick_random_custom_key
     generator_key: generator_source
     candidates:
-      # PK-recycle candidate: fixed key -- its expect_conflicts assertion
-      # depends on the key being the churned email column specifically.
+      # PK-recycle candidate: a single-column pool pins the key to the
+      # churned email column, which its expect_conflicts assertion depends on.
       - table: public.single_unique_constraint
-        columns: [email]
+        random_columns_pool: [email]
         expect_conflicts: true
       - table: public.multi_unique_constraint
         random_columns_pool: [first_name, last_name, status, metadata, amount, due_date, seq_no, is_active, priority, created_at, updated_at, deleted_at]

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -321,9 +321,6 @@ stages:
     condition: cutover_to_target_status_completed
     timeout_sec: 900
 
-  # Honest (nextval) insert on the DB just cut over to: fails with a duplicate key
-  # if its sequence was not restored past the migrated rows. Runs after validations
-  # since it adds a row on one side only.
   - name: stop_forward_exporter
     action: voyager_stop_command
     command: export_data
@@ -333,6 +330,15 @@ stages:
     action: voyager_stop_command
     command: import_data
     graceful_timeout_sec: 60
+
+  # Forward-leg validation, before the fallback leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
 
   - name: start_fallback_exporter_from_target
     action: voyager_export_from_target_start

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -131,19 +131,20 @@ stages:
     is_live_migration_fall_back: 1
 
   # Randomly select ONE table to route by --cdc-partition-key-overrides this
-  # run, then randomly sample WHICH of its columns (1-2, random order) form
-  # the custom key from that table's random_columns_pool -- so successive runs
-  # exercise a variety of key columns, column counts and datatypes, mirroring
-  # how a real user opts a specific table into custom-key routing. Pools hold
-  # only columns that are immutability-safe (never UPDATEd by source_dml.sql)
-  # and whose value is identical across each conflict pair's rows (DML-churned
-  # key columns, or columns the DML leaves at transaction-constant defaults);
-  # PK columns and uuid-default columns are excluded. The pick is also
-  # injected into the generator's exclude_columns_from_update so the random
-  # generator respects it. single_unique_constraint's DML is a deliberate
-  # PK-recycle pattern (see source_dml.sql section 1), so when IT is picked,
-  # conflicts MUST still be detected (expect_conflicts: true) -- every other
-  # candidate must show none.
+  # run -- mirroring how a real user opts a specific table into custom-key
+  # routing -- then, 50/50, either use its natural unique-key columns or
+  # sample 1-2 arbitrary columns (random order) from its random_columns_pool,
+  # so successive runs exercise a variety of key columns, counts and datatypes.
+  # Pools hold only immutability-safe columns (never UPDATEd by
+  # source_dml.sql); PK columns and uuid-default columns are excluded. The pick
+  # is also injected into the generator's exclude_columns_from_update so the
+  # random generator respects it. Zero conflicts is asserted for the picked
+  # table only when the key is a subset of every unique index on it
+  # (unique_index_columns) -- then colliding rows provably share a channel;
+  # for any other key, cross-channel collisions are legitimate and the count
+  # is only reported. single_unique_constraint's DML is a deliberate PK-recycle
+  # pattern (see source_dml.sql section 1), so when IT is picked, conflicts
+  # MUST still be detected (expect_conflicts: true).
   - name: pick_random_custom_key
     action: pick_random_custom_key
     generator_key: generator_source
@@ -154,26 +155,48 @@ stages:
         columns: [email]
         expect_conflicts: true
       - table: public.multi_unique_constraint
+        columns: [first_name, last_name]
+        unique_index_columns: [[first_name, last_name]]
         random_columns_pool: [first_name, last_name, status, metadata, amount, due_date, seq_no, is_active, priority, created_at, updated_at, deleted_at]
       - table: public.same_column_unique_constraint_and_index
+        columns: [email]
+        unique_index_columns: [[email]]
         random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, metadata, created_at, updated_at, deleted_at]
       - table: public.single_unique_index
+        columns: ["Ssn"]
+        unique_index_columns: [["Ssn"]]
         random_columns_pool: ["Ssn", status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.multi_unique_index
+        columns: [first_name, last_name]
+        unique_index_columns: [[first_name, last_name]]
         random_columns_pool: [first_name, last_name, status, description, amount, due_date, seq_no, is_active, external_ref, created_at, updated_at, deleted_at]
       - table: public.different_columns_unique_constraint_and_index
+        columns: [email]
+        unique_index_columns: [[email], [phone_number]]
         random_columns_pool: [email, phone_number, status, metadata, amount, due_date, seq_no, is_active, retry_count, created_at, updated_at, deleted_at]
       - table: public.subset_columns_unique_constraint_and_index
+        columns: [first_name, last_name]
+        unique_index_columns: [[first_name, last_name], [first_name, last_name, phone_number]]
         random_columns_pool: [first_name, last_name, phone_number, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at]
       - table: public.test_partial_unique_index
+        columns: [check_id]
+        unique_index_columns: [[check_id]]
         random_columns_pool: [check_id, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at]
       - table: public.partitioned_unique_conflict
+        columns: [region]
+        unique_index_columns: [[email, region]]
         random_columns_pool: [region, status, description, amount, due_date, seq_no, is_active, tags, retry_count, created_at, updated_at, deleted_at]
       - table: public.single_unique_index_nulls_not_distinct
+        columns: [email]
+        unique_index_columns: [[email]]
         random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, priority, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.multi_unique_index_nulls_not_distinct
+        columns: [first_name, last_name]
+        unique_index_columns: [[first_name, last_name]]
         random_columns_pool: [first_name, last_name, status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.single_unique_index_nulls_distinct
+        columns: [email]
+        unique_index_columns: [[email]]
         random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, external_ref, tags, created_at, updated_at, deleted_at]
 
   - name: export_schema_from_source

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -154,27 +154,27 @@ stages:
         columns: [email]
         expect_conflicts: true
       - table: public.multi_unique_constraint
-        random_columns_pool: [first_name, last_name, status, retry_count, is_active, metadata, description, created_at, updated_at, is_verified, notes, deleted_at]
+        random_columns_pool: [first_name, last_name, status, metadata, amount, due_date, seq_no, is_active, priority, created_at, updated_at, deleted_at]
       - table: public.same_column_unique_constraint_and_index
-        random_columns_pool: [email, status, currency, retry_count, attempt_count, tags, processed_at, deleted_at, created_at, updated_at, reference_code, org_unit]
+        random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, metadata, created_at, updated_at, deleted_at]
       - table: public.single_unique_index
-        random_columns_pool: ["Ssn", due_date, status, description, is_active, currency, is_verified, deleted_at, created_at, updated_at, notes, seq_no]
+        random_columns_pool: ["Ssn", status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.multi_unique_index
-        random_columns_pool: [first_name, last_name, description, status, currency, metadata, created_at, updated_at, notes, due_date, failure_reason, deleted_at]
+        random_columns_pool: [first_name, last_name, status, description, amount, due_date, seq_no, is_active, external_ref, created_at, updated_at, deleted_at]
       - table: public.different_columns_unique_constraint_and_index
-        random_columns_pool: [email, phone_number, status, retry_count, is_active, metadata, description, notes, failure_reason, created_at, updated_at, deleted_at]
+        random_columns_pool: [email, phone_number, status, metadata, amount, due_date, seq_no, is_active, retry_count, created_at, updated_at, deleted_at]
       - table: public.subset_columns_unique_constraint_and_index
-        random_columns_pool: [first_name, last_name, phone_number, status, currency, priority, processed_at, deleted_at, created_at, updated_at, is_active, retry_count, attempt_count]
+        random_columns_pool: [first_name, last_name, phone_number, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at]
       - table: public.test_partial_unique_index
-        random_columns_pool: [check_id, status, metadata, retry_count, is_active, currency, reference_code, org_unit, created_at, updated_at, deleted_at]
+        random_columns_pool: [check_id, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at]
       - table: public.partitioned_unique_conflict
-        random_columns_pool: [region, description, status, retry_count, currency, reference_code, attempt_count, score, created_at, updated_at, due_date, deleted_at]
+        random_columns_pool: [region, status, description, amount, due_date, seq_no, is_active, tags, retry_count, created_at, updated_at, deleted_at]
       - table: public.single_unique_index_nulls_not_distinct
-        random_columns_pool: [email, status, currency, due_date, reference_code, org_unit, seq_no, amount, is_active, deleted_at, created_at, updated_at, channel]
+        random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, priority, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.multi_unique_index_nulls_not_distinct
-        random_columns_pool: [first_name, last_name, description, notes, failure_reason, amount, status, created_at, updated_at, remarks, deleted_at, is_active, address_line]
+        random_columns_pool: [first_name, last_name, status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at]
       - table: public.single_unique_index_nulls_distinct
-        random_columns_pool: [email, status, currency, processed_at, expires_at, description, reference_code, org_unit, deleted_at, created_at, updated_at]
+        random_columns_pool: [email, status, description, amount, due_date, seq_no, is_active, external_ref, tags, created_at, updated_at, deleted_at]
 
   - name: export_schema_from_source
     action: voyager_export_schema

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/source_dml.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/source_dml.sql
@@ -1,0 +1,277 @@
+-- Deterministic unique-conflict DML for the FORWARD (source -> target) leg.
+-- Re-applied on a loop throughout streaming by the orchestrator's conflict
+-- generator, in parallel with the random event generator, so conflicts are
+-- produced continuously rather than once.
+--
+-- DYNAMIC per cycle: the generator passes `-v cycle=N`, and every id and
+-- unique-key value is derived from it -- ids = :base + offset where
+-- :base = 900000000 + cycle*100000, and unique-key values are suffixed with
+-- :cycle -- so each cycle exercises the conflicts on a FRESH set of rows instead
+-- of recycling the same ones. Run standalone (no -v cycle) it defaults to
+-- cycle 0.
+--
+-- Derived from fallback-unique-conflict-test/source_dml.sql, but reshaped for
+-- pick_random_custom_key (orchestrator.py): that action randomly selects one
+-- (table, columns) pair as this run's `--cdc-partition-key-overrides`, and the
+-- importer requires a custom key column to be immutable (never appear in an
+-- UPDATE). Since the pick happens at run time, EVERY candidate table's DML
+-- must already satisfy that regardless of which one gets picked -- so tables
+-- 1-7 and 10/11/13 below keep ONLY DELETE-based free/reuse (free a unique
+-- value via DELETE, reuse it via INSERT on a different PK) and drop any
+-- UPDATE that would touch the column(s) that might be this run's custom key.
+-- Tables 9 and 12 need no changes: their existing DML already never updates
+-- check_id/region. Only table 8 (expression-based unique index -- the
+-- importer rejects pk/custom routing on these outright, a hard guardrail, not
+-- a DML limitation) is excluded from the candidate pool and keeps its
+-- original, fuller DML, always PK-routed.
+
+\if :{?cycle}
+\else
+  \set cycle 0
+\endif
+\set base (900000000 + :cycle * 100000)
+
+-- ============================================================
+-- 1. single_unique_constraint (id PK, email UNIQUE) -- custom-key candidate: (email)
+-- ============================================================
+BEGIN;
+INSERT INTO single_unique_constraint (id, email) VALUES
+    (:base + 1, ('suc_user1@conflict.test' || :cycle));
+
+-- DELETE-INSERT: free suc_user1, reuse it on a new PK
+DELETE FROM single_unique_constraint WHERE id = :base + 1;
+INSERT INTO single_unique_constraint (id, email) VALUES (:base + 101, ('suc_user1@conflict.test' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 2. multi_unique_constraint (id PK, UNIQUE(first_name, last_name)) -- custom-key candidate: (first_name, last_name)
+-- ============================================================
+BEGIN;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES
+    (:base + 10001, ('SrcJohn' || :cycle), ('Doe' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM multi_unique_constraint WHERE id = :base + 10001;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES (:base + 10101, ('SrcJohn' || :cycle), ('Doe' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 3. same_column_unique_constraint_and_index (id PK, email UNIQUE + UNIQUE INDEX on email) -- custom-key candidate: (email)
+-- ============================================================
+BEGIN;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES
+    (:base + 20001, ('scuci_user1@conflict.test' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM same_column_unique_constraint_and_index WHERE id = :base + 20001;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES (:base + 20101, ('scuci_user1@conflict.test' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 4. single_unique_index (id PK, UNIQUE INDEX on "Ssn" -- case-sensitive column) -- custom-key candidate: ("Ssn")
+-- ============================================================
+BEGIN;
+INSERT INTO single_unique_index (id, "Ssn") VALUES
+    (:base + 30001, ('SRC-SSN-1' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM single_unique_index WHERE id = :base + 30001;
+INSERT INTO single_unique_index (id, "Ssn") VALUES (:base + 30101, ('SRC-SSN-1' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 5. multi_unique_index (id PK, UNIQUE INDEX(first_name, last_name)) -- custom-key candidate: (first_name, last_name)
+-- ============================================================
+BEGIN;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES
+    (:base + 40001, ('IdxJohn' || :cycle), ('Doe' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM multi_unique_index WHERE id = :base + 40001;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES (:base + 40101, ('IdxJohn' || :cycle), ('Doe' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 6. different_columns_unique_constraint_and_index
+--    (id PK, email UNIQUE, UNIQUE INDEX on phone_number) -- two independent unique keys
+--    custom-key candidates: (email) or (phone_number)
+-- ============================================================
+BEGIN;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES
+    (:base + 50001, ('dcuci_user1@conflict.test' || :cycle), ('dcph-1' || :cycle));
+
+-- DELETE-INSERT (conflict on both email and phone_number)
+DELETE FROM different_columns_unique_constraint_and_index WHERE id = :base + 50001;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES (:base + 50101, ('dcuci_user1@conflict.test' || :cycle), ('dcph-1' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 7. subset_columns_unique_constraint_and_index
+--    (id PK, UNIQUE(first_name,last_name), UNIQUE INDEX(first_name,last_name,phone_number))
+--    custom-key candidate: (first_name, last_name)
+-- ============================================================
+BEGIN;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES
+    (:base + 60001, ('SubJohn' || :cycle), ('Doe' || :cycle), ('subph-1' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM subset_columns_unique_constraint_and_index WHERE id = :base + 60001;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES (:base + 60101, ('SubJohn' || :cycle), ('Doe' || :cycle), ('subph-101' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 8. expression_based_unique_index (id PK, UNIQUE INDEX on LOWER(email))
+--    NOT a custom-key candidate: the importer rejects pk/custom routing for
+--    tables with an expression-based unique index. Kept PK-routed with its
+--    full original conflict coverage.
+--    Conflicts are produced via different letter-casing that collapses to the
+--    same LOWER(email) value.
+-- ============================================================
+BEGIN;
+INSERT INTO expression_based_unique_index (id, email) VALUES
+    (:base + 70001, ('Expr_User1@conflict.test' || :cycle)),
+    (:base + 70002, ('Expr_User2@conflict.test' || :cycle)),
+    (:base + 70003, ('Expr_User3@conflict.test' || :cycle)),
+    (:base + 70004, ('Expr_User4@conflict.test' || :cycle)),
+    (:base + 70005, ('Expr_User5@conflict.test' || :cycle)),
+    (:base + 70006, ('Expr_User6@conflict.test' || :cycle));
+
+-- DELETE-INSERT (LOWER(email) collision)
+DELETE FROM expression_based_unique_index WHERE id = :base + 70001;
+INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70101, ('EXPR_USER1@conflict.test' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM expression_based_unique_index WHERE id = :base + 70002;
+UPDATE expression_based_unique_index SET email = ('EXPR_USER2@conflict.test' || :cycle) WHERE id = :base + 70003;
+
+-- UPDATE-INSERT
+UPDATE expression_based_unique_index SET email = ('Expr_User4_moved@conflict.test' || :cycle) WHERE id = :base + 70004;
+INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70102, ('expr_user4@conflict.test' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE expression_based_unique_index SET email = ('Expr_User5_moved@conflict.test' || :cycle) WHERE id = :base + 70005;
+UPDATE expression_based_unique_index SET email = ('EXPR_user5@conflict.test' || :cycle) WHERE id = :base + 70006;
+COMMIT;
+
+-- ============================================================
+-- 9. test_partial_unique_index (id PK, UNIQUE INDEX(check_id) WHERE most_recent)
+--    custom-key candidate: (check_id) -- already immutable as written: only
+--    `most_recent` is ever updated, check_id itself is only ever inserted.
+--    Only rows with most_recent = true participate in the unique index, so the
+--    conflicts here exercise the partial-predicate before/after logic.
+--    check_id values are > 2e8 so they cannot collide with generator rows.
+-- ============================================================
+BEGIN;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES
+    (:base + 80001, :base + 91, true),    -- UPDATE-INSERT: active holder of check_id 900000091
+    (:base + 80002, :base + 92, true),    -- DELETE-INSERT: active holder of check_id 900000092
+    (:base + 80003, :base + 93, true),    -- DELETE-UPDATE: active holder of check_id 900000093 (to be deleted)
+    (:base + 80004, :base + 93, false),   -- DELETE-UPDATE: inactive partner, flipped to active
+    (:base + 80005, :base + 94, true),    -- UPDATE-UPDATE: active holder of check_id 900000094 (to be deactivated)
+    (:base + 80006, :base + 94, false);   -- UPDATE-UPDATE: inactive partner, flipped to active
+
+-- UPDATE-INSERT: deactivate active holder (frees the partial-index key), insert a new active row with same check_id
+UPDATE test_partial_unique_index SET most_recent = false WHERE id = :base + 80001;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80101, :base + 91, true);
+
+-- DELETE-INSERT: delete active holder, insert a new active row with same check_id
+DELETE FROM test_partial_unique_index WHERE id = :base + 80002;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80102, :base + 92, true);
+
+-- DELETE-UPDATE: delete active holder, flip the inactive partner to active (same check_id)
+DELETE FROM test_partial_unique_index WHERE id = :base + 80003;
+UPDATE test_partial_unique_index SET most_recent = true WHERE id = :base + 80004;
+
+-- UPDATE-UPDATE: deactivate active holder, activate the inactive partner (same check_id)
+UPDATE test_partial_unique_index SET most_recent = false WHERE id = :base + 80005;
+UPDATE test_partial_unique_index SET most_recent = true WHERE id = :base + 80006;
+COMMIT;
+
+-- ============================================================
+-- 10. single_unique_index_nulls_not_distinct (id PK, UNIQUE INDEX(email) NULLS NOT DISTINCT)
+--     custom-key candidate: (email) -- free/reuse rewritten to DELETE-INSERT
+--     (never UPDATE) so email is immutability-safe if picked as the custom key.
+-- Under NULLS NOT DISTINCT two NULLs are equal, so a NULL free->reuse across PKs is a
+-- real conflict. Only one NULL can exist at a time, so the NULL is cleared via DELETE
+-- at the end of the block, leaving none behind for the next cycle.
+-- ============================================================
+BEGIN;
+-- DELETE-INSERT (non-null value)
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85001, ('nnd1_user1@conflict.test' || :cycle));
+DELETE FROM single_unique_index_nulls_not_distinct WHERE id = :base + 85001;
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85101, ('nnd1_user1@conflict.test' || :cycle));
+
+-- NULL free->reuse: free the NULL by deleting base+85010, reuse NULL on base+85011
+-- (conflict under NULLS NOT DISTINCT), then delete base+85011 to leave none behind.
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85010, NULL);
+DELETE FROM single_unique_index_nulls_not_distinct WHERE id = :base + 85010;
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85011, NULL);
+DELETE FROM single_unique_index_nulls_not_distinct WHERE id = :base + 85011;
+COMMIT;
+
+-- ============================================================
+-- 11. multi_unique_index_nulls_not_distinct (id PK, UNIQUE INDEX(first_name, last_name) NULLS NOT DISTINCT)
+--     custom-key candidate: (first_name, last_name) -- free/reuse rewritten to
+--     DELETE-INSERT (never UPDATE), same reasoning as table 10.
+-- ============================================================
+BEGIN;
+-- DELETE-INSERT (non-null values)
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86001, ('nnd2First' || :cycle), ('nnd2Last' || :cycle));
+DELETE FROM multi_unique_index_nulls_not_distinct WHERE id = :base + 86001;
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86101, ('nnd2First' || :cycle), ('nnd2Last' || :cycle));
+
+-- (NULL, NULL) free->reuse: two all-NULL rows conflict under NULLS NOT DISTINCT.
+-- Cleared via DELETE at the end so none is left behind for the next cycle.
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86010, NULL, NULL);
+DELETE FROM multi_unique_index_nulls_not_distinct WHERE id = :base + 86010;
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86011, NULL, NULL);
+DELETE FROM multi_unique_index_nulls_not_distinct WHERE id = :base + 86011;
+COMMIT;
+
+-- ============================================================
+-- 12. partitioned_unique_conflict (PK(id, region), UNIQUE INDEX(email, region), PARTITION BY LIST(region))
+--     custom-key candidate: (region) -- already immutable as written: only
+--     `email` is ever updated, region is fixed per row.
+-- The unique key includes the partition-key column; conflicts are exercised within a partition.
+-- ============================================================
+BEGIN;
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES
+    (:base + 87001, 'east', ('puc_user1@conflict.test' || :cycle)),
+    (:base + 87002, 'east', ('puc_user2@conflict.test' || :cycle)),
+    (:base + 87003, 'west', ('puc_user3@conflict.test' || :cycle)),
+    (:base + 87004, 'west', ('puc_user4@conflict.test' || :cycle));
+
+-- DELETE-INSERT within the 'east' partition: free (puc_user1, east), reuse on a new PK
+DELETE FROM partitioned_unique_conflict WHERE id = :base + 87001 AND region = 'east';
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87101, 'east', ('puc_user1@conflict.test' || :cycle));
+
+-- UPDATE-INSERT within the 'west' partition: free (puc_user3, west) by moving it, reuse on a new PK
+UPDATE partitioned_unique_conflict SET email = ('puc_user3_moved@conflict.test' || :cycle) WHERE id = :base + 87003 AND region = 'west';
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87103, 'west', ('puc_user3@conflict.test' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 13. single_unique_index_nulls_distinct (id PK, UNIQUE INDEX(email) -- default NULLS DISTINCT)
+--     custom-key candidate: (email) -- the non-null free->reuse step is rewritten
+--     to DELETE-INSERT (never UPDATE) so email is immutability-safe if picked.
+-- Under NULLS DISTINCT multiple NULLs coexist and a NULL free->reuse is NOT a conflict,
+-- so these NULL rows must import without being (wrongly) serialized. A non-null value
+-- conflict is included to confirm real conflicts still fire on this table.
+-- ============================================================
+BEGIN;
+-- Multiple NULL rows coexist under NULLS DISTINCT (no conflict, no violation)
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES
+    (:base + 89001, NULL),
+    (:base + 89002, NULL),
+    (:base + 89003, NULL);
+
+-- NULL free->reuse: delete a NULL holder, insert another NULL. Under NULLS DISTINCT
+-- these NULLs do NOT conflict, so the cache must not serialize them.
+DELETE FROM single_unique_index_nulls_distinct WHERE id = :base + 89001;
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89101, NULL);
+
+-- Non-null value free->reuse (DELETE-INSERT): a real conflict that must still be detected here.
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89010, ('nd_user1@conflict.test' || :cycle));
+DELETE FROM single_unique_index_nulls_distinct WHERE id = :base + 89010;
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89110, ('nd_user1@conflict.test' || :cycle));
+COMMIT;

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/source_dml.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/source_dml.sql
@@ -11,19 +11,28 @@
 -- cycle 0.
 --
 -- Derived from fallback-unique-conflict-test/source_dml.sql, but reshaped for
--- pick_random_custom_key (orchestrator.py): that action randomly selects one
--- (table, columns) pair as this run's `--cdc-partition-key-overrides`, and the
--- importer requires a custom key column to be immutable (never appear in an
--- UPDATE). Since the pick happens at run time, EVERY candidate table's DML
--- must already satisfy that regardless of which one gets picked -- so tables
--- 1-7 and 10/11/13 below keep ONLY DELETE-based free/reuse (free a unique
--- value via DELETE, reuse it via INSERT on a different PK) and drop any
--- UPDATE that would touch the column(s) that might be this run's custom key.
--- Tables 9 and 12 need no changes: their existing DML already never updates
--- check_id/region. Only table 8 (expression-based unique index -- the
--- importer rejects pk/custom routing on these outright, a hard guardrail, not
--- a DML limitation) is excluded from the candidate pool and keeps its
--- original, fuller DML, always PK-routed.
+-- pick_random_custom_key (orchestrator.py): that action randomly selects ONE
+-- (table, columns) candidate as this run's `--cdc-partition-key-overrides`,
+-- and the importer requires a custom key column to be immutable (never appear
+-- in an UPDATE). Since the pick happens at run time, EVERY candidate table's
+-- DML must already satisfy that regardless of which one gets picked -- so
+-- tables 2-7 and 10/11/13 below keep ONLY DELETE-based free/reuse (free a
+-- unique value via DELETE, reuse it via INSERT on a different PK) and drop
+-- any UPDATE that would touch the column(s) that might be this run's custom
+-- key. Tables 9 and 12 need no changes: their existing DML already never
+-- updates check_id/region.
+--
+-- Table 1 is the deliberate exception among the candidates: instead of a
+-- same-value free/reuse (a no-false-negative case, like every other
+-- candidate), it reuses the SAME PK with a DIFFERENT custom-key value. When
+-- it is picked, that exercises the synthetic-PK-as-unique-index guard added
+-- for custom-key tables (PR #3746) and conflicts MUST still be detected
+-- (expect_conflicts: true in the scenario); when not picked, the same PK
+-- always routes to the same channel under pk routing, so the pattern is
+-- simply inert. Table 8 (expression-based unique index -- the importer
+-- rejects pk/custom routing on these outright, a hard guardrail, not a DML
+-- limitation) is never a candidate and keeps its original, fuller DML,
+-- always PK-routed.
 
 \if :{?cycle}
 \else
@@ -32,15 +41,24 @@
 \set base (900000000 + :cycle * 100000)
 
 -- ============================================================
--- 1. single_unique_constraint (id PK, email UNIQUE) -- custom-key candidate: (email)
+-- 1. single_unique_constraint (id PK, email UNIQUE) -- custom-key candidate: (email).
+-- PK-RECYCLE case, not a no-false-negative case like every other candidate:
+-- when picked, it exercises the synthetic-PK-as-unique-index guard added for
+-- custom-key tables (PR #3746, live_migration.go
+-- addPrimaryKeyToConflictSetForCustomTables). DELETE frees id=:base+1
+-- (email=A); a NEW row then reuses the SAME id with a DIFFERENT email (B).
+-- Because A != B, these two events route to DIFFERENT channels under
+-- custom-key routing even though they share a PK -- without the synthetic
+-- PK-index guard they could apply out of order on the target and violate the
+-- primary key. So when this table is picked, conflicts MUST still be
+-- detected (expect_conflicts: true in the scenario); when not picked, the
+-- same PK always routes to the same channel under pk routing and the
+-- pattern is simply inert.
 -- ============================================================
 BEGIN;
-INSERT INTO single_unique_constraint (id, email) VALUES
-    (:base + 1, ('suc_user1@conflict.test' || :cycle));
-
--- DELETE-INSERT: free suc_user1, reuse it on a new PK
+INSERT INTO single_unique_constraint (id, email) VALUES (:base + 1, ('suc_pkrecycle_a@conflict.test' || :cycle));
 DELETE FROM single_unique_constraint WHERE id = :base + 1;
-INSERT INTO single_unique_constraint (id, email) VALUES (:base + 101, ('suc_user1@conflict.test' || :cycle));
+INSERT INTO single_unique_constraint (id, email) VALUES (:base + 1, ('suc_pkrecycle_b@conflict.test' || :cycle));
 COMMIT;
 
 -- ============================================================

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/source_dml.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/source_dml.sql
@@ -10,13 +10,22 @@
 -- of recycling the same ones. Run standalone (no -v cycle) it defaults to
 -- cycle 0.
 --
+-- EVERY column is given an explicit value, and the two rows of a free/reuse
+-- pair differ in every column except the unique key they deliberately collide
+-- on. pick_random_custom_key samples the custom key from a table's non-key
+-- columns, so a column left at its DEFAULT (or NULL) would carry the SAME
+-- value on both rows of the pair, route them to the SAME channel, and quietly
+-- stop that pair from exercising conflict detection at all. Only the key
+-- columns carry :cycle; the rest are plain literals keyed off the row index,
+-- since all they have to do is differ within the pair.
+--
 -- Derived from fallback-unique-conflict-test/source_dml.sql, but reshaped for
 -- pick_random_custom_key (orchestrator.py): that action randomly selects ONE
 -- (table, columns) candidate as this run's `--cdc-partition-key-overrides`,
 -- and the importer requires a custom key column to be immutable (never appear
--- in an UPDATE). Since the pick happens at run time, EVERY candidate table's
--- DML must already satisfy that regardless of which one gets picked -- so
--- tables 2-7 and 10/11/13 below keep ONLY DELETE-based free/reuse (free a
+-- in an UPDATE's SET list). Since the pick happens at run time, EVERY candidate
+-- table's DML must already satisfy that regardless of which one gets picked --
+-- so tables 2-7 and 10/11/13 below keep ONLY DELETE-based free/reuse (free a
 -- unique value via DELETE, reuse it via INSERT on a different PK) and drop
 -- any UPDATE that would touch the column(s) that might be this run's custom
 -- key. Tables 9 and 12 need no changes: their existing DML already never
@@ -56,57 +65,99 @@
 -- pattern is simply inert.
 -- ============================================================
 BEGIN;
-INSERT INTO single_unique_constraint (id, email) VALUES (:base + 1, ('suc_pkrecycle_a@conflict.test' || :cycle));
+
+INSERT INTO single_unique_constraint
+    (id, email, status, description, amount, due_date, seq_no, is_active, metadata, priority, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 1), ('suc_pkrecycle_a@conflict.test' || :cycle), 'st_suc_a', 'desc_suc_a', 0.250000, DATE '2026-01-01', (:base + 0), true, '{"row": "suc_a"}'::jsonb, 0, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
+
 DELETE FROM single_unique_constraint WHERE id = :base + 1;
-INSERT INTO single_unique_constraint (id, email) VALUES (:base + 1, ('suc_pkrecycle_b@conflict.test' || :cycle));
+
+INSERT INTO single_unique_constraint
+    (id, email, status, description, amount, due_date, seq_no, is_active, metadata, priority, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 1), ('suc_pkrecycle_b@conflict.test' || :cycle), 'st_suc_b', 'desc_suc_b', 1.250000, DATE '2026-01-02', (:base + 1), false, '{"row": "suc_b"}'::jsonb, 1, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
+
 COMMIT;
 
 -- ============================================================
 -- 2. multi_unique_constraint (id PK, UNIQUE(first_name, last_name)) -- custom-key candidate: (first_name, last_name)
 -- ============================================================
 BEGIN;
-INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES
-    (:base + 10001, ('SrcJohn' || :cycle), ('Doe' || :cycle));
+
+INSERT INTO multi_unique_constraint
+    (id, first_name, last_name, status, metadata, amount, due_date, seq_no, is_active, priority, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 10001), ('SrcJohn' || :cycle), ('Doe' || :cycle), 'st_muc_a', '{"row": "muc_a"}'::jsonb, 0.250000, DATE '2026-01-01', (:base + 0), true, 0, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
 
 -- DELETE-INSERT
 DELETE FROM multi_unique_constraint WHERE id = :base + 10001;
-INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES (:base + 10101, ('SrcJohn' || :cycle), ('Doe' || :cycle));
+
+INSERT INTO multi_unique_constraint
+    (id, first_name, last_name, status, metadata, amount, due_date, seq_no, is_active, priority, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 10101), ('SrcJohn' || :cycle), ('Doe' || :cycle), 'st_muc_b', '{"row": "muc_b"}'::jsonb, 1.250000, DATE '2026-01-02', (:base + 1), false, 1, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
+
 COMMIT;
 
 -- ============================================================
 -- 3. same_column_unique_constraint_and_index (id PK, email UNIQUE + UNIQUE INDEX on email) -- custom-key candidate: (email)
 -- ============================================================
 BEGIN;
-INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES
-    (:base + 20001, ('scuci_user1@conflict.test' || :cycle));
+
+INSERT INTO same_column_unique_constraint_and_index
+    (id, email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, metadata, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 20001), ('scuci_user1@conflict.test' || :cycle), 'st_scuci_a', 'desc_scuci_a', 0.250000, DATE '2026-01-01', (:base + 0), true, '{tag_scuci_a}'::varchar[], 0, '{"row": "scuci_a"}'::jsonb, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
 
 -- DELETE-INSERT
 DELETE FROM same_column_unique_constraint_and_index WHERE id = :base + 20001;
-INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES (:base + 20101, ('scuci_user1@conflict.test' || :cycle));
+
+INSERT INTO same_column_unique_constraint_and_index
+    (id, email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, metadata, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 20101), ('scuci_user1@conflict.test' || :cycle), 'st_scuci_b', 'desc_scuci_b', 1.250000, DATE '2026-01-02', (:base + 1), false, '{tag_scuci_b}'::varchar[], 1, '{"row": "scuci_b"}'::jsonb, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
+
 COMMIT;
 
 -- ============================================================
 -- 4. single_unique_index (id PK, UNIQUE INDEX on "Ssn" -- case-sensitive column) -- custom-key candidate: ("Ssn")
 -- ============================================================
 BEGIN;
-INSERT INTO single_unique_index (id, "Ssn") VALUES
-    (:base + 30001, ('SRC-SSN-1' || :cycle));
+
+INSERT INTO single_unique_index
+    (id, "Ssn", status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 30001), ('SRC-SSN-1' || :cycle), 'st_sui_a', 'desc_sui_a', 0.250000, DATE '2026-01-01', (:base + 0), true, 0.5, md5('sui_a')::uuid, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
 
 -- DELETE-INSERT
 DELETE FROM single_unique_index WHERE id = :base + 30001;
-INSERT INTO single_unique_index (id, "Ssn") VALUES (:base + 30101, ('SRC-SSN-1' || :cycle));
+
+INSERT INTO single_unique_index
+    (id, "Ssn", status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 30101), ('SRC-SSN-1' || :cycle), 'st_sui_b', 'desc_sui_b', 1.250000, DATE '2026-01-02', (:base + 1), false, 1.5, md5('sui_b')::uuid, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
+
 COMMIT;
 
 -- ============================================================
 -- 5. multi_unique_index (id PK, UNIQUE INDEX(first_name, last_name)) -- custom-key candidate: (first_name, last_name)
 -- ============================================================
 BEGIN;
-INSERT INTO multi_unique_index (id, first_name, last_name) VALUES
-    (:base + 40001, ('IdxJohn' || :cycle), ('Doe' || :cycle));
+
+INSERT INTO multi_unique_index
+    (id, first_name, last_name, status, description, amount, due_date, seq_no, is_active, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 40001), ('IdxJohn' || :cycle), ('Doe' || :cycle), 'st_mui_a', 'desc_mui_a', 0.250000, DATE '2026-01-01', (:base + 0), true, md5('mui_a')::uuid, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
 
 -- DELETE-INSERT
 DELETE FROM multi_unique_index WHERE id = :base + 40001;
-INSERT INTO multi_unique_index (id, first_name, last_name) VALUES (:base + 40101, ('IdxJohn' || :cycle), ('Doe' || :cycle));
+
+INSERT INTO multi_unique_index
+    (id, first_name, last_name, status, description, amount, due_date, seq_no, is_active, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 40101), ('IdxJohn' || :cycle), ('Doe' || :cycle), 'st_mui_b', 'desc_mui_b', 1.250000, DATE '2026-01-02', (:base + 1), false, md5('mui_b')::uuid, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
+
 COMMIT;
 
 -- ============================================================
@@ -115,12 +166,20 @@ COMMIT;
 --    custom-key candidates: (email) or (phone_number)
 -- ============================================================
 BEGIN;
-INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES
-    (:base + 50001, ('dcuci_user1@conflict.test' || :cycle), ('dcph-1' || :cycle));
+
+INSERT INTO different_columns_unique_constraint_and_index
+    (id, email, phone_number, status, metadata, amount, due_date, seq_no, is_active, retry_count, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 50001), ('dcuci_user1@conflict.test' || :cycle), ('dcph-1' || :cycle), 'st_dcuci_a', '{"row": "dcuci_a"}'::jsonb, 0.250000, DATE '2026-01-01', (:base + 0), true, 0, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
 
 -- DELETE-INSERT (conflict on both email and phone_number)
 DELETE FROM different_columns_unique_constraint_and_index WHERE id = :base + 50001;
-INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES (:base + 50101, ('dcuci_user1@conflict.test' || :cycle), ('dcph-1' || :cycle));
+
+INSERT INTO different_columns_unique_constraint_and_index
+    (id, email, phone_number, status, metadata, amount, due_date, seq_no, is_active, retry_count, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 50101), ('dcuci_user1@conflict.test' || :cycle), ('dcph-1' || :cycle), 'st_dcuci_b', '{"row": "dcuci_b"}'::jsonb, 1.250000, DATE '2026-01-02', (:base + 1), false, 1, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
+
 COMMIT;
 
 -- ============================================================
@@ -129,12 +188,20 @@ COMMIT;
 --    custom-key candidate: (first_name, last_name)
 -- ============================================================
 BEGIN;
-INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES
-    (:base + 60001, ('SubJohn' || :cycle), ('Doe' || :cycle), ('subph-1' || :cycle));
+
+INSERT INTO subset_columns_unique_constraint_and_index
+    (id, first_name, last_name, phone_number, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 60001), ('SubJohn' || :cycle), ('Doe' || :cycle), ('subph-1' || :cycle), 'st_scui_a', 'desc_scui_a', 0.250000, DATE '2026-01-01', (:base + 0), true, '{"row": "scui_a"}'::jsonb, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
 
 -- DELETE-INSERT
 DELETE FROM subset_columns_unique_constraint_and_index WHERE id = :base + 60001;
-INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES (:base + 60101, ('SubJohn' || :cycle), ('Doe' || :cycle), ('subph-101' || :cycle));
+
+INSERT INTO subset_columns_unique_constraint_and_index
+    (id, first_name, last_name, phone_number, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 60101), ('SubJohn' || :cycle), ('Doe' || :cycle), ('subph-101' || :cycle), 'st_scui_b', 'desc_scui_b', 1.250000, DATE '2026-01-02', (:base + 1), false, '{"row": "scui_b"}'::jsonb, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
+
 COMMIT;
 
 -- ============================================================
@@ -146,17 +213,24 @@ COMMIT;
 --    same LOWER(email) value.
 -- ============================================================
 BEGIN;
-INSERT INTO expression_based_unique_index (id, email) VALUES
-    (:base + 70001, ('Expr_User1@conflict.test' || :cycle)),
-    (:base + 70002, ('Expr_User2@conflict.test' || :cycle)),
-    (:base + 70003, ('Expr_User3@conflict.test' || :cycle)),
-    (:base + 70004, ('Expr_User4@conflict.test' || :cycle)),
-    (:base + 70005, ('Expr_User5@conflict.test' || :cycle)),
-    (:base + 70006, ('Expr_User6@conflict.test' || :cycle));
+
+INSERT INTO expression_based_unique_index
+    (id, email, status, description, amount, due_date, seq_no, is_active, notes, metadata, priority, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 70001), ('Expr_User1@conflict.test' || :cycle), 'st_ebui_1', 'desc_ebui_1', 0.250000, DATE '2026-01-01', (:base + 0), true, 'notes_ebui_1', '{"row": "ebui_1"}'::jsonb, 0, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00'),
+    ((:base + 70002), ('Expr_User2@conflict.test' || :cycle), 'st_ebui_2', 'desc_ebui_2', 1.250000, DATE '2026-01-02', (:base + 1), false, 'notes_ebui_2', '{"row": "ebui_2"}'::jsonb, 1, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01'),
+    ((:base + 70003), ('Expr_User3@conflict.test' || :cycle), 'st_ebui_3', 'desc_ebui_3', 2.250000, DATE '2026-01-03', (:base + 2), true, 'notes_ebui_3', '{"row": "ebui_3"}'::jsonb, 2, TIMESTAMP '2026-01-01 00:00:02', TIMESTAMP '2026-03-01 00:00:02', TIMESTAMP '2026-06-01 00:00:02'),
+    ((:base + 70004), ('Expr_User4@conflict.test' || :cycle), 'st_ebui_4', 'desc_ebui_4', 3.250000, DATE '2026-01-04', (:base + 3), false, 'notes_ebui_4', '{"row": "ebui_4"}'::jsonb, 3, TIMESTAMP '2026-01-01 00:00:03', TIMESTAMP '2026-03-01 00:00:03', TIMESTAMP '2026-06-01 00:00:03'),
+    ((:base + 70005), ('Expr_User5@conflict.test' || :cycle), 'st_ebui_5', 'desc_ebui_5', 4.250000, DATE '2026-01-05', (:base + 4), true, 'notes_ebui_5', '{"row": "ebui_5"}'::jsonb, 4, TIMESTAMP '2026-01-01 00:00:04', TIMESTAMP '2026-03-01 00:00:04', TIMESTAMP '2026-06-01 00:00:04'),
+    ((:base + 70006), ('Expr_User6@conflict.test' || :cycle), 'st_ebui_6', 'desc_ebui_6', 5.250000, DATE '2026-01-06', (:base + 5), false, 'notes_ebui_6', '{"row": "ebui_6"}'::jsonb, 5, TIMESTAMP '2026-01-01 00:00:05', TIMESTAMP '2026-03-01 00:00:05', TIMESTAMP '2026-06-01 00:00:05');
 
 -- DELETE-INSERT (LOWER(email) collision)
 DELETE FROM expression_based_unique_index WHERE id = :base + 70001;
-INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70101, ('EXPR_USER1@conflict.test' || :cycle));
+
+INSERT INTO expression_based_unique_index
+    (id, email, status, description, amount, due_date, seq_no, is_active, notes, metadata, priority, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 70101), ('EXPR_USER1@conflict.test' || :cycle), 'st_ebui_101', 'desc_ebui_101', 7.250000, DATE '2026-01-08', (:base + 7), false, 'notes_ebui_101', '{"row": "ebui_101"}'::jsonb, 7, TIMESTAMP '2026-01-01 00:00:07', TIMESTAMP '2026-03-01 00:00:07', TIMESTAMP '2026-06-01 00:00:07');
 
 -- DELETE-UPDATE
 DELETE FROM expression_based_unique_index WHERE id = :base + 70002;
@@ -164,7 +238,11 @@ UPDATE expression_based_unique_index SET email = ('EXPR_USER2@conflict.test' || 
 
 -- UPDATE-INSERT
 UPDATE expression_based_unique_index SET email = ('Expr_User4_moved@conflict.test' || :cycle) WHERE id = :base + 70004;
-INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70102, ('expr_user4@conflict.test' || :cycle));
+
+INSERT INTO expression_based_unique_index
+    (id, email, status, description, amount, due_date, seq_no, is_active, notes, metadata, priority, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 70102), ('expr_user4@conflict.test' || :cycle), 'st_ebui_102', 'desc_ebui_102', 8.250000, DATE '2026-01-09', (:base + 8), true, 'notes_ebui_102', '{"row": "ebui_102"}'::jsonb, 8, TIMESTAMP '2026-01-01 00:00:08', TIMESTAMP '2026-03-01 00:00:08', TIMESTAMP '2026-06-01 00:00:08');
 
 -- UPDATE-UPDATE
 UPDATE expression_based_unique_index SET email = ('Expr_User5_moved@conflict.test' || :cycle) WHERE id = :base + 70005;
@@ -180,21 +258,32 @@ COMMIT;
 --    check_id values are > 2e8 so they cannot collide with generator rows.
 -- ============================================================
 BEGIN;
-INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES
-    (:base + 80001, :base + 91, true),    -- UPDATE-INSERT: active holder of check_id 900000091
-    (:base + 80002, :base + 92, true),    -- DELETE-INSERT: active holder of check_id 900000092
-    (:base + 80003, :base + 93, true),    -- DELETE-UPDATE: active holder of check_id 900000093 (to be deleted)
-    (:base + 80004, :base + 93, false),   -- DELETE-UPDATE: inactive partner, flipped to active
-    (:base + 80005, :base + 94, true),    -- UPDATE-UPDATE: active holder of check_id 900000094 (to be deactivated)
-    (:base + 80006, :base + 94, false);   -- UPDATE-UPDATE: inactive partner, flipped to active
+
+INSERT INTO test_partial_unique_index
+    (id, check_id, most_recent, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 80001), (:base + 91), true, 'st_tpui_1', 'desc_tpui_1', 0.250000, DATE '2026-01-01', (:base + 0), true, '{"row": "tpui_1"}'::jsonb, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00'),
+    ((:base + 80002), (:base + 92), true, 'st_tpui_2', 'desc_tpui_2', 2.250000, DATE '2026-01-03', (:base + 2), true, '{"row": "tpui_2"}'::jsonb, TIMESTAMP '2026-01-01 00:00:02', TIMESTAMP '2026-03-01 00:00:02', TIMESTAMP '2026-06-01 00:00:02'),
+    ((:base + 80003), (:base + 93), true, 'st_tpui_3', 'desc_tpui_3', 4.250000, DATE '2026-01-05', (:base + 4), true, '{"row": "tpui_3"}'::jsonb, TIMESTAMP '2026-01-01 00:00:04', TIMESTAMP '2026-03-01 00:00:04', TIMESTAMP '2026-06-01 00:00:04'),
+    ((:base + 80004), (:base + 93), false, 'st_tpui_4', 'desc_tpui_4', 5.250000, DATE '2026-01-06', (:base + 5), false, '{"row": "tpui_4"}'::jsonb, TIMESTAMP '2026-01-01 00:00:05', TIMESTAMP '2026-03-01 00:00:05', TIMESTAMP '2026-06-01 00:00:05'),
+    ((:base + 80005), (:base + 94), true, 'st_tpui_5', 'desc_tpui_5', 6.250000, DATE '2026-01-07', (:base + 6), true, '{"row": "tpui_5"}'::jsonb, TIMESTAMP '2026-01-01 00:00:06', TIMESTAMP '2026-03-01 00:00:06', TIMESTAMP '2026-06-01 00:00:06'),
+    ((:base + 80006), (:base + 94), false, 'st_tpui_6', 'desc_tpui_6', 7.250000, DATE '2026-01-08', (:base + 7), false, '{"row": "tpui_6"}'::jsonb, TIMESTAMP '2026-01-01 00:00:07', TIMESTAMP '2026-03-01 00:00:07', TIMESTAMP '2026-06-01 00:00:07');
 
 -- UPDATE-INSERT: deactivate active holder (frees the partial-index key), insert a new active row with same check_id
 UPDATE test_partial_unique_index SET most_recent = false WHERE id = :base + 80001;
-INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80101, :base + 91, true);
+
+INSERT INTO test_partial_unique_index
+    (id, check_id, most_recent, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 80101), (:base + 91), true, 'st_tpui_101', 'desc_tpui_101', 1.250000, DATE '2026-01-02', (:base + 1), false, '{"row": "tpui_101"}'::jsonb, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
 
 -- DELETE-INSERT: delete active holder, insert a new active row with same check_id
 DELETE FROM test_partial_unique_index WHERE id = :base + 80002;
-INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80102, :base + 92, true);
+
+INSERT INTO test_partial_unique_index
+    (id, check_id, most_recent, status, description, amount, due_date, seq_no, is_active, metadata, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 80102), (:base + 92), true, 'st_tpui_102', 'desc_tpui_102', 3.250000, DATE '2026-01-04', (:base + 3), false, '{"row": "tpui_102"}'::jsonb, TIMESTAMP '2026-01-01 00:00:03', TIMESTAMP '2026-03-01 00:00:03', TIMESTAMP '2026-06-01 00:00:03');
 
 -- DELETE-UPDATE: delete active holder, flip the inactive partner to active (same check_id)
 DELETE FROM test_partial_unique_index WHERE id = :base + 80003;
@@ -215,15 +304,34 @@ COMMIT;
 -- ============================================================
 BEGIN;
 -- DELETE-INSERT (non-null value)
-INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85001, ('nnd1_user1@conflict.test' || :cycle));
+
+INSERT INTO single_unique_index_nulls_not_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, priority, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 85001), ('nnd1_user1@conflict.test' || :cycle), 'st_nnd1_a', 'desc_nnd1_a', 0.250000, DATE '2026-01-01', (:base + 0), true, 0, 0.5, md5('nnd1_a')::uuid, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
+
 DELETE FROM single_unique_index_nulls_not_distinct WHERE id = :base + 85001;
-INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85101, ('nnd1_user1@conflict.test' || :cycle));
+
+INSERT INTO single_unique_index_nulls_not_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, priority, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 85101), ('nnd1_user1@conflict.test' || :cycle), 'st_nnd1_b', 'desc_nnd1_b', 1.250000, DATE '2026-01-02', (:base + 1), false, 1, 1.5, md5('nnd1_b')::uuid, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
 
 -- NULL free->reuse: free the NULL by deleting base+85010, reuse NULL on base+85011
 -- (conflict under NULLS NOT DISTINCT), then delete base+85011 to leave none behind.
-INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85010, NULL);
+
+INSERT INTO single_unique_index_nulls_not_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, priority, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 85010), NULL, 'st_nnd1_n1', 'desc_nnd1_n1', 2.250000, DATE '2026-01-03', (:base + 2), true, 2, 2.5, md5('nnd1_n1')::uuid, TIMESTAMP '2026-01-01 00:00:02', TIMESTAMP '2026-03-01 00:00:02', TIMESTAMP '2026-06-01 00:00:02');
+
 DELETE FROM single_unique_index_nulls_not_distinct WHERE id = :base + 85010;
-INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85011, NULL);
+
+INSERT INTO single_unique_index_nulls_not_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, priority, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 85011), NULL, 'st_nnd1_n2', 'desc_nnd1_n2', 3.250000, DATE '2026-01-04', (:base + 3), false, 3, 3.5, md5('nnd1_n2')::uuid, TIMESTAMP '2026-01-01 00:00:03', TIMESTAMP '2026-03-01 00:00:03', TIMESTAMP '2026-06-01 00:00:03');
+
 DELETE FROM single_unique_index_nulls_not_distinct WHERE id = :base + 85011;
 COMMIT;
 
@@ -234,15 +342,34 @@ COMMIT;
 -- ============================================================
 BEGIN;
 -- DELETE-INSERT (non-null values)
-INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86001, ('nnd2First' || :cycle), ('nnd2Last' || :cycle));
+
+INSERT INTO multi_unique_index_nulls_not_distinct
+    (id, first_name, last_name, status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 86001), ('nnd2First' || :cycle), ('nnd2Last' || :cycle), 'st_nnd2_a', 'desc_nnd2_a', 0.250000, DATE '2026-01-01', (:base + 0), true, 0.5, md5('nnd2_a')::uuid, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00');
+
 DELETE FROM multi_unique_index_nulls_not_distinct WHERE id = :base + 86001;
-INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86101, ('nnd2First' || :cycle), ('nnd2Last' || :cycle));
+
+INSERT INTO multi_unique_index_nulls_not_distinct
+    (id, first_name, last_name, status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 86101), ('nnd2First' || :cycle), ('nnd2Last' || :cycle), 'st_nnd2_b', 'desc_nnd2_b', 1.250000, DATE '2026-01-02', (:base + 1), false, 1.5, md5('nnd2_b')::uuid, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
 
 -- (NULL, NULL) free->reuse: two all-NULL rows conflict under NULLS NOT DISTINCT.
 -- Cleared via DELETE at the end so none is left behind for the next cycle.
-INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86010, NULL, NULL);
+
+INSERT INTO multi_unique_index_nulls_not_distinct
+    (id, first_name, last_name, status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 86010), NULL, NULL, 'st_nnd2_n1', 'desc_nnd2_n1', 2.250000, DATE '2026-01-03', (:base + 2), true, 2.5, md5('nnd2_n1')::uuid, TIMESTAMP '2026-01-01 00:00:02', TIMESTAMP '2026-03-01 00:00:02', TIMESTAMP '2026-06-01 00:00:02');
+
 DELETE FROM multi_unique_index_nulls_not_distinct WHERE id = :base + 86010;
-INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86011, NULL, NULL);
+
+INSERT INTO multi_unique_index_nulls_not_distinct
+    (id, first_name, last_name, status, description, amount, due_date, seq_no, is_active, score, external_ref, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 86011), NULL, NULL, 'st_nnd2_n2', 'desc_nnd2_n2', 3.250000, DATE '2026-01-04', (:base + 3), false, 3.5, md5('nnd2_n2')::uuid, TIMESTAMP '2026-01-01 00:00:03', TIMESTAMP '2026-03-01 00:00:03', TIMESTAMP '2026-06-01 00:00:03');
+
 DELETE FROM multi_unique_index_nulls_not_distinct WHERE id = :base + 86011;
 COMMIT;
 
@@ -253,19 +380,31 @@ COMMIT;
 -- The unique key includes the partition-key column; conflicts are exercised within a partition.
 -- ============================================================
 BEGIN;
-INSERT INTO partitioned_unique_conflict (id, region, email) VALUES
-    (:base + 87001, 'east', ('puc_user1@conflict.test' || :cycle)),
-    (:base + 87002, 'east', ('puc_user2@conflict.test' || :cycle)),
-    (:base + 87003, 'west', ('puc_user3@conflict.test' || :cycle)),
-    (:base + 87004, 'west', ('puc_user4@conflict.test' || :cycle));
+
+INSERT INTO partitioned_unique_conflict
+    (id, region, email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 87001), 'east', ('puc_user1@conflict.test' || :cycle), 'st_puc_1', 'desc_puc_1', 0.250000, DATE '2026-01-01', (:base + 0), true, '{tag_puc_1}'::varchar[], 0, TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00'),
+    ((:base + 87002), 'east', ('puc_user2@conflict.test' || :cycle), 'st_puc_2', 'desc_puc_2', 2.250000, DATE '2026-01-03', (:base + 2), true, '{tag_puc_2}'::varchar[], 2, TIMESTAMP '2026-01-01 00:00:02', TIMESTAMP '2026-03-01 00:00:02', TIMESTAMP '2026-06-01 00:00:02'),
+    ((:base + 87003), 'west', ('puc_user3@conflict.test' || :cycle), 'st_puc_3', 'desc_puc_3', 4.250000, DATE '2026-01-05', (:base + 4), true, '{tag_puc_3}'::varchar[], 4, TIMESTAMP '2026-01-01 00:00:04', TIMESTAMP '2026-03-01 00:00:04', TIMESTAMP '2026-06-01 00:00:04'),
+    ((:base + 87004), 'west', ('puc_user4@conflict.test' || :cycle), 'st_puc_4', 'desc_puc_4', 6.250000, DATE '2026-01-07', (:base + 6), true, '{tag_puc_4}'::varchar[], 6, TIMESTAMP '2026-01-01 00:00:06', TIMESTAMP '2026-03-01 00:00:06', TIMESTAMP '2026-06-01 00:00:06');
 
 -- DELETE-INSERT within the 'east' partition: free (puc_user1, east), reuse on a new PK
 DELETE FROM partitioned_unique_conflict WHERE id = :base + 87001 AND region = 'east';
-INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87101, 'east', ('puc_user1@conflict.test' || :cycle));
+
+INSERT INTO partitioned_unique_conflict
+    (id, region, email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 87101), 'east', ('puc_user1@conflict.test' || :cycle), 'st_puc_101', 'desc_puc_101', 1.250000, DATE '2026-01-02', (:base + 1), false, '{tag_puc_101}'::varchar[], 1, TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
 
 -- UPDATE-INSERT within the 'west' partition: free (puc_user3, west) by moving it, reuse on a new PK
 UPDATE partitioned_unique_conflict SET email = ('puc_user3_moved@conflict.test' || :cycle) WHERE id = :base + 87003 AND region = 'west';
-INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87103, 'west', ('puc_user3@conflict.test' || :cycle));
+
+INSERT INTO partitioned_unique_conflict
+    (id, region, email, status, description, amount, due_date, seq_no, is_active, tags, retry_count, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 87103), 'west', ('puc_user3@conflict.test' || :cycle), 'st_puc_103', 'desc_puc_103', 5.250000, DATE '2026-01-06', (:base + 5), false, '{tag_puc_103}'::varchar[], 5, TIMESTAMP '2026-01-01 00:00:05', TIMESTAMP '2026-03-01 00:00:05', TIMESTAMP '2026-06-01 00:00:05');
+
 COMMIT;
 
 -- ============================================================
@@ -278,18 +417,35 @@ COMMIT;
 -- ============================================================
 BEGIN;
 -- Multiple NULL rows coexist under NULLS DISTINCT (no conflict, no violation)
-INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES
-    (:base + 89001, NULL),
-    (:base + 89002, NULL),
-    (:base + 89003, NULL);
+
+INSERT INTO single_unique_index_nulls_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, external_ref, tags, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 89001), NULL, 'st_nd_n1', 'desc_nd_n1', 0.250000, DATE '2026-01-01', (:base + 0), true, md5('nd_n1')::uuid, '{tag_nd_n1}'::varchar[], TIMESTAMP '2026-01-01 00:00:00', TIMESTAMP '2026-03-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00'),
+    ((:base + 89002), NULL, 'st_nd_n2', 'desc_nd_n2', 2.250000, DATE '2026-01-03', (:base + 2), true, md5('nd_n2')::uuid, '{tag_nd_n2}'::varchar[], TIMESTAMP '2026-01-01 00:00:02', TIMESTAMP '2026-03-01 00:00:02', TIMESTAMP '2026-06-01 00:00:02'),
+    ((:base + 89003), NULL, 'st_nd_n3', 'desc_nd_n3', 4.250000, DATE '2026-01-05', (:base + 4), true, md5('nd_n3')::uuid, '{tag_nd_n3}'::varchar[], TIMESTAMP '2026-01-01 00:00:04', TIMESTAMP '2026-03-01 00:00:04', TIMESTAMP '2026-06-01 00:00:04');
 
 -- NULL free->reuse: delete a NULL holder, insert another NULL. Under NULLS DISTINCT
 -- these NULLs do NOT conflict, so the cache must not serialize them.
 DELETE FROM single_unique_index_nulls_distinct WHERE id = :base + 89001;
-INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89101, NULL);
+
+INSERT INTO single_unique_index_nulls_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, external_ref, tags, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 89101), NULL, 'st_nd_n101', 'desc_nd_n101', 1.250000, DATE '2026-01-02', (:base + 1), false, md5('nd_n101')::uuid, '{tag_nd_n101}'::varchar[], TIMESTAMP '2026-01-01 00:00:01', TIMESTAMP '2026-03-01 00:00:01', TIMESTAMP '2026-06-01 00:00:01');
 
 -- Non-null value free->reuse (DELETE-INSERT): a real conflict that must still be detected here.
-INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89010, ('nd_user1@conflict.test' || :cycle));
+
+INSERT INTO single_unique_index_nulls_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, external_ref, tags, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 89010), ('nd_user1@conflict.test' || :cycle), 'st_nd_a', 'desc_nd_a', 6.250000, DATE '2026-01-07', (:base + 6), true, md5('nd_a')::uuid, '{tag_nd_a}'::varchar[], TIMESTAMP '2026-01-01 00:00:06', TIMESTAMP '2026-03-01 00:00:06', TIMESTAMP '2026-06-01 00:00:06');
+
 DELETE FROM single_unique_index_nulls_distinct WHERE id = :base + 89010;
-INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89110, ('nd_user1@conflict.test' || :cycle));
+
+INSERT INTO single_unique_index_nulls_distinct
+    (id, email, status, description, amount, due_date, seq_no, is_active, external_ref, tags, created_at, updated_at, deleted_at)
+VALUES
+    ((:base + 89110), ('nd_user1@conflict.test' || :cycle), 'st_nd_b', 'desc_nd_b', 7.250000, DATE '2026-01-08', (:base + 7), false, md5('nd_b')::uuid, '{tag_nd_b}'::varchar[], TIMESTAMP '2026-01-01 00:00:07', TIMESTAMP '2026-03-01 00:00:07', TIMESTAMP '2026-06-01 00:00:07');
+
 COMMIT;

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/target_dml.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/target_dml.sql
@@ -1,0 +1,368 @@
+-- Deterministic unique-conflict DML for the FALLBACK (target -> source) leg.
+-- Re-applied on a loop throughout fallback streaming by the orchestrator's
+-- conflict generator (conflict_generator_target), in parallel with the
+-- target-side random generator, so conflicts are produced continuously.
+--
+-- DYNAMIC per cycle: the generator passes `-v cycle=N`; ids = :base + offset
+-- (:base = 950000000 + cycle*100000) and unique-key values are suffixed with
+-- :cycle, so each cycle hits a FRESH set of rows (the freeing + reusing events
+-- within a cycle still share that cycle's value, so the conflict is preserved).
+-- The 950,000,000 base keeps these rows clear of the forward-migrated rows
+-- (900,000,000 base) and the random generator (integers in -2e8 .. 2e8).
+-- Run standalone (no -v cycle) it defaults to cycle 0.
+--
+-- Same four conflict types as the forward leg (DELETE-INSERT, DELETE-UPDATE,
+-- UPDATE-INSERT, UPDATE-UPDATE). For an export-from-target source the
+-- conflict-detection cache cannot rely on YB-CDC before-images, so it falls
+-- back to a coarser rule (cached DELETE => conflict; cached UPDATE touching the
+-- same unique-key columns => conflict). These scenarios exercise that path.
+-- Each table's seed + conflicts run in one transaction.
+
+-- ============================================================
+-- 1. single_unique_constraint (id PK, email UNIQUE)
+-- ============================================================
+\if :{?cycle}
+\else
+  \set cycle 0
+\endif
+\set base (950000000 + :cycle * 100000)
+
+BEGIN;
+INSERT INTO single_unique_constraint (id, email) VALUES
+    (:base + 1, ('tgt_suc_user1@conflict.test' || :cycle)),
+    (:base + 2, ('tgt_suc_user2@conflict.test' || :cycle)),
+    (:base + 3, ('tgt_suc_user3@conflict.test' || :cycle)),
+    (:base + 4, ('tgt_suc_user4@conflict.test' || :cycle)),
+    (:base + 5, ('tgt_suc_user5@conflict.test' || :cycle)),
+    (:base + 6, ('tgt_suc_user6@conflict.test' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM single_unique_constraint WHERE id = :base + 1;
+INSERT INTO single_unique_constraint (id, email) VALUES (:base + 101, ('tgt_suc_user1@conflict.test' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM single_unique_constraint WHERE id = :base + 2;
+UPDATE single_unique_constraint SET email = ('tgt_suc_user2@conflict.test' || :cycle) WHERE id = :base + 3;
+
+-- UPDATE-INSERT
+UPDATE single_unique_constraint SET email = ('tgt_suc_user4_moved@conflict.test' || :cycle) WHERE id = :base + 4;
+INSERT INTO single_unique_constraint (id, email) VALUES (:base + 102, ('tgt_suc_user4@conflict.test' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE single_unique_constraint SET email = ('tgt_suc_user5_moved@conflict.test' || :cycle) WHERE id = :base + 5;
+UPDATE single_unique_constraint SET email = ('tgt_suc_user5@conflict.test' || :cycle) WHERE id = :base + 6;
+COMMIT;
+
+-- ============================================================
+-- 2. multi_unique_constraint (id PK, UNIQUE(first_name, last_name))
+-- ============================================================
+BEGIN;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES
+    (:base + 10001, ('TgtJohn' || :cycle),  ('Doe' || :cycle)),
+    (:base + 10002, ('TgtJane' || :cycle),  ('Smith' || :cycle)),
+    (:base + 10003, ('TgtBob' || :cycle),   ('Jones' || :cycle)),
+    (:base + 10004, ('TgtAlice' || :cycle), ('Williams' || :cycle)),
+    (:base + 10005, ('TgtTom' || :cycle),   ('Clark' || :cycle)),
+    (:base + 10006, ('TgtEve' || :cycle),   ('Davis' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM multi_unique_constraint WHERE id = :base + 10001;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES (:base + 10101, ('TgtJohn' || :cycle), ('Doe' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM multi_unique_constraint WHERE id = :base + 10002;
+UPDATE multi_unique_constraint SET first_name = ('TgtJane' || :cycle), last_name = ('Smith' || :cycle) WHERE id = :base + 10003;
+
+-- UPDATE-INSERT
+UPDATE multi_unique_constraint SET first_name = ('TgtAlice_moved' || :cycle) WHERE id = :base + 10004;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES (:base + 10102, ('TgtAlice' || :cycle), ('Williams' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE multi_unique_constraint SET first_name = ('TgtTom_moved' || :cycle) WHERE id = :base + 10005;
+UPDATE multi_unique_constraint SET first_name = ('TgtTom' || :cycle), last_name = ('Clark' || :cycle) WHERE id = :base + 10006;
+COMMIT;
+
+-- ============================================================
+-- 3. same_column_unique_constraint_and_index (id PK, email UNIQUE + UNIQUE INDEX on email)
+-- ============================================================
+BEGIN;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES
+    (:base + 20001, ('tgt_scuci_user1@conflict.test' || :cycle)),
+    (:base + 20002, ('tgt_scuci_user2@conflict.test' || :cycle)),
+    (:base + 20003, ('tgt_scuci_user3@conflict.test' || :cycle)),
+    (:base + 20004, ('tgt_scuci_user4@conflict.test' || :cycle)),
+    (:base + 20005, ('tgt_scuci_user5@conflict.test' || :cycle)),
+    (:base + 20006, ('tgt_scuci_user6@conflict.test' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM same_column_unique_constraint_and_index WHERE id = :base + 20001;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES (:base + 20101, ('tgt_scuci_user1@conflict.test' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM same_column_unique_constraint_and_index WHERE id = :base + 20002;
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user2@conflict.test' || :cycle) WHERE id = :base + 20003;
+
+-- UPDATE-INSERT
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user4_moved@conflict.test' || :cycle) WHERE id = :base + 20004;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES (:base + 20102, ('tgt_scuci_user4@conflict.test' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user5_moved@conflict.test' || :cycle) WHERE id = :base + 20005;
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user5@conflict.test' || :cycle) WHERE id = :base + 20006;
+COMMIT;
+
+-- ============================================================
+-- 4. single_unique_index (id PK, UNIQUE INDEX on "Ssn" -- case-sensitive column)
+-- ============================================================
+BEGIN;
+INSERT INTO single_unique_index (id, "Ssn") VALUES
+    (:base + 30001, ('TGT-SSN-1' || :cycle)),
+    (:base + 30002, ('TGT-SSN-2' || :cycle)),
+    (:base + 30003, ('TGT-SSN-3' || :cycle)),
+    (:base + 30004, ('TGT-SSN-4' || :cycle)),
+    (:base + 30005, ('TGT-SSN-5' || :cycle)),
+    (:base + 30006, ('TGT-SSN-6' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM single_unique_index WHERE id = :base + 30001;
+INSERT INTO single_unique_index (id, "Ssn") VALUES (:base + 30101, ('TGT-SSN-1' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM single_unique_index WHERE id = :base + 30002;
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-2' || :cycle) WHERE id = :base + 30003;
+
+-- UPDATE-INSERT
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-4-moved' || :cycle) WHERE id = :base + 30004;
+INSERT INTO single_unique_index (id, "Ssn") VALUES (:base + 30102, ('TGT-SSN-4' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-5-moved' || :cycle) WHERE id = :base + 30005;
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-5' || :cycle) WHERE id = :base + 30006;
+COMMIT;
+
+-- ============================================================
+-- 5. multi_unique_index (id PK, UNIQUE INDEX(first_name, last_name))
+-- ============================================================
+BEGIN;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES
+    (:base + 40001, ('TgtIdxJohn' || :cycle),  ('Doe' || :cycle)),
+    (:base + 40002, ('TgtIdxJane' || :cycle),  ('Smith' || :cycle)),
+    (:base + 40003, ('TgtIdxBob' || :cycle),   ('Jones' || :cycle)),
+    (:base + 40004, ('TgtIdxAlice' || :cycle), ('Williams' || :cycle)),
+    (:base + 40005, ('TgtIdxTom' || :cycle),   ('Clark' || :cycle)),
+    (:base + 40006, ('TgtIdxEve' || :cycle),   ('Davis' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM multi_unique_index WHERE id = :base + 40001;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES (:base + 40101, ('TgtIdxJohn' || :cycle), ('Doe' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM multi_unique_index WHERE id = :base + 40002;
+UPDATE multi_unique_index SET first_name = ('TgtIdxJane' || :cycle), last_name = ('Smith' || :cycle) WHERE id = :base + 40003;
+
+-- UPDATE-INSERT
+UPDATE multi_unique_index SET first_name = ('TgtIdxAlice_moved' || :cycle) WHERE id = :base + 40004;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES (:base + 40102, ('TgtIdxAlice' || :cycle), ('Williams' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE multi_unique_index SET first_name = ('TgtIdxTom_moved' || :cycle) WHERE id = :base + 40005;
+UPDATE multi_unique_index SET first_name = ('TgtIdxTom' || :cycle), last_name = ('Clark' || :cycle) WHERE id = :base + 40006;
+COMMIT;
+
+-- ============================================================
+-- 6. different_columns_unique_constraint_and_index
+--    (id PK, email UNIQUE, UNIQUE INDEX on phone_number)
+-- ============================================================
+BEGIN;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES
+    (:base + 50001, ('tgt_dcuci_user1@conflict.test' || :cycle), ('tgtdcph-1' || :cycle)),
+    (:base + 50002, ('tgt_dcuci_user2@conflict.test' || :cycle), ('tgtdcph-2' || :cycle)),
+    (:base + 50003, ('tgt_dcuci_user3@conflict.test' || :cycle), ('tgtdcph-3' || :cycle)),
+    (:base + 50004, ('tgt_dcuci_user4@conflict.test' || :cycle), ('tgtdcph-4' || :cycle)),
+    (:base + 50005, ('tgt_dcuci_user5@conflict.test' || :cycle), ('tgtdcph-5' || :cycle)),
+    (:base + 50006, ('tgt_dcuci_user6@conflict.test' || :cycle), ('tgtdcph-6' || :cycle));
+
+-- DELETE-INSERT (conflict on both email and phone_number)
+DELETE FROM different_columns_unique_constraint_and_index WHERE id = :base + 50001;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES (:base + 50101, ('tgt_dcuci_user1@conflict.test' || :cycle), ('tgtdcph-1' || :cycle));
+
+-- DELETE-UPDATE (conflict on phone_number unique index)
+DELETE FROM different_columns_unique_constraint_and_index WHERE id = :base + 50002;
+UPDATE different_columns_unique_constraint_and_index SET phone_number = ('tgtdcph-2' || :cycle) WHERE id = :base + 50003;
+
+-- UPDATE-INSERT (conflict on email unique constraint)
+UPDATE different_columns_unique_constraint_and_index SET email = ('tgt_dcuci_user4_moved@conflict.test' || :cycle) WHERE id = :base + 50004;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES (:base + 50102, ('tgt_dcuci_user4@conflict.test' || :cycle), ('tgtdcph-104' || :cycle));
+
+-- UPDATE-UPDATE (conflict on phone_number unique index)
+UPDATE different_columns_unique_constraint_and_index SET phone_number = ('tgtdcph-5-moved' || :cycle) WHERE id = :base + 50005;
+UPDATE different_columns_unique_constraint_and_index SET phone_number = ('tgtdcph-5' || :cycle) WHERE id = :base + 50006;
+COMMIT;
+
+-- ============================================================
+-- 7. subset_columns_unique_constraint_and_index
+--    (id PK, UNIQUE(first_name,last_name), UNIQUE INDEX(first_name,last_name,phone_number))
+-- ============================================================
+BEGIN;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES
+    (:base + 60001, ('TgtSubJohn' || :cycle),  ('Doe' || :cycle),      ('tgtsubph-1' || :cycle)),
+    (:base + 60002, ('TgtSubJane' || :cycle),  ('Smith' || :cycle),    ('tgtsubph-2' || :cycle)),
+    (:base + 60003, ('TgtSubBob' || :cycle),   ('Jones' || :cycle),    ('tgtsubph-3' || :cycle)),
+    (:base + 60004, ('TgtSubAlice' || :cycle), ('Williams' || :cycle), ('tgtsubph-4' || :cycle)),
+    (:base + 60005, ('TgtSubTom' || :cycle),   ('Clark' || :cycle),    ('tgtsubph-5' || :cycle)),
+    (:base + 60006, ('TgtSubEve' || :cycle),   ('Davis' || :cycle),    ('tgtsubph-6' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM subset_columns_unique_constraint_and_index WHERE id = :base + 60001;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES (:base + 60101, ('TgtSubJohn' || :cycle), ('Doe' || :cycle), ('tgtsubph-101' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM subset_columns_unique_constraint_and_index WHERE id = :base + 60002;
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubJane' || :cycle), last_name = ('Smith' || :cycle) WHERE id = :base + 60003;
+
+-- UPDATE-INSERT
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubAlice_moved' || :cycle) WHERE id = :base + 60004;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES (:base + 60102, ('TgtSubAlice' || :cycle), ('Williams' || :cycle), ('tgtsubph-102' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubTom_moved' || :cycle) WHERE id = :base + 60005;
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubTom' || :cycle), last_name = ('Clark' || :cycle) WHERE id = :base + 60006;
+COMMIT;
+
+-- ============================================================
+-- 8. expression_based_unique_index (id PK, UNIQUE INDEX on LOWER(email))
+-- ============================================================
+BEGIN;
+INSERT INTO expression_based_unique_index (id, email) VALUES
+    (:base + 70001, ('Tgt_Expr_User1@conflict.test' || :cycle)),
+    (:base + 70002, ('Tgt_Expr_User2@conflict.test' || :cycle)),
+    (:base + 70003, ('Tgt_Expr_User3@conflict.test' || :cycle)),
+    (:base + 70004, ('Tgt_Expr_User4@conflict.test' || :cycle)),
+    (:base + 70005, ('Tgt_Expr_User5@conflict.test' || :cycle)),
+    (:base + 70006, ('Tgt_Expr_User6@conflict.test' || :cycle));
+
+-- DELETE-INSERT (LOWER(email) collision)
+DELETE FROM expression_based_unique_index WHERE id = :base + 70001;
+INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70101, ('TGT_EXPR_USER1@conflict.test' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM expression_based_unique_index WHERE id = :base + 70002;
+UPDATE expression_based_unique_index SET email = ('TGT_EXPR_USER2@conflict.test' || :cycle) WHERE id = :base + 70003;
+
+-- UPDATE-INSERT
+UPDATE expression_based_unique_index SET email = ('Tgt_Expr_User4_moved@conflict.test' || :cycle) WHERE id = :base + 70004;
+INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70102, ('tgt_expr_user4@conflict.test' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE expression_based_unique_index SET email = ('Tgt_Expr_User5_moved@conflict.test' || :cycle) WHERE id = :base + 70005;
+UPDATE expression_based_unique_index SET email = ('TGT_EXPR_user5@conflict.test' || :cycle) WHERE id = :base + 70006;
+COMMIT;
+
+-- ============================================================
+-- 9. test_partial_unique_index (id PK, UNIQUE INDEX(check_id) WHERE most_recent)
+-- ============================================================
+BEGIN;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES
+    (:base + 80001, :base + 91, true),
+    (:base + 80002, :base + 92, true),
+    (:base + 80003, :base + 93, true),
+    (:base + 80004, :base + 93, false),
+    (:base + 80005, :base + 94, true),
+    (:base + 80006, :base + 94, false);
+
+-- UPDATE-INSERT
+UPDATE test_partial_unique_index SET most_recent = false WHERE id = :base + 80001;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80101, :base + 91, true);
+
+-- DELETE-INSERT
+DELETE FROM test_partial_unique_index WHERE id = :base + 80002;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80102, :base + 92, true);
+
+-- DELETE-UPDATE
+DELETE FROM test_partial_unique_index WHERE id = :base + 80003;
+UPDATE test_partial_unique_index SET most_recent = true WHERE id = :base + 80004;
+
+-- UPDATE-UPDATE
+UPDATE test_partial_unique_index SET most_recent = false WHERE id = :base + 80005;
+UPDATE test_partial_unique_index SET most_recent = true WHERE id = :base + 80006;
+COMMIT;
+
+-- ============================================================
+-- 10. single_unique_index_nulls_not_distinct (id PK, UNIQUE INDEX(email) NULLS NOT DISTINCT)
+-- Under NULLS NOT DISTINCT two NULLs are equal, so a NULL free->reuse across PKs is a
+-- real conflict. Only one NULL can exist at a time, so the NULL is moved off at the end
+-- of the block, leaving none behind for the next cycle.
+-- ============================================================
+BEGIN;
+-- UPDATE-INSERT (non-null value)
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85001, ('tgt_nnd1_user1@conflict.test' || :cycle));
+UPDATE single_unique_index_nulls_not_distinct SET email = ('tgt_nnd1_user1_moved@conflict.test' || :cycle) WHERE id = :base + 85001;
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85101, ('tgt_nnd1_user1@conflict.test' || :cycle));
+
+-- NULL free->reuse: free the NULL by moving base+85010 off it, reuse NULL on base+85011
+-- (conflict under NULLS NOT DISTINCT), then move base+85011 off NULL to leave none behind.
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85010, NULL);
+UPDATE single_unique_index_nulls_not_distinct SET email = ('tgt_nnd1_wasnull_a@conflict.test' || :cycle) WHERE id = :base + 85010;
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85011, NULL);
+UPDATE single_unique_index_nulls_not_distinct SET email = ('tgt_nnd1_wasnull_b@conflict.test' || :cycle) WHERE id = :base + 85011;
+COMMIT;
+
+-- ============================================================
+-- 11. multi_unique_index_nulls_not_distinct (id PK, UNIQUE INDEX(first_name, last_name) NULLS NOT DISTINCT)
+-- ============================================================
+BEGIN;
+-- UPDATE-INSERT (non-null values)
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86001, ('tgt_nnd2First' || :cycle), ('tgt_nnd2Last' || :cycle));
+UPDATE multi_unique_index_nulls_not_distinct SET first_name = ('tgt_nnd2First_moved' || :cycle) WHERE id = :base + 86001;
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86101, ('tgt_nnd2First' || :cycle), ('tgt_nnd2Last' || :cycle));
+
+-- (NULL, NULL) free->reuse: two all-NULL rows conflict under NULLS NOT DISTINCT.
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86010, NULL, NULL);
+UPDATE multi_unique_index_nulls_not_distinct SET first_name = ('tgt_nnd2wasnull_a' || :cycle) WHERE id = :base + 86010;
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86011, NULL, NULL);
+UPDATE multi_unique_index_nulls_not_distinct SET first_name = ('tgt_nnd2wasnull_b' || :cycle) WHERE id = :base + 86011;
+COMMIT;
+
+-- ============================================================
+-- 12. partitioned_unique_conflict (PK(id, region), UNIQUE INDEX(email, region), PARTITION BY LIST(region))
+-- The unique key includes the partition-key column; conflicts are exercised within a partition.
+-- ============================================================
+BEGIN;
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES
+    (:base + 87001, 'east', ('tgt_puc_user1@conflict.test' || :cycle)),
+    (:base + 87002, 'east', ('tgt_puc_user2@conflict.test' || :cycle)),
+    (:base + 87003, 'west', ('tgt_puc_user3@conflict.test' || :cycle)),
+    (:base + 87004, 'west', ('tgt_puc_user4@conflict.test' || :cycle));
+
+-- DELETE-INSERT within the 'east' partition: free (puc_user1, east), reuse on a new PK
+DELETE FROM partitioned_unique_conflict WHERE id = :base + 87001 AND region = 'east';
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87101, 'east', ('tgt_puc_user1@conflict.test' || :cycle));
+
+-- UPDATE-INSERT within the 'west' partition: free (puc_user3, west) by moving it, reuse on a new PK
+UPDATE partitioned_unique_conflict SET email = ('tgt_puc_user3_moved@conflict.test' || :cycle) WHERE id = :base + 87003 AND region = 'west';
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87103, 'west', ('tgt_puc_user3@conflict.test' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 13. single_unique_index_nulls_distinct (id PK, UNIQUE INDEX(email) -- default NULLS DISTINCT)
+-- Under NULLS DISTINCT multiple NULLs coexist and a NULL free->reuse is NOT a conflict,
+-- so these NULL rows must import without being (wrongly) serialized. A non-null value
+-- conflict is included to confirm real conflicts still fire on this table.
+-- ============================================================
+BEGIN;
+-- Multiple NULL rows coexist under NULLS DISTINCT (no conflict, no violation)
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES
+    (:base + 89001, NULL),
+    (:base + 89002, NULL),
+    (:base + 89003, NULL);
+
+-- NULL free->reuse: delete a NULL holder, insert another NULL. Under NULLS DISTINCT
+-- these NULLs do NOT conflict, so the cache must not serialize them.
+DELETE FROM single_unique_index_nulls_distinct WHERE id = :base + 89001;
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89101, NULL);
+
+-- Non-null value free->reuse: a real conflict that must still be detected here.
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89010, ('tgt_nd_user1@conflict.test' || :cycle));
+UPDATE single_unique_index_nulls_distinct SET email = ('tgt_nd_user1_moved@conflict.test' || :cycle) WHERE id = :base + 89010;
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89110, ('tgt_nd_user1@conflict.test' || :cycle));
+COMMIT;


### PR DESCRIPTION
### Describe the changes in this pull request
Adds `custom-cdc-partition-key-test`, a two-phase resumption migtest for `--cdc-partition-key-overrides` (no soak-level coverage existed for the feature).

- **Random pick, two levels**: each run randomly picks one of 12 candidate tables to route by a custom key, then randomly samples 1-2 of that table's columns (random order) from a per-table pool — so runs vary across table, column count, column combination and key datatype (varchar, text, int, bigint, numeric, boolean, date, timestamp, jsonb). Pools hold only immutability-safe columns whose value is identical across each conflict pair's rows; PK columns, DML-updated columns and uuid-default columns are excluded.
- **Assertions**: zero conflict-cache activity for the picked table (same-key events already share a channel), while other tables keep detecting real conflicts.
- **PK-recycle candidate**: one candidate (fixed `(email)` key) reuses the same PK with a different key value; when picked, the test asserts conflicts ARE still detected (the synthetic-PK guard from #3746).
- **Immutability**: new `exclude_columns_from_update` generator option keeps the random generator off whatever columns get sampled.
- **Resume guardrails**: mid-run, the importer is restarted with a changed global `--cdc-partition-key` and a changed per-table override; both must be rejected (new `voyager_import_start_expect_fail` action).
- **Fallback phase** (mirrors `fallback-unique-conflict-test`): full four-conflict-type DML on target, fallback resumptions, zero-conflicts assertion on import-to-source (table routing forced; forward custom keys must not leak), cutover-to-source, row/hash/sequence validations.
- **Schema**: 13-14 columns per table, shaped like production tables (audit backbone + realistic type mix incl. `numeric(38,6)`, jsonb, uuid, arrays).

Development of this test also surfaced a guardrail gap for PK-less-root partitioned tables under default `--use-partition-root=true` (silent acceptance, then a permanent `42P10` wedge on a mid-batch importer restart) — being filed as a DB-21011 follow-up; that shape's supported path is covered by `use-partition-root-false-test`.

### Describe if there are any user-facing changes
No user-facing changes (test infra and migtest harness scripts only).

### How was this pull request tested?
Repeated full local runs (both phases) across different random table/column picks, including the PK-recycle candidate and pool-sampled keys — conflict assertions, guardrail rejections, cutover-to-source and row/hash/sequence validations all passed.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?
No.

https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/1278/.
https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-testing/job/yb-voyager-live-migration-resumption/1279/.