### PR TITLE
ci: stop every PR from writing the 1.3 GiB Maven cache

### DIFF
--- a/.github/workflows/failpoint-tests.yml
+++ b/.github/workflows/failpoint-tests.yml
@@ -68,11 +68,24 @@ jobs:
           echo "BYTEMAN_JAR=/tmp/${DIR_NAME}/lib/byteman.jar" >> $GITHUB_ENV
           echo "Byteman installed at /tmp/${DIR_NAME}"
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Compute Maven cache key
+        id: maven-cache-key
+        # Computed once, before the build: the Debezium build creates
+        # debezium-server-voyager/target/, so recomputing this hash afterwards would
+        # yield a different key and save under one that no restore ever looks for.
+        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
+        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
+        # what actually gets built live in that script and **/pom.xml misses them.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore local Maven repository
+        id: maven-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-cache-key.outputs.key }}
+          # Prefix fallback, so a PR that does change the cached inputs still
+          # restores most of the dependency tree and only fetches the delta.
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -103,6 +116,28 @@ jobs:
           psql --version
         env:
           ON_INSTALLER_ERROR_OUTPUT_LOG: Y
+
+      # Save only from the default branch (or a PR labelled `cache-maven`).
+      # This gate is load-bearing: ~/.m2 is ~1.3 GiB against a 10 GiB repo budget,
+      # so when every PR saved its own copy, 8 duplicates of the same key filled the
+      # budget (measured 10.43 GiB), LRU eviction took out main's entry, ~95% of jobs
+      # then missed, and each miss wrote another copy that evicted the next one.
+      # A run falls back to the default branch's cache, so one entry on main serves
+      # every PR. Label a PR `cache-maven` if it legitimately changes the cached
+      # inputs (e.g. a Debezium ref bump) and needs to populate its own entry.
+      #
+      # success() is explicit because a custom `if:` drops the implicit success()
+      # check, and a ~/.m2 left behind by a failed build must never be cached.
+      - name: Save local Maven repository
+        if: >-
+          success() &&
+          steps.maven-cache.outputs.cache-hit != 'true' &&
+          (github.ref == 'refs/heads/main' ||
+          contains(github.event.pull_request.labels.*.name, 'cache-maven'))
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ steps.maven-cache-key.outputs.key }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/failpoint-tests.yml
+++ b/.github/workflows/failpoint-tests.yml
@@ -70,13 +70,11 @@ jobs:
 
       - name: Compute Maven cache key
         id: maven-cache-key
-        # Computed once, before the build: the Debezium build creates
-        # debezium-server-voyager/target/, so recomputing this hash afterwards would
-        # yield a different key and save under one that no restore ever looks for.
-        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
-        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
-        # what actually gets built live in that script and **/pom.xml misses them.
-        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+        # Computed once, before the build, so the restore and save steps agree on it.
+        # The Debezium build writes into debezium-server-voyager/target/, and
+        # hashFiles() is evaluated over the workspace, so re-evaluating it after the
+        # installer has run risks saving under a key no restore ever looks for.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Restore local Maven repository
         id: maven-cache

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,11 +34,24 @@ jobs:
         java-version: ${{ needs.prepare-versions.outputs.java_version }}
         check-latest: true
 
-    - name: Cache local Maven repository
-      uses: actions/cache@v4
+    - name: Compute Maven cache key
+      id: maven-cache-key
+      # Computed once, before the build: the Debezium build creates
+      # debezium-server-voyager/target/, so recomputing this hash afterwards would
+      # yield a different key and save under one that no restore ever looks for.
+      # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
+      # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
+      # what actually gets built live in that script and **/pom.xml misses them.
+      run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore local Maven repository
+      id: maven-cache
+      uses: actions/cache/restore@v4
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ steps.maven-cache-key.outputs.key }}
+        # Prefix fallback, so a PR that does change the cached inputs still
+        # restores most of the dependency tree and only fetches the delta.
         restore-keys: |
           ${{ runner.os }}-maven-
 
@@ -60,6 +73,28 @@ jobs:
         psql --version
       env:
         ON_INSTALLER_ERROR_OUTPUT_LOG: Y
