### PR TITLE
custom-cdc-partition-key-test follow-up: production-shaped schema, resume guardrail checks, fallback phase

### DIFF
--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -4,6 +4,7 @@ import os
 import sys
 import glob
 import argparse
+import copy
 import random
 import subprocess
 import time
@@ -472,6 +473,58 @@ def validate_picked_custom_key_conflicts_action(stage: Dict[str, Any], ctx: Any)
         validate_conflicts_detected_action(scoped_stage, ctx)
     else:
         validate_no_conflicts_detected_action(scoped_stage, ctx)
+
+
+@action("voyager_import_start_expect_fail")
+def voyager_import_start_expect_fail_action(stage: Dict[str, Any], ctx: Any) -> None:
+    """Run `import data` in the foreground with the scenario's flags plus the
+    stage's `flags` on top, and require it to FAIL with `error_contains` in its
+    output -- used to verify resume guardrails at the real CLI level (e.g.
+    changing cdc-partition-key / cdc-partition-key-overrides between runs must
+    be rejected). The running importer must be stopped first
+    (voyager_stop_command), or this run fails on the export-dir lock instead.
+
+    Stage keys:
+      - flags (required): flag overrides merged over voyager.import_data.flags
+        for this one invocation only (ctx.cfg is not mutated). The placeholder
+        "{picked_table}" in a value is replaced with the table
+        pick_random_custom_key selected.
+      - error_contains (required): substring that must appear in the failed
+        run's stdout/stderr.
+      - timeout_sec (optional, default 120): how long the invocation may run
+        before being killed and the stage failed.
+    """
+    error_contains = stage.get("error_contains")
+    if not error_contains:
+        raise ValueError("voyager_import_start_expect_fail: 'error_contains' stage key is required")
+    extra_flags = dict(stage.get("flags") or {})
+    if not extra_flags:
+        raise ValueError("voyager_import_start_expect_fail: 'flags' stage key is required and must be non-empty")
+    for k, v in extra_flags.items():
+        if isinstance(v, str) and "{picked_table}" in v:
+            if not ctx.picked_custom_key:
+                raise RuntimeError(
+                    "voyager_import_start_expect_fail: '{picked_table}' used but no custom key was picked "
+                    "-- run 'pick_random_custom_key' earlier in this scenario"
+                )
+            extra_flags[k] = v.replace("{picked_table}", ctx.picked_custom_key["table"])
+
+    cfg = copy.deepcopy(ctx.cfg)
+    flags = cfg.setdefault("voyager", {}).setdefault("import_data", {}).setdefault("flags", {})
+    flags.update(extra_flags)
+    cmd = H.build_import_data_cmd(cfg)
+    timeout = int(stage.get("timeout_sec", 120))
+    H.log(f"voyager_import_start_expect_fail: running import data expecting failure with {extra_flags}")
+    proc = subprocess.run(cmd, env=ctx.env, capture_output=True, text=True, timeout=timeout)
+    output = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode == 0:
+        raise RuntimeError(f"voyager_import_start_expect_fail: import unexpectedly SUCCEEDED with flags {extra_flags}")
+    if error_contains not in output:
+        raise RuntimeError(
+            f"voyager_import_start_expect_fail: import failed (exit {proc.returncode}) but the expected "
+            f"error text was not found.\nexpected substring: {error_contains}\noutput (tail):\n{output[-3000:]}"
+        )
+    H.log(f"voyager_import_start_expect_fail: import correctly rejected (exit {proc.returncode})")
 
 
 @action("start_resumptions")

--- a/migtests/tests/resumption/live-migration/common-sql/verify_sequence_restored_after_cutover.sql
+++ b/migtests/tests/resumption/live-migration/common-sql/verify_sequence_restored_after_cutover.sql
@@ -1,0 +1,6 @@
+-- Honest insert: relies on cutover_table's SERIAL default (nextval) instead of
+-- supplying an id. If the cutover did not restore the sequence past the migrated
+-- rows, nextval returns an already-used id and this fails with a duplicate-key
+-- error, surfacing the missed sequence bump. Run against the DB just cut over to.
+INSERT INTO public.cutover_table(status)
+VALUES ('verify sequence restored after cutover');

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/init.sql
@@ -1,12 +1,34 @@
--- Schema for the live-migration unique-conflict resumption test.
--- Tables are copied from migtests/tests/pg/unique-key-conflicts-test/snapshot_schema.sql
--- and cover every unique-key shape the streaming-phase conflict-detection cache
--- (yb-voyager/cmd/conflictDetectionCache.go) reasons about.
+-- Schema for the custom-cdc-partition-key live-migration resumption test.
+-- Unique-key shapes are copied from fallback-unique-conflict-test/init.sql
+-- (originally migtests/tests/pg/unique-key-conflicts-test/snapshot_schema.sql)
+-- and cover every unique-key shape the streaming-phase conflict-detection
+-- cache (yb-voyager/cmd/conflictDetectionCache.go) reasons about.
+--
+-- Each table carries 13-14 columns shaped like a production table: an audit
+-- backbone (created_at/updated_at NOT NULL, nullable deleted_at) plus a
+-- realistic mix of business columns -- varchar/text/timestamp-heavy, with
+-- boolean, int, bigint, smallint, date, numeric(38,6), jsonb, uuid, arrays
+-- and double precision spread across the tables. NOT NULL columns get a
+-- DEFAULT so the deterministic conflict DML (source_dml.sql), which names
+-- only the key columns, works unchanged. numeric stays bounded -- unbounded
+-- numeric loses trailing zeros through live CDC and breaks row-hash
+-- validation.
 
 -- Table with Single Column Unique Constraint
 CREATE TABLE single_unique_constraint (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255) UNIQUE
+    email VARCHAR(255) UNIQUE,
+    description text NOT NULL DEFAULT '',
+    notes text NOT NULL DEFAULT '',
+    failure_reason text NOT NULL DEFAULT '',
+    remarks text NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    address_line text NOT NULL DEFAULT '',
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    deleted_at timestamp
 );
 
 -- Table with Multiple Column Unique Constraint
