### PR TITLE
implement api handling for amp

### DIFF
--- a/docker/yb-voyager-docker
+++ b/docker/yb-voyager-docker
@@ -24,6 +24,7 @@ variables=("BETA_FAST_DATA_EXPORT"
 "TARGET_DB_PASSWORD" 
 "SOURCE_REPLICA_DB_PASSWORD" 
 "YB_VOYAGER_SEND_DIAGNOSTICS" 
+"YB_VOYAGER_MIGRATION_UUID"
 "YB_MASTER_PORT" 
 "YB_TSERVER_PORT" 
 "QUEUE_SEGMENT_MAX_BYTES" 
@@ -256,14 +257,15 @@ fi
 if [[ ${command_name} == "end-migration" || ${command_name} == "export-data-from-target" || ${command_name} == "import-data-to-source" || ${command_name} == "get-data-migration-report" ]]
 then
     # There are multiple files saved in export dir which start with docker-metadata-*. Read each file and map the paths to the container.
-	for file in $(ls $export_dir/metainfo/docker-metadata-*)
+	for file in "$export_dir"/metainfo/docker-metadata-*
 	do
+		[ -e "$file" ] || continue
 		while read line
 		do
 			flag_name=$(echo $line | awk '{print $1}')
 			dir_path=$(echo $line | awk '{print $2}')
 			map_host_path_inside_container $flag_name $dir_path
-		done < $file
+		done < "$file"
 	done
 fi
 

--- a/yb-voyager/src/metadb/migrationStatus.go
+++ b/yb-voyager/src/metadb/migrationStatus.go
@@ -17,6 +17,7 @@ package metadb
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -119,7 +120,6 @@ type MigrationStatusRecord struct {
 	//Iteration specific details
 	ExportDataFromSourceStarted bool `json:"ExportDataFromSourceStarted"`
 	ImportDataToTargetStarted   bool `json:"ImportDataToTargetStarted"`
-
 }
 
 type CutoverTimingRecord struct {
@@ -146,7 +146,10 @@ type CutoverTimingRecord struct {
 	ExportFromTargetFallBackStartedAt    time.Time `json:"ExportFromTargetFallBackStartedAt,omitempty"`
 }
 
-const MIGRATION_STATUS_KEY = "migration_status"
+const (
+	MIGRATION_STATUS_KEY    = "migration_status"
+	migrationUUIDEnvVarName = "YB_VOYAGER_MIGRATION_UUID"
+)
 
 func (m *MetaDB) UpdateMigrationStatusRecord(updateFn func(*MigrationStatusRecord)) error {
 	return UpdateJsonObjectInMetaDB(m, MIGRATION_STATUS_KEY, updateFn)
@@ -165,6 +168,19 @@ func (m *MetaDB) GetMigrationStatusRecord() (*MigrationStatusRecord, error) {
 }
 
 func (m *MetaDB) InitMigrationStatusRecord(cfgFile string) error {
+	record, err := m.GetMigrationStatusRecord()
+	if err != nil {
+		return err
+	}
+	if record != nil && record.MigrationUUID != "" {
+		return nil // already initialized
+	}
+
+	migrationUUID, err := externalOrNewMigrationUUID()
+	if err != nil {
+		return err
+	}
+
 	return m.UpdateMigrationStatusRecord(func(record *MigrationStatusRecord) {
 		if record != nil && record.MigrationUUID != "" {
 			return // already initialized
@@ -177,8 +193,25 @@ func (m *MetaDB) InitMigrationStatusRecord(cfgFile string) error {
 			record.ConfigFile = cfgFile
 		}
 
-		record.MigrationUUID = uuid.New().String()
+		record.MigrationUUID = migrationUUID
 	})
+}
+
+// externalOrNewMigrationUUID returns the migration UUID to use for a new migration.
+// If YB_VOYAGER_MIGRATION_UUID is unset, a fresh UUID is generated. If it is set but
+// not a valid UUID, an error is returned instead of silently falling back, so that an
+// external caller relying on this UUID for correlation is notified of the bad value.
+func externalOrNewMigrationUUID() (string, error) {
+	envVal := os.Getenv(migrationUUIDEnvVarName)
+	if envVal == "" {
+		return uuid.New().String(), nil
+	}
+
+	migrationUUID, err := uuid.Parse(envVal)
+	if err != nil {
+		return "", fmt.Errorf("invalid %s=%q: %w", migrationUUIDEnvVarName, envVal, err)
+	}
+	return migrationUUID.String(), nil
 }
 
 func (msr *MigrationStatusRecord) IsSnapshotExportedViaDebezium() bool {

--- a/yb-voyager/src/metadb/migrationStatus_test.go
+++ b/yb-voyager/src/metadb/migrationStatus_test.go
@@ -1,0 +1,85 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package metadb
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitMigrationStatusRecordMigrationUUID(t *testing.T) {
+	t.Run("uses valid UUID from environment", func(t *testing.T) {
+		externalUUID := uuid.New().String()
+		t.Setenv(migrationUUIDEnvVarName, externalUUID)
+		mdb := newTestMetaDB(t)
+
+		require.NoError(t, mdb.InitMigrationStatusRecord("config.yaml"))
+		record, err := mdb.GetMigrationStatusRecord()
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, externalUUID, record.MigrationUUID)
+	})
+
+	t.Run("generates UUID when environment is absent", func(t *testing.T) {
+		t.Setenv(migrationUUIDEnvVarName, "")
+		mdb := newTestMetaDB(t)
+
+		require.NoError(t, mdb.InitMigrationStatusRecord("config.yaml"))
+		record, err := mdb.GetMigrationStatusRecord()
+		require.NoError(t, err)
+		require.NotNil(t, record)
+
+		generatedUUID, err := uuid.Parse(record.MigrationUUID)
+		require.NoError(t, err)
+		assert.NotEqual(t, uuid.Nil, generatedUUID)
+	})
+
+	t.Run("errors when environment is set but invalid", func(t *testing.T) {
+		t.Setenv(migrationUUIDEnvVarName, "not-a-uuid")
+		mdb := newTestMetaDB(t)
+
+		err := mdb.InitMigrationStatusRecord("config.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), migrationUUIDEnvVarName)
+
+		// nothing should have been persisted for a rejected value
+		record, err := mdb.GetMigrationStatusRecord()
+		require.NoError(t, err)
+		assert.Nil(t, record)
+	})
+
+	t.Run("preserves persisted UUID", func(t *testing.T) {
+		persistedUUID := uuid.New().String()
+		t.Setenv(migrationUUIDEnvVarName, uuid.New().String())
+		mdb := newTestMetaDB(t)
+		require.NoError(t, mdb.UpdateMigrationStatusRecord(func(record *MigrationStatusRecord) {
+			record.MigrationUUID = persistedUUID
+			record.ConfigFile = "persisted-config.yaml"
+		}))
+
+		require.NoError(t, mdb.InitMigrationStatusRecord("new-config.yaml"))
+		record, err := mdb.GetMigrationStatusRecord()
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, persistedUUID, record.MigrationUUID)
+		assert.Equal(t, "persisted-config.yaml", record.ConfigFile)
+	})
+}


### PR DESCRIPTION
### Describe the changes in this pull request
- Let external orchestration supply a valid `YB_VOYAGER_MIGRATION_UUID` for a new migration. Invalid or absent values still generate a UUID.
- Forward that variable through the Docker wrapper and safely handle export directories with no Docker metadata files.
- Clean up assessment-test containers per test to avoid cross-test leakage.

### Describe if there are any user-facing changes
New optional environment variable: `YB_VOYAGER_MIGRATION_UUID`.

### How was this pull request tested?
Added `TestInitMigrationStatusRecordMigrationUUID`.
`go test -tags unit ./src/metadb`

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?
No.

---

### Reference
#### On-disk structures potentially causing breaking changes:
| Component |
| :----------------------------------------------: |
| MetaDB |
| Name registry json |
| Data File Descriptor Json |
| Export Snapshot Status Json |
| Callhome Json |
| Export Status Json |
| YugabyteD Tables |
| TargetDB Metadata Tables |
| Schema Dump |
| AssessmentDB |
| Migration Assessment Report Json |
| Import Data State |
| Export and import data queue |
| Data .sql files of tables |