+
+    # Save only from the default branch (or a PR labelled `cache-maven`).
+    # This gate is load-bearing: ~/.m2 is ~1.3 GiB against a 10 GiB repo budget,
+    # so when every PR saved its own copy, 8 duplicates of the same key filled the
+    # budget (measured 10.43 GiB), LRU eviction took out main's entry, ~95% of jobs
+    # then missed, and each miss wrote another copy that evicted the next one.
+    # A run falls back to the default branch's cache, so one entry on main serves
+    # every PR. Label a PR `cache-maven` if it legitimately changes the cached
+    # inputs (e.g. a Debezium ref bump) and needs to populate its own entry.
+    #
+    # success() is explicit because a custom `if:` drops the implicit success()
+    # check, and a ~/.m2 left behind by a failed build must never be cached.
+    - name: Save local Maven repository
+      if: >-
+        success() &&
+        steps.maven-cache.outputs.cache-hit != 'true' &&
+        (github.ref == 'refs/heads/main' ||
+        contains(github.event.pull_request.labels.*.name, 'cache-maven'))
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ steps.maven-cache-key.outputs.key }}
 
     - name: Free disk 
       run: df -h /

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,13 +36,11 @@ jobs:
 
     - name: Compute Maven cache key
       id: maven-cache-key
-      # Computed once, before the build: the Debezium build creates
-      # debezium-server-voyager/target/, so recomputing this hash afterwards would
-      # yield a different key and save under one that no restore ever looks for.
-      # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
-      # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
-      # what actually gets built live in that script and **/pom.xml misses them.
-      run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+      # Computed once, before the build, so the restore and save steps agree on it.
+      # The Debezium build writes into debezium-server-voyager/target/, and
+      # hashFiles() is evaluated over the workspace, so re-evaluating it after the
+      # installer has run risks saving under a key no restore ever looks for.
+      run: echo "key=${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
     - name: Restore local Maven repository
       id: maven-cache

--- a/.github/workflows/misc-migtests.yml
+++ b/.github/workflows/misc-migtests.yml
@@ -42,11 +42,24 @@ jobs:
           java-version: ${{ needs.prepare-versions.outputs.java_version }}
           check-latest: true
       
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Compute Maven cache key
+        id: maven-cache-key
+        # Computed once, before the build: the Debezium build creates
+        # debezium-server-voyager/target/, so recomputing this hash afterwards would
+        # yield a different key and save under one that no restore ever looks for.
+        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
+        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
+        # what actually gets built live in that script and **/pom.xml misses them.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore local Maven repository
+        id: maven-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-cache-key.outputs.key }}
+          # Prefix fallback, so a PR that does change the cached inputs still
+          # restores most of the dependency tree and only fetches the delta.
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -109,6 +122,28 @@ jobs:
           psql --version
         env:
           ON_INSTALLER_ERROR_OUTPUT_LOG: Y
+
+      # Save only from the default branch (or a PR labelled `cache-maven`).
+      # This gate is load-bearing: ~/.m2 is ~1.3 GiB against a 10 GiB repo budget,
+      # so when every PR saved its own copy, 8 duplicates of the same key filled the
+      # budget (measured 10.43 GiB), LRU eviction took out main's entry, ~95% of jobs
+      # then missed, and each miss wrote another copy that evicted the next one.
+      # A run falls back to the default branch's cache, so one entry on main serves
+      # every PR. Label a PR `cache-maven` if it legitimately changes the cached
+      # inputs (e.g. a Debezium ref bump) and needs to populate its own entry.
+      #
+      # success() is explicit because a custom `if:` drops the implicit success()
+      # check, and a ~/.m2 left behind by a failed build must never be cached.
+      - name: Save local Maven repository
+        if: >-
+          success() &&
+          steps.maven-cache.outputs.cache-hit != 'true' &&
+          (github.ref == 'refs/heads/main' ||
+          contains(github.event.pull_request.labels.*.name, 'cache-maven'))
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ steps.maven-cache-key.outputs.key }}
 
       - name: Test PostgreSQL Connection
         run: |

--- a/.github/workflows/misc-migtests.yml
+++ b/.github/workflows/misc-migtests.yml
@@ -44,13 +44,11 @@ jobs:
       
       - name: Compute Maven cache key
         id: maven-cache-key
