### PR TITLE
refactor(import-data): move snapshot import components to src/importdata (PR B of 3)

### DIFF
--- a/yb-voyager/cmd/cdc_ingest_bench_test.go
+++ b/yb-voyager/cmd/cdc_ingest_bench_test.go
@@ -37,6 +37,7 @@ import (
 	"testing"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -47,7 +48,7 @@ import (
 func BenchmarkCDCIngest(b *testing.B) {
 	// state shared between Bootstrap and StreamAll within one run
 	var run struct {
-		state                *ImportDataState
+		state                *importdata.ImportDataState
 		tableList            []sqlname.NameTuple
 		tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]
 		tableToPKColumns     *utils.StructMap[sqlname.NameTuple, []string]
@@ -87,8 +88,8 @@ func BenchmarkCDCIngest(b *testing.B) {
 			if err != nil {
 				return fmt.Errorf("get import table list: %w", err)
 			}
-			run.state = NewImportDataState(exportDir)
 			tdb = mock
+			run.state = newImportDataStateFromGlobals()
 
 			// make sure the mock has the same table list as the real target DB
 			run.tableToUniqueIndexes, err = tdb.GetTableToUniqueIndexesMap(run.tableList)

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -372,7 +372,7 @@ func renameDatafileDescriptor(exportDir string) {
 	datafileDescriptor.Save()
 }
 
-func displayImportedRowCountSnapshot(state *ImportDataState, tasks []*ImportFileTask, errorHandler importdata.ImportDataErrorHandler) {
+func displayImportedRowCountSnapshot(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask, errorHandler importdata.ImportDataErrorHandler) {
 	if importerRole == IMPORT_FILE_ROLE {
 		fmt.Printf("import report\n")
 	} else {
@@ -1129,7 +1129,7 @@ func getImportedSnapshotRowsMap(dbType string, tableList []sqlname.NameTuple, er
 	case "source-replica":
 		importerRole = SOURCE_REPLICA_DB_IMPORTER_ROLE
 	}
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	var snapshotDataFileDescriptor *datafile.Descriptor
 
 	if dataFileDescriptor != nil {
@@ -1211,7 +1211,7 @@ func getImportedSnapshotRowsMap(dbType string, tableList []sqlname.NameTuple, er
 
 func getImportedSizeMap() (*utils.StructMap[sqlname.NameTuple, int64], error) { //used for import data file case right now
 	importerRole = IMPORT_FILE_ROLE
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	dataFileDescriptor, err := prepareDummyDescriptor(state)
 	if err != nil {
 		return nil, fmt.Errorf("prepare dummy descriptor: %w", err)

--- a/yb-voyager/cmd/failpoints.go
+++ b/yb-voyager/cmd/failpoints.go
@@ -71,20 +71,6 @@ func injectImportCDCNonRetryableBatchDBError() error {
 // during snapshot batch production. Tests can use a hit-counter expression
 // (e.g. 20*off->return(true)) to crash after N rows are processed.
 // Black-box tests can set YB_VOYAGER_FAILPOINT_MARKER_DIR to write a marker file.
-func injectImportSnapshotTransformError() error {
-	var fpErr error
-	failpoint.Inject("importSnapshotTransformError", func(val failpoint.Value) {
-		if val != nil {
-			if markerDir := os.Getenv("YB_VOYAGER_FAILPOINT_MARKER_DIR"); markerDir != "" {
-				_ = os.MkdirAll(markerDir, 0755)
-				_ = os.WriteFile(filepath.Join(markerDir, "failpoint-import-snapshot-transform-error.log"), []byte("hit\n"), 0644)
-			}
-			fpErr = goerrors.Errorf("failpoint: snapshot row transform failed")
-		}
-	})
-	return fpErr
-}
-
 func writeFailpointMarker(filename string) {
 	_ = os.MkdirAll(filepath.Join(exportDir, "failpoints"), 0755)
 	_ = os.WriteFile(filepath.Join(exportDir, "failpoints", filename), []byte("hit\n"), 0644)

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -673,7 +673,7 @@ func getImportedEventsMap(dbType string, tableNameTups []sqlname.NameTuple, targ
 		return nil, fmt.Errorf("failed to initialize the target DB: %w", err)
 	}
 	defer tdb.Finalize()
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	tableNameTupToEventsCounter, err := state.GetImportedEventsStatsForTableList(tableNameTups, migrationUUID)
 	if err != nil {
 		return nil, fmt.Errorf("imported events stats for tableList: %w", err)

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -77,7 +77,7 @@ var targetDBDetails *callhome.TargetDBDetails
 var skipReplicationChecks utils.BoolStr
 var skipNodeHealthChecks utils.BoolStr
 var skipDiskUsageHealthChecks utils.BoolStr
-var progressReporter *ImportDataProgressReporter
+var progressReporter *importdata.ImportDataProgressReporter
 var callhomeMetricsCollector *callhome.ImportDataMetricsCollector
 
 // ShutdownImportProgressBars stops the mpb progress container so that its
@@ -255,7 +255,7 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 		utils.ErrExit("initialize name registry: %w", err)
 	}
 
-	var importFileTasks []*ImportFileTask
+	var importFileTasks []*importdata.ImportFileTask
 	if importSnapshotRequired() {
 
 		dataStore = datastore.NewDataStore(filepath.Join(exportDir, "data"))
@@ -750,18 +750,6 @@ func generateExportDataFromTargetCommand(msr *metadb.MigrationStatusRecord) []st
 	return cmd
 }
 
-type ImportFileTask struct {
-	ID           int
-	FilePath     string
-	TableNameTup sqlname.NameTuple
-	RowCount     int64
-	FileSize     int64
-}
-
-func (task *ImportFileTask) String() string {
-	return fmt.Sprintf("{ID: %d, FilePath: %s, TableName: %s, RowCount: %d, FileSize: %d}", task.ID, task.FilePath, task.TableNameTup.ForOutput(), task.RowCount, task.FileSize)
-}
-
 // func quoteTableNameIfRequired() {
 // 	if tconf.TargetDBType != ORACLE {
 // 		return
@@ -782,8 +770,8 @@ func (task *ImportFileTask) String() string {
 // 	}
 // }
 
-func discoverFilesToImport() []*ImportFileTask {
-	result := []*ImportFileTask{}
+func discoverFilesToImport() []*importdata.ImportFileTask {
+	result := []*importdata.ImportFileTask{}
 	if dataFileDescriptor.DataFileList == nil {
 		utils.ErrExit("It looks like the data is exported using older version of Voyager. Please use matching version to import the data.")
 	}
@@ -801,7 +789,7 @@ func discoverFilesToImport() []*ImportFileTask {
 		if err != nil {
 			utils.ErrExit("lookup table name from name registry: %w", err)
 		}
-		task := &ImportFileTask{
+		task := &importdata.ImportFileTask{
 			ID:           i,
 			FilePath:     fileEntry.FilePath,
 			TableNameTup: tableName,
@@ -813,8 +801,8 @@ func discoverFilesToImport() []*ImportFileTask {
 	return result
 }
 
-func applyTableListFilter(importFileTasks []*ImportFileTask) []*ImportFileTask {
-	result := []*ImportFileTask{}
+func applyTableListFilter(importFileTasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
+	result := []*importdata.ImportFileTask{}
 
 	msr, err := metaDB.GetMigrationStatusRecord()
 	if err != nil {
@@ -823,7 +811,7 @@ func applyTableListFilter(importFileTasks []*ImportFileTask) []*ImportFileTask {
 	source = *msr.SourceDBConf
 	_, noDefaultSchema := getDefaultSourceSchemaName()
 
-	allTables := lo.Uniq(lo.Map(importFileTasks, func(task *ImportFileTask, _ int) sqlname.NameTuple {
+	allTables := lo.Uniq(lo.Map(importFileTasks, func(task *importdata.ImportFileTask, _ int) sqlname.NameTuple {
 		return task.TableNameTup
 	}))
 	slices.SortFunc(allTables, func(a, b sqlname.NameTuple) int {
@@ -1036,7 +1024,7 @@ func prepareTargetDBForImport() error {
 	return nil
 }
 
-func handleStartCleanForSnapshot(state *ImportDataState, importFileTasks []*ImportFileTask, errorHandler importdata.ImportDataErrorHandler) error {
+func handleStartCleanForSnapshot(state *importdata.ImportDataState, importFileTasks []*importdata.ImportFileTask, errorHandler importdata.ImportDataErrorHandler) error {
 	cleanImportState(state, importFileTasks)
 	err := cleanStoredErrors(errorHandler, importFileTasks)
 	if err != nil {
@@ -1045,7 +1033,7 @@ func handleStartCleanForSnapshot(state *ImportDataState, importFileTasks []*Impo
 	return nil
 }
 
-func initialiseImportTableList(importFileTasks []*ImportFileTask, msr *metadb.MigrationStatusRecord) ([]*ImportFileTask, []sqlname.NameTuple, error) {
+func initialiseImportTableList(importFileTasks []*importdata.ImportFileTask, msr *metadb.MigrationStatusRecord) ([]*importdata.ImportFileTask, []sqlname.NameTuple, error) {
 	var err error
 	if changeStreamingIsEnabled(importType) {
 		if tconf.TableList != "" || tconf.ExcludeTableList != "" {
@@ -1108,9 +1096,9 @@ func handleIdentityColumns(importTableList []sqlname.NameTuple) error {
 }
 
 func importSnapshotData(msr *metadb.MigrationStatusRecord, errorHandler importdata.ImportDataErrorHandler,
-	state *ImportDataState, importFileTasks []*ImportFileTask, importTableList []sqlname.NameTuple) error {
+	state *importdata.ImportDataState, importFileTasks []*importdata.ImportFileTask, importTableList []sqlname.NameTuple) error {
 	var err error
-	var pendingTasks, completedTasks []*ImportFileTask
+	var pendingTasks, completedTasks []*importdata.ImportFileTask
 
 	if startClean {
 		pendingTasks = importFileTasks
@@ -1175,12 +1163,12 @@ func importSnapshotData(msr *metadb.MigrationStatusRecord, errorHandler importda
 			batchImportPool = pool.New().WithMaxGoroutines(poolSize)
 			log.Infof("created batch import pool of size: %d", poolSize)
 
-			batchProducer, err := NewSequentialFileBatchProducer(task, state, msr.IsSnapshotExportedViaDebezium(), errorHandler, progressReporter)
+			batchProducer, err := importdata.NewSequentialFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, msr.IsSnapshotExportedViaDebezium(), errorHandler, progressReporter)
 			if err != nil {
 				utils.ErrExit("Failed to create batch producer: %w", err)
 			}
 
-			taskImporter, err := NewFileTaskImporter(task, state, batchProducer, batchImportPool, progressReporter, nil, false, errorHandler, callhomeMetricsCollector)
+			taskImporter, err := importdata.NewFileTaskImporter(fileTaskImporterConfigFromGlobals(), task, state, batchProducer, batchImportPool, progressReporter, nil, false, errorHandler, callhomeMetricsCollector)
 			if err != nil {
 				utils.ErrExit("Failed to create file task importer: %w", err)
 			}
@@ -1201,7 +1189,7 @@ func importSnapshotData(msr *metadb.MigrationStatusRecord, errorHandler importda
 	return nil
 }
 
-func importData(importFileTasks []*ImportFileTask, errorPolicy importdata.ErrorPolicy) {
+func importData(importFileTasks []*importdata.ImportFileTask, errorPolicy importdata.ErrorPolicy) {
 	errorHandler, err := initialiseErrorHandler(errorPolicy)
 	if err != nil {
 		utils.ErrExit("Failed to initialize error policy and error handler: %w", err)
@@ -1220,14 +1208,14 @@ func importData(importFileTasks []*ImportFileTask, errorPolicy importdata.ErrorP
 		utils.ErrExit("Failed to get migration status record: %w", err)
 	}
 	//create progress reporter
-	progressReporter = NewImportDataProgressReporter(bool(disablePb))
+	progressReporter = importdata.NewImportDataProgressReporter(bool(disablePb))
 
 	err = prepareTargetDBForImport()
 	if err != nil {
 		utils.ErrExit("Failed to prepare target DB for import: %w", err)
 	}
 
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 
 	err = clearMigrationStateForImportDataStartClean(state, importFileTasks, errorHandler)
 	if err != nil {
@@ -1465,7 +1453,7 @@ func getPrimaryKeyColumnsForImportTables(tableNames []sqlname.NameTuple) (*utils
 }
 
 // For a fresh start but non empty tables in tableList && OnPrimaryKeyConflict is set to IGNORE -> notify user
-func runPKConflictModeGuardrails(state *ImportDataState, allTasks []*ImportFileTask) error {
+func runPKConflictModeGuardrails(state *importdata.ImportDataState, allTasks []*importdata.ImportFileTask) error {
 	// in case of ERROR mode, no need to check for non-empty tables
 	// but for IGNORE or UPDATE(in future), we need to prompt user
 	if tconf.OnPrimaryKeyConflictAction == constants.PRIMARY_KEY_CONFLICT_ACTION_ERROR_POLICY {
@@ -1522,7 +1510,7 @@ func runPKConflictModeGuardrails(state *ImportDataState, allTasks []*ImportFileT
 }
 
 // A fresh start is when all tasks are pending(non-zero), no started or completed tasks.
-func isFreshStart(state *ImportDataState, allTasks []*ImportFileTask) bool {
+func isFreshStart(state *importdata.ImportDataState, allTasks []*importdata.ImportFileTask) bool {
 	inProgressTasks := getInProgressTasks(state, allTasks)
 	notStartedTasks := getNotStartedTasks(state, allTasks)
 	completedTasks := getCompletedTasks(state, allTasks)
@@ -1566,7 +1554,7 @@ func getMaxParallelConnections() (int, error) {
 	return maxParallelConns, nil
 }
 
-func waitIfNoBatchAvailableForAllTasks(taskPicker FileTaskPicker, taskImporters map[int]*FileTaskImporter) {
+func waitIfNoBatchAvailableForAllTasks(taskPicker importdata.FileTaskPicker, taskImporters map[int]*importdata.FileTaskImporter) {
 	inProgressTasks := taskPicker.InProgressTasks()
 	if len(inProgressTasks) == 0 {
 		return
@@ -1594,7 +1582,7 @@ func waitIfNoBatchAvailableForAllTasks(taskPicker FileTaskPicker, taskImporters 
 	}
 }
 
-func waitIfAllBatchesSubmittedForAllTasks(taskPicker FileTaskPicker, taskImporters map[int]*FileTaskImporter) {
+func waitIfAllBatchesSubmittedForAllTasks(taskPicker importdata.FileTaskPicker, taskImporters map[int]*importdata.FileTaskImporter) {
 	inProgressTasks := taskPicker.InProgressTasks()
 	if len(inProgressTasks) == 0 {
 		return
@@ -1630,15 +1618,15 @@ func waitIfAllBatchesSubmittedForAllTasks(taskPicker FileTaskPicker, taskImporte
   - For the task that is picked, produce the next batch and submit it to the worker pool. Worker will asynchronously import the batch.
   - If task is done, mark it as done in the task picker.
 */
-func importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataState, progressReporter *ImportDataProgressReporter,
+func importTasksViaTaskPicker(pendingTasks []*importdata.ImportFileTask, state *importdata.ImportDataState, progressReporter *importdata.ImportDataProgressReporter,
 	maxParallelConns int, maxShardedTasksInProgress int, maxColocatedBatchesInProgress int,
 	isRowTransformationRequired bool, maxConcurrentBatchProductions int, enableRandomBatchProduction bool,
 	errorHandler importdata.ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) error {
 
 	var err error
 	setupWorkerPoolAndQueue(maxParallelConns, maxColocatedBatchesInProgress)
-	taskImporters := map[int]*FileTaskImporter{}
-	tableTypes, err := getTableTypes(pendingTasks)
+	taskImporters := map[int]*importdata.FileTaskImporter{}
+	tableTypes, err := importdata.GetTableTypes(importerRole, tconf.TargetDBType, tdb, pendingTasks)
 	if err != nil {
 		return fmt.Errorf("get table types: %w", err)
 	}
@@ -1646,7 +1634,7 @@ func importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataS
 	// Initialize semaphore to limit concurrent batch productions
 	concurrentBatchProductionSem := semaphore.NewWeighted(int64(maxConcurrentBatchProductions))
 
-	var taskPicker FileTaskPicker
+	var taskPicker importdata.FileTaskPicker
 	// The colocation-aware task picker only applies to a real YugabyteDB
 	// target. yb-amp (PostgreSQL-compatible, no colocation/tablets) and the
 	// PG fall-forward/back roles use the sequential picker instead.
@@ -1655,12 +1643,12 @@ func importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataS
 		if !ok {
 			return goerrors.Errorf("expected tdb to be of type TargetYugabyteDB, got: %T", tdb)
 		}
-		taskPicker, err = NewColocatedCappedRandomTaskPicker(maxShardedTasksInProgress, maxColocatedBatchesInProgress, pendingTasks, state, yb, colocatedBatchImportQueue, tableTypes)
+		taskPicker, err = importdata.NewColocatedCappedRandomTaskPicker(maxShardedTasksInProgress, maxColocatedBatchesInProgress, pendingTasks, state, yb, colocatedBatchImportQueue, tableTypes)
 		if err != nil {
 			return fmt.Errorf("create colocated aware randmo task picker: %w", err)
 		}
 	} else {
-		taskPicker, err = NewSequentialTaskPicker(pendingTasks, state)
+		taskPicker, err = importdata.NewSequentialTaskPicker(pendingTasks, state)
 		if err != nil {
 			return fmt.Errorf("create sequential task picker: %w", err)
 		}
@@ -1672,7 +1660,7 @@ func importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataS
 			return fmt.Errorf("get next task: %w", err)
 		}
 		log.Debugf("Picked task for import: %s", task)
-		var taskImporter *FileTaskImporter
+		var taskImporter *importdata.FileTaskImporter
 		var ok bool
 		taskImporter, ok = taskImporters[task.ID]
 		if !ok {
@@ -1749,43 +1737,52 @@ func setupWorkerPoolAndQueue(maxParallelConns int, maxColocatedBatchesInProgress
 }
 
 // getTableTypes returns a map of table name to table type (sharded/colocated) for all tables in the tasks.
-func getTableTypes(tasks []*ImportFileTask) (*utils.StructMap[sqlname.NameTuple, string], error) {
-	if !slices.Contains([]string{TARGET_DB_IMPORTER_ROLE, IMPORT_FILE_ROLE}, importerRole) {
-		return nil, nil
+// The *FromGlobals helpers copy the cmd package-level variables the importdata
+// components used to read directly into their config structs. They are a bridge
+// until the import engine itself moves out of cmd (PR C), after which
+// importdata.Config supplies these values.
+func importDataStateConfigFromGlobals() importdata.ImportDataStateConfig {
+	return importdata.ImportDataStateConfig{
+		ExportDir:          exportDir,
+		ImporterRole:       importerRole,
+		Tdb:                tdb,
+		Tconf:              tconf,
+		MigrationUUID:      migrationUUID,
+		TruncateSplits:     truncateSplits,
+		DataFileDescriptor: dataFileDescriptor,
 	}
-	// Colocation is a YugabyteDB-only concept; table types are only meaningful
-	// for a real YugabyteDB target. Non-YB targets (yb-amp, etc.) use plain heap
-	// storage and the sequential task picker, which does not consult table types.
-	if tconf.TargetDBType != YUGABYTEDB {
-		return nil, nil
-	}
+}
 
-	tableTypes := utils.NewStructMap[sqlname.NameTuple, string]()
-	yb, ok := tdb.(YbTargetDBColocatedChecker)
-	if !ok {
-		return nil, goerrors.Errorf("expected tdb to be of type TargetYugabyteDB, got: %T", tdb)
-	}
-	isDBColocated, err := yb.IsDBColocated()
-	if err != nil {
-		return nil, fmt.Errorf("checking if db is colocated: %w", err)
-	}
-	for _, task := range tasks {
-		if _, ok := tableTypes.Get(task.TableNameTup); !ok {
-			var tableType string
-			if !isDBColocated {
-				tableType = SHARDED
-			} else {
-				isColocated, err := yb.IsTableColocated(task.TableNameTup)
-				if err != nil {
-					return nil, fmt.Errorf("checking if table is colocated: table: %v: %w", task.TableNameTup.ForOutput(), err)
-				}
-				tableType = lo.Ternary(isColocated, COLOCATED, SHARDED)
-			}
-			tableTypes.Put(task.TableNameTup, tableType)
-		}
-	}
-	return tableTypes, nil
+func newImportDataStateFromGlobals() *importdata.ImportDataState {
+	return importdata.NewImportDataState(importDataStateConfigFromGlobals())
+}
 
+func sequentialFileBatchProducerConfigFromGlobals() importdata.SequentialFileBatchProducerConfig {
+	return importdata.SequentialFileBatchProducerConfig{
+		ImporterRole:       importerRole,
+		Tdb:                tdb,
+		Tconf:              tconf,
+		DataFileDescriptor: dataFileDescriptor,
+		DataStore:          dataStore,
+		BatchSizeInNumRows: batchSizeInNumRows,
+		ValueConverter:     valueConverter,
+		TableToColumnNames: TableToColumnNames,
+	}
+}
+
+func fileTaskImporterConfigFromGlobals() importdata.FileTaskImporterConfig {
+	return importdata.FileTaskImporterConfig{
+		ImporterRole:          importerRole,
+		Tdb:                   tdb,
+		Tconf:                 tconf,
+		ExportDir:             exportDir,
+		MigrationUUID:         migrationUUID,
+		DataFileDescriptor:    dataFileDescriptor,
+		ReportProgressInBytes: reportProgressInBytes,
+		ControlPlane:          controlPlane,
+		TableToColumnNames:    TableToColumnNames,
+		TableNameToSchema:     TableNameToSchema,
+	}
 }
 
 /*
@@ -1796,11 +1793,11 @@ and colocated table batches to the colocatedBatchImportQueue.
 
 Otherwise, we simply pass the batchImportPool to the FileTaskImporter.
 */
-func createFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchImportPool *pool.Pool, progressReporter *ImportDataProgressReporter, colocatedBatchImportQueue chan func(),
-	tableTypes *utils.StructMap[sqlname.NameTuple, string], isRowTransformationRequired bool, enableRandomBatchProduction bool, concurrentBatchProductionSem *semaphore.Weighted, errorHandler importdata.ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (*FileTaskImporter, error) {
-	var taskImporter *FileTaskImporter
+func createFileTaskImporter(task *importdata.ImportFileTask, state *importdata.ImportDataState, batchImportPool *pool.Pool, progressReporter *importdata.ImportDataProgressReporter, colocatedBatchImportQueue chan func(),
+	tableTypes *utils.StructMap[sqlname.NameTuple, string], isRowTransformationRequired bool, enableRandomBatchProduction bool, concurrentBatchProductionSem *semaphore.Weighted, errorHandler importdata.ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (*importdata.FileTaskImporter, error) {
+	var taskImporter *importdata.FileTaskImporter
 	var err error
-	var batchProducer FileBatchProducer
+	var batchProducer importdata.FileBatchProducer
 
 	// tableTypes (the colocation map) is only populated for a real YugabyteDB
 	// target. For yb-amp (PostgreSQL-compatible, no colocation) and the PG
@@ -1816,28 +1813,28 @@ func createFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchI
 		}
 
 		if enableRandomBatchProduction {
-			batchProducer, err = NewRandomFileBatchProducer(task, state, isRowTransformationRequired, errorHandler, progressReporter, concurrentBatchProductionSem)
+			batchProducer, err = importdata.NewRandomFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, isRowTransformationRequired, errorHandler, progressReporter, concurrentBatchProductionSem)
 			if err != nil {
 				return nil, fmt.Errorf("creating random batch producer: %w", err)
 			}
 		} else {
-			batchProducer, err = NewSequentialFileBatchProducer(task, state, isRowTransformationRequired, errorHandler, progressReporter)
+			batchProducer, err = importdata.NewSequentialFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, isRowTransformationRequired, errorHandler, progressReporter)
 			if err != nil {
 				return nil, fmt.Errorf("creating sequential batch producer: %w", err)
 			}
 		}
-		taskImporter, err = NewFileTaskImporter(task, state, batchProducer, batchImportPool, progressReporter, colocatedBatchImportQueue, tableType == COLOCATED, errorHandler, callhomeMetricsCollector)
+		taskImporter, err = importdata.NewFileTaskImporter(fileTaskImporterConfigFromGlobals(), task, state, batchProducer, batchImportPool, progressReporter, colocatedBatchImportQueue, tableType == importdata.COLOCATED, errorHandler, callhomeMetricsCollector)
 
 		if err != nil {
 			return nil, fmt.Errorf("create file task importer: %w", err)
 		}
 	} else {
-		batchProducer, err = NewSequentialFileBatchProducer(task, state, isRowTransformationRequired, errorHandler, progressReporter)
+		batchProducer, err = importdata.NewSequentialFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, isRowTransformationRequired, errorHandler, progressReporter)
 		if err != nil {
 			return nil, fmt.Errorf("creating sequential batch producer: %w", err)
 		}
 
-		taskImporter, err = NewFileTaskImporter(task, state, batchProducer, batchImportPool, progressReporter, nil, false, errorHandler, callhomeMetricsCollector)
+		taskImporter, err = importdata.NewFileTaskImporter(fileTaskImporterConfigFromGlobals(), task, state, batchProducer, batchImportPool, progressReporter, nil, false, errorHandler, callhomeMetricsCollector)
 		if err != nil {
 			return nil, fmt.Errorf("create file task importer: %w", err)
 		}
@@ -2132,7 +2129,7 @@ func restoreGeneratedByDefaultAsIdentityColumns(tables []sqlname.NameTuple) erro
 	return nil
 }
 
-func importFileTasksToTableNames(tasks []*ImportFileTask) []string {
+func importFileTasksToTableNames(tasks []*importdata.ImportFileTask) []string {
 	tableNames := []string{}
 	for _, t := range tasks {
 		tableNames = append(tableNames, t.TableNameTup.ForKey())
@@ -2140,7 +2137,7 @@ func importFileTasksToTableNames(tasks []*ImportFileTask) []string {
 	return lo.Uniq(tableNames)
 }
 
-func importFileTasksToTableNameTuples(tasks []*ImportFileTask) []sqlname.NameTuple {
+func importFileTasksToTableNameTuples(tasks []*importdata.ImportFileTask) []sqlname.NameTuple {
 	tableNames := []sqlname.NameTuple{}
 	for _, t := range tasks {
 		tableNames = append(tableNames, t.TableNameTup)
@@ -2150,20 +2147,20 @@ func importFileTasksToTableNameTuples(tasks []*ImportFileTask) []sqlname.NameTup
 	})
 }
 
-func classifyTasksForImport(state *ImportDataState, tasks []*ImportFileTask) (pendingTasks, completedTasks []*ImportFileTask, err error) {
-	inProgressTasks := []*ImportFileTask{}
-	notStartedTasks := []*ImportFileTask{}
+func classifyTasksForImport(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) (pendingTasks, completedTasks []*importdata.ImportFileTask, err error) {
+	inProgressTasks := []*importdata.ImportFileTask{}
+	notStartedTasks := []*importdata.ImportFileTask{}
 	for _, task := range tasks {
 		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
 		if err != nil {
 			return nil, nil, fmt.Errorf("get table import state: %w", err)
 		}
 		switch fileImportState {
-		case FILE_IMPORT_COMPLETED, FILE_IMPORT_COMPLETED_WITH_ERRORS:
+		case importdata.FILE_IMPORT_COMPLETED, importdata.FILE_IMPORT_COMPLETED_WITH_ERRORS:
 			completedTasks = append(completedTasks, task)
-		case FILE_IMPORT_IN_PROGRESS:
+		case importdata.FILE_IMPORT_IN_PROGRESS:
 			inProgressTasks = append(inProgressTasks, task)
-		case FILE_IMPORT_NOT_STARTED:
+		case importdata.FILE_IMPORT_NOT_STARTED:
 			notStartedTasks = append(notStartedTasks, task)
 		default:
 			return nil, nil, goerrors.Errorf("invalid table import state: %s", fileImportState)
@@ -2173,53 +2170,53 @@ func classifyTasksForImport(state *ImportDataState, tasks []*ImportFileTask) (pe
 	return append(inProgressTasks, notStartedTasks...), completedTasks, nil
 }
 
-func getNotStartedTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
-	notStartedTasks := []*ImportFileTask{}
+func getNotStartedTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
+	notStartedTasks := []*importdata.ImportFileTask{}
 	for _, task := range tasks {
 		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
 		if err != nil {
 			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
 		}
-		if fileImportState == FILE_IMPORT_NOT_STARTED {
+		if fileImportState == importdata.FILE_IMPORT_NOT_STARTED {
 			notStartedTasks = append(notStartedTasks, task)
 		}
 	}
 	return notStartedTasks
 }
 
-func getInProgressTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
-	inProgressTasks := []*ImportFileTask{}
+func getInProgressTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
+	inProgressTasks := []*importdata.ImportFileTask{}
 	for _, task := range tasks {
 		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
 		if err != nil {
 			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
 		}
-		if fileImportState == FILE_IMPORT_IN_PROGRESS {
+		if fileImportState == importdata.FILE_IMPORT_IN_PROGRESS {
 			inProgressTasks = append(inProgressTasks, task)
 		}
 	}
 	return inProgressTasks
 }
 
-func getPendingTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
+func getPendingTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
 	return append(getInProgressTasks(state, tasks), getNotStartedTasks(state, tasks)...)
 }
 
-func getCompletedTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
-	completedTasks := []*ImportFileTask{}
+func getCompletedTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
+	completedTasks := []*importdata.ImportFileTask{}
 	for _, task := range tasks {
 		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
 		if err != nil {
 			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
 		}
-		if fileImportState == FILE_IMPORT_COMPLETED || fileImportState == FILE_IMPORT_COMPLETED_WITH_ERRORS {
+		if fileImportState == importdata.FILE_IMPORT_COMPLETED || fileImportState == importdata.FILE_IMPORT_COMPLETED_WITH_ERRORS {
 			completedTasks = append(completedTasks, task)
 		}
 	}
 	return completedTasks
 }
 
-func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
+func cleanImportState(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) {
 	tableNames := importFileTasksToTableNameTuples(tasks)
 	nonEmptyNts := tdb.GetNonEmptyTables(tableNames)
 	if len(nonEmptyNts) > 0 {
@@ -2262,7 +2259,7 @@ func cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
 	}
 }
 
-func prepareTableToColumns(tasks []*ImportFileTask) error {
+func prepareTableToColumns(tasks []*importdata.ImportFileTask) error {
 	for _, task := range tasks {
 		var columns []string
 		dfdTableToExportedColumns, err := getDfdTableNameToExportedColumns(tasks, dataFileDescriptor)
@@ -2292,7 +2289,7 @@ func prepareTableToColumns(tasks []*ImportFileTask) error {
 	return nil
 }
 
-func getDfdTableNameToExportedColumns(tasks []*ImportFileTask, dataFileDescriptor *datafile.Descriptor) (*utils.StructMap[sqlname.NameTuple, []string], error) {
+func getDfdTableNameToExportedColumns(tasks []*importdata.ImportFileTask, dataFileDescriptor *datafile.Descriptor) (*utils.StructMap[sqlname.NameTuple, []string], error) {
 	if dataFileDescriptor.TableNameToExportedColumns == nil {
 		return nil, nil
 	}
@@ -2395,7 +2392,7 @@ func createSnapshotImportCompletedEvent() cp.SnapshotImportCompletedEvent {
 // a prior run. The control-plane event list is still built from pendingTasks only
 // (unchanged behaviour: the control plane only expects updates for tables being
 // worked on in this run).
-func createInitialImportDataTableMetrics(allTasks, pendingTasks []*ImportFileTask) []*cp.UpdateImportedRowCountEvent {
+func createInitialImportDataTableMetrics(allTasks, pendingTasks []*importdata.ImportFileTask) []*cp.UpdateImportedRowCountEvent {
 	metrics.Get().SetImportSnapshotTablesTotal(importerRole, len(allTasks))
 	for _, task := range allTasks {
 		metrics.Get().SetImportSnapshotTableExpectedRows(importerRole, task.TableNameTup, task.RowCount)
@@ -2414,7 +2411,7 @@ func createInitialImportDataTableMetrics(allTasks, pendingTasks []*ImportFileTas
 				},
 				TableName:         tableName,
 				Status:            cp.EXPORT_OR_IMPORT_DATA_STATUS_INT_TO_STR[ROW_UPDATE_STATUS_NOT_STARTED],
-				TotalRowCount:     getTotalProgressAmount(task),
+				TotalRowCount:     importdata.GetTotalProgressAmount(task, reportProgressInBytes),
 				CompletedRowCount: 0,
 			},
 		}
@@ -2437,7 +2434,7 @@ func saveOnPrimaryKeyConflictActionInMSR() {
 	}
 }
 
-func clearMigrationStateForImportDataStartClean(state *ImportDataState, importFileTasks []*ImportFileTask, errorHandler importdata.ImportDataErrorHandler) error {
+func clearMigrationStateForImportDataStartClean(state *importdata.ImportDataState, importFileTasks []*importdata.ImportFileTask, errorHandler importdata.ImportDataErrorHandler) error {
 	if !startClean {
 		log.Infof("skipping cleaning migration status record for import data command start clean")
 		return nil
@@ -2507,7 +2504,7 @@ func isPrimaryKeyConflictModeValid() bool {
 	return importerRole == IMPORT_FILE_ROLE || importerRole == TARGET_DB_IMPORTER_ROLE
 }
 
-func cleanStoredErrors(errorHandler importdata.ImportDataErrorHandler, tasks []*ImportFileTask) error {
+func cleanStoredErrors(errorHandler importdata.ImportDataErrorHandler, tasks []*importdata.ImportFileTask) error {
 	// clean stored errors for all tasks
 	for _, task := range tasks {
 		err := errorHandler.CleanUpStoredErrors(task.TableNameTup, task.FilePath)

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -30,6 +30,7 @@ import (
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
@@ -130,7 +131,7 @@ func storeFileTableMapAndDataDirInMSR() {
 	}
 }
 
-func prepareForImportDataCmd(importFileTasks []*ImportFileTask) {
+func prepareForImportDataCmd(importFileTasks []*importdata.ImportFileTask) {
 	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
 		source.DBType = POSTGRESQL
 		record.SourceDBConf = source.Clone()
@@ -163,7 +164,7 @@ func prepareForImportDataCmd(importFileTasks []*ImportFileTask) {
 	setDataIsExported()
 }
 
-func getFileSizeInfo(importFileTasks []*ImportFileTask) []*datafile.FileEntry {
+func getFileSizeInfo(importFileTasks []*importdata.ImportFileTask) []*datafile.FileEntry {
 	dataFileList := make([]*datafile.FileEntry, 0)
 	for _, task := range importFileTasks {
 		filePath := task.FilePath
@@ -181,7 +182,7 @@ func getFileSizeInfo(importFileTasks []*ImportFileTask) []*datafile.FileEntry {
 	return dataFileList
 }
 
-func setImportTableListFlag(importFileTasks []*ImportFileTask) {
+func setImportTableListFlag(importFileTasks []*importdata.ImportFileTask) {
 	tableList := map[string]bool{}
 	for _, task := range importFileTasks {
 		//TODO:TABLENAME
@@ -190,8 +191,8 @@ func setImportTableListFlag(importFileTasks []*ImportFileTask) {
 	tconf.TableList = strings.Join(maps.Keys(tableList), ",")
 }
 
-func getImportFileTasks(currFileTableMapping string) []*ImportFileTask {
-	result := []*ImportFileTask{}
+func getImportFileTasks(currFileTableMapping string) []*importdata.ImportFileTask {
+	result := []*importdata.ImportFileTask{}
 	if currFileTableMapping == "" {
 		return result
 	}
@@ -215,7 +216,7 @@ func getImportFileTasks(currFileTableMapping string) []*ImportFileTask {
 			if err != nil {
 				utils.ErrExit("calculating file size in bytes: %q: %w", filePath, err)
 			}
-			task := &ImportFileTask{
+			task := &importdata.ImportFileTask{
 				ID:           idCounter,
 				FilePath:     filePath,
 				TableNameTup: tableNameTuple,

--- a/yb-voyager/cmd/importDataFile_test.go
+++ b/yb-voyager/cmd/importDataFile_test.go
@@ -92,7 +92,7 @@ func TestImportDataFileReport(t *testing.T) {
 	err = InitNameRegistry(exportDir, IMPORT_FILE_ROLE, nil, nil, &testYugabyteDBTarget.Tconf, yb, false)
 	testutils.FatalIfError(t, err, "Failed to initialize name registry")
 	metaDB = initMetaDB(exportDir)
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	dataFileDescriptor, err = prepareDummyDescriptor(state)
 	defer func() {
 		dataFileDescriptor = nil
@@ -219,7 +219,7 @@ func TestImportDataFileReport_ErrorPolicyStashAndContinue_BatchIngestionError(t 
 	err = InitNameRegistry(exportDir, IMPORT_FILE_ROLE, nil, nil, &testYugabyteDBTarget.Tconf, yb, false)
 	testutils.FatalIfError(t, err, "Failed to initialize name registry")
 	metaDB = initMetaDB(exportDir)
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	dataFileDescriptor, err = prepareDummyDescriptor(state)
 	defer func() {
 		dataFileDescriptor = nil
@@ -373,7 +373,7 @@ func TestImportDataFileReport_ErrorPolicyStashAndContinue_ProcessingError(t *tes
 	err = InitNameRegistry(exportDir, IMPORT_FILE_ROLE, nil, nil, &testYugabyteDBTarget.Tconf, yb, false)
 	testutils.FatalIfError(t, err, "Failed to initialize name registry")
 	metaDB = initMetaDB(exportDir)
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	dataFileDescriptor, err = prepareDummyDescriptor(state)
 	defer func() {
 		dataFileDescriptor = nil
@@ -530,7 +530,7 @@ func TestImportDataFile_MultipleTasksForATable(t *testing.T) {
 	err = InitNameRegistry(exportDir, IMPORT_FILE_ROLE, nil, nil, &testYugabyteDBTarget.Tconf, yb, false)
 	testutils.FatalIfError(t, err, "Failed to initialize name registry")
 	metaDB = initMetaDB(exportDir)
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	dataFileDescriptor, err = prepareDummyDescriptor(state)
 	defer func() {
 		dataFileDescriptor = nil
@@ -662,7 +662,7 @@ func TestImportDataFile_SameFileForMultipleTables(t *testing.T) {
 	err = InitNameRegistry(exportDir, IMPORT_FILE_ROLE, nil, nil, &testYugabyteDBTarget.Tconf, yb, false)
 	testutils.FatalIfError(t, err, "Failed to initialize name registry")
 	metaDB = initMetaDB(exportDir)
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	dataFileDescriptor, err = prepareDummyDescriptor(state)
 	defer func() {
 		dataFileDescriptor = nil

--- a/yb-voyager/cmd/importDataStatusCommand.go
+++ b/yb-voyager/cmd/importDataStatusCommand.go
@@ -152,7 +152,7 @@ func runImportDataStatusCmd() error {
 	return nil
 }
 
-func prepareDummyDescriptor(state *ImportDataState) (*datafile.Descriptor, error) {
+func prepareDummyDescriptor(state *importdata.ImportDataState) (*datafile.Descriptor, error) {
 	var dataFileDescriptor datafile.Descriptor
 	msr, err := metaDB.GetMigrationStatusRecord()
 	if err != nil {
@@ -177,7 +177,7 @@ func prepareImportDataStatusTable() ([]*tableMigStatusOutputRow, error) {
 	var err error
 	var dataFileDescriptor *datafile.Descriptor
 
-	state := NewImportDataState(exportDir)
+	state := newImportDataStateFromGlobals()
 	dataFileDescriptorPath := filepath.Join(exportDir, datafile.DESCRIPTOR_PATH)
 	if utils.FileOrFolderExists(dataFileDescriptorPath) {
 		// Case of `import data` command where row counts are available.
@@ -186,7 +186,7 @@ func prepareImportDataStatusTable() ([]*tableMigStatusOutputRow, error) {
 		// Case of `import data file` command where row counts are not available.
 		// Use file sizes for progress reporting.
 		importerRole = IMPORT_FILE_ROLE
-		state = NewImportDataState(exportDir)
+		state = newImportDataStateFromGlobals()
 		dataFileDescriptor, err = prepareDummyDescriptor(state)
 		if err != nil {
 			return nil, fmt.Errorf("prepare dummy descriptor: %w", err)
@@ -258,7 +258,7 @@ func prepareImportDataStatusTable() ([]*tableMigStatusOutputRow, error) {
 	return table, nil
 }
 
-func prepareRowWithDatafile(dataFile *datafile.FileEntry, state *ImportDataState) (*tableMigStatusOutputRow, error) {
+func prepareRowWithDatafile(dataFile *datafile.FileEntry, state *importdata.ImportDataState) (*tableMigStatusOutputRow, error) {
 	var totalCount, importedCount, erroredCount, processingErrorRowCount, processingErrorByteCount int64
 	var err error
 	var perc float64

--- a/yb-voyager/cmd/importData_metrics_test.go
+++ b/yb-voyager/cmd/importData_metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
@@ -32,7 +33,7 @@ func TestCreateInitialImportDataTableMetrics_SetsTotalRows(t *testing.T) {
 	reportProgressInBytes = false
 
 	tup := newImportMetricsTestTuple("public", "orders")
-	tasks := []*ImportFileTask{
+	tasks := []*importdata.ImportFileTask{
 		{
 			ID:           1,
 			FilePath:     "orders_data.sql",

--- a/yb-voyager/cmd/importData_observability_test.go
+++ b/yb-voyager/cmd/importData_observability_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
@@ -88,12 +89,12 @@ func TestResolveMetricsPort(t *testing.T) {
 	}
 }
 
-func makeTasksForTest(n int) []*ImportFileTask {
-	tasks := make([]*ImportFileTask, n)
+func makeTasksForTest(n int) []*importdata.ImportFileTask {
+	tasks := make([]*importdata.ImportFileTask, n)
 	for i := 0; i < n; i++ {
 		obj := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", fmt.Sprintf("table_%d", i))
 		tup := sqlname.NameTuple{CurrentName: obj, SourceName: obj, TargetName: obj}
-		tasks[i] = &ImportFileTask{
+		tasks[i] = &importdata.ImportFileTask{
 			ID:           i,
 			FilePath:     fmt.Sprintf("/tmp/table_%d.sql", i),
 			TableNameTup: tup,

--- a/yb-voyager/cmd/live_migration.go
+++ b/yb-voyager/cmd/live_migration.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	reporter "github.com/yugabyte/yb-voyager/yb-voyager/src/reporter/stats"
@@ -108,7 +109,7 @@ func cutoverInitiatedAndCutoverEventProcessed() (bool, error) {
 	return false, nil
 }
 
-func streamChanges(state *ImportDataState, tableNames []sqlname.NameTuple, tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string], tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
+func streamChanges(state *importdata.ImportDataState, tableNames []sqlname.NameTuple, tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string], tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
 	if err := waitForDebeziumStartIfRequired(); err != nil {
 		return fmt.Errorf("waiting for debezium to start: %w", err)
 	}
@@ -198,9 +199,9 @@ func streamChangesFromSegment(
 	segment *EventQueueSegment,
 	evChans []chan *tgtdb.Event,
 	processingDoneChans []chan bool,
-	eventChannelsMetaInfo map[int]EventChannelMetaInfo,
+	eventChannelsMetaInfo map[int]importdata.EventChannelMetaInfo,
 	statsReporter *reporter.StreamImportStatsReporter,
-	state *ImportDataState,
+	state *importdata.ImportDataState,
 	streamingPhaseValueConverter dbzm.StreamingPhaseValueConverter,
 	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride],
 	tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string],
@@ -535,7 +536,7 @@ func customPartitionKeyColumnValue(e *tgtdb.Event, col string) (*string, bool, e
 	}
 	return nil, false, nil
 }
-func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, done chan bool, statsReporter *reporter.StreamImportStatsReporter, state *ImportDataState) {
+func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, done chan bool, statsReporter *reporter.StreamImportStatsReporter, state *importdata.ImportDataState) {
 	endOfProcessing := false
 	for !endOfProcessing {
 		batch := []*tgtdb.Event{}
@@ -594,8 +595,8 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 			}
 			log.Warnf("retriable error executing batch(%s) on channel %v (last VSN: %d): %v", eventBatch.ID(), chanNo, eventBatch.GetLastVsn(), err)
 			sleepIntervalSec += 10
-			if sleepIntervalSec > MAX_SLEEP_SECOND {
-				sleepIntervalSec = MAX_SLEEP_SECOND
+			if sleepIntervalSec > importdata.MAX_SLEEP_SECOND {
+				sleepIntervalSec = importdata.MAX_SLEEP_SECOND
 			}
 			log.Infof("sleep for %d seconds before retrying the batch on channel %v (attempt %d)",
 				sleepIntervalSec, chanNo, attempt)
@@ -737,7 +738,7 @@ func uniqueIndexWithSameColumnsExists(indexes []tgtdb.UniqueIndex, columns []str
 	return false
 }
 
-func checkifEventBatchAlreadyImported(state *ImportDataState, eventBatch *tgtdb.EventBatch, migrationUUID uuid.UUID) (bool, error) {
+func checkifEventBatchAlreadyImported(state *importdata.ImportDataState, eventBatch *tgtdb.EventBatch, migrationUUID uuid.UUID) (bool, error) {
 	var res bool
 	var err error
 	sleepIntervalSec := 0
@@ -749,8 +750,8 @@ func checkifEventBatchAlreadyImported(state *ImportDataState, eventBatch *tgtdb.
 			break
 		}
 		sleepIntervalSec += 10
-		if sleepIntervalSec > MAX_SLEEP_SECOND {
-			sleepIntervalSec = MAX_SLEEP_SECOND
+		if sleepIntervalSec > importdata.MAX_SLEEP_SECOND {
+			sleepIntervalSec = importdata.MAX_SLEEP_SECOND
 		}
 		log.Infof("sleep for %d seconds before retrying to check if event batch (last vsn: %d) already imported (attempt %d)",
 			sleepIntervalSec, eventBatch.GetLastVsn(), attempt)

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -64,8 +64,8 @@ func TestProcessEventsBasic(t *testing.T) {
 	lastAppliedVsn := int64(0)
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
-	state := NewImportDataState(exportDir)
 	tdb = &mockYugabyteDB{}
+	state := newImportDataStateFromGlobals()
 	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]())
 
 	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
@@ -91,8 +91,8 @@ func TestProcessEventsRemovesEventFromConflicDetectionCache(t *testing.T) {
 	lastAppliedVsn := int64(0)
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
-	state := NewImportDataState(exportDir)
 	tdb = &mockYugabyteDB{}
+	state := newImportDataStateFromGlobals()
 	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]())
 
 	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
@@ -128,8 +128,8 @@ func TestProcessEventsRemovesIgnoredEventFromConflicDetectionCache(t *testing.T)
 	lastAppliedVsn := int64(100) // so that event with vsn 1 is ignored.
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
-	state := NewImportDataState(exportDir)
 	tdb = &mockYugabyteDB{}
+	state := newImportDataStateFromGlobals()
 	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]())
 
 	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")

--- a/yb-voyager/src/importdata/failpoints.go
+++ b/yb-voyager/src/importdata/failpoints.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package importdata
+
+import (
+	"os"
+	"path/filepath"
+
+	goerrors "github.com/go-errors/errors"
+	"github.com/pingcap/failpoint"
+)
+
+func injectImportSnapshotTransformError() error {
+	var fpErr error
+	failpoint.Inject("importSnapshotTransformError", func(val failpoint.Value) {
+		if val != nil {
+			if markerDir := os.Getenv("YB_VOYAGER_FAILPOINT_MARKER_DIR"); markerDir != "" {
+				_ = os.MkdirAll(markerDir, 0755)
+				_ = os.WriteFile(filepath.Join(markerDir, "failpoint-import-snapshot-transform-error.log"), []byte("hit\n"), 0644)
+			}
+			fpErr = goerrors.Errorf("failpoint: snapshot row transform failed")
+		}
+	})
+	return fpErr
+}

--- a/yb-voyager/src/importdata/importDataFileTaskImporter.go
+++ b/yb-voyager/src/importdata/importDataFileTaskImporter.go
@@ -25,14 +25,15 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/color"
 	goerrors "github.com/go-errors/errors"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/cp"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/errs"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -83,7 +84,23 @@ FileTaskImporter is responsible for importing an ImportFileTask.
 It uses a FileBatchProducer to produce batches. It submits each batch to a provided
 worker pool for processing. It also maintains and updates the progress of the task.
 */
+// FileTaskImporterConfig holds the values FileTaskImporter reads. They used to be
+// cmd package-level variables; cmd copies them in.
+type FileTaskImporterConfig struct {
+	ImporterRole          string
+	Tdb                   tgtdb.TargetDB
+	Tconf                 tgtdb.TargetConf
+	ExportDir             string
+	MigrationUUID         uuid.UUID
+	DataFileDescriptor    *datafile.Descriptor
+	ReportProgressInBytes bool
+	ControlPlane          cp.ControlPlane
+	TableToColumnNames    *utils.StructMap[sqlname.NameTuple, []string]
+	TableNameToSchema     *utils.StructMap[sqlname.NameTuple, map[string]map[string]string]
+}
+
 type FileTaskImporter struct {
+	cfg   FileTaskImporterConfig
 	state *ImportDataState
 
 	task                 *ImportFileTask
@@ -98,28 +115,28 @@ type FileTaskImporter struct {
 	currentProgressAmount int64
 	progressReporter      *ImportDataProgressReporter
 
-	errorHandler             importdata.ImportDataErrorHandler
+	errorHandler             ImportDataErrorHandler
 	callhomeMetricsCollector *callhome.ImportDataMetricsCollector
 
 	resumeInfoShown bool
 }
 
-func NewFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchProducer FileBatchProducer, workerPool *pool.Pool,
+func NewFileTaskImporter(cfg FileTaskImporterConfig, task *ImportFileTask, state *ImportDataState, batchProducer FileBatchProducer, workerPool *pool.Pool,
 	progressReporter *ImportDataProgressReporter, colocatedImportBatchQueue chan func(), isTableColocated bool,
-	errorHandler importdata.ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (*FileTaskImporter, error) {
-	totalProgressAmount := getTotalProgressAmount(task)
+	errorHandler ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (*FileTaskImporter, error) {
+	totalProgressAmount := GetTotalProgressAmount(task, cfg.ReportProgressInBytes)
 	progressReporter.ImportFileStarted(task, totalProgressAmount)
-	currentProgressAmount := getImportedProgressAmount(task, state)
+	currentProgressAmount := getImportedProgressAmount(task, state, cfg.ReportProgressInBytes)
 	progressReporter.AddProgressAmount(task, currentProgressAmount)
 
 	if currentProgressAmount == 0 {
-		metrics.Get().SetImportSnapshotTableStarted(importerRole, task.TableNameTup)
+		metrics.Get().SetImportSnapshotTableStarted(cfg.ImporterRole, task.TableNameTup)
 	}
 
 	resumeInfoShown := false
 	if currentProgressAmount > 0 {
 		var resumeMsg string
-		if reportProgressInBytes {
+		if cfg.ReportProgressInBytes {
 			resumeMsg = "Resuming"
 		} else {
 			resumeMsg = fmt.Sprintf("Resuming: %d rows imported", currentProgressAmount)
@@ -129,13 +146,14 @@ func NewFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchProd
 	}
 
 	fti := &FileTaskImporter{
+		cfg:                       cfg,
 		state:                     state,
 		task:                      task,
 		batchProducer:             batchProducer,
 		workerPool:                workerPool,
 		colocatedImportBatchQueue: colocatedImportBatchQueue,
 		isTableColocated:          isTableColocated,
-		importBatchArgsProto:      getImportBatchArgsProto(task.TableNameTup, task.FilePath),
+		importBatchArgsProto:      getImportBatchArgsProto(cfg, task.TableNameTup, task.FilePath),
 		progressReporter:          progressReporter,
 		totalProgressAmount:       totalProgressAmount,
 		currentProgressAmount:     currentProgressAmount,
@@ -167,14 +185,14 @@ func (fti *FileTaskImporter) TableHasPrimaryKey() bool {
 func (fti *FileTaskImporter) recommendationForBatchError(ibe errs.ImportBatchError) string {
 	switch ibe.ErrorType() {
 	case errs.ERROR_TYPE_PK_VIOLATION:
-		return importdata.PK_VIOLATION_RECOMMENDATION_MESSAGE
+		return PK_VIOLATION_RECOMMENDATION_MESSAGE
 	case errs.ERROR_TYPE_FOREIGN_KEY_VIOLATION:
-		if importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE {
-			return importdata.FK_VIOLATION_RECOMMENDATION_MESSAGE
+		if fti.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE || fti.cfg.ImporterRole == constants.IMPORT_FILE_ROLE {
+			return FK_VIOLATION_RECOMMENDATION_MESSAGE
 		}
-		return importdata.STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE
+		return STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE
 	default:
-		return importdata.STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE
+		return STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE
 	}
 }
 
@@ -207,7 +225,7 @@ func (fti *FileTaskImporter) submitBatch(batch *Batch) error {
 		fti.workerPool.Go(importBatchFunc)
 	}
 
-	metrics.Get().RecordImportSnapshotBatchSubmitted(importerRole, fti.task.TableNameTup)
+	metrics.Get().RecordImportSnapshotBatchSubmitted(fti.cfg.ImporterRole, fti.task.TableNameTup)
 
 	log.Infof("Queued batch: %s", spew.Sdump(batch))
 	return nil
@@ -265,10 +283,10 @@ func (fti *FileTaskImporter) importBatch(batch *Batch) {
 		If that also fails then batch gets executed as fast path recovery due to attempt > 0 from here.
 	*/
 	for attempt := 0; attempt < COPY_MAX_RETRY_COUNT; attempt++ {
-		tableSchema, _ := TableNameToSchema.Get(batch.TableNameTup)
+		tableSchema, _ := fti.cfg.TableNameToSchema.Get(batch.TableNameTup)
 		isRecoveryCandidate := (recoveryBatch || attempt > 0)
-		rowsAffected, err, isPartialBatchIngestionPossibleOnError = tdb.ImportBatch(batch, &importBatchArgs, exportDir, tableSchema, isRecoveryCandidate)
-		if err == nil || tdb.IsNonRetryableCopyError(err) {
+		rowsAffected, err, isPartialBatchIngestionPossibleOnError = fti.cfg.Tdb.ImportBatch(batch, &importBatchArgs, fti.cfg.ExportDir, tableSchema, isRecoveryCandidate)
+		if err == nil || fti.cfg.Tdb.IsNonRetryableCopyError(err) {
 			break
 		}
 		log.Warnf("COPY FROM file %q: %s", batch.FilePath, err)
@@ -283,7 +301,7 @@ func (fti *FileTaskImporter) importBatch(batch *Batch) {
 	log.Infof("%q => %d rows affected", batch.FilePath, rowsAffected)
 	if err != nil {
 		if fti.errorHandler.ShouldAbort() {
-			msg := importdata.STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE
+			msg := STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE
 			var ibe errs.ImportBatchError
 			if errors.As(err, &ibe) {
 				msg = fti.recommendationForBatchError(ibe)
@@ -316,7 +334,7 @@ func (fti *FileTaskImporter) updateProgressForCompletedBatch(batch *Batch) {
 
 	// Update basic progress update for progress bar and control plane.
 	var progressAmount int64
-	if reportProgressInBytes {
+	if fti.cfg.ReportProgressInBytes {
 		progressAmount = batch.ByteCount
 	} else {
 		progressAmount = batch.RecordCount
@@ -327,7 +345,7 @@ func (fti *FileTaskImporter) updateProgressForCompletedBatch(batch *Batch) {
 
 	// The metrics are sent after evry 5 secs in implementation of UpdateImportedRowCount
 	if fti.totalProgressAmount > fti.currentProgressAmount {
-		fti.updateProgressInControlPlane(ROW_UPDATE_STATUS_IN_PROGRESS)
+		fti.updateProgressInControlPlane(constants.ROW_UPDATE_STATUS_IN_PROGRESS)
 	}
 
 	// update callhome metrics collector
@@ -335,8 +353,8 @@ func (fti *FileTaskImporter) updateProgressForCompletedBatch(batch *Batch) {
 		fti.callhomeMetricsCollector.IncrementSnapshotProgress(batch.RecordCount, batch.ByteCount)
 	}
 
-	metrics.Get().RecordImportSnapshotBatchIngested(importerRole, fti.task.TableNameTup, batch.RecordCount, batch.ByteCount)
-	metrics.Get().ObserveImportSnapshotBatchSize(importerRole, fti.task.TableNameTup, batch.RecordCount, batch.ByteCount)
+	metrics.Get().RecordImportSnapshotBatchIngested(fti.cfg.ImporterRole, fti.task.TableNameTup, batch.RecordCount, batch.ByteCount)
+	metrics.Get().ObserveImportSnapshotBatchSize(fti.cfg.ImporterRole, fti.task.TableNameTup, batch.RecordCount, batch.ByteCount)
 }
 
 func (fti *FileTaskImporter) PostProcess() {
@@ -344,25 +362,25 @@ func (fti *FileTaskImporter) PostProcess() {
 		fti.batchProducer.Close()
 	}
 
-	fti.updateProgressInControlPlane(ROW_UPDATE_STATUS_COMPLETED)
+	fti.updateProgressInControlPlane(constants.ROW_UPDATE_STATUS_COMPLETED)
 
-	metrics.Get().SetImportSnapshotTableCompleted(importerRole, fti.task.TableNameTup)
+	metrics.Get().SetImportSnapshotTableCompleted(fti.cfg.ImporterRole, fti.task.TableNameTup)
 
 	fti.progressReporter.FileImportDone(fti.task) // Remove the progress-bar for the file.\
 }
 
 func (fti *FileTaskImporter) updateProgressInControlPlane(status int) {
-	if importerRole == TARGET_DB_IMPORTER_ROLE {
+	if fti.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE {
 		importDataTableMetrics := createImportDataTableMetrics(fti.task.TableNameTup,
-			fti.currentProgressAmount, fti.totalProgressAmount, status)
-		controlPlane.UpdateImportedRowCount(
+			fti.currentProgressAmount, fti.totalProgressAmount, status, fti.cfg.MigrationUUID)
+		fti.cfg.ControlPlane.UpdateImportedRowCount(
 			[]*cp.UpdateImportedRowCountEvent{&importDataTableMetrics})
 	}
 }
 
 // ============================================================================= //
 
-func getTotalProgressAmount(task *ImportFileTask) int64 {
+func GetTotalProgressAmount(task *ImportFileTask, reportProgressInBytes bool) int64 {
 	if reportProgressInBytes {
 		return task.FileSize
 	} else {
@@ -370,7 +388,7 @@ func getTotalProgressAmount(task *ImportFileTask) int64 {
 	}
 }
 
-func getImportedProgressAmount(task *ImportFileTask, state *ImportDataState) int64 {
+func getImportedProgressAmount(task *ImportFileTask, state *ImportDataState, reportProgressInBytes bool) int64 {
 	if reportProgressInBytes {
 		byteCount, err := state.GetImportedByteCount(task.FilePath, task.TableNameTup)
 		if err != nil {
@@ -387,7 +405,7 @@ func getImportedProgressAmount(task *ImportFileTask, state *ImportDataState) int
 }
 
 func createImportDataTableMetrics(tableNameTup sqlname.NameTuple, countLiveRows int64, countTotalRows int64,
-	status int) cp.UpdateImportedRowCountEvent {
+	status int, migrationUUID uuid.UUID) cp.UpdateImportedRowCountEvent {
 
 	//Earlier we were parsing the ForKey format of qualified table name for schema and table name
 	//now we are using the ForKeyTableSchema method to get same the schema and table name
@@ -409,9 +427,9 @@ func createImportDataTableMetrics(tableNameTup sqlname.NameTuple, countLiveRows 
 	return result
 }
 
-func getImportBatchArgsProto(tableNameTup sqlname.NameTuple, filePath string) *tgtdb.ImportBatchArgs {
-	columns, _ := TableToColumnNames.Get(tableNameTup)
-	columns, err := tdb.QuoteAttributeNames(tableNameTup, columns)
+func getImportBatchArgsProto(cfg FileTaskImporterConfig, tableNameTup sqlname.NameTuple, filePath string) *tgtdb.ImportBatchArgs {
+	columns, _ := cfg.TableToColumnNames.Get(tableNameTup)
+	columns, err := cfg.Tdb.QuoteAttributeNames(tableNameTup, columns)
 	if err != nil {
 		utils.ErrExit("if required quote column names: %w", err)
 	}
@@ -422,23 +440,23 @@ func getImportBatchArgsProto(tableNameTup sqlname.NameTuple, filePath string) *t
 		  Hence query is made on root tables which will fetch all the constraints names(parent and all children)
 	*/
 	// TODO: Optimize this by fetching the primary key columns and constraint names in one go for all tables
-	tableToPKColumns, err := tdb.GetPrimaryKeyColumnsForTables([]sqlname.NameTuple{tableNameTup})
+	tableToPKColumns, err := cfg.Tdb.GetPrimaryKeyColumnsForTables([]sqlname.NameTuple{tableNameTup})
 	if err != nil {
 		utils.ErrExit("getting primary key columns for table %s: %w", tableNameTup.ForMinOutput(), err)
 	}
 	pkColumns, _ := tableToPKColumns.Get(tableNameTup)
-	pkColumns, err = tdb.QuoteAttributeNames(tableNameTup, pkColumns)
+	pkColumns, err = cfg.Tdb.QuoteAttributeNames(tableNameTup, pkColumns)
 	if err != nil {
 		utils.ErrExit("if required quote primary key column names: %w", err)
 	}
 
-	pkConstraintNames, err := tdb.GetPrimaryKeyConstraintNames(tableNameTup)
+	pkConstraintNames, err := cfg.Tdb.GetPrimaryKeyConstraintNames(tableNameTup)
 	if err != nil {
 		utils.ErrExit("getting primary key constraint name for table %s: %w", tableNameTup.ForMinOutput(), err)
 	}
 
 	// If `columns` is unset at this point, no attribute list is passed in the COPY command.
-	fileFormat := dataFileDescriptor.FileFormat
+	fileFormat := cfg.DataFileDescriptor.FileFormat
 
 	// from export data with ora2pg, it comes as an SQL file, with COPY command having data.
 	// Import-data also reads it appropriately with the help of sqlDataFile.
@@ -451,13 +469,13 @@ func getImportBatchArgsProto(tableNameTup sqlname.NameTuple, filePath string) *t
 		Columns:           columns,
 		PrimaryKeyColumns: pkColumns,
 		PKConstraintNames: pkConstraintNames,
-		PKConflictAction:  tconf.OnPrimaryKeyConflictAction,
+		PKConflictAction:  cfg.Tconf.OnPrimaryKeyConflictAction,
 		FileFormat:        fileFormat,
-		Delimiter:         dataFileDescriptor.Delimiter,
-		HasHeader:         dataFileDescriptor.HasHeader && fileFormat == datafile.CSV,
-		QuoteChar:         dataFileDescriptor.QuoteChar,
-		EscapeChar:        dataFileDescriptor.EscapeChar,
-		NullString:        dataFileDescriptor.NullString,
+		Delimiter:         cfg.DataFileDescriptor.Delimiter,
+		HasHeader:         cfg.DataFileDescriptor.HasHeader && fileFormat == datafile.CSV,
+		QuoteChar:         cfg.DataFileDescriptor.QuoteChar,
+		EscapeChar:        cfg.DataFileDescriptor.EscapeChar,
+		NullString:        cfg.DataFileDescriptor.NullString,
 	}
 	log.Infof("ImportBatchArgs: %v", spew.Sdump(importBatchArgsProto))
 	return importBatchArgsProto

--- a/yb-voyager/src/importdata/importDataFileTaskImporter.go
+++ b/yb-voyager/src/importdata/importDataFileTaskImporter.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"errors"

--- a/yb-voyager/src/importdata/importDataFileTaskImporterErrorPolicy_test.go
+++ b/yb-voyager/src/importdata/importDataFileTaskImporterErrorPolicy_test.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/importDataFileTaskImporterErrorPolicy_test.go
+++ b/yb-voyager/src/importdata/importDataFileTaskImporterErrorPolicy_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/ybversion"
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
@@ -52,14 +51,14 @@ func getBatchErrorBaseFilePath(batchBaseFilePath string) string {
 
 func assertTableRowCount(t *testing.T, tableName string, expectedCount int64) {
 	var rowCount int64
-	err := tdb.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s", tableName)).Scan(&rowCount)
+	err := testYugabyteDBTarget.TargetDB.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s", tableName)).Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedCount, rowCount, fmt.Sprintf("Expected row count for table %s to be %d", tableName, expectedCount))
 }
 
 func assertTableIds(t *testing.T, tableName string, expectedIds []int64) {
 	var ids []int64
-	rows, err := tdb.Query(fmt.Sprintf("SELECT id FROM %s", tableName))
+	rows, err := testYugabyteDBTarget.TargetDB.Query(fmt.Sprintf("SELECT id FROM %s", tableName))
 	require.NoError(t, err) // must halt here: a nil rows would panic in the defer below
 	defer rows.Close()
 
@@ -79,7 +78,7 @@ func assertBatchErrored(t *testing.T, batch *Batch, expectedRecordCount int64, e
 }
 
 func assertBatchErrorFileContents(t *testing.T, batch *Batch, lexportDir string, state *ImportDataState, task *ImportFileTask, rows string, expectedErrorSubstring string) {
-	taskFolderPath := fmt.Sprintf("file::%s:%s", filepath.Base(task.FilePath), importdata.ComputePathHash(task.FilePath))
+	taskFolderPath := fmt.Sprintf("file::%s:%s", filepath.Base(task.FilePath), ComputePathHash(task.FilePath))
 	tableFolderPath := fmt.Sprintf("table::%s", task.TableNameTup.ForKey())
 	batchErrorBaseFilePath := getBatchErrorBaseFilePath(filepath.Base(batch.GetFilePath()))
 	batchErrorFilePath := filepath.Join(getErrorsParentDir(lexportDir), "errors", tableFolderPath, taskFolderPath, batchErrorBaseFilePath)
@@ -94,7 +93,7 @@ func assertBatchErrorFileContents(t *testing.T, batch *Batch, lexportDir string,
 func TestBasicTaskImportStachAndContinueErrorPolicy(t *testing.T) {
 	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(2, 1024)
 	testutils.FatalIfError(t, err)
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 	// t.Cleanup(func() { cleanupExportDirDataDir(ldataDir, lexportDir) })
 
@@ -117,11 +116,11 @@ func TestBasicTaskImportStachAndContinueErrorPolicy(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_error", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	for !taskImporter.AllBatchesSubmitted() {
@@ -148,7 +147,7 @@ func TestBasicTaskImportStachAndContinueErrorPolicy(t *testing.T) {
 func TestTaskImportStachAndContinueErrorPolicy_NoErrors(t *testing.T) {
 	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(2, 1024)
 	testutils.FatalIfError(t, err)
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 	t.Cleanup(func() { cleanupExportDirDataDir(ldataDir, lexportDir) })
 
@@ -170,11 +169,11 @@ func TestTaskImportStachAndContinueErrorPolicy_NoErrors(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_error", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	for !taskImporter.AllBatchesSubmitted() {
@@ -194,7 +193,7 @@ func TestTaskImportStachAndContinueErrorPolicy_NoErrors(t *testing.T) {
 func TestTaskImportStachAndContinueErrorPolicy_SingleBatchWithError(t *testing.T) {
 	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(2, 1024)
 	testutils.FatalIfError(t, err)
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 	t.Cleanup(func() { cleanupExportDirDataDir(ldataDir, lexportDir) })
 
@@ -215,11 +214,11 @@ func TestTaskImportStachAndContinueErrorPolicy_SingleBatchWithError(t *testing.T
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_error", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	for !taskImporter.AllBatchesSubmitted() {
@@ -246,14 +245,14 @@ func TestTaskImportStachAndContinueErrorPolicy_SingleBatchWithError(t *testing.T
 func TestTaskImportStachAndContinueErrorPolicy_SingleBatch_OnPkConflictIgnore(t *testing.T) {
 	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(2, 1024)
 	testutils.FatalIfError(t, err)
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 	t.Cleanup(func() { cleanupExportDirDataDir(ldataDir, lexportDir) })
 
 	setupYugabyteTestDb(t)
-	tconf.OnPrimaryKeyConflictAction = constants.PRIMARY_KEY_CONFLICT_ACTION_IGNORE
+	testImporterCfg.Tconf.OnPrimaryKeyConflictAction = constants.PRIMARY_KEY_CONFLICT_ACTION_IGNORE
 	t.Cleanup(func() {
-		tconf.OnPrimaryKeyConflictAction = constants.PRIMARY_KEY_CONFLICT_ACTION_ERROR_POLICY
+		testImporterCfg.Tconf.OnPrimaryKeyConflictAction = constants.PRIMARY_KEY_CONFLICT_ACTION_ERROR_POLICY
 	})
 
 	defer testYugabyteDBTarget.Finalize()
@@ -272,11 +271,11 @@ func TestTaskImportStachAndContinueErrorPolicy_SingleBatch_OnPkConflictIgnore(t 
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_unique_error", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	for !taskImporter.AllBatchesSubmitted() {
@@ -308,7 +307,7 @@ func TestTaskImportStachAndContinueErrorPolicy_MultipleBatchesWithDifferentError
 	COPY_MAX_RETRY_COUNT = 1 // Disable retry for COPY command to test error handling
 	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(2, 1024)
 	testutils.FatalIfError(t, err)
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 	t.Cleanup(func() { cleanupExportDirDataDir(ldataDir, lexportDir) })
 
@@ -339,11 +338,11 @@ func TestTaskImportStachAndContinueErrorPolicy_MultipleBatchesWithDifferentError
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_error", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	for !taskImporter.AllBatchesSubmitted() {
@@ -394,7 +393,7 @@ func TestTaskImportStachAndContinueErrorPolicy_MultipleBatchesWithDifferentError
 func TestTaskImportStachAndContinueErrorPolicy_TaskResumptionAfterBatchError(t *testing.T) {
 	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(2, 1024)
 	testutils.FatalIfError(t, err)
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 	t.Cleanup(func() { cleanupExportDirDataDir(ldataDir, lexportDir) })
 
@@ -418,11 +417,11 @@ func TestTaskImportStachAndContinueErrorPolicy_TaskResumptionAfterBatchError(t *
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_error", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	// ingest first batch.
@@ -443,11 +442,11 @@ func TestTaskImportStachAndContinueErrorPolicy_TaskResumptionAfterBatchError(t *
 		`ERROR: duplicate key value violates unique constraint "test_table_error_pkey" (SQLSTATE 23505)`)
 
 	// simulate resumption
-	batchProducer, err = NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchProducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool = pool.New().WithMaxGoroutines(2)
-	taskImporter, err = NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
+	taskImporter, err = NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, scErrorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	// ingest second batch. This should not retry the first errored-out batch.

--- a/yb-voyager/src/importdata/importDataFileTaskImporter_test.go
+++ b/yb-voyager/src/importdata/importDataFileTaskImporter_test.go
@@ -1,4 +1,5 @@
 //go:build integration
+
 /*
 Copyright (c) YugabyteDB, Inc.
 
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/errs"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -62,11 +62,11 @@ func TestBasicTaskImport(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_basic", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	for !taskImporter.AllBatchesSubmitted() {
@@ -76,7 +76,7 @@ func TestBasicTaskImport(t *testing.T) {
 
 	workerPool.Wait()
 	var rowCount int64
-	err = tdb.QueryRow("SELECT count(*) FROM test_table_basic").Scan(&rowCount)
+	err = testYugabyteDBTarget.TargetDB.QueryRow("SELECT count(*) FROM test_table_basic").Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), rowCount)
 }
@@ -105,11 +105,11 @@ func TestImportAllBatchesAndResume(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_all", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	for !taskImporter.AllBatchesSubmitted() {
@@ -119,17 +119,17 @@ func TestImportAllBatchesAndResume(t *testing.T) {
 
 	workerPool.Wait()
 	var rowCount int64
-	err = tdb.QueryRow("SELECT count(*) FROM test_table_all").Scan(&rowCount)
+	err = testYugabyteDBTarget.TargetDB.QueryRow("SELECT count(*) FROM test_table_all").Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), rowCount)
 
 	// simulate restart
 	progressReporter = NewImportDataProgressReporter(true)
-	batchProducer, err = NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool = pool.New().WithMaxGoroutines(2)
-	taskImporter, err = NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err = NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	assert.Equal(t, true, taskImporter.AllBatchesSubmitted())
@@ -162,11 +162,11 @@ func TestTaskImportResumable(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_resume", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	// submit 1 batch
@@ -176,17 +176,17 @@ func TestTaskImportResumable(t *testing.T) {
 	// check that the first batch was imported
 	workerPool.Wait()
 	var rowCount int64
-	err = tdb.QueryRow("SELECT count(*) FROM test_table_resume").Scan(&rowCount)
+	err = testYugabyteDBTarget.TargetDB.QueryRow("SELECT count(*) FROM test_table_resume").Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), rowCount)
 
 	// simulate restart
 	progressReporter = NewImportDataProgressReporter(true)
-	batchProducer, err = NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool = pool.New().WithMaxGoroutines(2)
-	taskImporter, err = NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err = NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	// submit second batch, not first batch again as it was already imported
@@ -195,7 +195,7 @@ func TestTaskImportResumable(t *testing.T) {
 
 	assert.Equal(t, true, taskImporter.AllBatchesSubmitted())
 	workerPool.Wait()
-	err = tdb.QueryRow("SELECT count(*) FROM test_table_resume").Scan(&rowCount)
+	err = testYugabyteDBTarget.TargetDB.QueryRow("SELECT count(*) FROM test_table_resume").Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(4), rowCount)
 }
@@ -226,11 +226,11 @@ func TestTaskImportResumableNoPK(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_resume_no_pk", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	// submit 1 batch
@@ -240,17 +240,17 @@ func TestTaskImportResumableNoPK(t *testing.T) {
 	// check that the first batch was imported
 	workerPool.Wait()
 	var rowCount int64
-	err = tdb.QueryRow("SELECT count(*) FROM test_table_resume_no_pk").Scan(&rowCount)
+	err = testYugabyteDBTarget.TargetDB.QueryRow("SELECT count(*) FROM test_table_resume_no_pk").Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), rowCount)
 
 	// simulate restart
 	progressReporter = NewImportDataProgressReporter(true)
-	batchProducer, err = NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool = pool.New().WithMaxGoroutines(2)
-	taskImporter, err = NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err = NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	// submit second batch, not first batch again as it was already imported
@@ -259,7 +259,7 @@ func TestTaskImportResumableNoPK(t *testing.T) {
 
 	assert.Equal(t, true, taskImporter.AllBatchesSubmitted())
 	workerPool.Wait()
-	err = tdb.QueryRow("SELECT count(*) FROM test_table_resume_no_pk").Scan(&rowCount)
+	err = testYugabyteDBTarget.TargetDB.QueryRow("SELECT count(*) FROM test_table_resume_no_pk").Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(4), rowCount)
 }
@@ -292,11 +292,11 @@ func TestTaskImportErrorsOutWithAbortErrorPolicy(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table_error", 1)
 	testutils.FatalIfError(t, err)
 
-	batchProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 
 	workerPool := pool.New().WithMaxGoroutines(2)
-	taskImporter, err := NewFileTaskImporter(task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
+	taskImporter, err := NewFileTaskImporter(testImporterCfg, task, state, batchProducer, workerPool, progressReporter, nil, false, errorHandler, nil)
 	testutils.FatalIfError(t, err)
 
 	var capturedErr error
@@ -319,11 +319,11 @@ func TestTaskImportErrorsOutWithAbortErrorPolicy(t *testing.T) {
 	var ibErr errs.ImportBatchError
 	require.True(t, errors.As(capturedErr, &ibErr), "error should wrap an ImportBatchError")
 	assert.Equal(t, errs.ERROR_TYPE_PK_VIOLATION, ibErr.ErrorType())
-	assert.Contains(t, capturedErr.Error(), importdata.PK_VIOLATION_RECOMMENDATION_MESSAGE)
+	assert.Contains(t, capturedErr.Error(), PK_VIOLATION_RECOMMENDATION_MESSAGE)
 }
 
 func TestRecommendationForBatchError(t *testing.T) {
-	fti := &FileTaskImporter{}
+	fti := &FileTaskImporter{cfg: FileTaskImporterConfig{ImporterRole: testImporterRole}}
 	tableName := sqlname.NameTuple{CurrentName: sqlname.NewObjectName(tgtdb.YUGABYTEDB, "public", "public", "test_table")}
 
 	tests := []struct {
@@ -334,22 +334,22 @@ func TestRecommendationForBatchError(t *testing.T) {
 		{
 			name:            "pk_violation_returns_pk_message",
 			errorType:       errs.ERROR_TYPE_PK_VIOLATION,
-			expectedMessage: importdata.PK_VIOLATION_RECOMMENDATION_MESSAGE,
+			expectedMessage: PK_VIOLATION_RECOMMENDATION_MESSAGE,
 		},
 		{
 			name:            "fk_violation_returns_fk_message",
 			errorType:       errs.ERROR_TYPE_FOREIGN_KEY_VIOLATION,
-			expectedMessage: importdata.FK_VIOLATION_RECOMMENDATION_MESSAGE,
+			expectedMessage: FK_VIOLATION_RECOMMENDATION_MESSAGE,
 		},
 		{
 			name:            "unique_violation_returns_default_message",
 			errorType:       errs.ERROR_TYPE_UNIQUE_VIOLATION,
-			expectedMessage: importdata.STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE,
+			expectedMessage: STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE,
 		},
 		{
 			name:            "empty_error_type_returns_default_message",
 			errorType:       "",
-			expectedMessage: importdata.STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE,
+			expectedMessage: STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE,
 		},
 	}
 
@@ -560,16 +560,16 @@ func createBatchFromData(t *testing.T, data string, tableName sqlname.NameTuple)
 	require.NoError(t, err, "Failed to create batch file")
 
 	batch := &Batch{
-		Number:       1,
-		TableNameTup: tableName,
-		SchemaName:   tableName.CurrentName.SchemaName.Unquoted,
-		FilePath:     batchFilePath,
-		BaseFilePath: batchFilePath,
+		Number:          1,
+		TableNameTup:    tableName,
+		SchemaName:      tableName.CurrentName.SchemaName.Unquoted,
+		FilePath:        batchFilePath,
+		BaseFilePath:    batchFilePath,
 		LineOffsetStart: 0,
 		LineOffsetEnd:   int64(len(data)),
-		RecordCount:  1,
-		ByteCount:    int64(len(data)),
-		Interrupted:  false,
+		RecordCount:     1,
+		ByteCount:       int64(len(data)),
+		Interrupted:     false,
 	}
 
 	args := &tgtdb.ImportBatchArgs{

--- a/yb-voyager/src/importdata/importDataFileTaskImporter_test.go
+++ b/yb-voyager/src/importdata/importDataFileTaskImporter_test.go
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"context"

--- a/yb-voyager/src/importdata/importDataFileTaskPicker.go
+++ b/yb-voyager/src/importdata/importDataFileTaskPicker.go
@@ -25,9 +25,12 @@ import (
 	"github.com/mroth/weightedrand/v2"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 	"golang.org/x/exp/rand"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -698,3 +701,44 @@ func (c *ColocatedCappedRandomTaskPicker) MarkTaskAsDone(task *ImportFileTask) e
 	return goerrors.Errorf("task [%v] not found in inProgressTasks: %v", task, c.InProgressTasks())
 }
 
+// GetTableTypes classifies the tasks' tables as colocated or sharded on a YugabyteDB
+// target (nil map for other roles/targets). Callers pass the importer role, target DB
+// type and target DB handle that used to be cmd package-level variables.
+func GetTableTypes(importerRole string, targetDBType string, tdb tgtdb.TargetDB, tasks []*ImportFileTask) (*utils.StructMap[sqlname.NameTuple, string], error) {
+	if !slices.Contains([]string{constants.TARGET_DB_IMPORTER_ROLE, constants.IMPORT_FILE_ROLE}, importerRole) {
+		return nil, nil
+	}
+	// Colocation is a YugabyteDB-only concept; table types are only meaningful
+	// for a real YugabyteDB target. Non-YB targets (yb-amp, etc.) use plain heap
+	// storage and the sequential task picker, which does not consult table types.
+	if targetDBType != constants.YUGABYTEDB {
+		return nil, nil
+	}
+
+	tableTypes := utils.NewStructMap[sqlname.NameTuple, string]()
+	yb, ok := tdb.(YbTargetDBColocatedChecker)
+	if !ok {
+		return nil, goerrors.Errorf("expected tdb to be of type TargetYugabyteDB, got: %T", tdb)
+	}
+	isDBColocated, err := yb.IsDBColocated()
+	if err != nil {
+		return nil, fmt.Errorf("checking if db is colocated: %w", err)
+	}
+	for _, task := range tasks {
+		if _, ok := tableTypes.Get(task.TableNameTup); !ok {
+			var tableType string
+			if !isDBColocated {
+				tableType = SHARDED
+			} else {
+				isColocated, err := yb.IsTableColocated(task.TableNameTup)
+				if err != nil {
+					return nil, fmt.Errorf("checking if table is colocated: table: %v: %w", task.TableNameTup.ForOutput(), err)
+				}
+				tableType = lo.Ternary(isColocated, COLOCATED, SHARDED)
+			}
+			tableTypes.Put(task.TableNameTup, tableType)
+		}
+	}
+	return tableTypes, nil
+
+}

--- a/yb-voyager/src/importdata/importDataFileTaskPicker.go
+++ b/yb-voyager/src/importdata/importDataFileTaskPicker.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/importDataFileTaskPicker_test.go
+++ b/yb-voyager/src/importdata/importDataFileTaskPicker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
@@ -182,7 +183,7 @@ func TestSequentialTaskPickerResumePicksInProgressTask(t *testing.T) {
 	}
 
 	// update the state of the first task to in progress
-	fbp, err := NewSequentialFileBatchProducer(task1, state, false, errorHandler, progressReporter)
+	fbp, err := NewSequentialFileBatchProducer(testProducerCfg, task1, state, false, errorHandler, progressReporter)
 	testutils.FatalIfError(t, err)
 	batch, err := fbp.NextBatch()
 	assert.NoError(t, err)
@@ -1190,7 +1191,7 @@ func TestColocatedAwareRandomTaskPickerResumable(t *testing.T) {
 	// pick 3 tasks and start the process.
 	task1, err := picker.Pick()
 	assert.NoError(t, err)
-	fbp1, err := NewSequentialFileBatchProducer(task1, state, false, errorHandler, progressReporter)
+	fbp1, err := NewSequentialFileBatchProducer(testProducerCfg, task1, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch1, err := fbp1.NextBatch()
 	assert.NoError(t, err)
@@ -1198,7 +1199,7 @@ func TestColocatedAwareRandomTaskPickerResumable(t *testing.T) {
 
 	task2, err := picker.Pick()
 	assert.NoError(t, err)
-	fbp2, err := NewSequentialFileBatchProducer(task2, state, false, errorHandler, progressReporter)
+	fbp2, err := NewSequentialFileBatchProducer(testProducerCfg, task2, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch2, err := fbp2.NextBatch()
 	assert.NoError(t, err)
@@ -1206,7 +1207,7 @@ func TestColocatedAwareRandomTaskPickerResumable(t *testing.T) {
 
 	task3, err := picker.Pick()
 	assert.NoError(t, err)
-	fbp3, err := NewSequentialFileBatchProducer(task3, state, false, errorHandler, progressReporter)
+	fbp3, err := NewSequentialFileBatchProducer(testProducerCfg, task3, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch3, err := fbp3.NextBatch()
 	assert.NoError(t, err)
@@ -1254,9 +1255,7 @@ func TestColocatedCappedRandomTaskPickerSingleTaskSharded(t *testing.T) {
 			shardedTask1.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 1 task, 1 max tasks in progress
@@ -1315,9 +1314,7 @@ func TestColocatedCappedRandomTaskPickerSingleTaskColocated(t *testing.T) {
 			colocatedTask1.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 1 task, 1 max tasks in progress
@@ -1384,9 +1381,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksSharded(t *testing.T) {
 			shardedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 3 tasks, 10 max tasks in progress
@@ -1502,9 +1497,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksColocated(t *testing.T) {
 			colocatedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 3 tasks, 10 max tasks in progress
@@ -1634,9 +1627,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksColocatedAndSharded(t *test
 			shardedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 6 tasks, 10 max sharded tasks in progress, 10 max colocated tasks in progress
@@ -1798,9 +1789,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksSameTableColocated(t *testi
 			colocatedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 3 tasks, 10 max tasks in progress
@@ -1916,9 +1905,7 @@ func TestColocatedCappedRandomTaskPickerMultipleTasksSameTableSharded(t *testing
 			shardedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 3 tasks, 10 max tasks in progress
@@ -2048,9 +2035,7 @@ func TestColocatedCappedRandomTaskPickeResumable(t *testing.T) {
 			shardedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 5 tasks, 10 max tasks in progress
@@ -2061,7 +2046,7 @@ func TestColocatedCappedRandomTaskPickeResumable(t *testing.T) {
 	// pick 4 tasks and start the process.
 	task1, err := picker.Pick()
 	assert.NoError(t, err)
-	fbp1, err := NewSequentialFileBatchProducer(task1, state, false, errorHandler, progressReporter)
+	fbp1, err := NewSequentialFileBatchProducer(testProducerCfg, task1, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch1, err := fbp1.NextBatch()
 	assert.NoError(t, err)
@@ -2069,7 +2054,7 @@ func TestColocatedCappedRandomTaskPickeResumable(t *testing.T) {
 
 	task2, err := picker.Pick()
 	assert.NoError(t, err)
-	fbp2, err := NewSequentialFileBatchProducer(task2, state, false, errorHandler, progressReporter)
+	fbp2, err := NewSequentialFileBatchProducer(testProducerCfg, task2, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch2, err := fbp2.NextBatch()
 	assert.NoError(t, err)
@@ -2077,7 +2062,7 @@ func TestColocatedCappedRandomTaskPickeResumable(t *testing.T) {
 
 	task3, err := picker.Pick()
 	assert.NoError(t, err)
-	fbp3, err := NewSequentialFileBatchProducer(task3, state, false, errorHandler, progressReporter)
+	fbp3, err := NewSequentialFileBatchProducer(testProducerCfg, task3, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch3, err := fbp3.NextBatch()
 	assert.NoError(t, err)
@@ -2085,7 +2070,7 @@ func TestColocatedCappedRandomTaskPickeResumable(t *testing.T) {
 
 	task4, err := picker.Pick()
 	assert.NoError(t, err)
-	fbp4, err := NewSequentialFileBatchProducer(task4, state, false, errorHandler, progressReporter)
+	fbp4, err := NewSequentialFileBatchProducer(testProducerCfg, task4, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch4, err := fbp4.NextBatch()
 	assert.NoError(t, err)
@@ -2145,9 +2130,7 @@ func TestColocatedCappedRandomTaskPickerShardedTasksOrderedByRowCount(t *testing
 			shardedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 3 tasks, 3 max tasks in progress
@@ -2208,9 +2191,7 @@ func TestColocatedCappedRandomTaskPickerShardedTasksOrderedByFileSize(t *testing
 			shardedTask3.TableNameTup,
 		},
 	}
-	tdb = dummyYb
-	tconf.TargetDBType = YUGABYTEDB // colocation path is YugabyteDB-only
-	tableTypes, err := getTableTypes(tasks)
+	tableTypes, err := GetTableTypes(constants.TARGET_DB_IMPORTER_ROLE, constants.YUGABYTEDB, dummyYb, tasks)
 	testutils.FatalIfError(t, err)
 
 	// 3 tasks, 3 max tasks in progress

--- a/yb-voyager/src/importdata/importDataFileTaskPicker_test.go
+++ b/yb-voyager/src/importdata/importDataFileTaskPicker_test.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/importDataIntegrationTestUtils.go
+++ b/yb-voyager/src/importdata/importDataIntegrationTestUtils.go
@@ -1,0 +1,35 @@
+//go:build integration
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package importdata
+
+import (
+	"testing"
+
+	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
+)
+
+var testYugabyteDBTarget *testutils.TestTargetDB
+
+// setupYugabyteTestDb starts a YugabyteDB test container and points the fixture
+// configs at it (the cmd tests did this by assigning the package-level tdb).
+func setupYugabyteTestDb(t *testing.T) {
+	testYugabyteDBTarget = testutils.SetupYugabyteTestDb(t)
+	testStateCfg.Tdb = testYugabyteDBTarget.TargetDB
+	testProducerCfg.Tdb = testYugabyteDBTarget.TargetDB
+	testImporterCfg.Tdb = testYugabyteDBTarget.TargetDB
+}

--- a/yb-voyager/src/importdata/importDataProgressReporter.go
+++ b/yb-voyager/src/importdata/importDataProgressReporter.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/importDataRandomFileBatchProducer.go
+++ b/yb-voyager/src/importdata/importDataRandomFileBatchProducer.go
@@ -24,7 +24,6 @@ import (
 	goerrors "github.com/go-errors/errors"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"golang.org/x/exp/rand"
 	"golang.org/x/sync/semaphore"
@@ -46,8 +45,8 @@ type RandomBatchProducer struct {
 	concurrentBatchProductionSem        *semaphore.Weighted
 }
 
-func NewRandomFileBatchProducer(task *ImportFileTask, state *ImportDataState, isRowTransformationRequired bool, errorHandler importdata.ImportDataErrorHandler, progressReporter *ImportDataProgressReporter, concurrentBatchProductionSem *semaphore.Weighted) (*RandomBatchProducer, error) {
-	sequentialFileBatchProducer, err := NewSequentialFileBatchProducer(task, state, isRowTransformationRequired, errorHandler, progressReporter)
+func NewRandomFileBatchProducer(cfg SequentialFileBatchProducerConfig, task *ImportFileTask, state *ImportDataState, isRowTransformationRequired bool, errorHandler ImportDataErrorHandler, progressReporter *ImportDataProgressReporter, concurrentBatchProductionSem *semaphore.Weighted) (*RandomBatchProducer, error) {
+	sequentialFileBatchProducer, err := NewSequentialFileBatchProducer(cfg, task, state, isRowTransformationRequired, errorHandler, progressReporter)
 	if err != nil {
 		return nil, fmt.Errorf("creating sequential file batch producer: %w", err)
 	}

--- a/yb-voyager/src/importdata/importDataRandomFileBatchProducer.go
+++ b/yb-voyager/src/importdata/importDataRandomFileBatchProducer.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"context"

--- a/yb-voyager/src/importdata/importDataRandomFileBatchProducer_test.go
+++ b/yb-voyager/src/importdata/importDataRandomFileBatchProducer_test.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/importDataRandomFileBatchProducer_test.go
+++ b/yb-voyager/src/importdata/importDataRandomFileBatchProducer_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
@@ -70,7 +69,7 @@ func TestSingleBatchProductionAndConsumption(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create RandomBatchProducer
-	producer, err := NewRandomFileBatchProducer(task, state, false, errorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -296,7 +295,7 @@ func TestMultipleBatchesProductionAndConsumption(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create RandomBatchProducer
-	producer, err := NewRandomFileBatchProducer(task, state, false, errorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -328,7 +327,7 @@ func TestFileWithOnlyHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create RandomBatchProducer
-	producer, err := NewRandomFileBatchProducer(task, state, false, errorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -404,7 +403,7 @@ func TestSingleBatchMatchVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create SequentialFileBatchProducer to get the expected batch
-	sequentialProducer, err := NewSequentialFileBatchProducer(sequentialTask, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, sequentialTask, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 	defer sequentialProducer.Close()
 
@@ -414,7 +413,7 @@ func TestSingleBatchMatchVerification(t *testing.T) {
 	require.True(t, sequentialProducer.Done(), "Sequential producer should be done after producing 1 batch")
 
 	// Create RandomBatchProducer with separate task
-	randomProducer, err := NewRandomFileBatchProducer(randomTask, state, false, errorHandler, progressReporter, createTestSemaphore())
+	randomProducer, err := NewRandomFileBatchProducer(testProducerCfg, randomTask, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer randomProducer.Close()
 
@@ -471,7 +470,7 @@ func TestMultipleBatchesMatchVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create SequentialFileBatchProducer and collect all batches
-	sequentialProducer, err := NewSequentialFileBatchProducer(sequentialTask, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, sequentialTask, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 	defer sequentialProducer.Close()
 
@@ -487,7 +486,7 @@ func TestMultipleBatchesMatchVerification(t *testing.T) {
 	totalExpectedBatches := len(sequentialBatches)
 
 	// Create RandomBatchProducer
-	randomProducer, err := NewRandomFileBatchProducer(randomTask, state, false, errorHandler, progressReporter, createTestSemaphore())
+	randomProducer, err := NewRandomFileBatchProducer(testProducerCfg, randomTask, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer randomProducer.Close()
 
@@ -550,7 +549,7 @@ func TestNextBatchCalledWhenNoBatchesAvailableProducerRunning(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create RandomBatchProducer
-	producer, err := NewRandomFileBatchProducer(task, state, false, errorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -606,7 +605,7 @@ func TestNextBatchCalledWhenNoBatchesAvailableProducerFinished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create RandomBatchProducer
-	producer, err := NewRandomFileBatchProducer(task, state, false, errorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -639,7 +638,7 @@ func TestRandomBatchProducer_AbortHandler(t *testing.T) {
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	abortErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.AbortErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	abortErrorHandler, err := GetImportDataErrorHandler(AbortErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	require.NoError(t, err)
 
 	fileContents := `id,val
@@ -648,10 +647,10 @@ func TestRandomBatchProducer_AbortHandler(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	require.NoError(t, err)
 
-	// Swap in the mock valueConverter
-	origValueConverter := valueConverter
-	valueConverter = &mockValueConverterForTest{}
-	t.Cleanup(func() { valueConverter = origValueConverter })
+	// Swap in the mock testProducerCfg.ValueConverter
+	origValueConverter := testProducerCfg.ValueConverter
+	testProducerCfg.ValueConverter = &mockValueConverterForTest{}
+	t.Cleanup(func() { testProducerCfg.ValueConverter = origValueConverter })
 
 	// Expect error before Creating RandomBatchProducer
 	var errExitCalled bool
@@ -661,7 +660,7 @@ func TestRandomBatchProducer_AbortHandler(t *testing.T) {
 	t.Cleanup(func() {
 		utils.RestoreUtilsErrExit()
 	})
-	producer, err := NewRandomFileBatchProducer(task, state, true, abortErrorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, true, abortErrorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -690,7 +689,7 @@ func TestRandomBatchProducer_StashAndContinue(t *testing.T) {
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	require.NoError(t, err)
 
 	// The second row will be too large for the batch size
@@ -701,7 +700,7 @@ func TestRandomBatchProducer_StashAndContinue(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create RandomBatchProducer
-	producer, err := NewRandomFileBatchProducer(task, state, false, scErrorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -731,7 +730,7 @@ func TestRandomBatchProducer_StashAndContinue_LastBatchHasAllErrors(t *testing.T
 	ldataDir, lexportDir, state, _, progressReporter, err := setupExportDirAndImportDependencies(1000, maxBatchSizeBytes)
 	require.NoError(t, err)
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	require.NoError(t, err)
 
 	if ldataDir != "" {
@@ -747,7 +746,7 @@ func TestRandomBatchProducer_StashAndContinue_LastBatchHasAllErrors(t *testing.T
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	require.NoError(t, err)
 
-	producer, err := NewRandomFileBatchProducer(task, state, false, scErrorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer.Close()
 
@@ -817,7 +816,7 @@ func TestRandomBatchProducer_Resumption_PartialBatchesProduced_NoneConsumed(t *t
 	require.NoError(t, err)
 
 	// Create sequential producer
-	sequentialProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	// Wrap it with a delayed version that sleeps 500ms per batch
@@ -837,7 +836,7 @@ func TestRandomBatchProducer_Resumption_PartialBatchesProduced_NoneConsumed(t *t
 
 	// Create a new producer (simulating resumption)
 	// This should recover the batches that were already produced
-	sequentialProducer2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	producer2 := newRandomFileBatchProducer(sequentialProducer2, task, createTestSemaphore())
@@ -872,7 +871,7 @@ func TestRandomBatchProducer_Resumption_PartialBatchesProduced_PartialConsumed(t
 	require.NoError(t, err)
 
 	// Create sequential producer
-	sequentialProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	// Wrap it with a delayed version that sleeps 500ms per batch
@@ -906,7 +905,7 @@ func TestRandomBatchProducer_Resumption_PartialBatchesProduced_PartialConsumed(t
 
 	// Create a new producer (simulating resumption)
 	// This should recover the batches that were already produced
-	sequentialProducer2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	producer2 := newRandomFileBatchProducer(sequentialProducer2, task, createTestSemaphore())
@@ -941,7 +940,7 @@ func TestRandomBatchProducer_Resumption_PartialBatchesProduced_AllConsumed(t *te
 	require.NoError(t, err)
 
 	// Create sequential producer
-	sequentialProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	// Wrap it with a delayed version that sleeps 500ms per batch
@@ -971,7 +970,7 @@ func TestRandomBatchProducer_Resumption_PartialBatchesProduced_AllConsumed(t *te
 
 	// Create a new producer (simulating resumption)
 	// This should recover the batches that were already produced
-	sequentialProducer2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	producer2 := newRandomFileBatchProducer(sequentialProducer2, task, createTestSemaphore())
@@ -1002,7 +1001,7 @@ func TestRandomBatchProducer_Resumption_SingleBatchProduced_NotConsumed(t *testi
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	require.NoError(t, err)
 
-	producer, err := NewRandomFileBatchProducer(task, state, false, errorHandler, progressReporter, createTestSemaphore())
+	producer, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 
 	// Wait for all batches to be produced
@@ -1030,7 +1029,7 @@ func TestRandomBatchProducer_Resumption_SingleBatchProduced_NotConsumed(t *testi
 	// Create a new producer (simulating resumption)
 	// This should recover the batche that were already produced
 
-	producer2, err := NewRandomFileBatchProducer(task, state, false, errorHandler, progressReporter, createTestSemaphore())
+	producer2, err := NewRandomFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter, createTestSemaphore())
 	require.NoError(t, err)
 	defer producer2.Close()
 
@@ -1068,7 +1067,7 @@ func TestRandomBatchProducer_Resumption_AllBatchesProduced_NoneConsumed(t *testi
 	require.NoError(t, err)
 
 	// Create sequential producer
-	sequentialProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	// Create random producer
@@ -1098,7 +1097,7 @@ func TestRandomBatchProducer_Resumption_AllBatchesProduced_NoneConsumed(t *testi
 
 	// Create a new producer (simulating resumption)
 	// This should recover all the batches that were already produced
-	sequentialProducer2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	producer2 := newRandomFileBatchProducer(sequentialProducer2, task, createTestSemaphore())
@@ -1133,7 +1132,7 @@ func TestRandomBatchProducer_Resumption_AllBatchesProduced_PartialConsumed(t *te
 	require.NoError(t, err)
 
 	// Create sequential producer
-	sequentialProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	// Create random producer
@@ -1174,7 +1173,7 @@ func TestRandomBatchProducer_Resumption_AllBatchesProduced_PartialConsumed(t *te
 
 	// Create a new producer (simulating resumption)
 	// This should recover all the batches that were already produced
-	sequentialProducer2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	producer2 := newRandomFileBatchProducer(sequentialProducer2, task, createTestSemaphore())
@@ -1209,7 +1208,7 @@ func TestRandomBatchProducer_Resumption_AllBatchesProduced_AllConsumed(t *testin
 	require.NoError(t, err)
 
 	// Create sequential producer
-	sequentialProducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 
 	// Create random producer
@@ -1256,7 +1255,7 @@ func TestRandomBatchProducer_Resumption_AllBatchesProduced_AllConsumed(t *testin
 	t.Cleanup(func() {
 		utils.RestoreUtilsErrExit()
 	})
-	sequentialProducer2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	sequentialProducer2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	require.NoError(t, err)
 	producer2 := newRandomFileBatchProducer(sequentialProducer2, task, createTestSemaphore())
 	defer producer2.Close()

--- a/yb-voyager/src/importdata/importDataSequentialFileBatchProducer.go
+++ b/yb-voyager/src/importdata/importDataSequentialFileBatchProducer.go
@@ -26,17 +26,33 @@ import (
 	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
 const FIRST_BATCH_NUM = 1
 
+// SequentialFileBatchProducerConfig holds the values the batch producers read. They
+// used to be cmd package-level variables; cmd copies them in.
+type SequentialFileBatchProducerConfig struct {
+	ImporterRole       string
+	Tdb                tgtdb.TargetDB
+	Tconf              tgtdb.TargetConf
+	DataFileDescriptor *datafile.Descriptor
+	DataStore          datastore.DataStore
+	BatchSizeInNumRows int64
+	ValueConverter     dbzm.SnapshotPhaseValueConverter
+	TableToColumnNames *utils.StructMap[sqlname.NameTuple, []string]
+}
+
 type SequentialFileBatchProducer struct {
+	cfg   SequentialFileBatchProducerConfig
 	task  *ImportFileTask
 	state *ImportDataState
 
@@ -60,7 +76,7 @@ type SequentialFileBatchProducer struct {
 	isRowTransformationRequired bool
 	rowProcessor                rowProcessor // in case transformations are required, we use this to read line string -> column values and write column values -> line string
 
-	errorHandler importdata.ImportDataErrorHandler
+	errorHandler ImportDataErrorHandler
 
 	//required to print some information for users to display during batch production
 	progressReporter *ImportDataProgressReporter
@@ -71,7 +87,7 @@ type rowProcessor interface {
 	WriteRow(columnValues []string) (string, error)
 }
 
-func NewSequentialFileBatchProducer(task *ImportFileTask, state *ImportDataState, isRowTransformationRequired bool, errorHandler importdata.ImportDataErrorHandler, progressReporter *ImportDataProgressReporter) (*SequentialFileBatchProducer, error) {
+func NewSequentialFileBatchProducer(cfg SequentialFileBatchProducerConfig, task *ImportFileTask, state *ImportDataState, isRowTransformationRequired bool, errorHandler ImportDataErrorHandler, progressReporter *ImportDataProgressReporter) (*SequentialFileBatchProducer, error) {
 	if errorHandler == nil {
 		return nil, goerrors.Errorf("errorHandler must not be nil")
 	}
@@ -99,6 +115,7 @@ func NewSequentialFileBatchProducer(task *ImportFileTask, state *ImportDataState
 	}
 
 	return &SequentialFileBatchProducer{
+		cfg:                         cfg,
 		task:                        task,
 		state:                       state,
 		pendingBatches:              pendingBatches,
@@ -187,15 +204,15 @@ func (p *SequentialFileBatchProducer) produceNextBatch() (*Batch, error) {
 		// TODO: fix. Here we compare line_bytes with max_batch_size_bytes
 		// but below we compare header_bytes+line_bytes with max_batch_size_bytes
 		// and that can result in disregarding the row and adding it to the next batch (lineFromPreviousBatch)
-		if currentBytesRead > tdb.MaxBatchSizeInBytes() {
+		if currentBytesRead > p.cfg.Tdb.MaxBatchSizeInBytes() {
 			//If a row is itself larger than MaxBatchSizeInBytes erroring out
 			ybSpecificMsg := ""
-			if tconf.TargetDBType == YUGABYTEDB {
+			if p.cfg.Tconf.TargetDBType == constants.YUGABYTEDB {
 				ybSpecificMsg = ", but should be strictly lower than the the rpc_max_message_size on YugabyteDB (default 267386880 bytes)"
 			}
-			errMsg := goerrors.Errorf("record of size %d larger than max batch size: record num=%d for table %q in file %s is larger than the max batch size %d bytes. Max Batch size can be changed using env var MAX_BATCH_SIZE_BYTES%s", currentBytesRead, p.numLinesTaken, p.task.TableNameTup.ForOutput(), p.task.FilePath, tdb.MaxBatchSizeInBytes(), ybSpecificMsg)
+			errMsg := goerrors.Errorf("record of size %d larger than max batch size: record num=%d for table %q in file %s is larger than the max batch size %d bytes. Max Batch size can be changed using env var MAX_BATCH_SIZE_BYTES%s", currentBytesRead, p.numLinesTaken, p.task.TableNameTup.ForOutput(), p.task.FilePath, p.cfg.Tdb.MaxBatchSizeInBytes(), ybSpecificMsg)
 			if p.errorHandler.ShouldAbort() {
-				return nil, fmt.Errorf("%w\n%s", errMsg, color.YellowString(importdata.STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE))
+				return nil, fmt.Errorf("%w\n%s", errMsg, color.YellowString(STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE))
 			}
 			err := p.handleRowProcessingErrorAndResetBytes(batchNum, line, errMsg, currentBytesRead)
 			if err != nil {
@@ -205,13 +222,13 @@ func (p *SequentialFileBatchProducer) produceNextBatch() (*Batch, error) {
 		}
 		if line != "" {
 			// can't use importBatchArgsProto.Columns as to use case insenstiive column names
-			columnNames, _ := TableToColumnNames.Get(p.task.TableNameTup)
+			columnNames, _ := p.cfg.TableToColumnNames.Get(p.task.TableNameTup)
 			lineBeforeConversion := line
 			line, err = p.transformRow(line, columnNames)
 			if err != nil {
 				errMsg := goerrors.Errorf("transforming line number=%d for table: %q in file %s: %w", p.numLinesTaken, p.task.TableNameTup.ForOutput(), p.task.FilePath, err)
 				if p.errorHandler.ShouldAbort() {
-					return nil, fmt.Errorf("%w\n%s", errMsg, color.YellowString(importdata.STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE))
+					return nil, fmt.Errorf("%w\n%s", errMsg, color.YellowString(STASH_AND_CONTINUE_RECOMMENDATION_MESSAGE))
 				}
 				err := p.handleRowProcessingErrorAndResetBytes(batchNum, lineBeforeConversion, errMsg, currentBytesRead)
 				if err != nil {
@@ -225,8 +242,8 @@ func (p *SequentialFileBatchProducer) produceNextBatch() (*Batch, error) {
 			}
 
 			// Check if adding this record exceeds the max batch size
-			if batchWriter.NumRecordsWritten == batchSizeInNumRows ||
-				batchBytesCount > tdb.MaxBatchSizeInBytes() {
+			if batchWriter.NumRecordsWritten == p.cfg.BatchSizeInNumRows ||
+				batchBytesCount > p.cfg.Tdb.MaxBatchSizeInBytes() {
 
 				// Finalize the current batch without adding the record.
 				// cumByteOffsetEnd must exclude the carried-forward line's bytes so that
@@ -287,7 +304,7 @@ func (p *SequentialFileBatchProducer) transformRow(row string, columnNames []str
 	if err != nil {
 		return "", fmt.Errorf("reading input row to columns: %w", err)
 	}
-	err = valueConverter.ConvertRow(p.task.TableNameTup, columnNames, columnValues)
+	err = p.cfg.ValueConverter.ConvertRow(p.task.TableNameTup, columnNames, columnValues)
 	if err != nil {
 		return "", fmt.Errorf("converting row in value converter: %w", err)
 	}
@@ -310,18 +327,18 @@ func (p *SequentialFileBatchProducer) openDataFile() error {
 // the header if HasHeader is true. Returns the opened DataFile positioned after
 // the header (or at byte 0 if no header).
 func (p *SequentialFileBatchProducer) openDataFileAndReadHeaderIfRequired() (datafile.DataFile, error) {
-	reader, err := dataStore.Open(p.task.FilePath)
+	reader, err := p.cfg.DataStore.Open(p.task.FilePath)
 	if err != nil {
 		return nil, goerrors.Errorf("preparing reader for file: %q: %w", p.task.FilePath, err)
 	}
 
-	df, err := datafile.NewDataFile(p.task.FilePath, reader, dataFileDescriptor, 0)
+	df, err := datafile.NewDataFile(p.task.FilePath, reader, p.cfg.DataFileDescriptor, 0)
 	if err != nil {
 		_ = reader.Close() // best-effort cleanup on the error path
 		return nil, goerrors.Errorf("open datafile: %q: %w", p.task.FilePath, err)
 	}
 
-	if dataFileDescriptor.HasHeader {
+	if p.cfg.DataFileDescriptor.HasHeader {
 		p.header = df.GetHeader()
 		p.headerByteCount = df.GetBytesRead()
 		df.ResetBytesRead(0)
@@ -333,7 +350,7 @@ func (p *SequentialFileBatchProducer) openDataFileAndReadHeaderIfRequired() (dat
 // Used when lastBatchCumByteOffsetEnd > 0.
 func (p *SequentialFileBatchProducer) openDataFileAtByteOffset() error {
 	// Read header before seeking (seek jumps past it).
-	if dataFileDescriptor.HasHeader {
+	if p.cfg.DataFileDescriptor.HasHeader {
 		headerDataFile, err := p.openDataFileAndReadHeaderIfRequired()
 		if err != nil {
 			return err
@@ -343,7 +360,7 @@ func (p *SequentialFileBatchProducer) openDataFileAtByteOffset() error {
 
 	// Seek to byte offset. Falls back to SkipLines if datastore doesn't support OpenAt yet.
 	log.Infof("Seeking to byte offset %d in %q", p.lastBatchCumByteOffsetEnd, p.task.FilePath)
-	reader, err := dataStore.OpenAt(p.task.FilePath, p.lastBatchCumByteOffsetEnd)
+	reader, err := p.cfg.DataStore.OpenAt(p.task.FilePath, p.lastBatchCumByteOffsetEnd)
 	if err != nil {
 		if errors.Is(err, datastore.ErrOpenAtNotImplemented) {
 			log.Warnf("OpenAt not implemented for current datastore, falling back to SkipLines for %q", p.task.FilePath)
@@ -354,7 +371,7 @@ func (p *SequentialFileBatchProducer) openDataFileAtByteOffset() error {
 
 	// Build a fresh DataFile on the seeked reader, passing the offset so that
 	// format-specific logic (e.g., SQL assuming mid-COPY) is handled internally.
-	dataFile, err := datafile.NewDataFile(p.task.FilePath, reader, dataFileDescriptor, p.lastBatchCumByteOffsetEnd)
+	dataFile, err := datafile.NewDataFile(p.task.FilePath, reader, p.cfg.DataFileDescriptor, p.lastBatchCumByteOffsetEnd)
 	if err != nil {
 		_ = reader.Close() // best-effort cleanup on the error path
 		return goerrors.Errorf("open datafile after seek: %q: %w", p.task.FilePath, err)
@@ -403,7 +420,7 @@ func (p *SequentialFileBatchProducer) newBatchWriter() (*BatchWriter, error) {
 		return nil, goerrors.Errorf("initializing batch writer for table: %q: %w", p.task.TableNameTup, err)
 	}
 	// Write the header if necessary
-	if p.header != "" && dataFileDescriptor.FileFormat == datafile.CSV {
+	if p.header != "" && p.cfg.DataFileDescriptor.FileFormat == datafile.CSV {
 		err = batchWriter.WriteHeader(p.header)
 		if err != nil {
 			utils.ErrExit("writing header for table: %q: %w", p.task.TableNameTup, err)
@@ -435,7 +452,7 @@ func (p *SequentialFileBatchProducer) finalizeBatch(batchWriter *BatchWriter, is
 		utils.ErrExit("finalizing batch %d: %w", batchNum, err)
 	}
 
-	metrics.Get().RecordImportSnapshotBatchCreated(importerRole, p.task.TableNameTup)
+	metrics.Get().RecordImportSnapshotBatchCreated(p.cfg.ImporterRole, p.task.TableNameTup)
 
 	batchWriter = nil
 	p.lastBatchNumber = batchNum

--- a/yb-voyager/src/importdata/importDataSequentialFileBatchProducer.go
+++ b/yb-voyager/src/importdata/importDataSequentialFileBatchProducer.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"errors"

--- a/yb-voyager/src/importdata/importDataSequentialFileBatchProducer_test.go
+++ b/yb-voyager/src/importdata/importDataSequentialFileBatchProducer_test.go
@@ -26,13 +26,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
@@ -95,7 +95,7 @@ func TestBasicFileBatchProducer(t *testing.T) {
 1, "hello"`
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	assert.False(t, batchproducer.Done())
@@ -127,7 +127,7 @@ func TestFileBatchProducerBasedOnRowsThreshold(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	assert.False(t, batchproducer.Done())
@@ -178,7 +178,7 @@ func TestFileBatchProducerBasedOnSizeThreshold(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	assert.False(t, batchproducer.Done())
@@ -245,7 +245,7 @@ func TestFileBatchProducerThrowsErrorWhenSingleRowGreaterThanMaxBatchSize(t *tes
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	assert.False(t, batchproducer.Done())
@@ -279,7 +279,7 @@ func TestFileBatchProducerResumable(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.False(t, batchproducer.Done())
 
@@ -293,13 +293,13 @@ func TestFileBatchProducerResumable(t *testing.T) {
 		"Batch 1 CumByteOffsetEnd should equal header + rows 0-1")
 
 	// simulate a crash and recover
-	batchproducer, err = NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.False(t, batchproducer.Done())
 
 	// state should have recovered that one batch
 	assert.Equal(t, 1, len(batchproducer.pendingBatches))
-	assert.True(t, cmp.Equal(batch1, batchproducer.pendingBatches[0]))
+	assert.True(t, cmp.Equal(batch1, batchproducer.pendingBatches[0], cmpopts.IgnoreUnexported(Batch{})))
 	assert.Equal(t, batch1.CumByteOffsetEnd, batchproducer.lastBatchCumByteOffsetEnd)
 	assert.Equal(t, batch1.CumByteOffsetEnd, batchproducer.cumByteOffsetEnd)
 
@@ -308,7 +308,7 @@ func TestFileBatchProducerResumable(t *testing.T) {
 	batch1Recovered, err := batchproducer.NextBatch()
 	assert.NoError(t, err)
 	assert.NotNil(t, batch1Recovered)
-	assert.True(t, cmp.Equal(batch1, batch1Recovered))
+	assert.True(t, cmp.Equal(batch1, batch1Recovered, cmpopts.IgnoreUnexported(Batch{})))
 	assert.Equal(t, 0, len(batchproducer.pendingBatches))
 	assert.False(t, batchproducer.Done())
 
@@ -348,7 +348,7 @@ func TestFileBatchProducerResumeAfterAllBatchesProduced(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.False(t, batchproducer.Done())
 
@@ -362,7 +362,7 @@ func TestFileBatchProducerResumeAfterAllBatchesProduced(t *testing.T) {
 	}
 
 	// simulate a crash and recover
-	batchproducer, err = NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.False(t, batchproducer.Done())
 
@@ -396,7 +396,7 @@ func TestFileBatchProducer_StashAndContinue_ConversionError(t *testing.T) {
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	fileContents := `id,val
@@ -405,12 +405,12 @@ func TestFileBatchProducer_StashAndContinue_ConversionError(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	// Swap in the mock valueConverter
-	origValueConverter := valueConverter
-	valueConverter = &mockValueConverterForTest{}
-	t.Cleanup(func() { valueConverter = origValueConverter })
+	// Swap in the mock testProducerCfg.ValueConverter
+	origValueConverter := testProducerCfg.ValueConverter
+	testProducerCfg.ValueConverter = &mockValueConverterForTest{}
+	t.Cleanup(func() { testProducerCfg.ValueConverter = origValueConverter })
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, true, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, true, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := batchproducer.NextBatch()
@@ -441,7 +441,7 @@ func TestFileBatchProducer_AbortHandler_ConversionError(t *testing.T) {
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	abortErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.AbortErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	abortErrorHandler, err := GetImportDataErrorHandler(AbortErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	fileContents := `id,val
@@ -450,12 +450,12 @@ func TestFileBatchProducer_AbortHandler_ConversionError(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	// Swap in the mock valueConverter
-	origValueConverter := valueConverter
-	valueConverter = &mockValueConverterForTest{}
-	t.Cleanup(func() { valueConverter = origValueConverter })
+	// Swap in the mock testProducerCfg.ValueConverter
+	origValueConverter := testProducerCfg.ValueConverter
+	testProducerCfg.ValueConverter = &mockValueConverterForTest{}
+	t.Cleanup(func() { testProducerCfg.ValueConverter = origValueConverter })
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, true, abortErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, true, abortErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := batchproducer.NextBatch()
@@ -477,7 +477,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError(t *testing.T) {
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The second row will be too large for the batch size
@@ -487,7 +487,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := batchproducer.NextBatch()
@@ -518,7 +518,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_FirstRow(t *testing
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The first row will be too large for the batch size
@@ -528,7 +528,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_FirstRow(t *testing
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := batchproducer.NextBatch()
@@ -555,7 +555,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_FirstFiveRows(t *te
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The first 5 rows will be too large for the batch size
@@ -569,7 +569,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_FirstFiveRows(t *te
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := batchproducer.NextBatch()
@@ -600,7 +600,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_LastBatch(t *testin
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// First batch: small rows that fit within 20 bytes
@@ -617,7 +617,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_LastBatch(t *testin
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	// First batch should contain the first 3 small rows
@@ -655,7 +655,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_processingErrorFile
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The second row will be too large for the batch size
@@ -665,7 +665,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_processingErrorFile
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := batchproducer.NextBatch()
@@ -684,7 +684,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeError_processingErrorFile
 	err = os.Remove(batch.GetFilePath())
 	assert.NoError(t, err)
 
-	batchproducer, err = NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.False(t, batchproducer.Done())
 
@@ -713,7 +713,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeErrorDoesNotCountTowardsB
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The second row will be too large for the batch size, but the third row is small enough to fit if the second is skipped
@@ -724,7 +724,7 @@ func TestFileBatchProducer_StashAndContinue_RowTooLargeErrorDoesNotCountTowardsB
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	// First batch: should contain row 1 and row 3 (row 2 is too large and skipped, its size does not count)
@@ -754,7 +754,7 @@ func TestFileBatchProducer_StashAndContinue_ConversionErrorDoesNotCountTowardsBa
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The second row will error (conversion error), but is large enough that if it counted, the third row would not fit
@@ -765,12 +765,12 @@ func TestFileBatchProducer_StashAndContinue_ConversionErrorDoesNotCountTowardsBa
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	// Use a mock valueConverter that errors on row 2
-	origValueConverter := valueConverter
-	valueConverter = &mockRowErrorValueConverter{rowToError: 2}
-	t.Cleanup(func() { valueConverter = origValueConverter })
+	// Use a mock testProducerCfg.ValueConverter that errors on row 2
+	origValueConverter := testProducerCfg.ValueConverter
+	testProducerCfg.ValueConverter = &mockRowErrorValueConverter{rowToError: 2}
+	t.Cleanup(func() { testProducerCfg.ValueConverter = origValueConverter })
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, true, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, true, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	// First batch: should contain row 1 and row 3 (row 2 is errored and skipped, its size does not count)
@@ -800,7 +800,7 @@ func TestFileBatchProducer_StashAndContinue_Resumption(t *testing.T) {
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The second row will be too large for the batch size
@@ -813,7 +813,7 @@ func TestFileBatchProducer_StashAndContinue_Resumption(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	// first batch will contain the first row only
@@ -829,7 +829,7 @@ func TestFileBatchProducer_StashAndContinue_Resumption(t *testing.T) {
 		"ROW: 2, \"this row is too long and should trigger an error because it exceeds the max batch size\"")
 
 	// simulate a crash and recover
-	batchproducer, err = NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	batchproducer, err = NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.False(t, batchproducer.Done())
 	// get the batch1 again, because they would still be pending.
@@ -872,7 +872,7 @@ func TestFileBatchProducer_StashAndContinue_MultipleTasksSameTable(t *testing.T)
 		defer os.RemoveAll(fmt.Sprintf("%s/", lexportDir))
 	}
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	testutils.FatalIfError(t, err)
 
 	// The second row will error (conversion error), but is large enough that if it counted, the third row would not fit
@@ -890,12 +890,12 @@ func TestFileBatchProducer_StashAndContinue_MultipleTasksSameTable(t *testing.T)
 	_, task2, err := createFileAndTask(lexportDir, fileContents2, ldataDir, "test_table", 2)
 	assert.NoError(t, err)
 
-	// Use a mock valueConverter that errors on row 2
-	origValueConverter := valueConverter
-	valueConverter = &mockRowErrorValueConverter{rowToError: 2}
-	t.Cleanup(func() { valueConverter = origValueConverter })
+	// Use a mock testProducerCfg.ValueConverter that errors on row 2
+	origValueConverter := testProducerCfg.ValueConverter
+	testProducerCfg.ValueConverter = &mockRowErrorValueConverter{rowToError: 2}
+	t.Cleanup(func() { testProducerCfg.ValueConverter = origValueConverter })
 
-	batchproducer1, err := NewSequentialFileBatchProducer(task1, state, true, scErrorHandler, progressReporter)
+	batchproducer1, err := NewSequentialFileBatchProducer(testProducerCfg, task1, state, true, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	// First batch: should contain row 1 and row 3 (row 2 is errored and skipped, its size does not count)
@@ -904,7 +904,7 @@ func TestFileBatchProducer_StashAndContinue_MultipleTasksSameTable(t *testing.T)
 	assert.NotNil(t, batch1)
 	assert.Equal(t, int64(2), batch1.RecordCount)
 
-	batchproducer2, err := NewSequentialFileBatchProducer(task2, state, true, scErrorHandler, progressReporter)
+	batchproducer2, err := NewSequentialFileBatchProducer(testProducerCfg, task2, state, true, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	// First batch: should contain row 1 and row 3 (row 2 is errored and skipped, its size does not count)
@@ -933,7 +933,7 @@ func TestFileBatchProducer_StashAndContinue_MultipleTasksSameTable(t *testing.T)
 func assertProcessingErrorBatchFileContains(t *testing.T, lexportDir string, task *ImportFileTask,
 	batchNumber int64, expectedRowCount int64, expectedByteCount int64,
 	expectedSubstrings ...string) {
-	taskFolderPath := fmt.Sprintf("file::%s:%s", filepath.Base(task.FilePath), importdata.ComputePathHash(task.FilePath))
+	taskFolderPath := fmt.Sprintf("file::%s:%s", filepath.Base(task.FilePath), ComputePathHash(task.FilePath))
 	tableFolderPath := fmt.Sprintf("table::%s", task.TableNameTup.ForKey())
 	errorFileName := fmt.Sprintf("processing-errors.%d.%d.%d.log", batchNumber, expectedRowCount, expectedByteCount)
 	errorsFilePath := filepath.Join(getErrorsParentDir(lexportDir), "errors", tableFolderPath, taskFolderPath, errorFileName)
@@ -1011,7 +1011,7 @@ func TestBatchCumByteOffsetTracking(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	batchproducer, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	batchproducer, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	var batches []*Batch
@@ -1052,7 +1052,7 @@ func TestByteSeekResumption(t *testing.T) {
 	assert.NoError(t, err)
 
 	// First run: produce one batch (rows 1-2)
-	bp1, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp1, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch1, err := bp1.NextBatch()
 	assert.NoError(t, err)
@@ -1062,7 +1062,7 @@ func TestByteSeekResumption(t *testing.T) {
 	bp1.Close()
 
 	// Resume: should use byte-seek
-	bp2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.Equal(t, batch1.CumByteOffsetEnd, bp2.lastBatchCumByteOffsetEnd,
 		"Recovered lastBatchCumByteOffsetEnd should match batch1's CumByteOffsetEnd")
@@ -1099,7 +1099,7 @@ func TestByteSeekResumption_NoHeader(t *testing.T) {
 	defer os.RemoveAll(lexportDir)
 
 	rows := []string{"1\thello", "2\tworld", "3\tfoo", "4\tbar"}
-	dataFileDescriptor = &datafile.Descriptor{
+	testProducerCfg.DataFileDescriptor = &datafile.Descriptor{
 		FileFormat: "text",
 		Delimiter:  "\t",
 		HasHeader:  false,
@@ -1119,7 +1119,7 @@ func TestByteSeekResumption_NoHeader(t *testing.T) {
 	}
 
 	// First run: produce one batch (rows 1-2)
-	bp1, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp1, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch1, err := bp1.NextBatch()
 	assert.NoError(t, err)
@@ -1129,7 +1129,7 @@ func TestByteSeekResumption_NoHeader(t *testing.T) {
 	bp1.Close()
 
 	// Resume: should use byte-seek
-	bp2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	// Get pending batch 1
@@ -1173,7 +1173,7 @@ func TestCumByteOffset_CarriedForwardLine(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	bp, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch1, err := bp.NextBatch()
@@ -1218,7 +1218,7 @@ func TestMultipleResumeCycles(t *testing.T) {
 	defer os.RemoveAll(lexportDir)
 
 	rows := []string{"a\tb", "c\td", "e\tf", "g\th", "i\tj", "k\tl"}
-	dataFileDescriptor = &datafile.Descriptor{
+	testProducerCfg.DataFileDescriptor = &datafile.Descriptor{
 		FileFormat: "text",
 		Delimiter:  "\t",
 		HasHeader:  false,
@@ -1238,7 +1238,7 @@ func TestMultipleResumeCycles(t *testing.T) {
 	}
 
 	// Cycle 1: produce 2 batches
-	bp1, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp1, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	b1, err := bp1.NextBatch()
 	assert.NoError(t, err)
@@ -1248,7 +1248,7 @@ func TestMultipleResumeCycles(t *testing.T) {
 	bp1.Close()
 
 	// Cycle 2: resume, get 2 pending + produce 2 new
-	bp2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.Equal(t, b2.CumByteOffsetEnd, bp2.lastBatchCumByteOffsetEnd)
 
@@ -1267,7 +1267,7 @@ func TestMultipleResumeCycles(t *testing.T) {
 	bp2.Close()
 
 	// Cycle 3: resume again, get 4 pending + produce remaining 2
-	bp3, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp3, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.Equal(t, b4.CumByteOffsetEnd, bp3.lastBatchCumByteOffsetEnd)
 
@@ -1321,7 +1321,7 @@ func TestCumByteOffset_SingleRowFile(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	bp, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := bp.NextBatch()
@@ -1360,7 +1360,7 @@ func TestCumByteOffset_CsvNewlineInData(t *testing.T) {
 		_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 		assert.NoError(t, err)
 
-		bp, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+		bp, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 		assert.NoError(t, err)
 
 		var batches []*Batch
@@ -1396,7 +1396,7 @@ func TestCumByteOffset_CsvNewlineInData(t *testing.T) {
 		assert.NoError(t, err)
 
 		// First run: produce batch 1 (rows 0-1, where row 1 has embedded newline)
-		bp1, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+		bp1, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 		assert.NoError(t, err)
 		batch1, err := bp1.NextBatch()
 		assert.NoError(t, err)
@@ -1407,7 +1407,7 @@ func TestCumByteOffset_CsvNewlineInData(t *testing.T) {
 		bp1.Close()
 
 		// Resume via byte-seek past the multi-line row
-		bp2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+		bp2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 		assert.NoError(t, err)
 		assert.Equal(t, batch1.CumByteOffsetEnd, bp2.lastBatchCumByteOffsetEnd)
 
@@ -1447,7 +1447,7 @@ func TestCumByteOffset_WithStashedErrors(t *testing.T) {
 	defer os.RemoveAll(ldataDir)
 	defer os.RemoveAll(lexportDir)
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	assert.NoError(t, err)
 
 	longVal := strings.Repeat("x", 220) // 220+ bytes, exceeds MaxBatchSizeInBytes of 200
@@ -1455,7 +1455,7 @@ func TestCumByteOffset_WithStashedErrors(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	bp, err := NewSequentialFileBatchProducer(task, state, false, scErrorHandler, progressReporter)
+	bp, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := bp.NextBatch()
@@ -1478,7 +1478,7 @@ func TestByteSeekResumption_ManyBatches(t *testing.T) {
 	defer os.RemoveAll(ldataDir)
 	defer os.RemoveAll(lexportDir)
 
-	dataFileDescriptor = &datafile.Descriptor{
+	testProducerCfg.DataFileDescriptor = &datafile.Descriptor{
 		FileFormat: "text",
 		Delimiter:  "\t",
 		HasHeader:  false,
@@ -1499,7 +1499,7 @@ func TestByteSeekResumption_ManyBatches(t *testing.T) {
 	}
 
 	// First run: produce 4 batches
-	bp1, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp1, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	firstRunBatches := make([]*Batch, 0)
 	for i := 0; i < 4; i++ {
@@ -1510,7 +1510,7 @@ func TestByteSeekResumption_ManyBatches(t *testing.T) {
 	bp1.Close()
 
 	// Resume: byte-seek to midpoint
-	bp2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.Equal(t, firstRunBatches[3].CumByteOffsetEnd, bp2.lastBatchCumByteOffsetEnd)
 
@@ -1558,7 +1558,7 @@ func TestByteSeekResumption_SqlFormat(t *testing.T) {
 	dataRows := []string{"1\thello", "2\tworld", "3\tfoo", "4\tbar"}
 	sqlContent := preamble + "\n" + strings.Join(dataRows, "\n") + "\n\\.\n"
 
-	dataFileDescriptor = &datafile.Descriptor{
+	testProducerCfg.DataFileDescriptor = &datafile.Descriptor{
 		FileFormat: "sql",
 		HasHeader:  false,
 		ExportDir:  lexportDir,
@@ -1576,7 +1576,7 @@ func TestByteSeekResumption_SqlFormat(t *testing.T) {
 	}
 
 	// First run: produce one batch (rows 1-2)
-	bp1, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp1, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch1, err := bp1.NextBatch()
 	assert.NoError(t, err)
@@ -1587,7 +1587,7 @@ func TestByteSeekResumption_SqlFormat(t *testing.T) {
 	bp1.Close()
 
 	// Resume: byte-seek past the COPY preamble + first 2 data rows
-	bp2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.Equal(t, batch1.CumByteOffsetEnd, bp2.lastBatchCumByteOffsetEnd)
 
@@ -1623,7 +1623,7 @@ func TestCumByteOffset_WithConversionErrors(t *testing.T) {
 	defer os.RemoveAll(ldataDir)
 	defer os.RemoveAll(lexportDir)
 
-	scErrorHandler, err := importdata.GetImportDataErrorHandler(importdata.StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), importerRole)
+	scErrorHandler, err := GetImportDataErrorHandler(StashAndContinueErrorPolicy, getErrorsParentDir(lexportDir), testImporterRole)
 	assert.NoError(t, err)
 
 	fileContents := `id,val
@@ -1633,11 +1633,11 @@ func TestCumByteOffset_WithConversionErrors(t *testing.T) {
 	_, task, err := createFileAndTask(lexportDir, fileContents, ldataDir, "test_table", 1)
 	assert.NoError(t, err)
 
-	origValueConverter := valueConverter
-	valueConverter = &mockRowErrorValueConverter{rowToError: 2}
-	t.Cleanup(func() { valueConverter = origValueConverter })
+	origValueConverter := testProducerCfg.ValueConverter
+	testProducerCfg.ValueConverter = &mockRowErrorValueConverter{rowToError: 2}
+	t.Cleanup(func() { testProducerCfg.ValueConverter = origValueConverter })
 
-	bp, err := NewSequentialFileBatchProducer(task, state, true, scErrorHandler, progressReporter)
+	bp, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, true, scErrorHandler, progressReporter)
 	assert.NoError(t, err)
 
 	batch, err := bp.NextBatch()
@@ -1653,7 +1653,7 @@ func TestCumByteOffset_WithConversionErrors(t *testing.T) {
 }
 
 func assertNoProcessingErrorBatchFileExists(t *testing.T, lexportDir string, task *ImportFileTask, batchNumber int64) {
-	taskFolderPath := fmt.Sprintf("file::%s:%s", filepath.Base(task.FilePath), importdata.ComputePathHash(task.FilePath))
+	taskFolderPath := fmt.Sprintf("file::%s:%s", filepath.Base(task.FilePath), ComputePathHash(task.FilePath))
 	tableFolderPath := fmt.Sprintf("table::%s", task.TableNameTup.ForKey())
 	errorsDir := filepath.Join(getErrorsParentDir(lexportDir), "errors", tableFolderPath, taskFolderPath)
 
@@ -1718,7 +1718,7 @@ func TestResumeFallsBackToSkipLinesWhenOpenAtUnsupported(t *testing.T) {
 
 	// First run (real local datastore): produce one batch (rows 1-2) so that a
 	// resumption point with a recovered byte offset exists.
-	bp1, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp1, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	batch1, err := bp1.NextBatch()
 	assert.NoError(t, err)
@@ -1726,11 +1726,11 @@ func TestResumeFallsBackToSkipLinesWhenOpenAtUnsupported(t *testing.T) {
 	bp1.Close()
 
 	// Now wrap the datastore so OpenAt reports "not implemented", like GCS/Azure.
-	spy := &notImplementedOpenAtDataStore{DataStore: dataStore}
-	dataStore = spy
+	spy := &notImplementedOpenAtDataStore{DataStore: testProducerCfg.DataStore}
+	testProducerCfg.DataStore = spy
 
 	// Resume.
-	bp2, err := NewSequentialFileBatchProducer(task, state, false, errorHandler, progressReporter)
+	bp2, err := NewSequentialFileBatchProducer(testProducerCfg, task, state, false, errorHandler, progressReporter)
 	assert.NoError(t, err)
 	assert.Greater(t, bp2.lastBatchCumByteOffsetEnd, int64(0),
 		"a byte offset should have been recovered, so the producer would attempt byte-offset seek")

--- a/yb-voyager/src/importdata/importDataSequentialFileBatchProducer_test.go
+++ b/yb-voyager/src/importdata/importDataSequentialFileBatchProducer_test.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/importDataState.go
+++ b/yb-voyager/src/importdata/importDataState.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"bufio"

--- a/yb-voyager/src/importdata/importDataState.go
+++ b/yb-voyager/src/importdata/importDataState.go
@@ -32,6 +32,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
@@ -56,16 +57,30 @@ metainfo/import_data_state/table::<table_name>/file::<base_name>:<path_hash>/
 	link -> dataFile
 	batch::<batch_num>.<offset_end>.<record_count>.<byte_count>.<cum_byte_offset_end>.<state>
 */
+// ImportDataStateConfig holds the values ImportDataState, and the Batch objects it
+// creates, read. They used to be cmd package-level variables; cmd copies them in.
+type ImportDataStateConfig struct {
+	ExportDir          string
+	ImporterRole       string
+	Tdb                tgtdb.TargetDB
+	Tconf              tgtdb.TargetConf
+	MigrationUUID      uuid.UUID
+	TruncateSplits     utils.BoolStr
+	DataFileDescriptor *datafile.Descriptor
+}
+
 type ImportDataState struct {
+	cfg                     ImportDataStateConfig
 	exportDir               string
 	stateDir                string
 	inProgressTaskImporters map[int]fileTaskImportStatusChecker // used to fetch in-memory status from FileTaskImporter
 }
 
-func NewImportDataState(exportDir string) *ImportDataState {
+func NewImportDataState(cfg ImportDataStateConfig) *ImportDataState {
 	return &ImportDataState{
-		exportDir:               exportDir,
-		stateDir:                filepath.Join(exportDir, "metainfo", "import_data_state", importerRole),
+		cfg:                     cfg,
+		exportDir:               cfg.ExportDir,
+		stateDir:                filepath.Join(cfg.ExportDir, "metainfo", "import_data_state", cfg.ImporterRole),
 		inProgressTaskImporters: make(map[int]fileTaskImportStatusChecker),
 	}
 }
@@ -158,7 +173,7 @@ func (s *ImportDataState) GetFileImportState(filePath string, tableNameTup sqlna
 		} else if batch.IsErrored() {
 			errorCount++
 		}
-		if batch.Number == LAST_SPLIT_NUM {
+		if batch.Number == constants.LAST_SPLIT_NUM {
 			batchGenerationCompleted = true
 		}
 	}
@@ -199,7 +214,7 @@ func (s *ImportDataState) Recover(filePath string, tableNameTup sqlname.NameTupl
 			offsetStart is the line in original datafile from where current split starts
 			offsetEnd   is the line in original datafile from where next split starts
 		*/
-		if batch.Number == LAST_SPLIT_NUM {
+		if batch.Number == constants.LAST_SPLIT_NUM {
 			fileFullySplit = true
 		}
 		if batch.Number > lastBatchNumber {
@@ -332,15 +347,16 @@ func (s *ImportDataState) getBatches(filePath string, tableNameTup sqlname.NameT
 				continue
 			}
 			batch := &Batch{
-				SchemaName:    "",
-				TableNameTup:  tableNameTup,
-				FilePath:      filepath.Join(fileStateDir, file.Name()),
-				BaseFilePath:  filePath,
-				Number:        batchNum,
-				LineOffsetStart: offsetEnd - recordCount,
-				LineOffsetEnd:   offsetEnd,
-				ByteCount:     byteCount,
-				RecordCount:   recordCount,
+				cfg:              s.batchConfig(),
+				SchemaName:       "",
+				TableNameTup:     tableNameTup,
+				FilePath:         filepath.Join(fileStateDir, file.Name()),
+				BaseFilePath:     filePath,
+				Number:           batchNum,
+				LineOffsetStart:  offsetEnd - recordCount,
+				LineOffsetEnd:    offsetEnd,
+				ByteCount:        byteCount,
+				RecordCount:      recordCount,
 				CumByteOffsetEnd: cumByteOffsetEnd,
 			}
 			result = append(result, batch)
@@ -451,7 +467,7 @@ func (s *ImportDataState) GetTotalNumOfEventsImportedByType(migrationUUID uuid.U
 	query := fmt.Sprintf("SELECT SUM(num_inserts), SUM(num_updates), SUM(num_deletes) FROM %s where migration_uuid='%s'",
 		EVENT_CHANNELS_METADATA_TABLE_NAME, migrationUUID)
 	var numInserts, numUpdates, numDeletes int64
-	err := tdb.QueryRow(query).Scan(&numInserts, &numUpdates, &numDeletes)
+	err := s.cfg.Tdb.QueryRow(query).Scan(&numInserts, &numUpdates, &numDeletes)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("error in getting import stats from target db: %w", err)
 	}
@@ -471,11 +487,11 @@ func (s *ImportDataState) InitLiveMigrationState(migrationUUID uuid.UUID, numCha
 	if startClean {
 		// TODO: common definition for these batch metadata name tuples
 		evChanMetadataTbl := EVENT_CHANNELS_METADATA_TABLE_NAME
-		if tconf.TargetDBType == ORACLE {
+		if s.cfg.Tconf.TargetDBType == constants.ORACLE {
 			evChanMetadataTbl = strings.ToUpper(evChanMetadataTbl)
 		}
 		parts := strings.Split(evChanMetadataTbl, ".")
-		evChanMetadataTblName := sqlname.NewObjectName(tconf.TargetDBType, "public", parts[0], parts[1])
+		evChanMetadataTblName := sqlname.NewObjectName(s.cfg.Tconf.TargetDBType, "public", parts[0], parts[1])
 		evChanNt := sqlname.NameTuple{
 			CurrentName: evChanMetadataTblName,
 			SourceName:  nil,
@@ -487,11 +503,11 @@ func (s *ImportDataState) InitLiveMigrationState(migrationUUID uuid.UUID, numCha
 		}
 
 		evTblMetadataTbl := EVENTS_PER_TABLE_METADATA_TABLE_NAME
-		if tconf.TargetDBType == ORACLE {
+		if s.cfg.Tconf.TargetDBType == constants.ORACLE {
 			evTblMetadataTbl = strings.ToUpper(evTblMetadataTbl)
 		}
 		parts = strings.Split(evTblMetadataTbl, ".")
-		evTblMetadataTblName := sqlname.NewObjectName(tconf.TargetDBType, "public", parts[0], parts[1])
+		evTblMetadataTblName := sqlname.NewObjectName(s.cfg.Tconf.TargetDBType, "public", parts[0], parts[1])
 		evTblNt := sqlname.NameTuple{
 			CurrentName: evTblMetadataTblName,
 			SourceName:  nil,
@@ -516,7 +532,7 @@ func (s *ImportDataState) InitLiveMigrationState(migrationUUID uuid.UUID, numCha
 
 func (s *ImportDataState) clearMigrationStateFromTable(tableNameTup sqlname.NameTuple, migrationUUID uuid.UUID) error {
 	stmt := fmt.Sprintf("DELETE FROM %s where migration_uuid='%s'", tableNameTup.ForUserQuery(), migrationUUID)
-	rowsAffected, err := tdb.Exec(stmt)
+	rowsAffected, err := s.cfg.Tdb.Exec(stmt)
 	if err != nil {
 		return fmt.Errorf("error executing stmt - %v: %w", stmt, err)
 	}
@@ -548,7 +564,7 @@ func (s *ImportDataState) initChannelMetaInfo(migrationUUID uuid.UUID, numChans 
 		log.Info("event channels meta info already created. Skipping init.")
 		return nil
 	}
-	err = tdb.WithTx(func(tx *sql.Tx) error {
+	err = s.cfg.Tdb.WithTx(func(tx *sql.Tx) error {
 		for c := 0; c < numChans; c++ {
 			insertStmt := fmt.Sprintf("INSERT INTO %s VALUES ('%s', %d, -1, %d, %d, %d)", EVENT_CHANNELS_METADATA_TABLE_NAME, migrationUUID, c, 0, 0, 0)
 			_, err := tx.Exec(insertStmt)
@@ -573,7 +589,7 @@ func (s *ImportDataState) getEventChannelsRowCount(migrationUUID uuid.UUID) (int
 	rowsStmt := fmt.Sprintf(
 		"SELECT count(*) FROM %s where migration_uuid='%s'", EVENT_CHANNELS_METADATA_TABLE_NAME, migrationUUID)
 	var rowCount int64
-	err := tdb.QueryRow(rowsStmt).Scan(&rowCount)
+	err := s.cfg.Tdb.QueryRow(rowsStmt).Scan(&rowCount)
 	if err != nil {
 		return 0, fmt.Errorf("error executing stmt - %v: %w", rowsStmt, err)
 	}
@@ -590,7 +606,7 @@ func (s *ImportDataState) initEventStatsByTableMetainfo(migrationUUID uuid.UUID,
 		tableRowCount.Put(tableNameTup, rowCount)
 	}
 
-	return tdb.WithTx(func(tx *sql.Tx) error {
+	return s.cfg.Tdb.WithTx(func(tx *sql.Tx) error {
 		for _, tableNameTup := range tableNameTups {
 			rowCount, _ := tableRowCount.Get(tableNameTup)
 			if rowCount > 0 {
@@ -615,7 +631,7 @@ func (s *ImportDataState) getLiveMigrationMetaInfoByTable(migrationUUID uuid.UUI
 		"SELECT count(*) FROM %s where migration_uuid='%s' AND table_name='%s'",
 		EVENTS_PER_TABLE_METADATA_TABLE_NAME, migrationUUID, tableNameTup.ForKey())
 	var rowCount int64
-	err := tdb.QueryRow(rowsStmt).Scan(&rowCount)
+	err := s.cfg.Tdb.QueryRow(rowsStmt).Scan(&rowCount)
 	if err != nil {
 		return 0, fmt.Errorf("error executing stmt - %v: %w", rowsStmt, err)
 	}
@@ -627,8 +643,8 @@ func (s *ImportDataState) cleanFileImportStateFromDB(filePath string, tableNameT
 	sname, tname := tableNameTup.ForCatalogQuery()
 	cmd := fmt.Sprintf(
 		`DELETE FROM %s WHERE migration_uuid = '%s' AND data_file_name = '%s' AND schema_name = '%s' AND table_name = '%s'`,
-		BATCH_METADATA_TABLE_NAME, migrationUUID, filePath, sname, tname)
-	rowsAffected, err := tdb.Exec(cmd)
+		BATCH_METADATA_TABLE_NAME, s.cfg.MigrationUUID, filePath, sname, tname)
+	rowsAffected, err := s.cfg.Tdb.Exec(cmd)
 	if err != nil {
 		return fmt.Errorf("remove %q related entries from %s: %w", tableNameTup, BATCH_METADATA_TABLE_NAME, err)
 	}
@@ -640,9 +656,9 @@ func (s *ImportDataState) GetImportedSnapshotRowCountForTable(tableNameTup sqlna
 	var snapshotRowCount int64
 	sname, tname := tableNameTup.ForCatalogQuery()
 	query := fmt.Sprintf(`SELECT COALESCE(SUM(rows_imported),0) FROM %s where migration_uuid='%s' AND schema_name='%s' AND table_name='%s'`,
-		BATCH_METADATA_TABLE_NAME, migrationUUID, sname, tname)
+		BATCH_METADATA_TABLE_NAME, s.cfg.MigrationUUID, sname, tname)
 	log.Infof("query to get total row count for snapshot import of table %s: %s", tableNameTup, query)
-	err := tdb.QueryRow(query).Scan(&snapshotRowCount)
+	err := s.cfg.Tdb.QueryRow(query).Scan(&snapshotRowCount)
 	if err != nil {
 		log.Errorf("error in querying row_imported for snapshot import of table %s: %v", tableNameTup, err)
 		return 0, fmt.Errorf("error in querying row_imported for snapshot import of table %s: %w", tableNameTup, err)
@@ -660,7 +676,7 @@ func (s *ImportDataState) GetEventChannelsMetaInfo(migrationUUID uuid.UUID) (map
 	metainfo := map[int]EventChannelMetaInfo{}
 
 	query := fmt.Sprintf("SELECT channel_no, last_applied_vsn FROM %s where migration_uuid='%s'", EVENT_CHANNELS_METADATA_TABLE_NAME, migrationUUID)
-	rows, err := tdb.Query(query)
+	rows, err := s.cfg.Tdb.Query(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query meta info for channels: %w", err)
 	}
@@ -680,7 +696,7 @@ func (s *ImportDataState) IsEventBatchAlreadyImported(batch *tgtdb.EventBatch, m
 	query := fmt.Sprintf("SELECT last_applied_vsn FROM %s WHERE migration_uuid='%s' AND channel_no=%d",
 		EVENT_CHANNELS_METADATA_TABLE_NAME, migrationUUID, batch.ChanNo)
 	var lastAppliedVsnInChan int64
-	err := tdb.QueryRow(query).Scan(&lastAppliedVsnInChan)
+	err := s.cfg.Tdb.QueryRow(query).Scan(&lastAppliedVsnInChan)
 	if err != nil {
 		return false, err
 	}
@@ -692,7 +708,7 @@ func (s *ImportDataState) GetImportedEventsStatsForTable(tableNameTup sqlname.Na
 	query := fmt.Sprintf(`SELECT SUM(total_events), SUM(num_inserts), SUM(num_updates), SUM(num_deletes) FROM %s 
 		WHERE table_name='%s' AND migration_uuid='%s'`, EVENTS_PER_TABLE_METADATA_TABLE_NAME, tableNameTup.ForKey(), migrationUUID)
 	log.Infof("query to get import stats for table %s: %s", tableNameTup.ForKey(), query)
-	err := tdb.QueryRow(query).Scan(&eventCounter.TotalEvents,
+	err := s.cfg.Tdb.QueryRow(query).Scan(&eventCounter.TotalEvents,
 		&eventCounter.NumInserts, &eventCounter.NumUpdates, &eventCounter.NumDeletes)
 	if err != nil {
 		log.Errorf("error in getting import stats from target db: %v", err)
@@ -720,7 +736,7 @@ func (s *ImportDataState) GetImportedEventsStatsForTableList(tableNameTupList []
 	query := fmt.Sprintf(`SELECT table_name, SUM(total_events), SUM(num_inserts), SUM(num_updates), SUM(num_deletes) FROM %s 
 		WHERE migration_uuid='%s' GROUP BY table_name HAVING table_name in ('%s')`, EVENTS_PER_TABLE_METADATA_TABLE_NAME, migrationUUID, tableListQuery)
 	log.Infof("query to get import stats for tables '%s': %s", tableListQuery, query)
-	rows, err := tdb.Query(query)
+	rows, err := s.cfg.Tdb.Query(query)
 	if err != nil {
 		log.Errorf("error in getting import stats from target db: %v", err)
 		return nil, fmt.Errorf("error in getting import stats from target db: %w", err)
@@ -803,7 +819,7 @@ func (bw *BatchWriter) Init() error {
 		return goerrors.Errorf("create file %q: %w", currTmpFileName, err)
 	}
 	bw.outFile = outFile
-	bw.w = bufio.NewWriterSize(outFile, 4*MB)
+	bw.w = bufio.NewWriterSize(outFile, 4*constants.MB)
 	return nil
 }
 
@@ -851,7 +867,7 @@ func (bw *BatchWriter) Done(isLastBatch bool, offsetEnd int64, byteCount int64, 
 
 	batchNumber := bw.batchNumber
 	if isLastBatch {
-		batchNumber = LAST_SPLIT_NUM
+		batchNumber = constants.LAST_SPLIT_NUM
 	}
 	fileStateDir := bw.state.getFileStateDir(bw.filePath, bw.tableName)
 	batchFilePath := fmt.Sprintf("%s/batch::%d.%d.%d.%d.%d.C",
@@ -862,15 +878,16 @@ func (bw *BatchWriter) Done(isLastBatch bool, offsetEnd int64, byteCount int64, 
 		return nil, goerrors.Errorf("rename %q to %q: %w", tmpFileName, batchFilePath, err)
 	}
 	batch := &Batch{
-		SchemaName:    "",
-		TableNameTup:  bw.tableName,
-		FilePath:      batchFilePath,
-		BaseFilePath:  bw.filePath,
-		Number:        batchNumber,
-		LineOffsetStart: offsetEnd - bw.NumRecordsWritten,
-		LineOffsetEnd:   offsetEnd,
-		RecordCount:   bw.NumRecordsWritten,
-		ByteCount:     byteCount,
+		cfg:              bw.state.batchConfig(),
+		SchemaName:       "",
+		TableNameTup:     bw.tableName,
+		FilePath:         batchFilePath,
+		BaseFilePath:     bw.filePath,
+		Number:           batchNumber,
+		LineOffsetStart:  offsetEnd - bw.NumRecordsWritten,
+		LineOffsetEnd:    offsetEnd,
+		RecordCount:      bw.NumRecordsWritten,
+		ByteCount:        byteCount,
 		CumByteOffsetEnd: cumByteOffsetEnd,
 	}
 	return batch, nil
@@ -883,18 +900,34 @@ const (
 	PARTIAL_BATCH_ERROR_NOTE = "NOTE: It is possible that the batch was partially ingested. Therefore, some of the rows in this batch may have been imported successfully."
 )
 
+// batchConfig is the subset of ImportDataStateConfig the Batch methods read.
+type batchConfig struct {
+	MigrationUUID      uuid.UUID
+	TruncateSplits     utils.BoolStr
+	DataFileDescriptor *datafile.Descriptor
+}
+
+func (s *ImportDataState) batchConfig() batchConfig {
+	return batchConfig{
+		MigrationUUID:      s.cfg.MigrationUUID,
+		TruncateSplits:     s.cfg.TruncateSplits,
+		DataFileDescriptor: s.cfg.DataFileDescriptor,
+	}
+}
+
 type Batch struct {
-	Number        int64
-	TableNameTup  sqlname.NameTuple
-	SchemaName    string
-	FilePath      string // Path of the batch file.
-	BaseFilePath  string // Path of the original data file.
-	LineOffsetStart int64
-	LineOffsetEnd   int64
-	RecordCount   int64
-	ByteCount     int64
+	cfg              batchConfig
+	Number           int64
+	TableNameTup     sqlname.NameTuple
+	SchemaName       string
+	FilePath         string // Path of the batch file.
+	BaseFilePath     string // Path of the original data file.
+	LineOffsetStart  int64
+	LineOffsetEnd    int64
+	RecordCount      int64
+	ByteCount        int64
 	CumByteOffsetEnd int64 // Absolute byte position in the original data file after this batch.
-	Interrupted   bool
+	Interrupted      bool
 }
 
 func (batch *Batch) Open() (*os.File, error) {
@@ -909,7 +942,7 @@ func (batch *Batch) OpenAsDataFile() (datafile.DataFile, error) {
 		return nil, goerrors.Errorf("open batch file %q: %w", batch.GetFilePath(), err)
 	}
 
-	datafile, err := datafile.NewDataFile(batch.GetFilePath(), file, dataFileDescriptor, 0)
+	datafile, err := datafile.NewDataFile(batch.GetFilePath(), file, batch.cfg.DataFileDescriptor, 0)
 	if err != nil {
 		return nil, goerrors.Errorf("create datafile for %q: %w", batch.GetFilePath(), err)
 	}
@@ -1003,7 +1036,7 @@ func (batch *Batch) MarkDone() error {
 		return fmt.Errorf("rename %q => %q: %w", inProgressFilePath, doneFilePath, err)
 	}
 
-	if truncateSplits {
+	if batch.cfg.TruncateSplits {
 		err = os.Truncate(doneFilePath, 0)
 		if err != nil {
 			log.Warnf("truncate file %q: %s", doneFilePath, err)
@@ -1018,7 +1051,7 @@ func (batch *Batch) GetQueryIsBatchAlreadyImported() string {
 	query := fmt.Sprintf(
 		"SELECT rows_imported FROM %s "+
 			"WHERE migration_uuid = '%s' AND data_file_name = '%s' AND batch_number = %d AND schema_name = '%s' AND table_name = '%s'",
-		BATCH_METADATA_TABLE_NAME, migrationUUID, batch.BaseFilePath, batch.Number, schemaName, tableName)
+		BATCH_METADATA_TABLE_NAME, batch.cfg.MigrationUUID, batch.BaseFilePath, batch.Number, schemaName, tableName)
 
 	return query
 }
@@ -1029,7 +1062,7 @@ func (batch *Batch) GetQueryToRecordEntryInDB(rowsAffected int64) string {
 	cmd := fmt.Sprintf(
 		`INSERT INTO %s (migration_uuid, data_file_name, batch_number, schema_name, table_name, rows_imported)
 			VALUES ('%s', '%s', %d, '%s', '%s', %v)`,
-		BATCH_METADATA_TABLE_NAME, migrationUUID, batch.BaseFilePath, batch.Number, schemaName, tableName, rowsAffected)
+		BATCH_METADATA_TABLE_NAME, batch.cfg.MigrationUUID, batch.BaseFilePath, batch.Number, schemaName, tableName, rowsAffected)
 
 	return cmd
 }

--- a/yb-voyager/src/importdata/importDataTestUtils.go
+++ b/yb-voyager/src/importdata/importDataTestUtils.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"os"

--- a/yb-voyager/src/importdata/importDataTestUtils.go
+++ b/yb-voyager/src/importdata/importDataTestUtils.go
@@ -1,4 +1,4 @@
-//go:build unit || integration || integration_voyager_command
+//go:build unit || integration
 
 /*
 Copyright (c) YugabyteDB, Inc.
@@ -21,11 +21,13 @@ import (
 	"os"
 	"path/filepath"
 
+	_ "github.com/mattn/go-sqlite3"
+
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -41,7 +43,64 @@ func (d *dummyTDB) MaxBatchSizeInBytes() int64 {
 	return d.maxSizeBytes
 }
 
-func setupExportDirAndImportDependencies(batchSizeRows int64, batchSizeBytes int64) (string, string, *ImportDataState, importdata.ImportDataErrorHandler, *ImportDataProgressReporter, error) {
+// testImporterRole is the importer role every component test in this package runs as.
+const testImporterRole = constants.TARGET_DB_IMPORTER_ROLE
+
+// Test fixture shared by the component tests in this package. It stands in for the
+// cmd package-level variables the components used to read directly; every test's
+// setupExportDirAndImportDependencies call resets it.
+var (
+	testStateCfg    ImportDataStateConfig
+	testProducerCfg SequentialFileBatchProducerConfig
+	testImporterCfg FileTaskImporterConfig
+)
+
+func testDataFileDescriptor(lexportDir string) *datafile.Descriptor {
+	return &datafile.Descriptor{
+		FileFormat: "csv",
+		Delimiter:  ",",
+		HasHeader:  true,
+		ExportDir:  lexportDir,
+		QuoteChar:  '"',
+		EscapeChar: '\\',
+		NullString: "NULL",
+	}
+}
+
+// initTestMetaDB creates the export-dir skeleton and metadata DB the way cmd's
+// CreateMigrationProjectIfNotExists + initMetaDB do for these tests (minus the
+// schema object dirs and the anonymizer, which no component here reads).
+func initTestMetaDB(exportDir string) error {
+	for _, subdir := range []string{
+		"schema", "data", "reports",
+		"assessment", "assessment/metadata", "assessment/dbs", "assessment/metadata/schema", "assessment/reports",
+		"metainfo", "metainfo/data", "metainfo/conf", "metainfo/ssl",
+		"temp", "temp/ora2pg_temp_dir", "temp/schema",
+	} {
+		if err := os.MkdirAll(filepath.Join(exportDir, subdir), 0755); err != nil {
+			return err
+		}
+	}
+	if err := metadb.CreateAndInitMetaDBIfRequired(exportDir); err != nil {
+		return err
+	}
+	m, err := metadb.NewMetaDB(exportDir)
+	if err != nil {
+		return err
+	}
+	if err := m.InitMigrationStatusRecord(""); err != nil {
+		return err
+	}
+	if err := m.InitImportDataStatusRecord(); err != nil {
+		return err
+	}
+	if err := m.InitImportDataFileStatusRecord(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupExportDirAndImportDependencies(batchSizeRows int64, batchSizeBytes int64) (string, string, *ImportDataState, ImportDataErrorHandler, *ImportDataProgressReporter, error) {
 	lexportDir, err := os.MkdirTemp("/tmp", "export-dir-*")
 	if err != nil {
 		return "", "", nil, nil, nil, err
@@ -52,18 +111,40 @@ func setupExportDirAndImportDependencies(batchSizeRows int64, batchSizeBytes int
 		return "", "", nil, nil, nil, err
 	}
 
-	metaDB = CreateMigrationProjectIfNotExists(constants.POSTGRESQL, lexportDir)
-	tdb = &dummyTDB{maxSizeBytes: batchSizeBytes}
-	valueConverter = &dbzm.SnapshotPhaseNoOpValueConverter{}
-	dataStore = datastore.NewDataStore(ldataDir)
+	err = initTestMetaDB(lexportDir)
+	if err != nil {
+		return "", "", nil, nil, nil, err
+	}
+	tdb := &dummyTDB{maxSizeBytes: batchSizeBytes}
+	dfd := testDataFileDescriptor(lexportDir)
+	tableToColumnNames := utils.NewStructMap[sqlname.NameTuple, []string]()
 
-	batchSizeInNumRows = batchSizeRows
+	testStateCfg = ImportDataStateConfig{
+		ExportDir:          lexportDir,
+		ImporterRole:       testImporterRole,
+		Tdb:                tdb,
+		DataFileDescriptor: dfd,
+	}
+	testProducerCfg = SequentialFileBatchProducerConfig{
+		ImporterRole:       testImporterRole,
+		Tdb:                tdb,
+		DataFileDescriptor: dfd,
+		DataStore:          datastore.NewDataStore(ldataDir),
+		BatchSizeInNumRows: batchSizeRows,
+		ValueConverter:     &dbzm.SnapshotPhaseNoOpValueConverter{},
+		TableToColumnNames: tableToColumnNames,
+	}
+	testImporterCfg = FileTaskImporterConfig{
+		ImporterRole:       testImporterRole,
+		Tdb:                tdb,
+		DataFileDescriptor: dfd,
+		TableToColumnNames: tableToColumnNames,
+		TableNameToSchema:  utils.NewStructMap[sqlname.NameTuple, map[string]map[string]string](),
+	}
 
-	state := NewImportDataState(lexportDir)
-	TableNameToSchema = utils.NewStructMap[sqlname.NameTuple, map[string]map[string]string]()
-	importerRole = TARGET_DB_IMPORTER_ROLE
+	state := NewImportDataState(testStateCfg)
 
-	errorHandler, err := importdata.GetImportDataErrorHandler(importdata.AbortErrorPolicy, filepath.Join(lexportDir, "data"), importerRole)
+	errorHandler, err := GetImportDataErrorHandler(AbortErrorPolicy, filepath.Join(lexportDir, "data"), testImporterRole)
 
 	if err != nil {
 		return "", "", nil, nil, nil, err
@@ -74,16 +155,11 @@ func setupExportDirAndImportDependencies(batchSizeRows int64, batchSizeBytes int
 }
 
 func createFileAndTask(lexportDir string, fileContents string, ldataDir string, tableName string, id int) (string, *ImportFileTask, error) {
-	dataFileDescriptor = &datafile.Descriptor{
-		FileFormat: "csv",
-		Delimiter:  ",",
-		HasHeader:  true,
-		ExportDir:  lexportDir,
-		QuoteChar:  '"',
-		EscapeChar: '\\',
-		NullString: "NULL",
-	}
-	tempFile, err := testutils.CreateTempFile(ldataDir, fileContents, dataFileDescriptor.FileFormat)
+	dfd := testDataFileDescriptor(lexportDir)
+	testStateCfg.DataFileDescriptor = dfd
+	testProducerCfg.DataFileDescriptor = dfd
+	testImporterCfg.DataFileDescriptor = dfd
+	tempFile, err := testutils.CreateTempFile(ldataDir, fileContents, dfd.FileFormat)
 	if err != nil {
 		return "", nil, err
 	}

--- a/yb-voyager/src/importdata/importFileTask.go
+++ b/yb-voyager/src/importdata/importFileTask.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package importdata
+
+import (
+	"fmt"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
+)
+
+type ImportFileTask struct {
+	ID           int
+	FilePath     string
+	TableNameTup sqlname.NameTuple
+	RowCount     int64
+	FileSize     int64
+}
+
+func (task *ImportFileTask) String() string {
+	return fmt.Sprintf("{ID: %d, FilePath: %s, TableName: %s, RowCount: %d, FileSize: %d}", task.ID, task.FilePath, task.TableNameTup.ForOutput(), task.RowCount, task.FileSize)
+}

--- a/yb-voyager/src/testlivemigration/import_data_snapshot_and_changes_snapshot_failures_test.go
+++ b/yb-voyager/src/testlivemigration/import_data_snapshot_and_changes_snapshot_failures_test.go
@@ -235,7 +235,7 @@ func TestImportSnapshotTransformFailureAndResume(t *testing.T) {
 		// Skip the first 20 per-row transform calls (let them succeed), then inject
 		// a transform error on the 21st row. With batch-size=100, all 20 rows fit
 		// in the first batch which is never finalized, so zero rows reach the target.
-		"github.com/yugabyte/yb-voyager/yb-voyager/cmd/importSnapshotTransformError=20*off->return(true)",
+		"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/importSnapshotTransformError=20*off->return(true)",
 	)
 	failMarkerPath := filepath.Join(lm.GetCurrentExportDir(), "failpoints", "failpoint-import-snapshot-transform-error.log")
 


### PR DESCRIPTION
### Describe the changes in this pull request

Moves the snapshot-import components from `cmd/` to `src/importdata/` (PR B of 3, stacked on #3788). No behavior change.

Review tip: two commits. The first is a pure `git mv` with only the package clause changed (it does not compile alone). The second, "adapt", is the real diff: config structs plus `global` → `field` prefixes.

- **Moved** — `ImportDataState` (+ `Batch`, `BatchWriter`), progress reporter, task pickers, both batch producers, `FileTaskImporter`, `ImportFileTask`, `GetTableTypes`, the snapshot-transform failpoint, and their tests.
- **Configs** — each component takes a by-value struct holding exactly the values it used to read from cmd globals: `ImportDataStateConfig`, `FileTaskImporterConfig`, `SequentialFileBatchProducerConfig`. `Batch` carries the three values its `tgtdb.Batch` methods read.
- **cmd bridge** — three `*FromGlobals` helpers in `cmd/importData.go` build those configs. PR C replaces them with `importdata.Config`.
- **One semantic wrinkle** — components capture the target handle at construction instead of reading the global at call time. Production constructs them after `tdb` is initialized, so this is equivalent. The bench shim and three unit tests now set `tdb` before building the state.
- **Tests** — the fixture replaces the former globals with `testStateCfg` / `testProducerCfg` / `testImporterCfg` and registers the sqlite driver the cmd binary used to register.
- **Formatting** — gofmt realigned two struct literals in `importDataState.go` and one test file that were already out of format.

Plan and decision record: https://claude.ai/code/artifact/bb4ab0a1-ad28-4e45-a556-4a6b483db845

### Describe if there are any user-facing changes

No user-facing changes.

### How was this pull request tested?

Existing tests, moved with their code: `go test -tags unit ./src/importdata/ ./cmd/`, `go test -tags integration ./src/importdata/` (YugabyteDB container), and every `integration_voyager_command` test matching `Import` against a binary built from this branch. `TestImportSnapshotTransformFailureAndResume` (failpoint_import) with `failpoint-ctl enable`. Vet under all tags, staticcheck, gofmt.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