@@ -14,13 +36,34 @@ CREATE TABLE multi_unique_constraint (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
     last_name VARCHAR(100),
+    status varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    metadata jsonb NOT NULL DEFAULT '{}',
+    description text NOT NULL DEFAULT '',
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    is_verified boolean,
+    notes text,
+    deleted_at timestamp,
     CONSTRAINT unique_name UNIQUE (first_name, last_name)
 );
 
 -- Table with Single Column Unique Index
 CREATE TABLE single_unique_index (
     id SERIAL PRIMARY KEY,
-    "Ssn" VARCHAR(100)
+    "Ssn" VARCHAR(100),
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    status varchar NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    is_active boolean NOT NULL DEFAULT false,
+    currency varchar NOT NULL DEFAULT '',
+    is_verified boolean NOT NULL DEFAULT false,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    notes text,
+    seq_no bigint
 );
 CREATE UNIQUE INDEX idx_ssn_unique ON single_unique_index ("Ssn");
 
@@ -28,14 +71,36 @@ CREATE UNIQUE INDEX idx_ssn_unique ON single_unique_index ("Ssn");
 CREATE TABLE multi_unique_index (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
-    last_name VARCHAR(100)
+    last_name VARCHAR(100),
+    description text,
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    metadata jsonb NOT NULL DEFAULT '{}',
+    created_at timestamp,
+    updated_at timestamp,
+    notes text,
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    failure_reason text,
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_name_unique ON multi_unique_index (first_name, last_name);
 
 -- Table with Unique Constraint and Unique Index on the Same Column
 CREATE TABLE same_column_unique_constraint_and_index (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255) UNIQUE
+    email VARCHAR(255) UNIQUE,
+    status varchar NOT NULL DEFAULT '',
+    external_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    currency varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    attempt_count int NOT NULL DEFAULT 0,
+    tags varchar[] NOT NULL DEFAULT '{}',
+    processed_at timestamp,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    reference_code varchar NOT NULL DEFAULT '',
+    org_unit varchar NOT NULL DEFAULT ''
 );
 CREATE UNIQUE INDEX idx_email_unique ON same_column_unique_constraint_and_index (email);
 
@@ -43,7 +108,17 @@ CREATE UNIQUE INDEX idx_email_unique ON same_column_unique_constraint_and_index 
 CREATE TABLE different_columns_unique_constraint_and_index (
     id SERIAL PRIMARY KEY,
     email VARCHAR(255) UNIQUE,
-    phone_number VARCHAR(20)
+    phone_number VARCHAR(20),
+    status varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    metadata jsonb NOT NULL DEFAULT '{}',
+    description text NOT NULL DEFAULT '',
+    notes text,
+    failure_reason text,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    deleted_at timestamp
 );
 CREATE UNIQUE INDEX idx_phone_unique ON different_columns_unique_constraint_and_index (phone_number);
 
@@ -52,7 +127,17 @@ CREATE TABLE subset_columns_unique_constraint_and_index (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
     last_name VARCHAR(100),
-    phone_number VARCHAR(20)
+    phone_number VARCHAR(20),
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    priority smallint NOT NULL DEFAULT 0,
+    processed_at timestamp,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    is_active boolean NOT NULL DEFAULT false,
+    retry_count int NOT NULL DEFAULT 0,
+    attempt_count int NOT NULL DEFAULT 0
 );
 
 -- Unique constraint on first_name and last_name
@@ -64,14 +149,36 @@ CREATE UNIQUE INDEX idx_name_phone_unique ON subset_columns_unique_constraint_an
 
 CREATE TABLE expression_based_unique_index (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255)
+    email VARCHAR(255),
+    description text NOT NULL DEFAULT '',
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    status varchar NOT NULL DEFAULT '',
+    is_active boolean NOT NULL DEFAULT false,
+    deleted_at timestamp,
+    amount numeric(38,6),
+    notes text,
+    failure_reason text,
+    remarks text,
+    address_line text
 );
 CREATE UNIQUE INDEX idx_email_unique_expression ON expression_based_unique_index (LOWER(email));
 
 CREATE TABLE test_partial_unique_index (
     id SERIAL PRIMARY KEY,
     check_id int,
-    most_recent boolean
+    most_recent boolean,
+    status varchar NOT NULL DEFAULT '',
+    metadata jsonb,
+    retry_count int NOT NULL DEFAULT 0,
+    is_active boolean NOT NULL DEFAULT false,
+    currency varchar NOT NULL DEFAULT '',
+    reference_code varchar NOT NULL DEFAULT '',
+    org_unit varchar,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    deleted_at timestamp
 );
 
 CREATE UNIQUE INDEX idx_test_partial_unique_index ON test_partial_unique_index (check_id) WHERE most_recent;
@@ -80,7 +187,19 @@ CREATE UNIQUE INDEX idx_test_partial_unique_index ON test_partial_unique_index (
 -- equal, so a NULL free->reuse across different PKs is a real conflict.
 CREATE TABLE single_unique_index_nulls_not_distinct (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255)
+    email VARCHAR(255),
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    due_date date NOT NULL DEFAULT CURRENT_DATE,
+    reference_code varchar NOT NULL DEFAULT '',
+    org_unit varchar NOT NULL DEFAULT '',
+    seq_no bigint NOT NULL DEFAULT 0,
+    amount numeric(38,6),
+    is_active boolean NOT NULL DEFAULT false,
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    channel varchar
 );
 CREATE UNIQUE INDEX idx_email_nnd ON single_unique_index_nulls_not_distinct (email) NULLS NOT DISTINCT;
 