-        # Computed once, before the build: the Debezium build creates
-        # debezium-server-voyager/target/, so recomputing this hash afterwards would
-        # yield a different key and save under one that no restore ever looks for.
-        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
-        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
-        # what actually gets built live in that script and **/pom.xml misses them.
-        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+        # Computed once, before the build, so the restore and save steps agree on it.
+        # The Debezium build writes into debezium-server-voyager/target/, and
+        # hashFiles() is evaluated over the workspace, so re-evaluating it after the
+        # installer has run risks saving under a key no restore ever looks for.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Restore local Maven repository
         id: maven-cache

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -29,11 +29,24 @@ jobs:
           java-version: ${{ needs.prepare-versions.outputs.java_version }}
           check-latest: true
       
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Compute Maven cache key
+        id: maven-cache-key
+        # Computed once, before the build: the Debezium build creates
+        # debezium-server-voyager/target/, so recomputing this hash afterwards would
+        # yield a different key and save under one that no restore ever looks for.
+        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
+        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
+        # what actually gets built live in that script and **/pom.xml misses them.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore local Maven repository
+        id: maven-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-cache-key.outputs.key }}
+          # Prefix fallback, so a PR that does change the cached inputs still
+          # restores most of the dependency tree and only fetches the delta.
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -48,6 +61,28 @@ jobs:
           yes | ./installer_scripts/install-yb-voyager --install-from-local-source
         env:
           ON_INSTALLER_ERROR_OUTPUT_LOG: Y
+
+      # Save only from the default branch (or a PR labelled `cache-maven`).
+      # This gate is load-bearing: ~/.m2 is ~1.3 GiB against a 10 GiB repo budget,
+      # so when every PR saved its own copy, 8 duplicates of the same key filled the
+      # budget (measured 10.43 GiB), LRU eviction took out main's entry, ~95% of jobs
+      # then missed, and each miss wrote another copy that evicted the next one.
+      # A run falls back to the default branch's cache, so one entry on main serves
+      # every PR. Label a PR `cache-maven` if it legitimately changes the cached
+      # inputs (e.g. a Debezium ref bump) and needs to populate its own entry.
+      #
+      # success() is explicit because a custom `if:` drops the implicit success()
+      # check, and a ~/.m2 left behind by a failed build must never be cached.
+      - name: Save local Maven repository
+        if: >-
+          success() &&
+          steps.maven-cache.outputs.cache-hit != 'true' &&
+          (github.ref == 'refs/heads/main' ||
+          contains(github.event.pull_request.labels.*.name, 'cache-maven'))
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ steps.maven-cache-key.outputs.key }}
           DEBEZIUM_VERSION: aneesh_ff-fb-remove
           DEBEZIUM_RELEASE_TAG: voyager-debezium
 

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -31,13 +31,11 @@ jobs:
       
       - name: Compute Maven cache key
         id: maven-cache-key
-        # Computed once, before the build: the Debezium build creates
-        # debezium-server-voyager/target/, so recomputing this hash afterwards would
-        # yield a different key and save under one that no restore ever looks for.
-        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
-        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
-        # what actually gets built live in that script and **/pom.xml misses them.
-        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+        # Computed once, before the build, so the restore and save steps agree on it.
+        # The Debezium build writes into debezium-server-voyager/target/, and
+        # hashFiles() is evaluated over the workspace, so re-evaluating it after the
+        # installer has run risks saving under a key no restore ever looks for.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Restore local Maven repository
         id: maven-cache

--- a/.github/workflows/mysql-migtests.yml
+++ b/.github/workflows/mysql-migtests.yml
@@ -81,8 +81,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ steps.maven-cache-key.outputs.key }}
-          DEBEZIUM_VERSION: aneesh_ff-fb-remove
-          DEBEZIUM_RELEASE_TAG: voyager-debezium
 
       - name: Start MySQL
         run: |

--- a/.github/workflows/pg-13-migtests.yml
+++ b/.github/workflows/pg-13-migtests.yml
@@ -46,11 +46,24 @@ jobs:
           java-version: ${{ needs.prepare-versions.outputs.java_version }}
           check-latest: true
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Compute Maven cache key
+        id: maven-cache-key
+        # Computed once, before the build: the Debezium build creates
+        # debezium-server-voyager/target/, so recomputing this hash afterwards would
+        # yield a different key and save under one that no restore ever looks for.
+        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
+        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
+        # what actually gets built live in that script and **/pom.xml misses them.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore local Maven repository
+        id: maven-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-cache-key.outputs.key }}
+          # Prefix fallback, so a PR that does change the cached inputs still
+          # restores most of the dependency tree and only fetches the delta.
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -89,6 +102,28 @@ jobs:
           psql --version
         env:
           ON_INSTALLER_ERROR_OUTPUT_LOG: Y