@@ -88,7 +207,18 @@ CREATE UNIQUE INDEX idx_email_nnd ON single_unique_index_nulls_not_distinct (ema
 CREATE TABLE multi_unique_index_nulls_not_distinct (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(100),
-    last_name VARCHAR(100)
+    last_name VARCHAR(100),
+    description text NOT NULL DEFAULT '',
+    notes text NOT NULL DEFAULT '',
+    failure_reason text,
+    amount numeric(38,6) NOT NULL DEFAULT 0,
+    status varchar NOT NULL DEFAULT '',
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    remarks text,
+    deleted_at timestamp,
+    is_active boolean,
+    address_line text
 );
 CREATE UNIQUE INDEX idx_name_nnd ON multi_unique_index_nulls_not_distinct (first_name, last_name) NULLS NOT DISTINCT;
 
@@ -98,7 +228,18 @@ CREATE UNIQUE INDEX idx_name_nnd ON multi_unique_index_nulls_not_distinct (first
 -- NULLS DISTINCT branch of the per-index conflict handling.
 CREATE TABLE single_unique_index_nulls_distinct (
     id SERIAL PRIMARY KEY,
-    email VARCHAR(255)
+    email VARCHAR(255),
+    status varchar NOT NULL DEFAULT '',
+    currency varchar NOT NULL DEFAULT '',
+    processed_at timestamp,
+    expires_at timestamp,
+    description text,
+    external_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    reference_code varchar,
+    org_unit varchar NOT NULL DEFAULT '',
+    deleted_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now()
 );
 CREATE UNIQUE INDEX idx_email_nd ON single_unique_index_nulls_distinct (email);
 
@@ -108,6 +249,17 @@ CREATE TABLE partitioned_unique_conflict (
     id INT,
     region VARCHAR(50),
     email VARCHAR(255),
+    description text NOT NULL DEFAULT '',
+    status varchar NOT NULL DEFAULT '',
+    retry_count int NOT NULL DEFAULT 0,
+    currency varchar,
+    reference_code varchar,
+    attempt_count int NOT NULL DEFAULT 0,
+    score double precision,
+    created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(),
+    due_date date,
+    deleted_at timestamp,
     PRIMARY KEY (id, region)
 ) PARTITION BY LIST (region);
 CREATE TABLE partitioned_unique_conflict_east PARTITION OF partitioned_unique_conflict FOR VALUES IN ('east');

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/scenario.yaml.template
@@ -34,7 +34,7 @@ target:
 # key below gets added to exclude_columns_from_update at run time, so the
 # generator never updates that custom key column (the importer requires it to
 # be immutable) while still touching that table's other columns normally.
-generator:
+generator_source:
   config_inline:
     connection:
       host: 127.0.0.1
@@ -62,16 +62,55 @@ generator:
 
 # Deterministic unique-conflict DML (same file as fallback-unique-conflict-test),
 # re-applied on a loop throughout streaming in parallel with the random generator.
-conflict_generator:
+conflict_generator_source:
   config_inline:
     conflict:
       sql_path: ./source_dml.sql
       interval_seconds: 10
 
+# Fallback (target) event generator: random traffic on target during fallback.
+generator_target:
+  config_inline:
+    connection:
+      host: ${TARGET_DB_HOST}
+      port: ${TARGET_DB_PORT}
+      database: test_db
+      user: ${TARGET_DB_USER}
+      password: ${TARGET_DB_PASSWORD}
+
+    generator:
+      schema_name: public
+      manual_table_list: []
+      exclude_table_list: [cutover_table]
+      num_iterations: -1
+      wait_after_operations: 1000
+      wait_duration_seconds: 1
+      table_weights: {}
+      operation_weights: {INSERT: 3, UPDATE: 2, DELETE: 1}
+      random_seed: 456
+      faker_seed: 456
+      insert_rows: 3
+      update_rows: 2
+      delete_rows: 1
+      insert_max_retries: 5
+      update_max_retries: 1
+
+# Fallback (target) conflict generator: re-applies the deterministic
+# unique-conflict DML on the target on a loop, in parallel with
+# generator_target. Custom keys do not apply on the fallback leg (import to
+# source forces table routing), so target_dml.sql keeps the full four
+# conflict types with no immutability restrictions.
+conflict_generator_target:
+  config_inline:
+    conflict:
+      sql_path: ./target_dml.sql
+      interval_seconds: 10
+
+
 voyager:
   cutover_to_target:
     flags:
-      prepare-for-fall-back: false
+      prepare-for-fall-back: true
 
 stages:
   - name: create_source_and_target_dbs
@@ -89,6 +128,7 @@ stages:
 
   - name: grant_source_permissions
     action: grant_source_permissions
+    is_live_migration_fall_back: 1
 
   # Randomly select ONE (table, columns) pair to route by
   # --cdc-partition-key-overrides this run -- mirroring how a real user opts a
@@ -101,6 +141,7 @@ stages:
   # detected (expect_conflicts: true) -- every other candidate must show none.
   - name: pick_random_custom_key
     action: pick_random_custom_key
+    generator_key: generator_source
     candidates:
       - table: public.single_unique_constraint
         columns: [email]
@@ -138,6 +179,7 @@ stages:
 
   - name: start_event_generator
     action: generator_start
+    generator_key: generator_source
 
   - name: load_snapshot
     action: sleep
@@ -161,6 +203,7 @@ stages:
   # streaming, in parallel with the random event generator.
   - name: start_conflict_generator
     action: conflict_generator_start
+    generator_key: conflict_generator_source
 
   - name: start_import_resumptions
     action: start_resumptions
@@ -193,10 +236,12 @@ stages:
 
   - name: stop_conflict_generator
     action: conflict_generator_stop
+    generator_key: conflict_generator_source
     graceful_timeout_sec: 60
 
   - name: stop_event_generator
     action: generator_stop
+    generator_key: generator_source
     graceful_timeout_sec: 60
 
   - name: insert_backlog_marker
@@ -238,6 +283,31 @@ stages:
     log: yb-voyager-import-data.log
     min_count: 1
 
+  # Resume guardrail: changing cdc-partition-key / cdc-partition-key-overrides
+  # between runs must be rejected (diffCdcPartitioningStrategy). Stop the
+  # importer, try to resume twice with a changed config -- once changing the
+  # global default, once changing the picked table's override to pk -- assert
+  # both are refused, then resume with the original flags.
+  - name: stop_importer_for_guardrail_check
+    action: voyager_stop_command
+    command: import_data
+    timeout_sec: 60
+
+  - name: guardrail_reject_global_default_change
+    action: voyager_import_start_expect_fail
+    flags:
+      cdc-partition-key: table
+    error_contains: "not allowed after the import data has started"
+
+  - name: guardrail_reject_picked_override_change
+    action: voyager_import_start_expect_fail
+    flags:
+      cdc-partition-key-overrides: "{picked_table}:pk"
+    error_contains: "not allowed after the import data has started"
+
+  - name: restart_importer_after_guardrail_check
+    action: voyager_import_start
+
   - name: cutover_to_target
     action: cutover_to_target
 
@@ -246,11 +316,128 @@ stages:
     condition: cutover_to_target_status_completed
     timeout_sec: 900
 
+  # Honest (nextval) insert on the DB just cut over to: fails with a duplicate key
+  # if its sequence was not restored past the migrated rows. Runs after validations
+  # since it adds a row on one side only.
+  - name: verify_target_sequence_restored_after_cutover
+    action: run_sql
+    target: target
+    sql_path: ../common-sql/verify_sequence_restored_after_cutover.sql
+
+  - name: stop_forward_exporter
+    action: voyager_stop_command
+    command: export_data
+    graceful_timeout_sec: 60
+
+  - name: stop_forward_importer
+    action: voyager_stop_command
+    command: import_data
+    graceful_timeout_sec: 60
+
+  - name: start_fallback_exporter_from_target
+    action: voyager_export_from_target_start
+
+  - name: start_fallback_importer_to_source
+    action: voyager_import_to_source_start
+
+  # Deterministic unique-conflict DML applied once up-front on the target for
+  # an immediate burst as fallback streaming starts. Custom keys do not apply
+  # on this leg (import to source forces table routing), so the fallback
+  # importer must log ZERO conflicts even with conflict-prone DML flowing.
+  - name: run_target_dml
+    action: run_sql
+    target: target
+    sql_path: ./target_dml.sql
+    use_admin: true
+
+  - name: start_target_conflict_generator
+    action: conflict_generator_start
+    generator_key: conflict_generator_target
+
+  - name: start_target_event_generator
+    action: generator_start
+    generator_key: generator_target
+
+  - name: start_fallback_resumptions
+    action: start_resumptions
+    resumption:
+      export_from_target:
+        max_restarts: 100
+        min_interrupt_seconds: 15
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 5
+        max_restart_wait_seconds: 30
+
+  - name: start_import_to_source_resumptions
+    action: start_resumptions
+    resumption:
+      import_to_source:
+        max_restarts: 100
+        min_interrupt_seconds: 15
+        max_interrupt_seconds: 60
+        min_restart_wait_seconds: 5
+        max_restart_wait_seconds: 30
+
+  - name: soak_fallback_with_resumptions
+    action: sleep
+    seconds: 3000
+
+  - name: stop_target_conflict_generator
+    action: conflict_generator_stop
+    generator_key: conflict_generator_target
+    graceful_timeout_sec: 60
+
+  - name: stop_target_event_generator
+    action: generator_stop
+    generator_key: generator_target
+    graceful_timeout_sec: 60
+
+  - name: insert_backlog_marker_on_target
+    action: run_sql
+    target: target
+    sql_path: ../common-sql/insert_marker.sql
+
+  - name: wait_backlog_zero_after_fallback
+    action: wait_for
+    condition: remaining_events_eq_0
+    timeout_sec: 6000
+
+  - name: stop_fallback_export_resumptions
+    action: voyager_stop_resumptions
+    command: export_from_target
+    timeout_sec: 60
+
+  - name: stop_fallback_import_resumptions
+    action: voyager_stop_resumptions
+    command: import_to_source
+    timeout_sec: 60
+
+  # The fallback importer forces PARTITION_BY_TABLE (custom keys are rejected
+  # outside import-data-to-target), so conflict detection must never fire on
+  # this leg -- also proves the forward leg's custom-key config doesn't leak
+  # into or break the fallback.
+  - name: validate_no_conflicts_on_fallback
+    action: validate_no_conflicts_detected
+    log: yb-voyager-import-data-to-source.log
+
+  - name: cutover_to_source
+    action: cutover_to_source
+
+  - name: wait_cutover_to_source_completed
+    action: wait_for
+    condition: cutover_to_source_status_completed
+    timeout_sec: 900
+
   - name: row_count_validations
     action: row_count_validations
 
   - name: row_hash_validations
     action: row_hash_validations
+
+  - name: verify_source_sequence_restored_after_cutover
+    action: run_sql
+    target: source
+    sql_path: ../common-sql/verify_sequence_restored_after_cutover.sql
 
   - name: cleanup_source
     action: run_sql

--- a/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/target_dml.sql
+++ b/migtests/tests/resumption/live-migration/custom-cdc-partition-key-test/target_dml.sql
@@ -1,0 +1,368 @@
+-- Deterministic unique-conflict DML for the FALLBACK (target -> source) leg.
+-- Re-applied on a loop throughout fallback streaming by the orchestrator's
+-- conflict generator (conflict_generator_target), in parallel with the
+-- target-side random generator, so conflicts are produced continuously.
+--
+-- DYNAMIC per cycle: the generator passes `-v cycle=N`; ids = :base + offset
+-- (:base = 950000000 + cycle*100000) and unique-key values are suffixed with
+-- :cycle, so each cycle hits a FRESH set of rows (the freeing + reusing events
+-- within a cycle still share that cycle's value, so the conflict is preserved).
+-- The 950,000,000 base keeps these rows clear of the forward-migrated rows
+-- (900,000,000 base) and the random generator (integers in -2e8 .. 2e8).
+-- Run standalone (no -v cycle) it defaults to cycle 0.
+--
+-- Same four conflict types as the forward leg (DELETE-INSERT, DELETE-UPDATE,
+-- UPDATE-INSERT, UPDATE-UPDATE). For an export-from-target source the
+-- conflict-detection cache cannot rely on YB-CDC before-images, so it falls
+-- back to a coarser rule (cached DELETE => conflict; cached UPDATE touching the
+-- same unique-key columns => conflict). These scenarios exercise that path.
+-- Each table's seed + conflicts run in one transaction.
+
+-- ============================================================
+-- 1. single_unique_constraint (id PK, email UNIQUE)
+-- ============================================================
+\if :{?cycle}
+\else
+  \set cycle 0
+\endif
+\set base (950000000 + :cycle * 100000)
+
+BEGIN;
+INSERT INTO single_unique_constraint (id, email) VALUES
+    (:base + 1, ('tgt_suc_user1@conflict.test' || :cycle)),
+    (:base + 2, ('tgt_suc_user2@conflict.test' || :cycle)),
+    (:base + 3, ('tgt_suc_user3@conflict.test' || :cycle)),
+    (:base + 4, ('tgt_suc_user4@conflict.test' || :cycle)),
+    (:base + 5, ('tgt_suc_user5@conflict.test' || :cycle)),
+    (:base + 6, ('tgt_suc_user6@conflict.test' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM single_unique_constraint WHERE id = :base + 1;
+INSERT INTO single_unique_constraint (id, email) VALUES (:base + 101, ('tgt_suc_user1@conflict.test' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM single_unique_constraint WHERE id = :base + 2;
+UPDATE single_unique_constraint SET email = ('tgt_suc_user2@conflict.test' || :cycle) WHERE id = :base + 3;
+
+-- UPDATE-INSERT
+UPDATE single_unique_constraint SET email = ('tgt_suc_user4_moved@conflict.test' || :cycle) WHERE id = :base + 4;
+INSERT INTO single_unique_constraint (id, email) VALUES (:base + 102, ('tgt_suc_user4@conflict.test' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE single_unique_constraint SET email = ('tgt_suc_user5_moved@conflict.test' || :cycle) WHERE id = :base + 5;
+UPDATE single_unique_constraint SET email = ('tgt_suc_user5@conflict.test' || :cycle) WHERE id = :base + 6;
+COMMIT;
+
+-- ============================================================
+-- 2. multi_unique_constraint (id PK, UNIQUE(first_name, last_name))
+-- ============================================================
+BEGIN;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES
+    (:base + 10001, ('TgtJohn' || :cycle),  ('Doe' || :cycle)),
+    (:base + 10002, ('TgtJane' || :cycle),  ('Smith' || :cycle)),
+    (:base + 10003, ('TgtBob' || :cycle),   ('Jones' || :cycle)),
+    (:base + 10004, ('TgtAlice' || :cycle), ('Williams' || :cycle)),
+    (:base + 10005, ('TgtTom' || :cycle),   ('Clark' || :cycle)),
+    (:base + 10006, ('TgtEve' || :cycle),   ('Davis' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM multi_unique_constraint WHERE id = :base + 10001;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES (:base + 10101, ('TgtJohn' || :cycle), ('Doe' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM multi_unique_constraint WHERE id = :base + 10002;
+UPDATE multi_unique_constraint SET first_name = ('TgtJane' || :cycle), last_name = ('Smith' || :cycle) WHERE id = :base + 10003;
+
+-- UPDATE-INSERT
+UPDATE multi_unique_constraint SET first_name = ('TgtAlice_moved' || :cycle) WHERE id = :base + 10004;
+INSERT INTO multi_unique_constraint (id, first_name, last_name) VALUES (:base + 10102, ('TgtAlice' || :cycle), ('Williams' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE multi_unique_constraint SET first_name = ('TgtTom_moved' || :cycle) WHERE id = :base + 10005;
+UPDATE multi_unique_constraint SET first_name = ('TgtTom' || :cycle), last_name = ('Clark' || :cycle) WHERE id = :base + 10006;
+COMMIT;
+
+-- ============================================================
+-- 3. same_column_unique_constraint_and_index (id PK, email UNIQUE + UNIQUE INDEX on email)
+-- ============================================================
+BEGIN;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES
+    (:base + 20001, ('tgt_scuci_user1@conflict.test' || :cycle)),
+    (:base + 20002, ('tgt_scuci_user2@conflict.test' || :cycle)),
+    (:base + 20003, ('tgt_scuci_user3@conflict.test' || :cycle)),
+    (:base + 20004, ('tgt_scuci_user4@conflict.test' || :cycle)),
+    (:base + 20005, ('tgt_scuci_user5@conflict.test' || :cycle)),
+    (:base + 20006, ('tgt_scuci_user6@conflict.test' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM same_column_unique_constraint_and_index WHERE id = :base + 20001;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES (:base + 20101, ('tgt_scuci_user1@conflict.test' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM same_column_unique_constraint_and_index WHERE id = :base + 20002;
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user2@conflict.test' || :cycle) WHERE id = :base + 20003;
+
+-- UPDATE-INSERT
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user4_moved@conflict.test' || :cycle) WHERE id = :base + 20004;
+INSERT INTO same_column_unique_constraint_and_index (id, email) VALUES (:base + 20102, ('tgt_scuci_user4@conflict.test' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user5_moved@conflict.test' || :cycle) WHERE id = :base + 20005;
+UPDATE same_column_unique_constraint_and_index SET email = ('tgt_scuci_user5@conflict.test' || :cycle) WHERE id = :base + 20006;
+COMMIT;
+
+-- ============================================================
+-- 4. single_unique_index (id PK, UNIQUE INDEX on "Ssn" -- case-sensitive column)
+-- ============================================================
+BEGIN;
+INSERT INTO single_unique_index (id, "Ssn") VALUES
+    (:base + 30001, ('TGT-SSN-1' || :cycle)),
+    (:base + 30002, ('TGT-SSN-2' || :cycle)),
+    (:base + 30003, ('TGT-SSN-3' || :cycle)),
+    (:base + 30004, ('TGT-SSN-4' || :cycle)),
+    (:base + 30005, ('TGT-SSN-5' || :cycle)),
+    (:base + 30006, ('TGT-SSN-6' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM single_unique_index WHERE id = :base + 30001;
+INSERT INTO single_unique_index (id, "Ssn") VALUES (:base + 30101, ('TGT-SSN-1' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM single_unique_index WHERE id = :base + 30002;
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-2' || :cycle) WHERE id = :base + 30003;
+
+-- UPDATE-INSERT
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-4-moved' || :cycle) WHERE id = :base + 30004;
+INSERT INTO single_unique_index (id, "Ssn") VALUES (:base + 30102, ('TGT-SSN-4' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-5-moved' || :cycle) WHERE id = :base + 30005;
+UPDATE single_unique_index SET "Ssn" = ('TGT-SSN-5' || :cycle) WHERE id = :base + 30006;
+COMMIT;
+
+-- ============================================================
+-- 5. multi_unique_index (id PK, UNIQUE INDEX(first_name, last_name))
+-- ============================================================
+BEGIN;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES
+    (:base + 40001, ('TgtIdxJohn' || :cycle),  ('Doe' || :cycle)),
+    (:base + 40002, ('TgtIdxJane' || :cycle),  ('Smith' || :cycle)),
+    (:base + 40003, ('TgtIdxBob' || :cycle),   ('Jones' || :cycle)),
+    (:base + 40004, ('TgtIdxAlice' || :cycle), ('Williams' || :cycle)),
+    (:base + 40005, ('TgtIdxTom' || :cycle),   ('Clark' || :cycle)),
+    (:base + 40006, ('TgtIdxEve' || :cycle),   ('Davis' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM multi_unique_index WHERE id = :base + 40001;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES (:base + 40101, ('TgtIdxJohn' || :cycle), ('Doe' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM multi_unique_index WHERE id = :base + 40002;
+UPDATE multi_unique_index SET first_name = ('TgtIdxJane' || :cycle), last_name = ('Smith' || :cycle) WHERE id = :base + 40003;
+
+-- UPDATE-INSERT
+UPDATE multi_unique_index SET first_name = ('TgtIdxAlice_moved' || :cycle) WHERE id = :base + 40004;
+INSERT INTO multi_unique_index (id, first_name, last_name) VALUES (:base + 40102, ('TgtIdxAlice' || :cycle), ('Williams' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE multi_unique_index SET first_name = ('TgtIdxTom_moved' || :cycle) WHERE id = :base + 40005;
+UPDATE multi_unique_index SET first_name = ('TgtIdxTom' || :cycle), last_name = ('Clark' || :cycle) WHERE id = :base + 40006;
+COMMIT;
+
+-- ============================================================
+-- 6. different_columns_unique_constraint_and_index
+--    (id PK, email UNIQUE, UNIQUE INDEX on phone_number)
+-- ============================================================
+BEGIN;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES
+    (:base + 50001, ('tgt_dcuci_user1@conflict.test' || :cycle), ('tgtdcph-1' || :cycle)),
+    (:base + 50002, ('tgt_dcuci_user2@conflict.test' || :cycle), ('tgtdcph-2' || :cycle)),
+    (:base + 50003, ('tgt_dcuci_user3@conflict.test' || :cycle), ('tgtdcph-3' || :cycle)),
+    (:base + 50004, ('tgt_dcuci_user4@conflict.test' || :cycle), ('tgtdcph-4' || :cycle)),
+    (:base + 50005, ('tgt_dcuci_user5@conflict.test' || :cycle), ('tgtdcph-5' || :cycle)),
+    (:base + 50006, ('tgt_dcuci_user6@conflict.test' || :cycle), ('tgtdcph-6' || :cycle));
+
+-- DELETE-INSERT (conflict on both email and phone_number)
+DELETE FROM different_columns_unique_constraint_and_index WHERE id = :base + 50001;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES (:base + 50101, ('tgt_dcuci_user1@conflict.test' || :cycle), ('tgtdcph-1' || :cycle));
+
+-- DELETE-UPDATE (conflict on phone_number unique index)
+DELETE FROM different_columns_unique_constraint_and_index WHERE id = :base + 50002;
+UPDATE different_columns_unique_constraint_and_index SET phone_number = ('tgtdcph-2' || :cycle) WHERE id = :base + 50003;
+
+-- UPDATE-INSERT (conflict on email unique constraint)
+UPDATE different_columns_unique_constraint_and_index SET email = ('tgt_dcuci_user4_moved@conflict.test' || :cycle) WHERE id = :base + 50004;
+INSERT INTO different_columns_unique_constraint_and_index (id, email, phone_number) VALUES (:base + 50102, ('tgt_dcuci_user4@conflict.test' || :cycle), ('tgtdcph-104' || :cycle));
+
+-- UPDATE-UPDATE (conflict on phone_number unique index)
+UPDATE different_columns_unique_constraint_and_index SET phone_number = ('tgtdcph-5-moved' || :cycle) WHERE id = :base + 50005;
+UPDATE different_columns_unique_constraint_and_index SET phone_number = ('tgtdcph-5' || :cycle) WHERE id = :base + 50006;
+COMMIT;
+
+-- ============================================================
+-- 7. subset_columns_unique_constraint_and_index
+--    (id PK, UNIQUE(first_name,last_name), UNIQUE INDEX(first_name,last_name,phone_number))
+-- ============================================================
+BEGIN;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES
+    (:base + 60001, ('TgtSubJohn' || :cycle),  ('Doe' || :cycle),      ('tgtsubph-1' || :cycle)),
+    (:base + 60002, ('TgtSubJane' || :cycle),  ('Smith' || :cycle),    ('tgtsubph-2' || :cycle)),
+    (:base + 60003, ('TgtSubBob' || :cycle),   ('Jones' || :cycle),    ('tgtsubph-3' || :cycle)),
+    (:base + 60004, ('TgtSubAlice' || :cycle), ('Williams' || :cycle), ('tgtsubph-4' || :cycle)),
+    (:base + 60005, ('TgtSubTom' || :cycle),   ('Clark' || :cycle),    ('tgtsubph-5' || :cycle)),
+    (:base + 60006, ('TgtSubEve' || :cycle),   ('Davis' || :cycle),    ('tgtsubph-6' || :cycle));
+
+-- DELETE-INSERT
+DELETE FROM subset_columns_unique_constraint_and_index WHERE id = :base + 60001;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES (:base + 60101, ('TgtSubJohn' || :cycle), ('Doe' || :cycle), ('tgtsubph-101' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM subset_columns_unique_constraint_and_index WHERE id = :base + 60002;
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubJane' || :cycle), last_name = ('Smith' || :cycle) WHERE id = :base + 60003;
+
+-- UPDATE-INSERT
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubAlice_moved' || :cycle) WHERE id = :base + 60004;
+INSERT INTO subset_columns_unique_constraint_and_index (id, first_name, last_name, phone_number) VALUES (:base + 60102, ('TgtSubAlice' || :cycle), ('Williams' || :cycle), ('tgtsubph-102' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubTom_moved' || :cycle) WHERE id = :base + 60005;
+UPDATE subset_columns_unique_constraint_and_index SET first_name = ('TgtSubTom' || :cycle), last_name = ('Clark' || :cycle) WHERE id = :base + 60006;
+COMMIT;
+
+-- ============================================================
+-- 8. expression_based_unique_index (id PK, UNIQUE INDEX on LOWER(email))
+-- ============================================================
+BEGIN;
+INSERT INTO expression_based_unique_index (id, email) VALUES
+    (:base + 70001, ('Tgt_Expr_User1@conflict.test' || :cycle)),
+    (:base + 70002, ('Tgt_Expr_User2@conflict.test' || :cycle)),
+    (:base + 70003, ('Tgt_Expr_User3@conflict.test' || :cycle)),
+    (:base + 70004, ('Tgt_Expr_User4@conflict.test' || :cycle)),
+    (:base + 70005, ('Tgt_Expr_User5@conflict.test' || :cycle)),
+    (:base + 70006, ('Tgt_Expr_User6@conflict.test' || :cycle));
+
+-- DELETE-INSERT (LOWER(email) collision)
+DELETE FROM expression_based_unique_index WHERE id = :base + 70001;
+INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70101, ('TGT_EXPR_USER1@conflict.test' || :cycle));
+
+-- DELETE-UPDATE
+DELETE FROM expression_based_unique_index WHERE id = :base + 70002;
+UPDATE expression_based_unique_index SET email = ('TGT_EXPR_USER2@conflict.test' || :cycle) WHERE id = :base + 70003;
+
+-- UPDATE-INSERT
+UPDATE expression_based_unique_index SET email = ('Tgt_Expr_User4_moved@conflict.test' || :cycle) WHERE id = :base + 70004;
+INSERT INTO expression_based_unique_index (id, email) VALUES (:base + 70102, ('tgt_expr_user4@conflict.test' || :cycle));
+
+-- UPDATE-UPDATE
+UPDATE expression_based_unique_index SET email = ('Tgt_Expr_User5_moved@conflict.test' || :cycle) WHERE id = :base + 70005;
+UPDATE expression_based_unique_index SET email = ('TGT_EXPR_user5@conflict.test' || :cycle) WHERE id = :base + 70006;
+COMMIT;
+
+-- ============================================================
+-- 9. test_partial_unique_index (id PK, UNIQUE INDEX(check_id) WHERE most_recent)
+-- ============================================================
+BEGIN;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES
+    (:base + 80001, :base + 91, true),
+    (:base + 80002, :base + 92, true),
+    (:base + 80003, :base + 93, true),
+    (:base + 80004, :base + 93, false),
+    (:base + 80005, :base + 94, true),
+    (:base + 80006, :base + 94, false);
+
+-- UPDATE-INSERT
+UPDATE test_partial_unique_index SET most_recent = false WHERE id = :base + 80001;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80101, :base + 91, true);
+
+-- DELETE-INSERT
+DELETE FROM test_partial_unique_index WHERE id = :base + 80002;
+INSERT INTO test_partial_unique_index (id, check_id, most_recent) VALUES (:base + 80102, :base + 92, true);
+
+-- DELETE-UPDATE
+DELETE FROM test_partial_unique_index WHERE id = :base + 80003;
+UPDATE test_partial_unique_index SET most_recent = true WHERE id = :base + 80004;
+
+-- UPDATE-UPDATE
+UPDATE test_partial_unique_index SET most_recent = false WHERE id = :base + 80005;
+UPDATE test_partial_unique_index SET most_recent = true WHERE id = :base + 80006;
+COMMIT;
+
+-- ============================================================
+-- 10. single_unique_index_nulls_not_distinct (id PK, UNIQUE INDEX(email) NULLS NOT DISTINCT)
+-- Under NULLS NOT DISTINCT two NULLs are equal, so a NULL free->reuse across PKs is a
+-- real conflict. Only one NULL can exist at a time, so the NULL is moved off at the end
+-- of the block, leaving none behind for the next cycle.
+-- ============================================================
+BEGIN;
+-- UPDATE-INSERT (non-null value)
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85001, ('tgt_nnd1_user1@conflict.test' || :cycle));
+UPDATE single_unique_index_nulls_not_distinct SET email = ('tgt_nnd1_user1_moved@conflict.test' || :cycle) WHERE id = :base + 85001;
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85101, ('tgt_nnd1_user1@conflict.test' || :cycle));
+
+-- NULL free->reuse: free the NULL by moving base+85010 off it, reuse NULL on base+85011
+-- (conflict under NULLS NOT DISTINCT), then move base+85011 off NULL to leave none behind.
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85010, NULL);
+UPDATE single_unique_index_nulls_not_distinct SET email = ('tgt_nnd1_wasnull_a@conflict.test' || :cycle) WHERE id = :base + 85010;
+INSERT INTO single_unique_index_nulls_not_distinct (id, email) VALUES (:base + 85011, NULL);
+UPDATE single_unique_index_nulls_not_distinct SET email = ('tgt_nnd1_wasnull_b@conflict.test' || :cycle) WHERE id = :base + 85011;
+COMMIT;
+
+-- ============================================================
+-- 11. multi_unique_index_nulls_not_distinct (id PK, UNIQUE INDEX(first_name, last_name) NULLS NOT DISTINCT)
+-- ============================================================
+BEGIN;
+-- UPDATE-INSERT (non-null values)
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86001, ('tgt_nnd2First' || :cycle), ('tgt_nnd2Last' || :cycle));
+UPDATE multi_unique_index_nulls_not_distinct SET first_name = ('tgt_nnd2First_moved' || :cycle) WHERE id = :base + 86001;
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86101, ('tgt_nnd2First' || :cycle), ('tgt_nnd2Last' || :cycle));
+
+-- (NULL, NULL) free->reuse: two all-NULL rows conflict under NULLS NOT DISTINCT.
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86010, NULL, NULL);
+UPDATE multi_unique_index_nulls_not_distinct SET first_name = ('tgt_nnd2wasnull_a' || :cycle) WHERE id = :base + 86010;
+INSERT INTO multi_unique_index_nulls_not_distinct (id, first_name, last_name) VALUES (:base + 86011, NULL, NULL);
+UPDATE multi_unique_index_nulls_not_distinct SET first_name = ('tgt_nnd2wasnull_b' || :cycle) WHERE id = :base + 86011;
+COMMIT;
+
+-- ============================================================
+-- 12. partitioned_unique_conflict (PK(id, region), UNIQUE INDEX(email, region), PARTITION BY LIST(region))
+-- The unique key includes the partition-key column; conflicts are exercised within a partition.
+-- ============================================================
+BEGIN;
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES
+    (:base + 87001, 'east', ('tgt_puc_user1@conflict.test' || :cycle)),
+    (:base + 87002, 'east', ('tgt_puc_user2@conflict.test' || :cycle)),
+    (:base + 87003, 'west', ('tgt_puc_user3@conflict.test' || :cycle)),
+    (:base + 87004, 'west', ('tgt_puc_user4@conflict.test' || :cycle));
+
+-- DELETE-INSERT within the 'east' partition: free (puc_user1, east), reuse on a new PK
+DELETE FROM partitioned_unique_conflict WHERE id = :base + 87001 AND region = 'east';
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87101, 'east', ('tgt_puc_user1@conflict.test' || :cycle));
+
+-- UPDATE-INSERT within the 'west' partition: free (puc_user3, west) by moving it, reuse on a new PK
+UPDATE partitioned_unique_conflict SET email = ('tgt_puc_user3_moved@conflict.test' || :cycle) WHERE id = :base + 87003 AND region = 'west';
+INSERT INTO partitioned_unique_conflict (id, region, email) VALUES (:base + 87103, 'west', ('tgt_puc_user3@conflict.test' || :cycle));
+COMMIT;
+
+-- ============================================================
+-- 13. single_unique_index_nulls_distinct (id PK, UNIQUE INDEX(email) -- default NULLS DISTINCT)
+-- Under NULLS DISTINCT multiple NULLs coexist and a NULL free->reuse is NOT a conflict,
+-- so these NULL rows must import without being (wrongly) serialized. A non-null value
+-- conflict is included to confirm real conflicts still fire on this table.
+-- ============================================================
+BEGIN;
+-- Multiple NULL rows coexist under NULLS DISTINCT (no conflict, no violation)
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES
+    (:base + 89001, NULL),
+    (:base + 89002, NULL),
+    (:base + 89003, NULL);
+
+-- NULL free->reuse: delete a NULL holder, insert another NULL. Under NULLS DISTINCT
+-- these NULLs do NOT conflict, so the cache must not serialize them.
+DELETE FROM single_unique_index_nulls_distinct WHERE id = :base + 89001;
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89101, NULL);
+
+-- Non-null value free->reuse: a real conflict that must still be detected here.
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89010, ('tgt_nd_user1@conflict.test' || :cycle));
+UPDATE single_unique_index_nulls_distinct SET email = ('tgt_nd_user1_moved@conflict.test' || :cycle) WHERE id = :base + 89010;
+INSERT INTO single_unique_index_nulls_distinct (id, email) VALUES (:base + 89110, ('tgt_nd_user1@conflict.test' || :cycle));
+COMMIT;


### PR DESCRIPTION
Stacked on #3770 (base branch is that PR's branch; will retarget to main once it merges).

### Describe the changes in this pull request
Follow-up hardening of `custom-cdc-partition-key-test` before it joins nightly runs.

- **Schema**: every table widened to 13-14 columns shaped like production tables (audit-timestamp backbone; varchar/text/timestamp-heavy mix with boolean, int, bigint, smallint, date, `numeric(38,6)`, jsonb, uuid, arrays, double precision spread across tables). Keys/unique indexes unchanged, so the conflict DML is untouched. The picked custom-key table now keeps receiving real UPDATE traffic on its non-key columns.
- **Resume guardrails**: new `voyager_import_start_expect_fail` orchestrator action. Mid-run, the scenario stops the importer and asserts two illegal config changes are rejected — changing the global `--cdc-partition-key` default, and changing the picked table's override to `pk` — then resumes with the original flags and completes.
- **Fallback phase** mirroring `fallback-unique-conflict-test`: cutover-to-target with `prepare-for-fall-back`, target-side random + conflict generators (full four conflict types — custom keys don't apply on this leg), resumptions on export-from-target/import-to-source, a zero-conflicts assertion on the fallback importer (table routing forced; forward-leg custom-key config must not leak), cutover-to-source, then row-count/row-hash/sequence validations.

During development this test also surfaced a guardrail gap for partitioned tables whose root lacks a PK under default `--use-partition-root=true` (silently accepted, then permanently wedges on a mid-batch importer restart with SQLSTATE 42P10) — that table was moved out of this test (its supported path is covered by `use-partition-root-false-test`) and the gap is being filed as a follow-up to DB-21011.

### Describe if there are any user-facing changes
No user-facing changes (test infra and migtest harness scripts only).

### How was this pull request tested?
Full two-phase local runs (forward + fallback) passed repeatedly across different random picks, including the PK-recycle candidate; guardrail rejection stages verified against both config-change variants.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?
No.