+
+      # Save only from the default branch (or a PR labelled `cache-maven`).
+      # This gate is load-bearing: ~/.m2 is ~1.3 GiB against a 10 GiB repo budget,
+      # so when every PR saved its own copy, 8 duplicates of the same key filled the
+      # budget (measured 10.43 GiB), LRU eviction took out main's entry, ~95% of jobs
+      # then missed, and each miss wrote another copy that evicted the next one.
+      # A run falls back to the default branch's cache, so one entry on main serves
+      # every PR. Label a PR `cache-maven` if it legitimately changes the cached
+      # inputs (e.g. a Debezium ref bump) and needs to populate its own entry.
+      #
+      # success() is explicit because a custom `if:` drops the implicit success()
+      # check, and a ~/.m2 left behind by a failed build must never be cached.
+      - name: Save local Maven repository
+        if: >-
+          success() &&
+          steps.maven-cache.outputs.cache-hit != 'true' &&
+          (github.ref == 'refs/heads/main' ||
+          contains(github.event.pull_request.labels.*.name, 'cache-maven'))
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ steps.maven-cache-key.outputs.key }}
 
       - name: Test PostgreSQL Connection
         run: |

--- a/.github/workflows/pg-13-migtests.yml
+++ b/.github/workflows/pg-13-migtests.yml
@@ -48,13 +48,11 @@ jobs:
 
       - name: Compute Maven cache key
         id: maven-cache-key
-        # Computed once, before the build: the Debezium build creates
-        # debezium-server-voyager/target/, so recomputing this hash afterwards would
-        # yield a different key and save under one that no restore ever looks for.
-        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
-        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
-        # what actually gets built live in that script and **/pom.xml misses them.
-        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+        # Computed once, before the build, so the restore and save steps agree on it.
+        # The Debezium build writes into debezium-server-voyager/target/, and
+        # hashFiles() is evaluated over the workspace, so re-evaluating it after the
+        # installer has run risks saving under a key no restore ever looks for.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Restore local Maven repository
         id: maven-cache

--- a/.github/workflows/pg-17-migtests.yml
+++ b/.github/workflows/pg-17-migtests.yml
@@ -46,11 +46,24 @@ jobs:
           java-version: ${{ needs.prepare-versions.outputs.java_version }}
           check-latest: true
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+      - name: Compute Maven cache key
+        id: maven-cache-key
+        # Computed once, before the build: the Debezium build creates
+        # debezium-server-voyager/target/, so recomputing this hash afterwards would
+        # yield a different key and save under one that no restore ever looks for.
+        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
+        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
+        # what actually gets built live in that script and **/pom.xml misses them.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore local Maven repository
+        id: maven-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-cache-key.outputs.key }}
+          # Prefix fallback, so a PR that does change the cached inputs still
+          # restores most of the dependency tree and only fetches the delta.
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -89,6 +102,28 @@ jobs:
           psql --version
         env:
           ON_INSTALLER_ERROR_OUTPUT_LOG: Y
+
+      # Save only from the default branch (or a PR labelled `cache-maven`).
+      # This gate is load-bearing: ~/.m2 is ~1.3 GiB against a 10 GiB repo budget,
+      # so when every PR saved its own copy, 8 duplicates of the same key filled the
+      # budget (measured 10.43 GiB), LRU eviction took out main's entry, ~95% of jobs
+      # then missed, and each miss wrote another copy that evicted the next one.
+      # A run falls back to the default branch's cache, so one entry on main serves
+      # every PR. Label a PR `cache-maven` if it legitimately changes the cached
+      # inputs (e.g. a Debezium ref bump) and needs to populate its own entry.
+      #
+      # success() is explicit because a custom `if:` drops the implicit success()
+      # check, and a ~/.m2 left behind by a failed build must never be cached.
+      - name: Save local Maven repository
+        if: >-
+          success() &&
+          steps.maven-cache.outputs.cache-hit != 'true' &&
+          (github.ref == 'refs/heads/main' ||
+          contains(github.event.pull_request.labels.*.name, 'cache-maven'))
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ steps.maven-cache-key.outputs.key }}
 
       - name: Test PostgreSQL Connection
         run: |

--- a/.github/workflows/pg-17-migtests.yml
+++ b/.github/workflows/pg-17-migtests.yml
@@ -48,13 +48,11 @@ jobs:
 
       - name: Compute Maven cache key
         id: maven-cache-key
-        # Computed once, before the build: the Debezium build creates
-        # debezium-server-voyager/target/, so recomputing this hash afterwards would
-        # yield a different key and save under one that no restore ever looks for.
-        # Keyed on install-yb-voyager, not **/pom.xml: the Debezium fork's poms are
-        # downloaded at runtime, so the pinned DEBEZIUM_LOCAL_REF* SHAs that decide
-        # what actually gets built live in that script and **/pom.xml misses them.
-        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('installer_scripts/install-yb-voyager', 'debezium-server-voyager/**', 'yb-voyager/versions/yb-cdc-connector-versions.json') }}" >> "$GITHUB_OUTPUT"
+        # Computed once, before the build, so the restore and save steps agree on it.
+        # The Debezium build writes into debezium-server-voyager/target/, and
+        # hashFiles() is evaluated over the workspace, so re-evaluating it after the
+        # installer has run risks saving under a key no restore ever looks for.
+        run: echo "key=${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Restore local Maven repository
         id: maven-cache


### PR DESCRIPTION
### Describe the changes in this pull request

The Maven cache currently has a **~5% hit rate**, so nearly every CI job resolves the entire Debezium dependency tree from scratch. That is both the largest single chunk of CI wall clock and the main exposure behind the recurring Maven network failures.

The cause is neither the cache key nor GitHub's ref scoping. It's a self-sustaining eviction loop:

1. `~/.m2/repository` is **~1.3 GiB**; the repo's Actions cache budget is **10 GiB**.
2. `actions/cache` saves from whatever ref it runs on, so every PR that missed wrote its own 1.3 GiB copy under the same key. Measured state: **10.43 GiB across 8 entries, 7 of them `refs/pull/*/merge` duplicates of identical bytes**.
3. Over budget, GitHub evicts by least-recent-access — including `main`'s entry, the only one other branches can read.
4. The next PR misses, writes another copy, evicts the next one.

Each miss manufactured the next miss, which is why the hit rate sat near zero rather than near 50%. Even `main` pays it: a merge landed at 09:52 on 2 Sep and its cache entry was created at 10:24 — `main` also missed and rebuilt cold.

**What it costs**, like-for-like on the same workflows (installer step duration):

| Workflow | Cache | Installer step |
|---|---|---|
| PG 13 | miss | **28.3 min** (23.7–32.9) |
| PG 13 | hit | **6.1 min** (5.1–6.4) |
| MySQL | miss | **31.4 / 32.2 min** |
| MySQL | hit | **8.1 min** (6.2–8.9) |

A warm `~/.m2` is worth **~23 minutes per job**. The dominant cost is the cold Maven *download*, not the compile.

### The fix

Split `actions/cache` into `cache/restore` (unconditional) plus a `cache/save` gated to the default branch, so `main` is the sole writer in the steady state.

Per GitHub's [dependency caching reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching), a run restores from its own ref and then falls back to the default branch — so one entry on `main` serves every PR. That fallback is already observable here: PR runs at 10:27 hit the entry `main` created at 10:24.

A PR that legitimately needs to populate its own entry can add the **`cache-maven`** label. Even without it, `restore-keys` prefix fallback means such a PR restores most of the tree and only fetches the delta.

**The cache key is unchanged** — still `hashFiles('**/pom.xml')`. The key is not what's broken here, and `~/.m2` is a download accelerator rather than a correctness input: the installer runs `mvn clean install` on the Debezium fork every run, so a stale entry can only ever cost extra downloads, never yield a wrong artifact.

Two details that are easy to get wrong, both commented in-place:

- **The key is computed once, before the build.** `hashFiles()` is evaluated over the workspace and the Debezium build writes into `debezium-server-voyager/target/`, so the restore and save steps must be handed the same precomputed value — otherwise the save lands under a key no restore ever looks for.
- **`success()` is explicit in the save condition.** A custom `if:` drops the implicit `success()` check, and a `~/.m2` left behind by a failed build (carrying `*.lastUpdated` failure markers) must never be cached.

### Describe if there are any user-facing changes

None. CI configuration only — no changes to the CLI, configuration, installation, or reports.

### How was this pull request tested?

- All ten workflow files parse as valid YAML.
- Verified each of the six affected workflows has exactly one `Compute Maven cache key`, one `cache/restore@v4` and one `cache/save@v4`.
- Verified the save step lands **immediately after** the installer step in every file — a split `cache/save` is an ordinary step, not a post-job hook, so it must run after the Maven build.
- Verified each folded `if:` resolves to a single-line expression with no embedded newline.

Verifiable on merge:

```bash
# usage should fall to ~1.3 GiB, with a single refs/heads/main entry
gh api repos/yugabyte/yb-voyager/actions/cache/usage
gh api "repos/yugabyte/yb-voyager/actions/caches?per_page=50" \
  --jq '.actions_caches[] | [.ref, .key, .size_in_bytes] | @tsv'
```

Acceptance signal: a run on a branch **other** than the one that populated the cache logs `Cache restored from key`, and its installer step drops to ~7 min.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
