### PR TITLE
refactor(import-data): move the import engine and CDC streaming to src/importdata (PR C of 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The Go module uses build tags to separate test tiers. From `yb-voyager/`:
 | `integration_live_migration` | Live migration end-to-end with Debezium. |
 | `failpoint_export` / `failpoint_import` / `failpoint_cutover` | Failpoint-injected tests. Requires `failpoint-ctl enable` (from `github.com/pingcap/failpoint`) to rewrite source before building. |
 | `yb_version_latest_stable` | Version-gated issue tests run against the latest stable YB. |
-| `cdc_benchmark` | CDC ingest benchmarks (`test/cdcbench/`, shim in `cmd/`): replay real export-data queue segments through the import streaming path with `ExecuteBatch` mocked. Artifact generation needs Docker + installed `yb-voyager`/Debezium; cached artifacts replay with neither. Run: `go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./cmd/`. See `test/cdcbench/README.md`. |
+| `cdc_benchmark` | CDC ingest benchmarks (`test/cdcbench/`, shim in `src/importdata/`): replay real export-data queue segments through the import streaming path with `ExecuteBatch` mocked. Artifact generation needs Docker + installed `yb-voyager`/Debezium; cached artifacts replay with neither. Run: `go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./src/importdata/`. See `test/cdcbench/README.md`. |
 | `manual` | Local-only experiments, not run in CI. |
 
 Single test: `go test -tags unit -run TestName ./yb-voyager/cmd/...`
@@ -90,7 +90,8 @@ End-to-end migtests are invoked outside Go: `bash migtests/scripts/run-test.sh <
 - `src/migassessment/` — `assess-migration` engine: collects DB stats, sizing, replicas, permissions, produces the assessment DB and report. `cmd/templates/` holds the HTML/text report templates.
 - `src/callhome/` — anonymous telemetry payloads. Disabled with `YB_VOYAGER_SEND_DIAGNOSTICS=0` or `--send-diagnostics=false`.
 - `src/cp/` — control-plane abstractions (`noopcp`, `yugabyted`, `ybaeon`).
-- `src/anon/`, `src/errs/`, `src/errorpolicy/`, `src/adaptiveparallelism/`, `src/importdata/`, `src/lockfile/`, `src/datafile/`, `src/datastore/`, `src/reporter/`, `src/monitor/`, `src/version/`, `src/ybversion/` — focused helpers; names are descriptive.
+- `src/importdata/` — the import-data engine: `Config` (values cmd copies in from its flags/setup) + `Importer` (snapshot import, CDC streaming, conflict detection, cdc-partition-key resolution), the batch/task components, and the import error handlers. cmd keeps the cobra commands, flag validation, process succession, cutover choreography and callhome payloads.
+- `src/anon/`, `src/errs/`, `src/errorpolicy/`, `src/adaptiveparallelism/`, `src/lockfile/`, `src/datafile/`, `src/datastore/`, `src/reporter/`, `src/monitor/`, `src/version/`, `src/ybversion/` — focused helpers; names are descriptive.
 
 Test infrastructure for Go integration tests lives in `yb-voyager/test/containers/` (testcontainers wrappers for PG/MySQL/Oracle/YB) and `yb-voyager/test/utils/` (failpoint helpers, command runners, schema helpers).
 

--- a/yb-voyager/cmd/common.go
+++ b/yb-voyager/cmd/common.go
@@ -49,11 +49,9 @@ import (
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/anon"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/cp"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/migassessment"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
@@ -370,89 +368,6 @@ func renameDatafileDescriptor(exportDir string) {
 		}
 	}
 	datafileDescriptor.Save()
-}
-
-func displayImportedRowCountSnapshot(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask, errorHandler importdata.ImportDataErrorHandler) {
-	if importerRole == IMPORT_FILE_ROLE {
-		fmt.Printf("import report\n")
-	} else {
-		fmt.Printf("snapshot import report\n")
-	}
-	tableList := importFileTasksToTableNameTuples(tasks)
-	err := retrieveMigrationUUID()
-	if err != nil {
-		utils.ErrExit("could not retrieve migration UUID: %w", err)
-	}
-	uitable := uitable.New()
-
-	// TODO: refactor this; we don't need to pass the dbType as a parameter,
-	// we can just pass the importerRole directly.
-	var dbType string
-	switch importerRole {
-	case IMPORT_FILE_ROLE:
-		dbType = "target-file"
-	case SOURCE_REPLICA_DB_IMPORTER_ROLE:
-		dbType = "source-replica"
-	case TARGET_DB_IMPORTER_ROLE:
-		dbType = "target"
-	}
-
-	snapshotRowCount, err := getImportedSnapshotRowsMap(dbType, tableList, errorHandler)
-	if err != nil {
-		utils.ErrExit("failed to get imported snapshot rows map: %w", err)
-	}
-
-	keys := make([]sqlname.NameTuple, 0, len(snapshotRowCount.Keys()))
-	// the callback never returns an error
-	_ = snapshotRowCount.IterKV(func(k sqlname.NameTuple, v RowCountPair) (bool, error) {
-		keys = append(keys, k)
-		return true, nil
-	})
-
-	sort.Slice(keys, func(i, j int) bool {
-		val1, _ := snapshotRowCount.Get(keys[i])
-		val2, _ := snapshotRowCount.Get(keys[j])
-		return val1.Imported > val2.Imported
-	})
-
-	hasErrors := false
-	for _, tableName := range keys {
-		rowCountPair, _ := snapshotRowCount.Get(tableName)
-		if rowCountPair.Errored > 0 {
-			hasErrors = true
-			break
-		}
-	}
-
-	for i, tableName := range keys {
-		if i == 0 {
-			if hasErrors {
-				addHeader(uitable, "SCHEMA", "TABLE", "IMPORTED ROW COUNT", "ERRORED ROW COUNT")
-			} else {
-				addHeader(uitable, "SCHEMA", "TABLE", "IMPORTED ROW COUNT")
-			}
-		}
-		s, t := tableName.ForCatalogQuery()
-		rowCountPair, _ := snapshotRowCount.Get(tableName)
-		if hasErrors {
-			uitable.AddRow(s, t, rowCountPair.Imported, rowCountPair.Errored)
-		} else {
-			uitable.AddRow(s, t, rowCountPair.Imported)
-		}
-	}
-	if len(tableList) > 0 {
-		fmt.Printf("\n")
-		fmt.Println(uitable)
-		fmt.Printf("\n")
-	}
-	if hasErrors {
-		// in case there are errored rows, and we are in on-pk-conflict ignore mode,
-		// it is possible that the batches which errored out were partially ingested.
-		if tconf.OnPrimaryKeyConflictAction == constants.PRIMARY_KEY_CONFLICT_ACTION_IGNORE {
-			utils.PrintAndLog(color.YellowString("Note: It is possible that the table row count on the target DB may not match the IMPORTED ROW COUNT as some batches may have been partially ingested."))
-		}
-		utils.PrintAndLog(color.RedString("Errored snapshot rows are stashed in %q", errorHandler.GetErrorsLocation()))
-	}
 }
 
 // setup a project having subdirs for various database objects IF NOT EXISTS
@@ -1118,97 +1033,6 @@ func getExportedSnapshotRowsMap(exportSnapshotStatus *ExportSnapshotStatus) (*ut
 	return snapshotRowsMap, snapshotStatusMap, nil
 }
 
-func getImportedSnapshotRowsMap(dbType string, tableList []sqlname.NameTuple, errorHandler importdata.ImportDataErrorHandler) (*utils.StructMap[sqlname.NameTuple, RowCountPair], error) {
-
-	var err error
-	switch dbType {
-	case "target":
-		importerRole = TARGET_DB_IMPORTER_ROLE
-	case "target-file":
-		importerRole = IMPORT_FILE_ROLE
-	case "source-replica":
-		importerRole = SOURCE_REPLICA_DB_IMPORTER_ROLE
-	}
-	state := newImportDataStateFromGlobals()
-	var snapshotDataFileDescriptor *datafile.Descriptor
-
-	if dataFileDescriptor != nil {
-		// in case of import-data and import-data-file, import-data-to-source-replica,
-		// the data file descriptor is already loaded in memory
-		snapshotDataFileDescriptor = dataFileDescriptor
-	} else {
-		// get data-migration-report use-case where
-		// we need to read the data file descriptor from export-dir
-		dataFileDescriptorPath := filepath.Join(exportDir, datafile.DESCRIPTOR_PATH)
-		if utils.FileOrFolderExists(dataFileDescriptorPath) {
-			snapshotDataFileDescriptor = datafile.OpenDescriptor(exportDir)
-		}
-	}
-	snapshotRowsMap := utils.NewStructMap[sqlname.NameTuple, RowCountPair]()
-	nameTupleTodataFileEntry := utils.NewStructMap[sqlname.NameTuple, []*datafile.FileEntry]()
-	nameTupleTodataFilesMap := utils.NewStructMap[sqlname.NameTuple, []string]()
-	if snapshotDataFileDescriptor != nil {
-		for _, fileEntry := range snapshotDataFileDescriptor.DataFileList {
-			//ignoring target as the dataFileDescriptor can contain tables that exported but not present in target
-			nt, err := namereg.NameReg.LookupTableNameAndIgnoreIfTargetNotFoundBasedOnRole(fileEntry.TableName)
-			if err != nil {
-				return nil, goerrors.Errorf("lookup table name from data file descriptor %s : %w", fileEntry.TableName, err)
-			}
-			fileEntries, ok := nameTupleTodataFileEntry.Get(nt)
-			if !ok {
-				fileEntries = []*datafile.FileEntry{}
-			}
-			fileEntries = append(fileEntries, fileEntry)
-			nameTupleTodataFileEntry.Put(nt, fileEntries)
-		}
-		for _, table := range tableList {
-			fileEntries, ok := nameTupleTodataFileEntry.Get(table)
-			if !ok {
-				//We can't error out here as this is possible in case there are empty tables in live migraton scenario and
-				//In get data-migration-report, table list can consist that table name but it won't be present in dataFileDescriptor
-				log.Warnf("table %s not found in data file descriptor", table.ForKey())
-				continue
-			}
-			list := lo.Map(fileEntries, func(fileEntry *datafile.FileEntry, _ int) string {
-				return fileEntry.FilePath
-			})
-			nameTupleTodataFilesMap.Put(table, list)
-		}
-	}
-
-	err = nameTupleTodataFilesMap.IterKV(func(nt sqlname.NameTuple, dataFilePaths []string) (bool, error) {
-		for _, dataFilePath := range dataFilePaths {
-			importedRowCount, err := state.GetImportedRowCount(dataFilePath, nt)
-			if err != nil {
-				return false, fmt.Errorf("could not fetch imported row count for table %q: %w", nt, err)
-			}
-			erroredRowCount, err := state.GetErroredRowCount(dataFilePath, nt)
-			if err != nil {
-				return false, fmt.Errorf("could not fetch errored row count for table %q: %w", nt, err)
-			}
-			existingRowCountPair, _ := snapshotRowsMap.Get(nt)
-			existingRowCountPair.Imported += importedRowCount
-			existingRowCountPair.Errored += erroredRowCount
-
-			if isTargetDBImporter(importerRole) && errorHandler != nil {
-				// error handler will be nil if import-data/import-data-file was not run yet
-				processingErrorRowCount, _, err := errorHandler.GetProcessingErrorCountSize(nt, dataFilePath)
-				if err != nil {
-					return false, fmt.Errorf("get processing error count size: %w", err)
-				}
-				existingRowCountPair.Errored += processingErrorRowCount
-			}
-			snapshotRowsMap.Put(nt, existingRowCountPair)
-
-		}
-		return true, nil
-	})
-	if err != nil {
-		return nil, goerrors.Errorf("error getting row count of tables: %w", err)
-	}
-	return snapshotRowsMap, nil
-}
-
 func getImportedSizeMap() (*utils.StructMap[sqlname.NameTuple, int64], error) { //used for import data file case right now
 	importerRole = IMPORT_FILE_ROLE
 	state := newImportDataStateFromGlobals()
@@ -1611,12 +1435,6 @@ func parseObjectNamesToPayload(objectNames string, objectType string, dbType str
 		objects = append(objects, obj)
 	}
 	return objects
-}
-
-// RowCountPair holds imported and errored row counts for a table.
-type RowCountPair struct {
-	Imported int64
-	Errored  int64
 }
 
 /*

--- a/yb-voyager/cmd/failpoints.go
+++ b/yb-voyager/cmd/failpoints.go
@@ -16,61 +16,14 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 
-	goerrors "github.com/go-errors/errors"
-	"github.com/jackc/pgconn"
 	"github.com/pingcap/failpoint"
 
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
-// injectImportCDCTransformFailure simulates a failure during CDC event
-// transformation on the import side. Used by tests to verify resumability
-// and idempotency of the CDC apply path.
-func injectImportCDCTransformFailure() error {
-	var fpErr error
-	failpoint.Inject("importCDCTransformFailure", func(val failpoint.Value) {
-		if val != nil {
-			_ = os.MkdirAll(filepath.Join(exportDir, "failpoints"), 0755)
-			_ = os.WriteFile(filepath.Join(exportDir, "failpoints", "failpoint-import-cdc-transform.log"), []byte("hit\n"), 0644)
-			fpErr = goerrors.Errorf("failpoint: import CDC transform failure")
-		}
-	})
-	return fpErr
-}
-
-// injectImportCDCNonRetryableBatchDBError simulates a non-retryable DB error after a
-// successful CDC batch execution. Tests can use a hit-counter expression
-// (e.g. 100*off->return(true)) to crash after N successful batches.
-func injectImportCDCNonRetryableBatchDBError() error {
-	var fpErr error
-	failpoint.Inject("importCDCNonRetryableBatchDBError", func(val failpoint.Value) {
-		if val != nil {
-			_ = os.MkdirAll(filepath.Join(exportDir, "failpoints"), 0755)
-			_ = os.WriteFile(
-				filepath.Join(exportDir, "failpoints", "failpoint-import-cdc-non-retryable-batch-db-error.log"),
-				[]byte("hit\n"),
-				0644,
-			)
-			fpErr = &pgconn.PgError{
-				Code:    "23505",
-				Message: "failpoint: duplicate key value violates unique constraint",
-			}
-		}
-	})
-	return fpErr
-}
-
-// injectImportSnapshotTransformError simulates a per-row transform failure
-// during snapshot batch production. Tests can use a hit-counter expression
-// (e.g. 20*off->return(true)) to crash after N rows are processed.
-// Black-box tests can set YB_VOYAGER_FAILPOINT_MARKER_DIR to write a marker file.
 func writeFailpointMarker(filename string) {
 	_ = os.MkdirAll(filepath.Join(exportDir, "failpoints"), 0755)
 	_ = os.WriteFile(filepath.Join(exportDir, "failpoints", filename), []byte("hit\n"), 0644)
@@ -233,84 +186,4 @@ func injectAfterCompletingDebezium() {
 			utils.ErrExit("failpoint: crash after completing debezium")
 		}
 	})
-}
-
-// injectUniqueKeyConflictDetected supports two test modes via GO_FAILPOINTS:
-//   - return(true): crash on first conflict (false-positive validation)
-//   - return("count"): deduped conflict counting in unique-key-conflict-stats.json
-func injectUniqueKeyConflictDetectedFailpoint(cachedEvent, incomingEvent *tgtdb.Event) {
-	failpoint.Inject("uniqueKeyConflictDetected", func(val failpoint.Value) {
-		if val == nil {
-			return
-		}
-		if mode, ok := val.(string); ok && mode == "count" {
-			recordUniqueKeyConflictCount(cachedEvent, incomingEvent)
-			return
-		}
-		writeFailpointMarker("failpoint-unique-key-conflict-detected.log")
-		utils.ErrExit("failpoint: unexpected unique key conflict detected")
-	})
-}
-
-const uniqueKeyConflictStatsFileName = "unique-key-conflict-stats.json"
-
-// UniqueKeyConflictStats is written to <exportDir>/failpoints/unique-key-conflict-stats.json.
-type UniqueKeyConflictStats struct {
-	Total   int            `json:"total"`
-	ByTable map[string]int `json:"by_table"`
-}
-
-var (
-	ukConflictStatsMu sync.Mutex
-	ukConflictStats   UniqueKeyConflictStats
-	ukConflictSeen    map[string]struct{}
-)
-
-func initUniqueKeyConflictStatsLocked() {
-	if ukConflictSeen == nil {
-		ukConflictSeen = make(map[string]struct{})
-	}
-	if ukConflictStats.ByTable == nil {
-		ukConflictStats.ByTable = make(map[string]int)
-	}
-}
-
-func uniqueKeyConflictPairKey(table string, cachedVsn, incomingVsn int64) string {
-	vsn1, vsn2 := cachedVsn, incomingVsn
-	if vsn1 > vsn2 {
-		vsn1, vsn2 = vsn2, vsn1
-	}
-	return fmt.Sprintf("%s:%d:%d", table, vsn1, vsn2)
-}
-
-func recordUniqueKeyConflictCount(cachedEvent, incomingEvent *tgtdb.Event) {
-	table := cachedEvent.TableNameTup.ForKey()
-	pairKey := uniqueKeyConflictPairKey(table, cachedEvent.Vsn, incomingEvent.Vsn)
-
-	ukConflictStatsMu.Lock()
-	defer ukConflictStatsMu.Unlock()
-
-	initUniqueKeyConflictStatsLocked()
-	if _, seen := ukConflictSeen[pairKey]; seen {
-		return
-	}
-	ukConflictSeen[pairKey] = struct{}{}
-	ukConflictStats.Total++
-	ukConflictStats.ByTable[table]++
-	_ = writeUniqueKeyConflictStatsLocked()
-}
-
-func writeUniqueKeyConflictStatsLocked() error {
-	if exportDir == "" {
-		return nil
-	}
-	failpointsDir := filepath.Join(exportDir, "failpoints")
-	if err := os.MkdirAll(failpointsDir, 0755); err != nil {
-		return err
-	}
-	payload, err := json.MarshalIndent(ukConflictStats, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(failpointsDir, uniqueKeyConflictStatsFileName), payload, 0644)
 }

--- a/yb-voyager/cmd/getDataMigrationReportCommand.go
+++ b/yb-voyager/cmd/getDataMigrationReportCommand.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
@@ -222,14 +223,15 @@ func getDataMigrationReportCmdFn(msr *metadb.MigrationStatusRecord, donotPrint b
 		}
 	}
 
-	var targetImportedSnapshotRowsMap *utils.StructMap[sqlname.NameTuple, RowCountPair]
+	var targetImportedSnapshotRowsMap *utils.StructMap[sqlname.NameTuple, importdata.RowCountPair]
 	var targetEventsImportedMap *utils.StructMap[sqlname.NameTuple, *tgtdb.EventCounter]
 	if msr.TargetDBConf != nil {
 		errorHandler, err := getImportDataErrorHandlerUsed()
 		if err != nil {
 			utils.ErrExit("error while getting import data error handler: %w\n", err)
 		}
-		targetImportedSnapshotRowsMap, err = getImportedSnapshotRowsMap("target", tableNameTups, errorHandler)
+		importerRole = TARGET_DB_IMPORTER_ROLE // getImportedSnapshotRowsMap used to set this as a side effect
+		targetImportedSnapshotRowsMap, err = importdata.GetImportedSnapshotRowsMap("target", tableNameTups, errorHandler, importDataStateConfigFromGlobals())
 		if err != nil {
 			utils.ErrExit("error while getting imported snapshot rows for target DB: %w\n", err)
 		}
@@ -239,14 +241,15 @@ func getDataMigrationReportCmdFn(msr *metadb.MigrationStatusRecord, donotPrint b
 		}
 	}
 
-	var replicaImportedSnapshotRowsMap *utils.StructMap[sqlname.NameTuple, RowCountPair]
+	var replicaImportedSnapshotRowsMap *utils.StructMap[sqlname.NameTuple, importdata.RowCountPair]
 	var replicaEventsImportedMap *utils.StructMap[sqlname.NameTuple, *tgtdb.EventCounter]
 	if fFEnabled {
 		// In this case we need to lookup in a namereg where role is SOURCE_REPLICA_DB_IMPORTER_ROLE so that
 		// look up happens properly for source_replica names as here reg is the map of target->source-replica tablename
 		oldNameReg := namereg.NameReg
 		namereg.NameReg = *nameRegistryForSourceReplicaRole
-		replicaImportedSnapshotRowsMap, err = getImportedSnapshotRowsMap("source-replica", tableNameTups, nil)
+		importerRole = SOURCE_REPLICA_DB_IMPORTER_ROLE // getImportedSnapshotRowsMap used to set this as a side effect
+		replicaImportedSnapshotRowsMap, err = importdata.GetImportedSnapshotRowsMap("source-replica", tableNameTups, nil, importDataStateConfigFromGlobals())
 
 		if err != nil {
 			utils.ErrExit("error while getting imported snapshot rows for source-replica DB: %w\n", err)
@@ -681,7 +684,7 @@ func getImportedEventsMap(dbType string, tableNameTups []sqlname.NameTuple, targ
 	return tableNameTupToEventsCounter, nil
 }
 
-func updateImportedEventsCountsInTheRow(row *RowData, tableNameTup sqlname.NameTuple, snapshotImportedRowsMap *utils.StructMap[sqlname.NameTuple, RowCountPair],
+func updateImportedEventsCountsInTheRow(row *RowData, tableNameTup sqlname.NameTuple, snapshotImportedRowsMap *utils.StructMap[sqlname.NameTuple, importdata.RowCountPair],
 	eventsImportedMap *utils.StructMap[sqlname.NameTuple, *tgtdb.EventCounter], msr *metadb.MigrationStatusRecord) error {
 	switch row.DBType {
 	case "target":

--- a/yb-voyager/cmd/import.go
+++ b/yb-voyager/cmd/import.go
@@ -219,22 +219,13 @@ func validateImportUsePartitionRootFlag() error {
 	})
 }
 
-var validCdcPartitionKeys = []string{PARTITION_BY_PK, PARTITION_BY_TABLE, "auto"}
-
-// cdcPartitionKeyOverride is a single parsed per-table override from
-// --cdc-partition-key-overrides. Strategy is one of PARTITION_BY_PK,
-// PARTITION_BY_TABLE or PARTITION_BY_CUSTOM. Columns is set (non-empty, in the
-// user-specified order) only when Strategy == PARTITION_BY_CUSTOM.
-type cdcPartitionKeyOverride struct {
-	Strategy string
-	Columns  []string
-}
+var validCdcPartitionKeys = []string{importdata.PARTITION_BY_PK, importdata.PARTITION_BY_TABLE, "auto"}
 
 // parseCdcPartitionKeyOverrides parses "schema.table:pk;schema.other:(col1,col2)".
 // Each value is either pk, table, or a parenthesized comma-separated custom column
 // list (custom key), e.g. (col1,col2).
-func parseCdcPartitionKeyOverrides(overrides string) (map[string]cdcPartitionKeyOverride, error) {
-	result := make(map[string]cdcPartitionKeyOverride)
+func parseCdcPartitionKeyOverrides(overrides string) (map[string]importdata.CdcPartitionKeyOverride, error) {
+	result := make(map[string]importdata.CdcPartitionKeyOverride)
 	overrides = strings.TrimSpace(overrides)
 	if overrides == "" {
 		return result, nil
@@ -270,22 +261,22 @@ func parseCdcPartitionKeyOverrides(overrides string) (map[string]cdcPartitionKey
 
 // parseCdcPartitionKeyOverrideValue interprets a single override value. "pk" and
 // "table" map to the corresponding strategy; a custom key column list must be wrapped
-// in parentheses, e.g. (col1,col2), and maps to PARTITION_BY_CUSTOM.
-func parseCdcPartitionKeyOverrideValue(tableName, value string) (cdcPartitionKeyOverride, error) {
+// in parentheses, e.g. (col1,col2), and maps to importdata.PARTITION_BY_CUSTOM.
+func parseCdcPartitionKeyOverrideValue(tableName, value string) (importdata.CdcPartitionKeyOverride, error) {
 	switch value {
-	case PARTITION_BY_PK:
-		return cdcPartitionKeyOverride{Strategy: PARTITION_BY_PK}, nil
-	case PARTITION_BY_TABLE:
-		return cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE}, nil
+	case importdata.PARTITION_BY_PK:
+		return importdata.CdcPartitionKeyOverride{Strategy: importdata.PARTITION_BY_PK}, nil
+	case importdata.PARTITION_BY_TABLE:
+		return importdata.CdcPartitionKeyOverride{Strategy: importdata.PARTITION_BY_TABLE}, nil
 	}
 
 	// A custom key column list must be parenthesized: (col1,col2,...).
 	if !strings.HasPrefix(value, "(") || !strings.HasSuffix(value, ")") {
-		return cdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value %q for table %q: expected pk, table, or a parenthesized custom key column list like (col1,col2)", value, tableName)
+		return importdata.CdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value %q for table %q: expected pk, table, or a parenthesized custom key column list like (col1,col2)", value, tableName)
 	}
 	value = strings.TrimSpace(value[1 : len(value)-1])
 	if value == "" {
-		return cdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value for table %q: custom key column list is empty", tableName)
+		return importdata.CdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value for table %q: custom key column list is empty", tableName)
 	}
 
 	rawColumns := strings.Split(value, ",")
@@ -294,15 +285,15 @@ func parseCdcPartitionKeyOverrideValue(tableName, value string) (cdcPartitionKey
 	for _, col := range rawColumns {
 		col = strings.TrimSpace(col)
 		if col == "" {
-			return cdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value %q for table %q: empty column name in custom key", value, tableName)
+			return importdata.CdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value %q for table %q: empty column name in custom key", value, tableName)
 		}
 		if seen[col] {
-			return cdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value %q for table %q: duplicate column %q in custom key", value, tableName, col)
+			return importdata.CdcPartitionKeyOverride{}, goerrors.Errorf("invalid cdc-partition-key-overrides value %q for table %q: duplicate column %q in custom key", value, tableName, col)
 		}
 		seen[col] = true
 		columns = append(columns, col)
 	}
-	return cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: columns}, nil
+	return importdata.CdcPartitionKeyOverride{Strategy: importdata.PARTITION_BY_CUSTOM, Columns: columns}, nil
 }
 
 func validateCdcPartitionKeyFlags(cmd *cobra.Command) error {

--- a/yb-voyager/cmd/importData.go
+++ b/yb-voyager/cmd/importData.go
@@ -30,63 +30,71 @@ import (
 	goerrors "github.com/go-errors/errors"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
-	"github.com/sourcegraph/conc/pool"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
-	"golang.org/x/sync/semaphore"
 
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/adaptiveparallelism"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/config"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/cp"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/monitor"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
+	reporter "github.com/yugabyte/yb-voyager/yb-voyager/src/reporter/stats"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/types"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
 var metaInfoDirName = META_INFO_DIR_NAME
 var batchSizeInNumRows = int64(0)
-var batchImportPool *pool.Pool
-var colocatedBatchImportPool *pool.Pool
-var colocatedBatchImportQueue chan func()
-
 var importerRole string
 var identityColumnsMetaDBKey string
+
+// importPhase is the phase reported before the import engine exists (see
+// currentImportPhase); after that the engine owns the phase.
 var importPhase string
 
 // stores the data files description in a struct
 var dataFileDescriptor *datafile.Descriptor
-var truncateSplits utils.BoolStr                                             // to truncate *.D splits after import
-var TableToColumnNames = utils.NewStructMap[sqlname.NameTuple, []string]()   // map of table name to columnNames
-var TableToIdentityColumnNames *utils.StructMap[sqlname.NameTuple, []string] // map of table name to generated always as identity column's names
-var valueConverter dbzm.SnapshotPhaseValueConverter
-
-var TableNameToSchema *utils.StructMap[sqlname.NameTuple, map[string]map[string]string]
-var conflictDetectionCache *ConflictDetectionCache
+var truncateSplits utils.BoolStr // to truncate *.D splits after import
 var targetDBDetails *callhome.TargetDBDetails
 var skipReplicationChecks utils.BoolStr
 var skipNodeHealthChecks utils.BoolStr
 var skipDiskUsageHealthChecks utils.BoolStr
-var progressReporter *importdata.ImportDataProgressReporter
 var callhomeMetricsCollector *callhome.ImportDataMetricsCollector
 
 // ShutdownImportProgressBars stops the mpb progress container so that its
 // rendering goroutine no longer writes to stdout. Must be called before
 // printing any final messages on signal receipt to avoid the bars overwriting them.
 func ShutdownImportProgressBars() {
-	if progressReporter != nil {
-		progressReporter.Shutdown()
+	if importer != nil {
+		importer.ShutdownProgressBars()
 	}
+}
+
+// importer is the single handle cmd keeps on the running import engine
+// (src/importdata). The callhome payload builders read its phase and streaming
+// stats through currentImportPhase / currentStatsReporter.
+var importer *importdata.Importer
+
+// currentImportPhase returns the engine's phase once the engine exists, and the
+// command-level importPhase before that (set to snapshot at the start of the
+// import data command, empty during PreRun), exactly as the former global did.
+func currentImportPhase() string {
+	if importer == nil {
+		return importPhase
+	}
+	return importer.ImportPhase()
+}
+
+func currentStatsReporter() *reporter.StreamImportStatsReporter {
+	if importer == nil {
+		return nil
+	}
+	return importer.StatsReporter()
 }
 
 var importTableList []sqlname.NameTuple
@@ -256,7 +264,7 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 	}
 
 	var importFileTasks []*importdata.ImportFileTask
-	if importSnapshotRequired() {
+	if importdata.ImportSnapshotRequired(importerRole, importType) {
 
 		dataStore = datastore.NewDataStore(filepath.Join(exportDir, "data"))
 		dataFileDescriptor = datafile.OpenDescriptor(exportDir)
@@ -292,7 +300,7 @@ func importDataCommandFn(cmd *cobra.Command, args []string) {
 
 	handleCutoverAlreadyProcessedForImportData()
 
-	importData(importFileTasks, errorPolicySnapshotFlag)
+	runImportDataEngine(importFileTasks)
 	tdb.Finalize()
 
 	if furtherCommandsRequired() {
@@ -453,20 +461,6 @@ func startExportDataFromSourceOnNextIteration() {
 
 }
 
-func importSnapshotRequired() bool {
-	switch importerRole {
-	case SOURCE_REPLICA_DB_IMPORTER_ROLE:
-		return true
-	case IMPORT_FILE_ROLE:
-		return true
-	case SOURCE_DB_IMPORTER_ROLE:
-		return false
-	case TARGET_DB_IMPORTER_ROLE:
-		return importType == SNAPSHOT_ONLY || importType == SNAPSHOT_AND_CHANGES
-	default:
-		panic(fmt.Sprintf("invalid importer role: %s", importerRole))
-	}
-}
 func checkTablesPresentInTarget(tablesToImport []sqlname.NameTuple) {
 	if importerRole != TARGET_DB_IMPORTER_ROLE {
 		return
@@ -914,125 +908,6 @@ func setupImportDataObservability() error {
 	return nil
 }
 
-func updateImportDataStartedAndSomeConfigsInMetaDB() error {
-	switch importerRole {
-	case TARGET_DB_IMPORTER_ROLE:
-		log.Infof("updating import data started in meta db with cdc-partition-key: %s, overrides: %q", cdcPartitionKey, cdcPartitionKeyOverrides)
-		err := metaDB.UpdateImportDataStatusRecord(func(record *metadb.ImportDataStatusRecord) {
-			record.ImportDataStarted = true
-			record.CdcPartitioningStrategyConfig = cdcPartitionKey
-			record.CdcPartitionKeyOverridesConfig = cdcPartitionKeyOverrides
-		})
-		if err != nil {
-			return goerrors.Errorf("Failed to update import data status record: %w", err)
-		}
-		err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-			record.ImportDataToTargetStarted = true
-		})
-		if err != nil {
-			return goerrors.Errorf("failed to update migration status record: %w", err)
-		}
-
-	case IMPORT_FILE_ROLE:
-		err := metaDB.UpdateImportDataFileStatusRecord(func(record *metadb.ImportDataFileStatusRecord) {
-			record.ImportDataStarted = true
-		})
-		if err != nil {
-			return goerrors.Errorf("Failed to update import data file status record: %w", err)
-		}
-	case SOURCE_DB_IMPORTER_ROLE:
-		err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-			record.ImportDataToSourceStarted = true
-		})
-		if err != nil {
-			return goerrors.Errorf("failed to update migration status record: %w", err)
-		}
-	}
-	return nil
-}
-
-func initialiseErrorHandler(errorPolicy importdata.ErrorPolicy) (importdata.ImportDataErrorHandler, error) {
-	exportDirDataDir := filepath.Join(exportDir, "data")
-	errorHandler, err := importdata.GetImportDataErrorHandler(errorPolicy, exportDirDataDir, importerRole)
-	if err != nil {
-		return nil, goerrors.Errorf("Failed to initialize error handler: %w", err)
-	}
-	err = updateErrorPolicyInMetaDB(errorPolicy)
-	if err != nil {
-		return nil, goerrors.Errorf("Failed to update error policy in meta DB: %w", err)
-	}
-	return errorHandler, nil
-}
-
-func updateTargetConfInMigrationStatus() error {
-	err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-		switch importerRole {
-		case TARGET_DB_IMPORTER_ROLE, IMPORT_FILE_ROLE:
-			record.TargetDBConf = tconf.Clone()
-			record.TargetDBConf.Password = ""
-			record.TargetDBConf.Uri = ""
-		case SOURCE_REPLICA_DB_IMPORTER_ROLE:
-			record.SourceReplicaDBConf = tconf.Clone()
-			record.SourceReplicaDBConf.Password = ""
-			record.SourceReplicaDBConf.Uri = ""
-		case SOURCE_DB_IMPORTER_ROLE:
-			record.SourceDBAsTargetConf = tconf.Clone()
-			record.SourceDBAsTargetConf.Password = ""
-			record.SourceDBAsTargetConf.Uri = ""
-		default:
-			panic(fmt.Sprintf("unsupported importer role: %s", importerRole))
-		}
-	})
-	if err != nil {
-		return goerrors.Errorf("Failed to update target conf in migration status record: %w", err)
-	}
-	return nil
-}
-
-func prepareTargetDBForImport() error {
-	//init target db connection pool
-	err := tdb.InitConnPool()
-	if err != nil {
-		return goerrors.Errorf("Failed to initialize the target DB connection pool: %w", err)
-	}
-
-	//start adaptive parallelism
-	var adaptiveParallelismStarted bool
-	adaptiveParallelismStarted, err = startAdaptiveParallelism(tconf.AdaptiveParallelismMode, callhomeMetricsCollector)
-	if err != nil {
-		return goerrors.Errorf("Failed to start adaptive parallelism: %w", err)
-	}
-	//start monitoring target YB health
-	err = startMonitoringTargetYBHealth()
-	if err != nil {
-		return goerrors.Errorf("Failed to start monitoring health: %w", err)
-	}
-	if adaptiveParallelismStarted {
-		utils.PrintAndLogf("Using 1-%d parallel jobs (adaptive)", tconf.MaxParallelism)
-	} else {
-		utils.PrintAndLogf("Using %d parallel jobs.", tconf.Parallelism)
-	}
-
-	targetDBVersion := tdb.GetVersion()
-	fmt.Printf("%s version: %s\n", tconf.TargetDBType, targetDBVersion)
-
-	//create voyager metadata schema
-	err = tdb.CreateVoyagerSchema()
-	if err != nil {
-		return goerrors.Errorf("Failed to create voyager metadata schema on target DB: %w", err)
-	}
-	return nil
-}
-
-func handleStartCleanForSnapshot(state *importdata.ImportDataState, importFileTasks []*importdata.ImportFileTask, errorHandler importdata.ImportDataErrorHandler) error {
-	cleanImportState(state, importFileTasks)
-	err := cleanStoredErrors(errorHandler, importFileTasks)
-	if err != nil {
-		return goerrors.Errorf("Failed to clean stored errors: %w", err)
-	}
-	return nil
-}
-
 func initialiseImportTableList(importFileTasks []*importdata.ImportFileTask, msr *metadb.MigrationStatusRecord) ([]*importdata.ImportFileTask, []sqlname.NameTuple, error) {
 	var err error
 	if changeStreamingIsEnabled(importType) {
@@ -1060,242 +935,82 @@ func initialiseImportTableList(importFileTasks []*importdata.ImportFileTask, msr
 	//we don't need empty tables in offline case, data migration doesn't matter for them
 	//Table list after applying table list filter
 	importFileTasks = applyTableListFilter(importFileTasks)
-	importTableList = importFileTasksToTableNameTuples(importFileTasks)
+	importTableList = importdata.ImportFileTasksToTableNameTuples(importFileTasks)
 
 	return importFileTasks, importTableList, nil
 }
 
-func initialiseValueConverter(importTableList []sqlname.NameTuple, msr *metadb.MigrationStatusRecord) error {
-	var err error
-	if msr.IsSnapshotExportedViaDebezium() {
-		valueConverter, err = dbzm.NewSnapshotPhaseValueConverter(exportDir, tdb, tconf, importerRole, msr.SourceDBConf.DBType, importTableList)
-	} else {
-		valueConverter, err = dbzm.NewSnapshotPhaseNoOpValueConverter()
-	}
-	if err != nil {
-		return goerrors.Errorf("Failed to create value converter: %w", err)
-	}
+// buildImportDataConfig copies the cmd package-level variables the import engine
+// used to read directly into importdata.Config. Values only; no callbacks.
+func buildImportDataConfig() importdata.Config {
+	cfg := importdata.Config{
+		ExportDir:                exportDir,
+		MetaDB:                   metaDB,
+		MigrationUUID:            migrationUUID,
+		ImporterRole:             importerRole,
+		ImportType:               importType,
+		IdentityColumnsMetaDBKey: identityColumnsMetaDBKey,
+		SourceDBType:             sourceDBType,
+		Source:                   source,
+		Tconf:                    tconf,
+		Tdb:                      tdb,
+		ControlPlane:             controlPlane,
 
-	TableNameToSchema, err = valueConverter.GetTableNameToSchema()
-	if err != nil {
-		return goerrors.Errorf("Failed to get table name to schema: %w", err)
-	}
-	return nil
-}
+		StartClean:                    startClean,
+		TruncateTables:                truncateTables,
+		TruncateSplits:                truncateSplits,
+		DisablePb:                     disablePb,
+		BatchSizeInNumRows:            batchSizeInNumRows,
+		ErrorPolicySnapshot:           errorPolicySnapshotFlag,
+		EnableRandomBatchProduction:   enableRandomBatchProduction,
+		MaxConcurrentBatchProductions: maxConcurrentBatchProductionsConfig,
+		SkipReplicationChecks:         skipReplicationChecks,
+		SkipNodeHealthChecks:          skipNodeHealthChecks,
+		SkipDiskUsageHealthChecks:     skipDiskUsageHealthChecks,
+		CdcPartitionKey:               cdcPartitionKey,
+		CdcPartitionKeyOverrides:      cdcPartitionKeyOverrides,
+		ImportUsePartitionRoot:        importUsePartitionRoot,
+		EventBatchMaxRetryCount:       EVENT_BATCH_MAX_RETRY_COUNT,
+		ReportProgressInBytes:         reportProgressInBytes,
 
-func handleIdentityColumns(importTableList []sqlname.NameTuple) error {
-	err := fetchAndStoreGeneratedAlwaysIdentityColumnsInMetadb(importTableList)
+		DataFileDescriptor:       dataFileDescriptor,
+		DataStore:                dataStore,
+		ImportTableList:          importTableList,
+		CallhomeMetricsCollector: callhomeMetricsCollector,
+	}
+	// validateCdcPartitionKeyFlags already parsed this string during flag validation;
+	// parse it again here so the engine never re-parses the raw flag at runtime.
+	parsed, err := parseCdcPartitionKeyOverrides(cdcPartitionKeyOverrides)
 	if err != nil {
-		return goerrors.Errorf("Failed to fetch and store generated always identity columns: %w", err)
+		utils.ErrExit("%w", err)
 	}
-	err = disableGeneratedAlwaysAsIdentityColumns()
-	if err != nil {
-		return goerrors.Errorf("Failed to disable generated always identity columns: %w", err)
-	}
-	return nil
-}
-
-func importSnapshotData(msr *metadb.MigrationStatusRecord, errorHandler importdata.ImportDataErrorHandler,
-	state *importdata.ImportDataState, importFileTasks []*importdata.ImportFileTask, importTableList []sqlname.NameTuple) error {
-	var err error
-	var pendingTasks, completedTasks []*importdata.ImportFileTask
-
-	if startClean {
-		pendingTasks = importFileTasks
-	} else {
-		pendingTasks, completedTasks, err = classifyTasksForImport(state, importFileTasks)
-		if err != nil {
-			utils.ErrExit("Failed to classify tasks: %w", err)
-		}
-	}
-	log.Infof("pending tasks: %v", pendingTasks)
-	log.Infof("completed tasks: %v", completedTasks)
-
-	err = runPKConflictModeGuardrails(state, importFileTasks)
-	if err != nil {
-		utils.ErrExit("Error checking PK conflict mode on fresh start: %w", err)
-	}
-
-	err = initialiseValueConverter(importTableList, msr)
-	if err != nil {
-		utils.ErrExit("Failed to initialize value converter: %w", err)
-	}
-
-	utils.PrintAndLogf("Already imported tables: %v", importFileTasksToTableNames(completedTasks))
-	if len(pendingTasks) == 0 {
-		utils.PrintAndLogf("All the tables are already imported, nothing left to import\n")
-		return nil
-	}
-	utils.PrintAndLogf("Tables to import: %v", importFileTasksToTableNames(pendingTasks))
-	err = prepareTableToColumns(pendingTasks) //prepare the tableToColumns map
-	if err != nil {
-		utils.ErrExit("failed to prepare table to columns: %w", err)
-	}
-	maxParallelConns, err := getMaxParallelConnections()
-	if err != nil {
-		utils.ErrExit("Failed to get max parallel connections: %w", err)
-	}
-	if !tconf.AdaptiveParallelismMode.IsEnabled() {
-		// Adaptive parallelism emits this gauge itself once it starts polling;
-		// for a fixed --parallel-jobs run there's no such poller, so emit once here.
-		metrics.Get().SetImportParallelism(importerRole, maxParallelConns)
-	}
-	importDataAllTableMetrics := createInitialImportDataTableMetrics(importFileTasks, pendingTasks)
+	cfg.CdcPartitionKeyOverridesParsed = parsed
 	if importerRole == TARGET_DB_IMPORTER_ROLE {
-		controlPlane.UpdateImportedRowCount(importDataAllTableMetrics)
+		cfg.SnapshotImportStartedEvent = createSnapshotImportStartedEvent()
 	}
-
-	useTaskPicker := utils.GetEnvAsBool("YBVOYAGER_USE_TASK_PICKER_FOR_IMPORT", true)
-	if useTaskPicker {
-		maxColocatedBatchesInProgress := utils.GetEnvAsInt("YBVOYAGER_MAX_COLOCATED_BATCHES_IN_PROGRESS", 3)
-		err := importTasksViaTaskPicker(pendingTasks, state, progressReporter,
-			maxParallelConns, maxParallelConns, maxColocatedBatchesInProgress, msr.IsSnapshotExportedViaDebezium(),
-			maxConcurrentBatchProductionsConfig, bool(enableRandomBatchProduction),
-			errorHandler, callhomeMetricsCollector)
-		if err != nil {
-			utils.ErrExit("Failed to import tasks via task picker. %w", err)
-		}
-	} else {
-		poolSize := maxParallelConns * 2
-		for _, task := range pendingTasks {
-			// The code can produce `poolSize` number of batches at a time. But, it can consume only
-			// `parallelism` number of batches at a time.
-			batchImportPool = pool.New().WithMaxGoroutines(poolSize)
-			log.Infof("created batch import pool of size: %d", poolSize)
-
-			batchProducer, err := importdata.NewSequentialFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, msr.IsSnapshotExportedViaDebezium(), errorHandler, progressReporter)
-			if err != nil {
-				utils.ErrExit("Failed to create batch producer: %w", err)
-			}
-
-			taskImporter, err := importdata.NewFileTaskImporter(fileTaskImporterConfigFromGlobals(), task, state, batchProducer, batchImportPool, progressReporter, nil, false, errorHandler, callhomeMetricsCollector)
-			if err != nil {
-				utils.ErrExit("Failed to create file task importer: %w", err)
-			}
-
-			for !taskImporter.AllBatchesSubmitted() {
-				err := taskImporter.ProduceAndSubmitNextBatchToWorkerPool()
-				if err != nil {
-					utils.ErrExit("Failed to submit next batch: task:%v err: %w", task, err)
-				}
-			}
-
-			batchImportPool.Wait() // wait for file import to finish
-			taskImporter.PostProcess()
-		}
-		time.Sleep(time.Second * 2)
-	}
-
-	return nil
+	return cfg
 }
 
-func importData(importFileTasks []*importdata.ImportFileTask, errorPolicy importdata.ErrorPolicy) {
-	errorHandler, err := initialiseErrorHandler(errorPolicy)
-	if err != nil {
-		utils.ErrExit("Failed to initialize error policy and error handler: %w", err)
-	}
-
-	if importerRole == TARGET_DB_IMPORTER_ROLE {
-		importDataStartEvent := createSnapshotImportStartedEvent()
-		controlPlane.SnapshotImportStarted(&importDataStartEvent)
-	}
-	err = updateTargetConfInMigrationStatus()
-	if err != nil {
-		utils.ErrExit("Failed to update target conf in migration status record: %w", err)
-	}
+// runImportDataEngine runs the import engine for the given tasks and then the
+// post-processing that used to follow inside importData().
+func runImportDataEngine(importFileTasks []*importdata.ImportFileTask) {
 	msr, err := metaDB.GetMigrationStatusRecord()
 	if err != nil {
 		utils.ErrExit("Failed to get migration status record: %w", err)
 	}
-	//create progress reporter
-	progressReporter = importdata.NewImportDataProgressReporter(bool(disablePb))
-
-	err = prepareTargetDBForImport()
-	if err != nil {
-		utils.ErrExit("Failed to prepare target DB for import: %w", err)
-	}
-
-	state := newImportDataStateFromGlobals()
-
-	err = clearMigrationStateForImportDataStartClean(state, importFileTasks, errorHandler)
-	if err != nil {
-		utils.ErrExit("Failed to clean MigrationStatusRecord for import data start clean: %w", err)
-	}
-
-	var tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]
-	if changeStreamingIsEnabled(importType) {
-		tableToUniqueIndexes, err = tdb.GetTableToUniqueIndexesMap(importTableList)
-		if err != nil {
-			utils.ErrExit("Failed to get table unique indexes map from target: %s", err)
-		}
-	}
-	// Validate/resolve cdc-partition-key (+ overrides) and persist the per-table map
-	// before snapshot so bad configs fail fast (not at streamChanges).
-	// Runs after start-clean so a cleared map is recomputed for the new run.
-	// Must run before updateImportDataStartedInMetaDB so a failed prepare does not
-	// lock change-guard / ImportDataStarted for a config that never took effect.
-	err = prepareCdcPartitionKey(importTableList, tableToUniqueIndexes)
-	if err != nil {
-		utils.ErrExit("Failed to prepare cdc-partition-key: %w", err)
-	}
-
-	// Fetch the primary-key columns of the import tables from the target (before snapshot) so
-	// they can be passed to streamChanges and the conflict-detection cache without re-querying
-	// during streaming. Also fails fast if a custom-partition-key table has no primary key.
-	importTableToPKColumns, err := getPrimaryKeyColumnsForImportTables(importTableList)
-	if err != nil {
-		utils.ErrExit("Failed to get primary key columns for import tables: %w", err)
-	}
-	//updating the metadb after the startclean clears any required metadb state
-	err = updateImportDataStartedAndSomeConfigsInMetaDB()
-	if err != nil {
-		utils.ErrExit("Failed to update import data started in meta DB: %w", err)
-	}
-
-	if state.HasExistingState() {
-		utils.PrintAndLogf("\nResuming import of data in %q database", tconf.DBName)
-	} else {
-		utils.PrintAndLogf("\nimport of data in %q database started", tconf.DBName)
-	}
-
 	if msr.SourceDBConf != nil {
 		source = *msr.SourceDBConf
 	}
+	importer = importdata.NewImporter(buildImportDataConfig())
+	importer.ImportData(importFileTasks)
+	importDataPostProcessing(msr, importFileTasks)
+}
 
-	// Handle identity columns before snapshot import for Oracle targets (source-replica/source)
-	// Oracle requires GENERATED ALWAYS columns to be converted to GENERATED BY DEFAULT for COPY to work
-	if identityColumnsNeedHandlingForSnapshotImport() {
-		err = handleIdentityColumns(importTableList)
-		if err != nil {
-			utils.ErrExit("Failed to handle identity columns: %w", err)
-		}
-	}
-
-	// Import snapshots
-	if importSnapshotRequired() {
-		err = importSnapshotData(msr, errorHandler, state, importFileTasks, importTableList)
-		if err != nil {
-			utils.ErrExit("failed to import snapshot data: %w", err)
-		}
-		utils.PrintAndLogf("snapshot data import complete\n\n")
-	}
-
+// importDataPostProcessing is the tail of the former importData(): sequence and
+// identity-column restoration, cutover processing and the snapshot import report.
+func importDataPostProcessing(msr *metadb.MigrationStatusRecord, importFileTasks []*importdata.ImportFileTask) {
+	var err error
 	if changeStreamingIsEnabled(importType) {
-		// For non-Oracle targets (YugabyteDB/PostgreSQL), handle identity columns before streaming phase
-		// For Oracle targets, this was already done before snapshot import
-		if !identityColumnsNeedHandlingForSnapshotImport() {
-			err = handleIdentityColumns(importTableList)
-			if err != nil {
-				utils.ErrExit("Failed to handle identity columns: %w", err)
-			}
-		}
-		if importSnapshotRequired() {
-			displayImportedRowCountSnapshot(state, importFileTasks, errorHandler)
-		}
-		err = streamChanges(state, importTableList, importTableToPKColumns, tableToUniqueIndexes)
-		if err != nil {
-			utils.ErrExit("Failed to stream changes to %s: %w", tconf.TargetDBType, err)
-		}
 		err = postCutoverProcessing(importTableList)
 		if err != nil {
 			utils.ErrExit("failed to post cutover processing: %w", err)
@@ -1307,7 +1022,7 @@ func importData(importFileTasks []*importdata.ImportFileTask, errorPolicy import
 		if err != nil {
 			utils.ErrExit("failed to post snapshot import processing: %w", err)
 		}
-		displayImportedRowCountSnapshot(state, importFileTasks, errorHandler)
+		importdata.DisplayImportedRowCountSnapshot(importDataStateConfigFromGlobals(), importer.State(), importFileTasks, importer.ErrorHandler())
 	}
 	fmt.Printf("\nImport data complete.\n")
 }
@@ -1333,7 +1048,7 @@ func postCutoverProcessing(importTableList []sqlname.NameTuple) error {
 		return goerrors.Errorf("failed to restore sequences: %w", err)
 	}
 
-	err = restoreGeneratedIdentityColumns(importTableList)
+	err = importer.RestoreGeneratedIdentityColumns(importTableList)
 	if err != nil {
 		return goerrors.Errorf("failed to restore generated columns: %w", err)
 	}
@@ -1409,333 +1124,6 @@ func waitUntilCutoverProcessedByCorrespondingExporterForImporter(importerRole st
 	}
 }
 
-/*
-getPrimaryKeyColumnsForImportTables fetches the primary-key columns of every import table
-from the target DB (in one batched query) so they can be threaded into the streaming
-conflict-detection cache.
-
-It is called once near the start of importData (for the target PG→YB live path only; other
-paths return an empty map since conflict detection does not run for them). Because importData
-runs in the same process before streamChanges on both the first run and resume, the map does
-not need to be persisted in metaDB.
-
-It also fails fast, before the snapshot import, if a table routed by a custom partition key
-has no primary key on the target: custom routing adds the PK as a synthetic unique index for
-conflict detection (a recycled PK across different custom keys must be serialized), so a
-custom-key table without a PK cannot be made correct. This is scoped to custom-key tables so
-that legitimately PK-less tables under pk/table routing (e.g. partitioned roots imported via
---use-partition-root) are not blocked.
-*/
-func getPrimaryKeyColumnsForImportTables(tableNames []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, []string], error) {
-	tableToPKColumns := utils.NewStructMap[sqlname.NameTuple, []string]()
-
-	// Only the target PG→YB live streaming path runs conflict detection and needs primary keys.
-	if importerRole != TARGET_DB_IMPORTER_ROLE || !changeStreamingIsEnabled(importType) || sourceDBType != POSTGRESQL {
-		return tableToPKColumns, nil
-	}
-
-	tableToPKColumns, err := tdb.GetPrimaryKeyColumnsForTables(tableNames)
-	if err != nil {
-		return nil, fmt.Errorf("error getting primary key columns for import tables: %w", err)
-	}
-
-	var tablesWithoutPK []sqlname.NameTuple
-	for _, t := range tableNames {
-		if pkColumns, _ := tableToPKColumns.Get(t); len(pkColumns) == 0 {
-			tablesWithoutPK = append(tablesWithoutPK, t)
-		}
-	}
-	if len(tablesWithoutPK) > 0 {
-		return nil, goerrors.Errorf("table(s) %v have no primary key on the target; live migration is not allowed for these tables", tablesWithoutPK)
-	}
-
-	return tableToPKColumns, nil
-}
-
-// For a fresh start but non empty tables in tableList && OnPrimaryKeyConflict is set to IGNORE -> notify user
-func runPKConflictModeGuardrails(state *importdata.ImportDataState, allTasks []*importdata.ImportFileTask) error {
-	// in case of ERROR mode, no need to check for non-empty tables
-	// but for IGNORE or UPDATE(in future), we need to prompt user
-	if tconf.OnPrimaryKeyConflictAction == constants.PRIMARY_KEY_CONFLICT_ACTION_ERROR_POLICY {
-		return nil
-	}
-
-	if !isTargetDBImporter(importerRole) {
-		return nil
-	}
-
-	if !isFreshStart(state, allTasks) {
-		log.Info("Not a fresh start, skipping primary key conflict mode check.")
-		return nil
-	}
-
-	pendingTasks := getPendingTasks(state, allTasks)
-	pendingTablesList := importFileTasksToTableNameTuples(pendingTasks)
-	nonEmptyTables := tdb.GetNonEmptyTables(pendingTablesList)
-	if len(nonEmptyTables) == 0 {
-		log.Info("No non-empty tables found in the target DB, skipping primary key conflict mode check.")
-		return nil
-	}
-
-	tableToPKColumns, err := tdb.GetPrimaryKeyColumnsForTables(nonEmptyTables)
-	if err != nil {
-		return fmt.Errorf("failed to get primary key columns for tables: %w", err)
-	}
-	var nonEmptyTablesWithPK []sqlname.NameTuple
-	for _, table := range nonEmptyTables {
-		colList, _ := tableToPKColumns.Get(table)
-		if len(colList) > 0 { // table has PK
-			nonEmptyTablesWithPK = append(nonEmptyTablesWithPK, table)
-		}
-	}
-
-	// all nonEmptyTables have no primary key columns
-	if len(nonEmptyTablesWithPK) == 0 {
-		log.Infof("No non-empty tables with primary key found in %v, skipping primary key conflict mode check.",
-			sqlname.NameTupleListToStrings(nonEmptyTables))
-		return nil
-	}
-
-	utils.PrintAndLogf(
-		"\nTarget tables with pre-existing data: %v\n"+
-			"Note that because of the config on-primary-key-conflict as 'IGNORE', rows that have a primary key conflict "+
-			"with an existing row in the above set of tables will be silently ignored.\n",
-		sqlname.NameTupleListToStrings(nonEmptyTablesWithPK),
-	)
-	if !utils.AskPrompt("Please confirm whether to proceed") {
-		utils.ErrExit("Aborting import.")
-	}
-
-	return nil
-}
-
-// A fresh start is when all tasks are pending(non-zero), no started or completed tasks.
-func isFreshStart(state *importdata.ImportDataState, allTasks []*importdata.ImportFileTask) bool {
-	inProgressTasks := getInProgressTasks(state, allTasks)
-	notStartedTasks := getNotStartedTasks(state, allTasks)
-	completedTasks := getCompletedTasks(state, allTasks)
-
-	return len(inProgressTasks) == 0 && len(completedTasks) == 0 && len(notStartedTasks) == len(allTasks)
-}
-
-// restoreGeneratedIdentityColumns enables & restores generated identity columns
-// 1. GENERATED ALWAYS: Re-enables(also restores the values) 'GENERATED ALWAYS' identity columns previously disabled before import data
-// 2. GENERATED BY DEFAULT: Remaining columns were always 'generated by default'; just restore their values.
-func restoreGeneratedIdentityColumns(importTableList []sqlname.NameTuple) error {
-	if importTableList == nil {
-		return nil
-	}
-
-	err := enableGeneratedAlwaysAsIdentityColumns()
-	if err != nil {
-		return err
-	}
-
-	// TODO: these sequences of all identity columns are also covered as part of the RestoreSequences as well so we don't need this ALTER
-	// see if we should remove it.
-	err = restoreGeneratedByDefaultAsIdentityColumns(importTableList)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func getMaxParallelConnections() (int, error) {
-	maxParallelConns := tconf.Parallelism
-	if tconf.AdaptiveParallelismMode.IsEnabled() {
-		// in case of adaptive parallelism, we need to use maxParalllelism * 2
-		yb, ok := tdb.(*tgtdb.TargetYugabyteDB)
-		if !ok {
-			return 0, goerrors.Errorf("adaptive parallelism is only supported if target DB is YugabyteDB")
-		}
-		maxParallelConns = yb.GetNumMaxConnectionsInPool()
-	}
-	return maxParallelConns, nil
-}
-
-func waitIfNoBatchAvailableForAllTasks(taskPicker importdata.FileTaskPicker, taskImporters map[int]*importdata.FileTaskImporter) {
-	inProgressTasks := taskPicker.InProgressTasks()
-	if len(inProgressTasks) == 0 {
-		return
-	}
-
-	allTasksBatchNotAvailable := true
-
-	for _, task := range inProgressTasks {
-		importer, exists := taskImporters[task.ID]
-		if !exists {
-			// Importer not yet created for this task - the picker has picked a new task
-			// that the main loop hasn't processed yet. Don't wait, let the loop create it.
-			return
-		}
-
-		if importer.IsNextBatchAvailable() {
-			allTasksBatchNotAvailable = false
-			break
-		}
-	}
-
-	if allTasksBatchNotAvailable {
-		log.Infof("No batches available for all in-progress tasks. Waiting for batch production.")
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-func waitIfAllBatchesSubmittedForAllTasks(taskPicker importdata.FileTaskPicker, taskImporters map[int]*importdata.FileTaskImporter) {
-	inProgressTasks := taskPicker.InProgressTasks()
-	if len(inProgressTasks) == 0 {
-		return
-	}
-
-	allTasksAllBatchesSubmitted := true
-
-	for _, task := range inProgressTasks {
-		importer, exists := taskImporters[task.ID]
-		if !exists {
-			// Importer not yet created for this task - the picker has picked a new task
-			// that the main loop hasn't processed yet. Don't wait, let the loop create it.
-			return
-		}
-		if !importer.AllBatchesSubmitted() {
-			allTasksAllBatchesSubmitted = false
-			break
-		}
-	}
-
-	if allTasksAllBatchesSubmitted {
-		log.Infof("All batches submitted for all in-progress tasks. Waiting for import completion.")
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-/*
-1. Initialize a worker pool. In case of TARGET_DB_IMPORTER_ROLE  or IMPORT_FILE_ROLE, also create a colocated batch import pool and a corresponding queue.
-2. Create a task picker which helps the importer choose which task to process in each iteration.
-3. Loop until all tasks are done:
-  - Pick a task from the task picker.
-  - If the task is not already being processed, create a new FileTaskImporter for the task.
-  - For the task that is picked, produce the next batch and submit it to the worker pool. Worker will asynchronously import the batch.
-  - If task is done, mark it as done in the task picker.
-*/
-func importTasksViaTaskPicker(pendingTasks []*importdata.ImportFileTask, state *importdata.ImportDataState, progressReporter *importdata.ImportDataProgressReporter,
-	maxParallelConns int, maxShardedTasksInProgress int, maxColocatedBatchesInProgress int,
-	isRowTransformationRequired bool, maxConcurrentBatchProductions int, enableRandomBatchProduction bool,
-	errorHandler importdata.ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) error {
-
-	var err error
-	setupWorkerPoolAndQueue(maxParallelConns, maxColocatedBatchesInProgress)
-	taskImporters := map[int]*importdata.FileTaskImporter{}
-	tableTypes, err := importdata.GetTableTypes(importerRole, tconf.TargetDBType, tdb, pendingTasks)
-	if err != nil {
-		return fmt.Errorf("get table types: %w", err)
-	}
-
-	// Initialize semaphore to limit concurrent batch productions
-	concurrentBatchProductionSem := semaphore.NewWeighted(int64(maxConcurrentBatchProductions))
-
-	var taskPicker importdata.FileTaskPicker
-	// The colocation-aware task picker only applies to a real YugabyteDB
-	// target. yb-amp (PostgreSQL-compatible, no colocation/tablets) and the
-	// PG fall-forward/back roles use the sequential picker instead.
-	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && tconf.TargetDBType == YUGABYTEDB {
-		yb, ok := tdb.(*tgtdb.TargetYugabyteDB)
-		if !ok {
-			return goerrors.Errorf("expected tdb to be of type TargetYugabyteDB, got: %T", tdb)
-		}
-		taskPicker, err = importdata.NewColocatedCappedRandomTaskPicker(maxShardedTasksInProgress, maxColocatedBatchesInProgress, pendingTasks, state, yb, colocatedBatchImportQueue, tableTypes)
-		if err != nil {
-			return fmt.Errorf("create colocated aware randmo task picker: %w", err)
-		}
-	} else {
-		taskPicker, err = importdata.NewSequentialTaskPicker(pendingTasks, state)
-		if err != nil {
-			return fmt.Errorf("create sequential task picker: %w", err)
-		}
-	}
-
-	for taskPicker.HasMoreTasks() {
-		task, err := taskPicker.Pick()
-		if err != nil {
-			return fmt.Errorf("get next task: %w", err)
-		}
-		log.Debugf("Picked task for import: %s", task)
-		var taskImporter *importdata.FileTaskImporter
-		var ok bool
-		taskImporter, ok = taskImporters[task.ID]
-		if !ok {
-			taskImporter, err = createFileTaskImporter(task, state, batchImportPool, progressReporter, colocatedBatchImportQueue, tableTypes, isRowTransformationRequired, enableRandomBatchProduction, concurrentBatchProductionSem, errorHandler, callhomeMetricsCollector)
-			if err != nil {
-				return fmt.Errorf("create file task importer: %w", err)
-			}
-			log.Infof("created file task importer for table: %s, task: %v", task.TableNameTup.ForOutput(), task)
-			taskImporters[task.ID] = taskImporter
-		}
-
-		if taskImporter.AllBatchesSubmitted() {
-			// All batches for this task have been submitted.
-			// task could have been completed (all batches imported) OR still in progress
-			// in case task is done, we should inform task picker so that we stop picking that task.
-			log.Debugf("All batches submitted for task: %s", task)
-			taskDone, err := state.AllBatchesImported(task.FilePath, task.TableNameTup)
-			if err != nil {
-				return fmt.Errorf("check if all batches are imported: task: %v err :%w", task, err)
-			}
-			if taskDone {
-				taskImporter.PostProcess()
-				err = taskPicker.MarkTaskAsDone(task)
-				if err != nil {
-					return fmt.Errorf("mark task as done: task: %v, err: %w", task, err)
-				}
-				state.UnregisterFileTaskImporter(taskImporter)
-				log.Infof("Import of task done: %s", task)
-				continue
-			}
-			// Batches still being imported by workers; continue with some other task.
-			waitIfAllBatchesSubmittedForAllTasks(taskPicker, taskImporters)
-			continue
-		}
-
-		if !taskImporter.IsNextBatchAvailable() {
-			// Picked task has no batch ready. Small sleep to prevent tight spinning
-			// in case picker keeps returning tasks without batches.
-			log.Debugf("No next batch available for table: %s", task.TableNameTup.ForOutput())
-			waitIfNoBatchAvailableForAllTasks(taskPicker, taskImporters)
-			continue
-		}
-
-		log.Infof("Producing and submitting next batch for task: %s", task)
-
-		err = taskImporter.ProduceAndSubmitNextBatchToWorkerPool()
-		if err != nil {
-			return goerrors.Errorf("submit next batch: task:%v err: %w", task, err)
-		}
-	}
-	return nil
-}
-
-func setupWorkerPoolAndQueue(maxParallelConns int, maxColocatedBatchesInProgress int) {
-	shardedPoolSize := maxParallelConns * 2
-	batchImportPool = pool.New().WithMaxGoroutines(shardedPoolSize)
-	log.Infof("created batch import pool of size: %d", shardedPoolSize)
-
-	if importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE {
-		colocatedBatchImportPool = pool.New().WithMaxGoroutines(maxColocatedBatchesInProgress)
-		log.Infof("created colocated batch import pool of size: %d", maxColocatedBatchesInProgress)
-
-		colocatedBatchImportQueue = make(chan func(), maxColocatedBatchesInProgress*2)
-
-		colocatedBatchImportQueueConsumer := func() {
-			// just read from channel and submit to the worker pool.
-			// worker pool has a max size of maxColocatedBatchesInProgress, so it will block if all workers are busy.
-			for f := range colocatedBatchImportQueue {
-				colocatedBatchImportPool.Go(f)
-			}
-		}
-		go colocatedBatchImportQueueConsumer()
-	}
-}
-
 // getTableTypes returns a map of table name to table type (sharded/colocated) for all tables in the tasks.
 // The *FromGlobals helpers copy the cmd package-level variables the importdata
 // components used to read directly into their config structs. They are a bridge
@@ -1755,203 +1143,6 @@ func importDataStateConfigFromGlobals() importdata.ImportDataStateConfig {
 
 func newImportDataStateFromGlobals() *importdata.ImportDataState {
 	return importdata.NewImportDataState(importDataStateConfigFromGlobals())
-}
-
-func sequentialFileBatchProducerConfigFromGlobals() importdata.SequentialFileBatchProducerConfig {
-	return importdata.SequentialFileBatchProducerConfig{
-		ImporterRole:       importerRole,
-		Tdb:                tdb,
-		Tconf:              tconf,
-		DataFileDescriptor: dataFileDescriptor,
-		DataStore:          dataStore,
-		BatchSizeInNumRows: batchSizeInNumRows,
-		ValueConverter:     valueConverter,
-		TableToColumnNames: TableToColumnNames,
-	}
-}
-
-func fileTaskImporterConfigFromGlobals() importdata.FileTaskImporterConfig {
-	return importdata.FileTaskImporterConfig{
-		ImporterRole:          importerRole,
-		Tdb:                   tdb,
-		Tconf:                 tconf,
-		ExportDir:             exportDir,
-		MigrationUUID:         migrationUUID,
-		DataFileDescriptor:    dataFileDescriptor,
-		ReportProgressInBytes: reportProgressInBytes,
-		ControlPlane:          controlPlane,
-		TableToColumnNames:    TableToColumnNames,
-		TableNameToSchema:     TableNameToSchema,
-	}
-}
-
-/*
-when TARGET_DB_IMPORTER_ROLE or IMPORT_FILE_ROLE, we pass on
-the batchImportPool and the colocatedBatchImportQueue to the FileTaskImporter
-so that it can submit sharded table batches to the batchImportPool,
-and colocated table batches to the colocatedBatchImportQueue.
-
-Otherwise, we simply pass the batchImportPool to the FileTaskImporter.
-*/
-func createFileTaskImporter(task *importdata.ImportFileTask, state *importdata.ImportDataState, batchImportPool *pool.Pool, progressReporter *importdata.ImportDataProgressReporter, colocatedBatchImportQueue chan func(),
-	tableTypes *utils.StructMap[sqlname.NameTuple, string], isRowTransformationRequired bool, enableRandomBatchProduction bool, concurrentBatchProductionSem *semaphore.Weighted, errorHandler importdata.ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (*importdata.FileTaskImporter, error) {
-	var taskImporter *importdata.FileTaskImporter
-	var err error
-	var batchProducer importdata.FileBatchProducer
-
-	// tableTypes (the colocation map) is only populated for a real YugabyteDB
-	// target. For yb-amp (PostgreSQL-compatible, no colocation) and the PG
-	// fall-forward/back roles it is nil, so they take the plain sequential
-	// importer path below.
-	// The colocation-aware importer applies only to a real YugabyteDB target;
-	// tableTypes is populated (non-nil) exactly for that case (see getTableTypes).
-	// Non-YB targets (yb-amp, etc.) take the plain sequential importer below.
-	if (importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE) && tconf.TargetDBType == YUGABYTEDB {
-		tableType, ok := tableTypes.Get(task.TableNameTup)
-		if !ok {
-			return nil, goerrors.Errorf("table type not found for table: %s", task.TableNameTup.ForOutput())
-		}
-
-		if enableRandomBatchProduction {
-			batchProducer, err = importdata.NewRandomFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, isRowTransformationRequired, errorHandler, progressReporter, concurrentBatchProductionSem)
-			if err != nil {
-				return nil, fmt.Errorf("creating random batch producer: %w", err)
-			}
-		} else {
-			batchProducer, err = importdata.NewSequentialFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, isRowTransformationRequired, errorHandler, progressReporter)
-			if err != nil {
-				return nil, fmt.Errorf("creating sequential batch producer: %w", err)
-			}
-		}
-		taskImporter, err = importdata.NewFileTaskImporter(fileTaskImporterConfigFromGlobals(), task, state, batchProducer, batchImportPool, progressReporter, colocatedBatchImportQueue, tableType == importdata.COLOCATED, errorHandler, callhomeMetricsCollector)
-
-		if err != nil {
-			return nil, fmt.Errorf("create file task importer: %w", err)
-		}
-	} else {
-		batchProducer, err = importdata.NewSequentialFileBatchProducer(sequentialFileBatchProducerConfigFromGlobals(), task, state, isRowTransformationRequired, errorHandler, progressReporter)
-		if err != nil {
-			return nil, fmt.Errorf("creating sequential batch producer: %w", err)
-		}
-
-		taskImporter, err = importdata.NewFileTaskImporter(fileTaskImporterConfigFromGlobals(), task, state, batchProducer, batchImportPool, progressReporter, nil, false, errorHandler, callhomeMetricsCollector)
-		if err != nil {
-			return nil, fmt.Errorf("create file task importer: %w", err)
-		}
-	}
-	return taskImporter, nil
-}
-
-func startMonitoringTargetYBHealth() error {
-	if !slices.Contains([]string{TARGET_DB_IMPORTER_ROLE, IMPORT_FILE_ROLE}, importerRole) {
-		return nil
-	}
-	// Target health monitoring (node / disk-usage / replication metrics) is a
-	// YugabyteDB-cluster concept. Non-YB targets (yb-amp's stateless PG17 compute,
-	// etc.) expose no such API, so it does not apply.
-	if tconf.TargetDBType != YUGABYTEDB {
-		return nil
-	}
-	if skipNodeHealthChecks && skipDiskUsageHealthChecks && skipReplicationChecks {
-		return nil
-	}
-	yb, ok := tdb.(*tgtdb.TargetYugabyteDB)
-	if !ok {
-		return goerrors.Errorf("monitoring health is only supported if target DB is YugabyteDB")
-	}
-
-	go func() {
-		//for now not sending any other parameters as not required for monitor usage
-		ybClient := dbzm.NewYugabyteDBCDCClient(exportDir, "", tconf.SSLRootCert, tconf.DBName, "", nil)
-		err := ybClient.Init()
-		if err != nil {
-			log.Errorf("error intialising the yb client : %v", err)
-		}
-		monitorTDBHealth := monitor.NewMonitorTargetYBHealth(yb, bool(skipDiskUsageHealthChecks), bool(skipReplicationChecks), bool(skipNodeHealthChecks), ybClient, func(info string) {
-			displayMonitoringInformationOnTheConsole(info)
-		})
-
-		err = monitorTDBHealth.StartMonitoring()
-		//lint:ignore SA4023 StartMonitoring currently only returns on error; keep the conventional check
-		if err != nil {
-			log.Errorf("error monitoring the target health: %v", err)
-		}
-	}()
-	return nil
-}
-
-func displayMonitoringInformationOnTheConsole(info string) {
-	if info == "" {
-		return
-	}
-	if disablePb {
-		utils.PrintAndLog(info)
-	} else {
-		log.Warnf("monitoring: %v", info)
-		if importPhase == dbzm.MODE_SNAPSHOT || importerRole == IMPORT_FILE_ROLE {
-			progressReporter.DisplayInformation(info)
-		} else {
-			statsReporter.DisplayInformation(info)
-
-		}
-	}
-}
-
-func startAdaptiveParallelism(mode types.AdaptiveParallelismMode, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (bool, error) {
-	if !mode.IsEnabled() {
-		return false, nil
-	}
-	yb, ok := tdb.(*tgtdb.TargetYugabyteDB)
-	if !ok {
-		return false, goerrors.Errorf("adaptive parallelism is only supported if target DB is YugabyteDB")
-	}
-
-	if !yb.IsAdaptiveParallelismSupported() {
-		utils.PrintAndLog(color.YellowString("Note: Continuing without adaptive parallelism as it is not supported in this version of YugabyteDB."))
-		return false, nil
-	}
-
-	go func() {
-		err := adaptiveparallelism.AdaptParallelism(yb, mode, callhomeMetricsCollector)
-		if err != nil {
-			log.Errorf("adaptive parallelism error: %v", err)
-		}
-	}()
-	return true, nil
-}
-
-func waitForDebeziumStartIfRequired() error {
-	msr, err := metaDB.GetMigrationStatusRecord()
-	if err != nil {
-		return fmt.Errorf("failed to get migration status record: %w", err)
-	}
-	if msr.SnapshotMechanism == "debezium" {
-		// we already wait for snapshot to have completed by debezium
-		// so no need to wait again here.
-		return nil
-	}
-
-	// in case pg_dump was used to export snapshot data,
-	// we need to wait for export-data to have started debezium in cdc phase
-	// in order to avoid any race conditions.
-	fmt.Println("Initializing streaming phase...")
-	log.Infof("waiting for export-data to have started debezium in cdc phase")
-	for {
-		msr, err = metaDB.GetMigrationStatusRecord()
-		if err != nil {
-			return fmt.Errorf("failed to get migration status record: %w", err)
-		}
-		if lo.Contains([]string{TARGET_DB_IMPORTER_ROLE, SOURCE_REPLICA_DB_IMPORTER_ROLE}, importerRole) &&
-			msr.ExportDataSourceDebeziumStarted {
-			break
-		}
-		if importerRole == SOURCE_DB_IMPORTER_ROLE && msr.ExportDataTargetDebeziumStarted {
-			break
-		}
-		time.Sleep(2 * time.Second)
-	}
-
-	return nil
 }
 
 func packAndSendImportDataToTargetPayload(status string, errorMsg error) {
@@ -1980,12 +1171,12 @@ func packAndSendImportDataToTargetPayload(status string, errorMsg error) {
 
 	// Get phase-related metrics from existing logic
 	// TODO: fix: pass proper error handler here.
-	importRowsMap, err := getImportedSnapshotRowsMap("target", importTableList, nil)
+	importRowsMap, err := importdata.GetImportedSnapshotRowsMap("target", importTableList, nil, importDataStateConfigFromGlobals())
 	if err != nil {
 		log.Infof("callhome: error in getting the import data: %v", err)
 	} else {
 		// callhome payload assembly; the callback never returns an error
-		_ = importRowsMap.IterKV(func(key sqlname.NameTuple, value RowCountPair) (bool, error) {
+		_ = importRowsMap.IterKV(func(key sqlname.NameTuple, value importdata.RowCountPair) (bool, error) {
 			dataMetrics.MigrationSnapshotTotalRows += value.Imported
 			if value.Imported > dataMetrics.MigrationSnapshotLargestTableRows {
 				dataMetrics.MigrationSnapshotLargestTableRows = value.Imported
@@ -1995,9 +1186,9 @@ func packAndSendImportDataToTargetPayload(status string, errorMsg error) {
 	}
 
 	// Set live migration metrics if applicable
-	if importPhase != dbzm.MODE_SNAPSHOT && statsReporter != nil {
-		dataMetrics.MigrationCdcTotalImportedEvents = statsReporter.TotalEventsImported
-		dataMetrics.CdcEventsImportRate3min = statsReporter.EventsImportRateLast3Min
+	if currentImportPhase() != dbzm.MODE_SNAPSHOT && currentStatsReporter() != nil {
+		dataMetrics.MigrationCdcTotalImportedEvents = currentStatsReporter().TotalEventsImported
+		dataMetrics.CdcEventsImportRate3min = currentStatsReporter().EventsImportRateLast3Min
 	}
 
 	// Set table list count
@@ -2017,7 +1208,7 @@ func packAndSendImportDataToTargetPayload(status string, errorMsg error) {
 		AdaptiveParallelismMax:      int64(tconf.MaxParallelism),
 		ErrorPolicySnapshot:         errorPolicySnapshotFlag.String(),
 		DataMetrics:                 dataMetrics,
-		Phase:                       importPhase,
+		Phase:                       currentImportPhase(),
 	}
 
 	var err2 error
@@ -2041,280 +1232,6 @@ func packAndSendImportDataToTargetPayload(status string, errorMsg error) {
 	if err == nil && (status == COMPLETE || status == ERROR) {
 		callHomeErrorOrCompletePayloadSent = true
 	}
-}
-
-// Handling identity columns for resumable import data
-// Background: A previous incomplete import run may have disabled "GENERATED ALWAYS AS IDENTITY" columns.
-// Two scenarios:
-//  1. Columns are disabled: Restore TableToIdentityColumnNames map from metaDB
-//  2. Columns are enabled: Fetch identity columns from database and persist to metaDB for import data resumability
-func fetchAndStoreGeneratedAlwaysIdentityColumnsInMetadb(tables []sqlname.NameTuple) error {
-	tableKeyToIdentityColumnNames := make(map[string][]string)
-
-	// Fetch the table to identity columns information from metadb if present
-	found, err := metaDB.GetJsonObject(nil, identityColumnsMetaDBKey, &tableKeyToIdentityColumnNames)
-	if err != nil {
-		return goerrors.Errorf("failed to get identity columns from meta db: %w", err)
-	}
-	if found {
-		// Using retrieved identity columns from metaDB to populate TableToIdentityColumns
-		TableToIdentityColumnNames = utils.NewStructMap[sqlname.NameTuple, []string]()
-		for key, columns := range tableKeyToIdentityColumnNames {
-			nameTuple, err := namereg.NameReg.LookupTableName(key)
-			if err != nil {
-				return goerrors.Errorf("lookup for table name in name reg: %v with: %w", key, err)
-			}
-			TableToIdentityColumnNames.Put(nameTuple, columns)
-		}
-		return nil
-	}
-
-	// If not found, fetch it from target db and populate TableToIdentityColumnNames and persist it to metaDB
-	TableToIdentityColumnNames, err = tdb.GetIdentityColumnNamesForTables(tables, constants.IDENTITY_GENERATION_ALWAYS)
-	if err != nil {
-		return fmt.Errorf("failed to get identity(%s) columns for tables: %w", constants.IDENTITY_GENERATION_ALWAYS, err)
-	}
-
-	err = TableToIdentityColumnNames.IterKV(func(key sqlname.NameTuple, value []string) (bool, error) {
-		tableKeyToIdentityColumnNames[key.ForKey()] = value
-		return true, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to iterate identity column names: %w", err)
-	}
-	err = metaDB.InsertJsonObject(nil, identityColumnsMetaDBKey, tableKeyToIdentityColumnNames)
-	if err != nil {
-		return goerrors.Errorf("failed to insert into the key '%s': %w", identityColumnsMetaDBKey, err)
-	}
-	return nil
-}
-func disableGeneratedAlwaysAsIdentityColumns() error {
-	err := tdb.DisableGeneratedAlwaysAsIdentityColumns(TableToIdentityColumnNames)
-	if err != nil {
-		return goerrors.Errorf("failed to disable generated always as identity columns: %w", err)
-	}
-	return nil
-}
-
-// identityColumnsNeedHandlingForSnapshotImport checks if identity columns need to be handled
-// (disabled before snapshot import) for Oracle targets in live migration.
-// This is required because Oracle's SQL*Loader/COPY fails for GENERATED ALWAYS columns,
-// so we need to temporarily convert them to GENERATED BY DEFAULT for snapshot import.
-// The restoration is handled in postCutoverProcessing() for live migrations.
-// For PostgreSQL/YugabyteDB targets, COPY works with GENERATED ALWAYS columns, so no handling is needed.
-// Note: SOURCE_DB_IMPORTER_ROLE (fallback) doesn't import snapshots, so not included here.
-func identityColumnsNeedHandlingForSnapshotImport() bool {
-	// Only source-replica import has Oracle as target and requires snapshot import
-	return tconf.TargetDBType == ORACLE && importerRole == SOURCE_REPLICA_DB_IMPORTER_ROLE
-}
-
-func enableGeneratedAlwaysAsIdentityColumns() error {
-	err := tdb.EnableGeneratedAlwaysAsIdentityColumns(TableToIdentityColumnNames)
-	if err != nil {
-		return goerrors.Errorf("failed to enable generated always as identity columns: %w", err)
-	}
-	return nil
-}
-
-func restoreGeneratedByDefaultAsIdentityColumns(tables []sqlname.NameTuple) error {
-	log.Infof("restoring generated by default as identity columns for tables: %v", tables)
-	tablesToIdentityColumnNames, err := tdb.GetIdentityColumnNamesForTables(tables, constants.IDENTITY_GENERATION_BY_DEFAULT)
-	if err != nil {
-		return fmt.Errorf("failed to get identity(%s) columns for tables: %w", constants.IDENTITY_GENERATION_BY_DEFAULT, err)
-	}
-	err = tdb.EnableGeneratedByDefaultAsIdentityColumns(tablesToIdentityColumnNames)
-	if err != nil {
-		return fmt.Errorf("failed to enable generated by default as identity columns: %w", err)
-	}
-	return nil
-}
-
-func importFileTasksToTableNames(tasks []*importdata.ImportFileTask) []string {
-	tableNames := []string{}
-	for _, t := range tasks {
-		tableNames = append(tableNames, t.TableNameTup.ForKey())
-	}
-	return lo.Uniq(tableNames)
-}
-
-func importFileTasksToTableNameTuples(tasks []*importdata.ImportFileTask) []sqlname.NameTuple {
-	tableNames := []sqlname.NameTuple{}
-	for _, t := range tasks {
-		tableNames = append(tableNames, t.TableNameTup)
-	}
-	return lo.UniqBy(tableNames, func(t sqlname.NameTuple) string {
-		return t.ForKey()
-	})
-}
-
-func classifyTasksForImport(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) (pendingTasks, completedTasks []*importdata.ImportFileTask, err error) {
-	inProgressTasks := []*importdata.ImportFileTask{}
-	notStartedTasks := []*importdata.ImportFileTask{}
-	for _, task := range tasks {
-		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
-		if err != nil {
-			return nil, nil, fmt.Errorf("get table import state: %w", err)
-		}
-		switch fileImportState {
-		case importdata.FILE_IMPORT_COMPLETED, importdata.FILE_IMPORT_COMPLETED_WITH_ERRORS:
-			completedTasks = append(completedTasks, task)
-		case importdata.FILE_IMPORT_IN_PROGRESS:
-			inProgressTasks = append(inProgressTasks, task)
-		case importdata.FILE_IMPORT_NOT_STARTED:
-			notStartedTasks = append(notStartedTasks, task)
-		default:
-			return nil, nil, goerrors.Errorf("invalid table import state: %s", fileImportState)
-		}
-	}
-	// Start with in-progress tasks, followed by not-started tasks.
-	return append(inProgressTasks, notStartedTasks...), completedTasks, nil
-}
-
-func getNotStartedTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
-	notStartedTasks := []*importdata.ImportFileTask{}
-	for _, task := range tasks {
-		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
-		if err != nil {
-			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
-		}
-		if fileImportState == importdata.FILE_IMPORT_NOT_STARTED {
-			notStartedTasks = append(notStartedTasks, task)
-		}
-	}
-	return notStartedTasks
-}
-
-func getInProgressTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
-	inProgressTasks := []*importdata.ImportFileTask{}
-	for _, task := range tasks {
-		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
-		if err != nil {
-			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
-		}
-		if fileImportState == importdata.FILE_IMPORT_IN_PROGRESS {
-			inProgressTasks = append(inProgressTasks, task)
-		}
-	}
-	return inProgressTasks
-}
-
-func getPendingTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
-	return append(getInProgressTasks(state, tasks), getNotStartedTasks(state, tasks)...)
-}
-
-func getCompletedTasks(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) []*importdata.ImportFileTask {
-	completedTasks := []*importdata.ImportFileTask{}
-	for _, task := range tasks {
-		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
-		if err != nil {
-			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
-		}
-		if fileImportState == importdata.FILE_IMPORT_COMPLETED || fileImportState == importdata.FILE_IMPORT_COMPLETED_WITH_ERRORS {
-			completedTasks = append(completedTasks, task)
-		}
-	}
-	return completedTasks
-}
-
-func cleanImportState(state *importdata.ImportDataState, tasks []*importdata.ImportFileTask) {
-	tableNames := importFileTasksToTableNameTuples(tasks)
-	nonEmptyNts := tdb.GetNonEmptyTables(tableNames)
-	if len(nonEmptyNts) > 0 {
-		nonEmptyTableNames := lo.Map(nonEmptyNts, func(nt sqlname.NameTuple, _ int) string {
-			return nt.ForOutput()
-		})
-		if truncateTables {
-			// truncate tables only supported for import-data-to-target.
-			utils.PrintAndLogf("Non-empty tables on DB: %v", nonEmptyTableNames)
-			utils.PrintAndLogf("Truncating all tables in import scope on DB to keep FK-dependents consistent")
-			err := tdb.TruncateTables(tableNames)
-			if err != nil {
-				utils.ErrExit("failed to truncate tables: %w", err)
-			}
-		} else {
-			utils.PrintAndLogf("Non-Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
-			utils.PrintAndLogf("The above list of tables on DB are not empty.")
-			utils.PrintAndLogf("If you wish to truncate them, re-run the import command with --truncate-tables true")
-			yes := utils.AskPrompt("Do you want to start afresh without truncating tables")
-			if !yes {
-				utils.ErrExit("Aborting import.")
-			}
-		}
-
-	}
-
-	for _, task := range tasks {
-		err := state.Clean(task.FilePath, task.TableNameTup)
-		if err != nil {
-			utils.ErrExit("failed to clean import data state for table: %q: %w", task.TableNameTup, err)
-		}
-	}
-
-	sqlldrDir := filepath.Join(exportDir, "sqlldr")
-	if utils.FileOrFolderExists(sqlldrDir) {
-		err := os.RemoveAll(sqlldrDir)
-		if err != nil {
-			utils.ErrExit("failed to remove sqlldr directory: %q: %w", sqlldrDir, err)
-		}
-	}
-}
-
-func prepareTableToColumns(tasks []*importdata.ImportFileTask) error {
-	for _, task := range tasks {
-		var columns []string
-		dfdTableToExportedColumns, err := getDfdTableNameToExportedColumns(tasks, dataFileDescriptor)
-		if err != nil {
-			return goerrors.Errorf("failed to get dfd table to exported columns: %w", err)
-		}
-		if dfdTableToExportedColumns != nil {
-			columns, _ = dfdTableToExportedColumns.Get(task.TableNameTup)
-		} else if dataFileDescriptor.HasHeader {
-			// File is either exported from debezium OR this is `import data file` case.
-			reader, err := dataStore.Open(task.FilePath)
-			if err != nil {
-				return goerrors.Errorf("datastore.Open: %q: %w", task.FilePath, err)
-			}
-			df, err := datafile.NewDataFile(task.FilePath, reader, dataFileDescriptor, 0)
-			if err != nil {
-				return goerrors.Errorf("opening datafile: %q: %w", task.FilePath, err)
-			}
-			header := df.GetHeader()
-			columns = strings.Split(header, dataFileDescriptor.Delimiter)
-			log.Infof("read header from file %q: %s", task.FilePath, header)
-			log.Infof("header row split using delimiter %q: %v\n", dataFileDescriptor.Delimiter, columns)
-			df.Close()
-		}
-		TableToColumnNames.Put(task.TableNameTup, columns)
-	}
-	return nil
-}
-
-func getDfdTableNameToExportedColumns(tasks []*importdata.ImportFileTask, dataFileDescriptor *datafile.Descriptor) (*utils.StructMap[sqlname.NameTuple, []string], error) {
-	if dataFileDescriptor.TableNameToExportedColumns == nil {
-		return nil, nil
-	}
-	tableTupleToexportedColumns := utils.NewStructMap[sqlname.NameTuple, []string]()
-	for tableName, columnList := range dataFileDescriptor.TableNameToExportedColumns {
-		//Using lookup with ignoring if target not found as we are creating tuple for tables in datafile descriptor which are tables exported
-		tuple, err := namereg.NameReg.LookupTableNameAndIgnoreIfTargetNotFoundBasedOnRole(tableName)
-		if err != nil {
-			return nil, goerrors.Errorf("failed to lookup table name: %w", err)
-		}
-		tableTupleToexportedColumns.Put(tuple, columnList)
-	}
-
-	result := utils.NewStructMap[sqlname.NameTuple, []string]()
-	// checking columns for all tables in the datafile descriptor by using the file tasks
-	//as this is used only for import batch which is snapshot
-	for _, task := range tasks {
-		columnList, ok := tableTupleToexportedColumns.Get(task.TableNameTup)
-		if ok {
-			result.Put(task.TableNameTup, columnList)
-		} else {
-			return nil, goerrors.Errorf("table %q not found in data file descriptor", task.TableNameTup.ForKey())
-		}
-	}
-	return result, nil
 }
 
 func checkExportDataDoneOrStartedFlag() {
@@ -2386,41 +1303,6 @@ func createSnapshotImportCompletedEvent() cp.SnapshotImportCompletedEvent {
 	return result
 }
 
-// createInitialImportDataTableMetrics sets table-scope metrics (totals, expected
-// rows, pre-registered per-table series) from allTasks so they stay accurate on
-// resume, when pendingTasks alone would under-report tables already completed in
-// a prior run. The control-plane event list is still built from pendingTasks only
-// (unchanged behaviour: the control plane only expects updates for tables being
-// worked on in this run).
-func createInitialImportDataTableMetrics(allTasks, pendingTasks []*importdata.ImportFileTask) []*cp.UpdateImportedRowCountEvent {
-	metrics.Get().SetImportSnapshotTablesTotal(importerRole, len(allTasks))
-	for _, task := range allTasks {
-		metrics.Get().SetImportSnapshotTableExpectedRows(importerRole, task.TableNameTup, task.RowCount)
-		metrics.Get().InitImportSnapshotTable(importerRole, task.TableNameTup)
-	}
-
-	result := []*cp.UpdateImportedRowCountEvent{}
-	for _, task := range pendingTasks {
-		schemaName, tableName := task.TableNameTup.ForKeyTableSchema()
-		tableMetrics := cp.UpdateImportedRowCountEvent{
-			BaseUpdateRowCountEvent: cp.BaseUpdateRowCountEvent{
-				BaseEvent: cp.BaseEvent{
-					EventType:     "IMPORT DATA",
-					MigrationUUID: migrationUUID,
-					SchemaNames:   []string{schemaName},
-				},
-				TableName:         tableName,
-				Status:            cp.EXPORT_OR_IMPORT_DATA_STATUS_INT_TO_STR[ROW_UPDATE_STATUS_NOT_STARTED],
-				TotalRowCount:     importdata.GetTotalProgressAmount(task, reportProgressInBytes),
-				CompletedRowCount: 0,
-			},
-		}
-		result = append(result, &tableMetrics)
-	}
-
-	return result
-}
-
 func saveOnPrimaryKeyConflictActionInMSR() {
 	if !isPrimaryKeyConflictModeValid() {
 		return
@@ -2434,111 +1316,8 @@ func saveOnPrimaryKeyConflictActionInMSR() {
 	}
 }
 
-func clearMigrationStateForImportDataStartClean(state *importdata.ImportDataState, importFileTasks []*importdata.ImportFileTask, errorHandler importdata.ImportDataErrorHandler) error {
-	if !startClean {
-		log.Infof("skipping cleaning migration status record for import data command start clean")
-		return nil
-	}
-
-	if importType == CHANGES_ONLY {
-		utils.ErrExit("start-clean flag is not supported for changes-only import type")
-	}
-
-	msr, err := metaDB.GetMigrationStatusRecord()
-	if err != nil {
-		return goerrors.Errorf("failed to get migration status record: %w", err)
-	}
-
-	if msr == nil {
-		return goerrors.Errorf("migration status record not found.")
-	}
-
-	// Guardrail: for change-streaming imports, start-clean resets the per-importer
-	// imported_by flags and re-streams the queue from the earliest segment. If that
-	// segment has already been archived/deleted by `archive changes`, the queue can
-	// no longer be re-streamed from the beginning. Detect this and fail before
-	// mutating any metaDB state.
-	if changeStreamingIsEnabled(importType) {
-		resumeSegmentDeleted, err := metaDB.AnySegmentsDeletedOrArchived()
-		if err != nil {
-			return goerrors.Errorf("failed to check for archived/deleted queue segments: %w", err)
-		}
-		if resumeSegmentDeleted {
-			return goerrors.Errorf("cannot perform import data with --start-clean: some queue segments have already been archived/deleted by 'archive changes'. The change-event queue can no longer be re-streamed from the beginning, so a clean restart is not possible.")
-		}
-	}
-
-	err = metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-		record.OnPrimaryKeyConflictAction = ""
-	})
-	if err != nil {
-		return goerrors.Errorf("failed to update migration status record: %w", err)
-	}
-	err = metaDB.UpdateImportDataStatusRecord(func(record *metadb.ImportDataStatusRecord) {
-		record.TableToCDCPartitionKey = nil
-	})
-	if err != nil {
-		return goerrors.Errorf("failed to update import data status record: %w", err)
-	}
-
-	err = handleStartCleanForSnapshot(state, importFileTasks, errorHandler)
-	if err != nil {
-		utils.ErrExit("Failed to handle fresh start: %w", err)
-	}
-
-	if changeStreamingIsEnabled(importType) {
-		// clearing state from metaDB based on importerRole
-		err := metaDB.ResetQueueSegmentMeta(importerRole)
-		if err != nil {
-			utils.ErrExit("failed to reset queue segment meta: %w", err)
-		}
-		err = metaDB.DeleteJsonObject(identityColumnsMetaDBKey)
-		if err != nil {
-			utils.ErrExit("failed to reset identity columns meta: %w", err)
-		}
-	}
-	return nil
-}
-
 func isPrimaryKeyConflictModeValid() bool {
 	return importerRole == IMPORT_FILE_ROLE || importerRole == TARGET_DB_IMPORTER_ROLE
-}
-
-func cleanStoredErrors(errorHandler importdata.ImportDataErrorHandler, tasks []*importdata.ImportFileTask) error {
-	// clean stored errors for all tasks
-	for _, task := range tasks {
-		err := errorHandler.CleanUpStoredErrors(task.TableNameTup, task.FilePath)
-		if err != nil {
-			return fmt.Errorf("failed to clean up stored errors for task %s: %w", task.TableNameTup.ForOutput(), err)
-		}
-	}
-	return nil
-}
-
-func isTargetDBImporter(importerRole string) bool {
-	return importerRole == TARGET_DB_IMPORTER_ROLE || importerRole == IMPORT_FILE_ROLE
-}
-
-func updateErrorPolicyInMetaDB(errorPolicy importdata.ErrorPolicy) error {
-
-	switch importerRole {
-	case IMPORT_FILE_ROLE:
-		err := metaDB.UpdateImportDataFileStatusRecord(func(record *metadb.ImportDataFileStatusRecord) {
-			record.ErrorPolicy = errorPolicy.String()
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update error policy in import data file status record: %w", err)
-		}
-	case TARGET_DB_IMPORTER_ROLE:
-		err := metaDB.UpdateImportDataStatusRecord(func(record *metadb.ImportDataStatusRecord) {
-			record.ErrorPolicySnapshot = errorPolicy.String()
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update error policy in import data status record: %w", err)
-		}
-		// Not applicable for other roles
-	}
-	return nil
 }
 
 func BuildCallhomeYBClusterMetrics() (callhome.YBClusterMetrics, error) {

--- a/yb-voyager/cmd/importDataFileCommand.go
+++ b/yb-voyager/cmd/importDataFileCommand.go
@@ -112,7 +112,7 @@ var importDataFileCmd = &cobra.Command{
 				utils.ErrExit("Aborting import.")
 			}
 		}
-		importData(importFileTasks, errorPolicySnapshotFlag)
+		runImportDataEngine(importFileTasks)
 		packAndSendImportDataFilePayload(COMPLETE, nil)
 
 	},
@@ -160,7 +160,7 @@ func prepareForImportDataCmd(importFileTasks []*importdata.ImportFileTask) {
 
 	escapeFileOptsCharsIfRequired() // escaping for COPY command should be done after saving fileOpts in data file descriptor
 	setImportTableListFlag(importFileTasks)
-	importTableList = importFileTasksToTableNameTuples(importFileTasks)
+	importTableList = importdata.ImportFileTasksToTableNameTuples(importFileTasks)
 	setDataIsExported()
 }
 

--- a/yb-voyager/cmd/importDataFile_test.go
+++ b/yb-voyager/cmd/importDataFile_test.go
@@ -112,7 +112,7 @@ func TestImportDataFileReport(t *testing.T) {
 	tableList := []sqlname.NameTuple{
 		tblName,
 	}
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target-file", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target-file", tableList, errorHandler, importDataStateConfigFromGlobals())
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestImportDataFileReport_ErrorPolicyStashAndContinue_BatchIngestionError(t 
 	tableList := []sqlname.NameTuple{
 		tblName,
 	}
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target-file", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target-file", tableList, errorHandler, importDataStateConfigFromGlobals())
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestImportDataFileReport_ErrorPolicyStashAndContinue_ProcessingError(t *tes
 	tableList := []sqlname.NameTuple{
 		tblName,
 	}
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target-file", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target-file", tableList, errorHandler, importDataStateConfigFromGlobals())
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)
 	}
@@ -550,7 +550,7 @@ func TestImportDataFile_MultipleTasksForATable(t *testing.T) {
 	tableList := []sqlname.NameTuple{
 		tblName,
 	}
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target-file", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target-file", tableList, errorHandler, importDataStateConfigFromGlobals())
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)
 	}
@@ -688,7 +688,7 @@ func TestImportDataFile_SameFileForMultipleTables(t *testing.T) {
 		tblName,
 		tblName1,
 	}
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target-file", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target-file", tableList, errorHandler, importDataStateConfigFromGlobals())
 
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)

--- a/yb-voyager/cmd/importDataToSource.go
+++ b/yb-voyager/cmd/importDataToSource.go
@@ -129,9 +129,9 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg error) {
 	}
 
 	// Set live migration metrics if applicable
-	if importPhase != dbzm.MODE_SNAPSHOT && statsReporter != nil {
-		dataMetrics.MigrationCdcTotalImportedEvents = statsReporter.TotalEventsImported
-		dataMetrics.CdcEventsImportRate3min = statsReporter.EventsImportRateLast3Min
+	if currentImportPhase() != dbzm.MODE_SNAPSHOT && currentStatsReporter() != nil {
+		dataMetrics.MigrationCdcTotalImportedEvents = currentStatsReporter().TotalEventsImported
+		dataMetrics.CdcEventsImportRate3min = currentStatsReporter().EventsImportRateLast3Min
 	}
 
 	// Set table list count
@@ -152,7 +152,7 @@ func packAndSendImportDataToSourcePayload(status string, errorMsg error) {
 		Error:                   callhome.SanitizeErrorMsg(errorMsg, anonymizer),
 		ControlPlaneType:        getControlPlaneType(),
 		DataMetrics:             dataMetrics,
-		Phase:                   importPhase,
+		Phase:                   currentImportPhase(),
 		IterativeCutoverEnabled: iterativeCutoverEnabled,
 	}
 	if iterativeCutoverEnabled {

--- a/yb-voyager/cmd/importDataToSourceReplica.go
+++ b/yb-voyager/cmd/importDataToSourceReplica.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/types"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -124,12 +125,12 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg error) {
 	}
 
 	// Get phase-related metrics from existing logic
-	importRowsMap, err := getImportedSnapshotRowsMap("source-replica", importTableList, nil)
+	importRowsMap, err := importdata.GetImportedSnapshotRowsMap("source-replica", importTableList, nil, importDataStateConfigFromGlobals())
 	if err != nil {
 		log.Infof("callhome: error in getting the import data: %v", err)
 	} else {
 		// callhome payload assembly; the callback never returns an error
-		_ = importRowsMap.IterKV(func(key sqlname.NameTuple, value RowCountPair) (bool, error) {
+		_ = importRowsMap.IterKV(func(key sqlname.NameTuple, value importdata.RowCountPair) (bool, error) {
 			dataMetrics.MigrationSnapshotTotalRows += value.Imported
 			if value.Imported > dataMetrics.MigrationSnapshotLargestTableRows {
 				dataMetrics.MigrationSnapshotLargestTableRows = value.Imported
@@ -139,9 +140,9 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg error) {
 	}
 
 	// Set live migration metrics if applicable
-	if importPhase != dbzm.MODE_SNAPSHOT && statsReporter != nil {
-		dataMetrics.MigrationCdcTotalImportedEvents = statsReporter.TotalEventsImported
-		dataMetrics.CdcEventsImportRate3min = statsReporter.EventsImportRateLast3Min
+	if currentImportPhase() != dbzm.MODE_SNAPSHOT && currentStatsReporter() != nil {
+		dataMetrics.MigrationCdcTotalImportedEvents = currentStatsReporter().TotalEventsImported
+		dataMetrics.CdcEventsImportRate3min = currentStatsReporter().EventsImportRateLast3Min
 	}
 
 	// Set table list count
@@ -155,7 +156,7 @@ func packAndSendImportDataToSrcReplicaPayload(status string, errorMsg error) {
 		Error:            callhome.SanitizeErrorMsg(errorMsg, anonymizer),
 		ControlPlaneType: getControlPlaneType(),
 		DataMetrics:      dataMetrics,
-		Phase:            importPhase,
+		Phase:            currentImportPhase(),
 	}
 
 	// Add cutover timings if applicable

--- a/yb-voyager/cmd/importData_observability_test.go
+++ b/yb-voyager/cmd/importData_observability_test.go
@@ -3,14 +3,7 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
 
 func TestResolveMetricsPort(t *testing.T) {
@@ -87,42 +80,4 @@ func TestResolveMetricsPort(t *testing.T) {
 			}
 		})
 	}
-}
-
-func makeTasksForTest(n int) []*importdata.ImportFileTask {
-	tasks := make([]*importdata.ImportFileTask, n)
-	for i := 0; i < n; i++ {
-		obj := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", fmt.Sprintf("table_%d", i))
-		tup := sqlname.NameTuple{CurrentName: obj, SourceName: obj, TargetName: obj}
-		tasks[i] = &importdata.ImportFileTask{
-			ID:           i,
-			FilePath:     fmt.Sprintf("/tmp/table_%d.sql", i),
-			TableNameTup: tup,
-			RowCount:     100,
-		}
-	}
-	return tasks
-}
-
-// TestInitialImportMetricsUsesAllTasks guards against createInitialImportDataTableMetrics
-// under-reporting yb_voyager_import_data_snapshot_tables_total on resume, when only the
-// not-yet-imported (pending) tasks would otherwise be counted instead of all tasks.
-func TestInitialImportMetricsUsesAllTasks(t *testing.T) {
-	prevRole := importerRole
-	importerRole = TARGET_DB_IMPORTER_ROLE
-	defer func() { importerRole = prevRole }()
-
-	prev := metrics.Get()
-	rec := metrics.NewRecordingRecorder()
-	metrics.SetRecorder(rec)
-	defer metrics.SetRecorder(prev)
-
-	all := makeTasksForTest(3)
-	pending := all[2:] // 2 tables already completed in a prior run, 1 pending
-
-	result := createInitialImportDataTableMetrics(all, pending)
-
-	assert.Equal(t, int64(3), rec.ImportSnapshotTablesTotal[importerRole])
-	assert.Len(t, rec.ImportSnapshotTableInit, 3)
-	assert.Len(t, result, 1, "control-plane event list must still cover pending tasks only")
 }

--- a/yb-voyager/cmd/importData_test.go
+++ b/yb-voyager/cmd/importData_test.go
@@ -1198,7 +1198,7 @@ func TestExportAndImportDataSnapshotReport(t *testing.T) {
 		tblName,
 	}
 
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target", tableList, errorHandler, importDataStateConfigFromGlobals())
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)
 	}
@@ -1322,7 +1322,7 @@ func TestExportAndImportDataSnapshotReport_ErrorPolicyStashAndContinue_BatchInge
 		tblName,
 	}
 
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target", tableList, errorHandler, importDataStateConfigFromGlobals())
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)
 	}
@@ -1935,7 +1935,7 @@ func TestExportAndImportDataSnapshotReport_ErrorPolicyStashAndContinue_Processin
 	tableList := []sqlname.NameTuple{
 		tblName,
 	}
-	snapshotRowsMap, err := getImportedSnapshotRowsMap("target", tableList, errorHandler)
+	snapshotRowsMap, err := importdata.GetImportedSnapshotRowsMap("target", tableList, errorHandler, importDataStateConfigFromGlobals())
 	if err != nil {
 		t.Fatalf("Failed to get imported snapshot rows map: %v", err)
 	}

--- a/yb-voyager/cmd/live_migration_test.go
+++ b/yb-voyager/cmd/live_migration_test.go
@@ -1,0 +1,404 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+)
+
+func TestIsCDCSavepointFixedInTargetDBVersion(t *testing.T) {
+	tests := []struct {
+		name               string
+		dbVersionStr       string
+		expectedFixed      bool
+		expectedFixVersion string
+	}{
+		{name: "empty version string", dbVersionStr: "", expectedFixed: false, expectedFixVersion: ""},
+		{name: "malformed version string", dbVersionStr: "not-a-version", expectedFixed: false, expectedFixVersion: ""},
+
+		{name: "2024.2 series below fix", dbVersionStr: "11.2-YB-2024.2.7.0-b1", expectedFixed: false, expectedFixVersion: "2024.2.8.0"},
+		{name: "2024.2 series exactly at fix", dbVersionStr: "11.2-YB-2024.2.8.0-b85", expectedFixed: true, expectedFixVersion: "2024.2.8.0"},
+		{name: "2024.2 series above fix", dbVersionStr: "11.2-YB-2024.2.9.0-b1", expectedFixed: true, expectedFixVersion: "2024.2.8.0"},
+
+		{name: "2025.1 series below fix", dbVersionStr: "11.2-YB-2025.1.3.0-b1", expectedFixed: false, expectedFixVersion: "2025.1.4.0"},
+		{name: "2025.1 series exactly at fix", dbVersionStr: "11.2-YB-2025.1.4.0-b42", expectedFixed: true, expectedFixVersion: "2025.1.4.0"},
+		{name: "2025.1 series above fix", dbVersionStr: "11.2-YB-2025.1.5.0-b1", expectedFixed: true, expectedFixVersion: "2025.1.4.0"},
+
+		{name: "2025.2 series below fix", dbVersionStr: "11.2-YB-2025.2.1.0-b1", expectedFixed: false, expectedFixVersion: "2025.2.2.0"},
+		{name: "2025.2 series exactly at fix", dbVersionStr: "11.2-YB-2025.2.2.0-b10", expectedFixed: true, expectedFixVersion: "2025.2.2.0"},
+		{name: "2025.2 series above fix", dbVersionStr: "11.2-YB-2025.2.3.0-b1", expectedFixed: true, expectedFixVersion: "2025.2.2.0"},
+
+		{name: "2024.1 series has no fix entry", dbVersionStr: "11.2-YB-2024.1.5.0-b1", expectedFixed: false, expectedFixVersion: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixed, fixVersion := isCDCSavepointFixedInTargetDBVersion(tt.dbVersionStr)
+			assert.Equal(t, tt.expectedFixed, fixed)
+			assert.Equal(t, tt.expectedFixVersion, fixVersion)
+		})
+	}
+}
+
+func TestShouldWarnServerSeriesNewerThanConnector(t *testing.T) {
+	tests := []struct {
+		name             string
+		connectorVersion string
+		serverYBVersion  string
+		expectedWarn     bool
+		wantErr          bool
+	}{
+		{"same release, server higher maintenance is NOT newer", "2025.2.3", "2025.2.9.0", false, false},
+		{"same release, server higher connector-counter-equivalent is NOT newer", "2025.2.3", "2025.2.4.0", false, false},
+		{"same release exact", "2025.2.3", "2025.2.0.0", false, false},
+		{"server on newer release warns", "2024.2.5", "2025.1.0.0", true, false},
+		{"server on older release does not warn", "2025.2.3", "2024.2.8.0", false, false},
+		{"server on unrecognized (newer) release warns", "2025.2.3", "2026.1.0.0", true, false},
+		{"connector 2-segment release tag, same release", "2025.2", "2025.2.9.0", false, false},
+		{"preview server warns (connector not built for preview)", "2025.2.3", "2.25.1.0", true, false},
+		{"stable-old server does not warn (connector is newer and backward-compatible)", "2025.2.3", "2.20.1.0", false, false},
+		{"unparseable server version returns error", "2025.2.3", "not-a-version", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warn, _, err := shouldWarnServerSeriesNewerThanConnector(tt.connectorVersion, tt.serverYBVersion)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedWarn, warn)
+		})
+	}
+}
+
+func TestParseCdcPartitionKeyOverrides(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]importdata.CdcPartitionKeyOverride
+		wantErr string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  map[string]importdata.CdcPartitionKeyOverride{},
+		},
+		{
+			name:  "whitespace only",
+			input: "   ",
+			want:  map[string]importdata.CdcPartitionKeyOverride{},
+		},
+		{
+			name:  "single pk override",
+			input: "public.orders:pk",
+			want:  map[string]importdata.CdcPartitionKeyOverride{"public.orders": {Strategy: importdata.PARTITION_BY_PK}},
+		},
+		{
+			name:  "multiple overrides with semicolon",
+			input: "public.orders:table;sales.events:pk",
+			want: map[string]importdata.CdcPartitionKeyOverride{
+				"public.orders": {Strategy: importdata.PARTITION_BY_TABLE},
+				"sales.events":  {Strategy: importdata.PARTITION_BY_PK},
+			},
+		},
+		{
+			name:  "trims whitespace around entries",
+			input: " public.orders : table ; sales.events : pk ",
+			want: map[string]importdata.CdcPartitionKeyOverride{
+				"public.orders": {Strategy: importdata.PARTITION_BY_TABLE},
+				"sales.events":  {Strategy: importdata.PARTITION_BY_PK},
+			},
+		},
+		{
+			name:  "trailing semicolon ignored",
+			input: "public.orders:pk;",
+			want:  map[string]importdata.CdcPartitionKeyOverride{"public.orders": {Strategy: importdata.PARTITION_BY_PK}},
+		},
+		{
+			name:  "single custom column",
+			input: "public.orders:(customer_id)",
+			want: map[string]importdata.CdcPartitionKeyOverride{
+				"public.orders": {Strategy: importdata.PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}},
+			},
+		},
+		{
+			name:  "multi custom columns",
+			input: "public.orders:(customer_id,region)",
+			want: map[string]importdata.CdcPartitionKeyOverride{
+				"public.orders": {Strategy: importdata.PARTITION_BY_CUSTOM, Columns: []string{"customer_id", "region"}},
+			},
+		},
+		{
+			name:  "custom columns trim inner whitespace and preserve order",
+			input: "public.orders:( region , customer_id )",
+			want: map[string]importdata.CdcPartitionKeyOverride{
+				"public.orders": {Strategy: importdata.PARTITION_BY_CUSTOM, Columns: []string{"region", "customer_id"}},
+			},
+		},
+		{
+			name:  "custom mixed with pk override",
+			input: "public.orders:(customer_id);sales.events:pk",
+			want: map[string]importdata.CdcPartitionKeyOverride{
+				"public.orders": {Strategy: importdata.PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}},
+				"sales.events":  {Strategy: importdata.PARTITION_BY_PK},
+			},
+		},
+		{
+			name:    "rejects missing colon",
+			input:   "public.orders",
+			wantErr: "expected format",
+		},
+		{
+			name:    "rejects empty strategy",
+			input:   "public.orders:",
+			wantErr: "non-empty",
+		},
+		{
+			name:    "rejects custom column list without parentheses",
+			input:   "public.orders:customer_id",
+			wantErr: "parenthesized custom key column list",
+		},
+		{
+			name:    "rejects empty parenthesized custom key",
+			input:   "public.orders:()",
+			wantErr: "custom key column list is empty",
+		},
+		{
+			name:    "rejects empty column in custom key",
+			input:   "public.orders:(customer_id,,region)",
+			wantErr: "empty column name",
+		},
+		{
+			name:    "rejects duplicate column in custom key",
+			input:   "public.orders:(customer_id,customer_id)",
+			wantErr: "duplicate column",
+		},
+		{
+			name:    "rejects duplicate table with conflicting values",
+			input:   "public.orders:pk;public.orders:table",
+			wantErr: "duplicate table",
+		},
+		{
+			name:    "rejects duplicate table even with same value",
+			input:   "public.orders:(customer_id);public.orders:(customer_id)",
+			wantErr: "duplicate table",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseCdcPartitionKeyOverrides(tc.input)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestValidateCdcPartitionKeyFlags covers the flag-level guardrails in
+// validateCdcPartitionKeyFlags: context restrictions (target/YB/PG/streaming),
+// value validation, and the resume change-guards (including the positive
+// same-config and start-clean bypass paths).
+func TestValidateCdcPartitionKeyFlags(t *testing.T) {
+	origImporterRole := importerRole
+	origTargetDBType := tconf.TargetDBType
+	origSourceDBType := sourceDBType
+	origImportType := importType
+	origKey := cdcPartitionKey
+	origOverrides := cdcPartitionKeyOverrides
+	origStartClean := startClean
+	origMetaDB := metaDB
+	t.Cleanup(func() {
+		importerRole = origImporterRole
+		tconf.TargetDBType = origTargetDBType
+		sourceDBType = origSourceDBType
+		importType = origImportType
+		cdcPartitionKey = origKey
+		cdcPartitionKeyOverrides = origOverrides
+		startClean = origStartClean
+		metaDB = origMetaDB
+	})
+
+	// newCmd registers the two flags bound to the package globals. StringVar resets
+	// the globals to their defaults, so callers must set globals AFTER calling this.
+	newCmd := func() *cobra.Command {
+		c := &cobra.Command{Use: "import-data-test"}
+		c.Flags().StringVar(&cdcPartitionKey, "cdc-partition-key", "auto", "")
+		c.Flags().StringVar(&cdcPartitionKeyOverrides, "cdc-partition-key-overrides", "", "")
+		return c
+	}
+	setValidContext := func() {
+		importerRole = TARGET_DB_IMPORTER_ROLE
+		tconf.TargetDBType = YUGABYTEDB
+		sourceDBType = POSTGRESQL
+		importType = SNAPSHOT_AND_CHANGES
+		startClean = false
+	}
+	seedMetaDB := func(t *testing.T, mutate func(*metadb.ImportDataStatusRecord)) {
+		dir, err := os.MkdirTemp("", "cdcpk-metadb-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		metaDB = CreateMigrationProjectIfNotExists(POSTGRESQL, dir)
+		if mutate != nil {
+			require.NoError(t, metaDB.UpdateImportDataStatusRecord(mutate))
+		}
+	}
+
+	t.Run("rejected for non-target importer role", func(t *testing.T) {
+		setValidContext()
+		importerRole = SOURCE_REPLICA_DB_IMPORTER_ROLE
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only supported for import data to target")
+	})
+
+	t.Run("rejected for non-yugabytedb target", func(t *testing.T) {
+		setValidContext()
+		tconf.TargetDBType = POSTGRESQL
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only supported for import data to target")
+	})
+
+	t.Run("allowed (no-op) for non-target when no flags passed", func(t *testing.T) {
+		setValidContext()
+		importerRole = SOURCE_REPLICA_DB_IMPORTER_ROLE
+		cmd := newCmd() // no flags Set -> not passed
+		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
+	})
+
+	t.Run("rejected for offline migration", func(t *testing.T) {
+		setValidContext()
+		importType = SNAPSHOT_ONLY
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported for offline migration")
+	})
+
+	t.Run("rejected for non-postgres source", func(t *testing.T) {
+		setValidContext()
+		sourceDBType = ORACLE
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only supported for PostgreSQL source")
+	})
+
+	t.Run("rejects empty cdc-partition-key", func(t *testing.T) {
+		setValidContext()
+		seedMetaDB(t, nil)
+		cmd := newCmd()
+		cdcPartitionKey = ""
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cdc-partition-key is required")
+	})
+
+	t.Run("rejects invalid cdc-partition-key value", func(t *testing.T) {
+		setValidContext()
+		seedMetaDB(t, nil)
+		cmd := newCmd()
+		cdcPartitionKey = "foo"
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid cdc-partition-key")
+	})
+
+	t.Run("valid fresh start passes", func(t *testing.T) {
+		setValidContext()
+		seedMetaDB(t, nil) // no import started yet
+		cmd := newCmd()
+		cdcPartitionKey = "pk"
+		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
+	})
+
+	t.Run("resume with same config passes", func(t *testing.T) {
+		setValidContext()
+		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
+			r.ImportDataStarted = true
+			r.CdcPartitioningStrategyConfig = importdata.PARTITION_BY_PK
+			r.CdcPartitionKeyOverridesConfig = "test_schema.orders:table"
+		})
+		cmd := newCmd()
+		cdcPartitionKey = importdata.PARTITION_BY_PK
+		cdcPartitionKeyOverrides = "test_schema.orders:table"
+		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
+	})
+
+	t.Run("resume rejects changed global key", func(t *testing.T) {
+		setValidContext()
+		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
+			r.ImportDataStarted = true
+			r.CdcPartitioningStrategyConfig = "auto"
+		})
+		cmd := newCmd()
+		cdcPartitionKey = importdata.PARTITION_BY_PK
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "changing cdc-partition-key is not allowed")
+	})
+
+	// NOTE: changed cdc-partition-key-overrides is no longer rejected here by a raw string
+	// compare; the semantic per-table comparison is covered by
+	// TestValidateCdcPartitioningStrategyUnchanged.
+
+	t.Run("resume from older version without stored strategy is rejected", func(t *testing.T) {
+		setValidContext()
+		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
+			r.ImportDataStarted = true
+			r.CdcPartitioningStrategyConfig = ""
+		})
+		cmd := newCmd()
+		cdcPartitionKey = importdata.PARTITION_BY_PK
+		err := validateCdcPartitionKeyFlags(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Resuming from an earlier version")
+	})
+
+	t.Run("start-clean bypasses resume change-guards", func(t *testing.T) {
+		setValidContext()
+		startClean = true
+		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
+			r.ImportDataStarted = true
+			r.CdcPartitioningStrategyConfig = "auto"
+		})
+		cmd := newCmd()
+		cdcPartitionKey = importdata.PARTITION_BY_PK
+		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
+	})
+}

--- a/yb-voyager/src/importdata/cdc_ingest_bench_test.go
+++ b/yb-voyager/src/importdata/cdc_ingest_bench_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package importdata
 
 /*
 CDC ingest benchmark: replays real export-data queue segments through the

--- a/yb-voyager/src/importdata/cdc_ingest_bench_test.go
+++ b/yb-voyager/src/importdata/cdc_ingest_bench_test.go
@@ -24,7 +24,7 @@ real import streaming path with only TargetDB.ExecuteBatch mocked.
 
 All orchestration (workloads, artifact generation/caching, metrics,
 assertions) lives in test/cdcbench; this file only injects the closures that
-need cmd-package internals. Workloads are sub-benchmarks:
+need importdata-package internals. Workloads are sub-benchmarks:
 
 	go test -tags cdc_benchmark -bench CDCIngest -benchtime 1x -count 5 ./cmd/
 	go test -tags cdc_benchmark -bench 'CDCIngest/updates-uk-no-conflict' -benchtime 1x ./cmd/
@@ -36,9 +36,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -48,7 +51,8 @@ import (
 func BenchmarkCDCIngest(b *testing.B) {
 	// state shared between Bootstrap and StreamAll within one run
 	var run struct {
-		state                *importdata.ImportDataState
+		imp                  *Importer
+		state                *ImportDataState
 		tableList            []sqlname.NameTuple
 		tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]
 		tableToPKColumns     *utils.StructMap[sqlname.NameTuple, []string]
@@ -61,43 +65,61 @@ func BenchmarkCDCIngest(b *testing.B) {
 			// metadata, stats reporter) is done by the real streamChanges call
 			// in StreamAll, with the mock answering the target-side metadata
 			// queries with fresh-migration values.
-			exportDir = artifactDir
-			metaDB = initMetaDB(exportDir)
-			if err := retrieveMigrationUUID(); err != nil {
-				return fmt.Errorf("retrieve migration uuid: %w", err)
-			}
-			sourceDBType = GetSourceDBTypeFromMSR()
-			sqlname.SourceDBType = sourceDBType
-			importerRole = TARGET_DB_IMPORTER_ROLE
-			callhome.SendDiagnostics = false
-			disablePb = true
-			// production default resolution for tables without expression-based
-			// unique indexes; avoids the target-DB query of the "auto" path
-			cdcPartitionKey = "pk"
-			tconf = tgtdb.TargetConf{TargetDBType: YUGABYTEDB, SchemaConfig: "public"}
-			tconf.Schemas = sqlname.ParseIdentifiersFromString(tconf.TargetDBType, tconf.SchemaConfig, ",")
-
-			if err := InitNameRegistry(exportDir, importerRole, nil, nil, &tconf, nil, false); err != nil {
-				return fmt.Errorf("init name registry: %w", err)
+			// mirrors the cmd-level setup the import data command does before it hands
+			// over to the engine (metadb, migration uuid, name registry, table list)
+			exportDir := artifactDir
+			metaDB, err := initTestMetaDB(exportDir)
+			if err != nil {
+				return fmt.Errorf("init meta db: %w", err)
 			}
 			msr, err := metaDB.GetMigrationStatusRecord()
 			if err != nil {
 				return fmt.Errorf("get migration status record: %w", err)
 			}
-			run.tableList, err = getInitialImportTableListForLive(msr.TableListExportedFromSource)
-			if err != nil {
-				return fmt.Errorf("get import table list: %w", err)
+			sourceDBType := msr.SourceDBConf.DBType
+			sqlname.SourceDBType = sourceDBType
+			callhome.SendDiagnostics = false
+			tconf := tgtdb.TargetConf{TargetDBType: constants.YUGABYTEDB, SchemaConfig: "public"}
+			tconf.Schemas = sqlname.ParseIdentifiersFromString(tconf.TargetDBType, tconf.SchemaConfig, ",")
+
+			if err := namereg.InitNameRegistry(namereg.NameRegistryParams{
+				FilePath:       fmt.Sprintf("%s/metainfo/name_registry.json", exportDir),
+				Role:           constants.TARGET_DB_IMPORTER_ROLE,
+				TargetDBSchema: sqlname.ExtractIdentifiersUnquoted(tconf.Schemas),
+			}); err != nil {
+				return fmt.Errorf("init name registry: %w", err)
 			}
-			tdb = mock
-			run.state = newImportDataStateFromGlobals()
+			run.tableList = nil
+			for _, qualifiedTableName := range msr.TableListExportedFromSource {
+				table, err := namereg.NameReg.LookupTableNameAndIgnoreIfTargetNotFoundBasedOnRole(qualifiedTableName)
+				if err != nil {
+					return fmt.Errorf("lookup table %s in name registry : %w", qualifiedTableName, err)
+				}
+				run.tableList = append(run.tableList, table)
+			}
+			run.imp = NewImporter(Config{
+				ExportDir:     exportDir,
+				MetaDB:        metaDB,
+				MigrationUUID: uuid.MustParse(msr.MigrationUUID),
+				ImporterRole:  constants.TARGET_DB_IMPORTER_ROLE,
+				SourceDBType:  sourceDBType,
+				Tconf:         tconf,
+				Tdb:           mock,
+				DisablePb:     true,
+				// production default resolution for tables without expression-based
+				// unique indexes; avoids the target-DB query of the "auto" path
+				CdcPartitionKey: "pk",
+				ImportTableList: run.tableList,
+			})
+			run.state = NewImportDataState(run.imp.importDataStateConfig())
 
 			// make sure the mock has the same table list as the real target DB
-			run.tableToUniqueIndexes, err = tdb.GetTableToUniqueIndexesMap(run.tableList)
+			run.tableToUniqueIndexes, err = mock.GetTableToUniqueIndexesMap(run.tableList)
 			if err != nil {
 				utils.ErrExit("Failed to get table unique indexes map from target: %s", err)
 			}
 
-			run.tableToPKColumns, err = getPrimaryKeyColumnsForImportTables(run.tableList)
+			run.tableToPKColumns, err = run.imp.getPrimaryKeyColumnsForImportTables(run.tableList)
 			if err != nil {
 				utils.ErrExit("Failed to get primary key columns for import tables: %s", err)
 			}
@@ -120,8 +142,8 @@ func BenchmarkCDCIngest(b *testing.B) {
 			// pair, accepted for the benchmark: artifacts carry a single
 			// exporter role, so the pointer is written exactly once and never
 			// changes mid-run.
-			conflictDetectionCache = nil
-			prevExporterRole = ""
+			run.imp.conflictDetectionCache = nil
+			run.imp.prevExporterRole = ""
 			return nil
 		},
 
@@ -129,11 +151,11 @@ func BenchmarkCDCIngest(b *testing.B) {
 		// metadata (answered by the mock's metadata store), conflict cache,
 		// stats reporter, and the segment loop
 		StreamAll: func() error {
-			return streamChanges(run.state, run.tableList, run.tableToPKColumns, run.tableToUniqueIndexes)
+			return run.imp.streamChanges(run.state, run.tableList, run.tableToPKColumns, run.tableToUniqueIndexes)
 		},
 
 		CacheDepth: func() int {
-			c := conflictDetectionCache
+			c := run.imp.conflictDetectionCache
 			if c == nil {
 				return 0
 			}

--- a/yb-voyager/src/importdata/conflictDetectionCache.go
+++ b/yb-voyager/src/importdata/conflictDetectionCache.go
@@ -137,7 +137,7 @@ type ConflictDetectionCache struct {
 	// event's partition key (see GetEventPartitionKey). Two events with the same partition
 	// key are routed to the same channel and applied in commit order, so they are excluded
 	// from conflict detection (they can never race).
-	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]
+	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]
 
 	/*
 		ukLookup is a value-keyed secondary index over the cached events used to avoid
@@ -154,10 +154,15 @@ type ConflictDetectionCache struct {
 	// vsnToBuckets records, per cached event VSN, the bucket keys it was added to,
 	// so removal from ukLookup is O(#buckets-for-event) instead of a full scan.
 	vsnToBuckets map[int64][]string
+
+	// exportDir is only read by the unique-key-conflict failpoint, which writes its
+	// marker/stats files under <exportDir>/failpoints.
+	exportDir string
 }
 
-func NewConflictDetectionCache(tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex], evChans []chan *tgtdb.Event, sourceDBType string, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) *ConflictDetectionCache {
+func NewConflictDetectionCache(tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex], evChans []chan *tgtdb.Event, sourceDBType string, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], exportDir string) *ConflictDetectionCache {
 	c := &ConflictDetectionCache{}
+	c.exportDir = exportDir
 	c.m = make(map[int64]*tgtdb.Event)
 	c.cond = sync.NewCond(&c.Mutex)
 	c.tableToUniqueIndexes = tableToUniqueIndexes
@@ -285,7 +290,7 @@ func (c *ConflictDetectionCache) WaitUntilNoConflict(incomingEvent *tgtdb.Event)
 
 		for _, info := range conflictInfo {
 			for _, cachedEvent := range info.eventsConflicting {
-				injectUniqueKeyConflictDetectedFailpoint(cachedEvent, incomingEvent)
+				injectUniqueKeyConflictDetectedFailpoint(c.exportDir, cachedEvent, incomingEvent)
 			}
 			// Concise INFO once per blocked incoming event; the per-index/column-value
 			// detail is logged at DEBUG in findValueConflictLocked. The target-DB-exporter

--- a/yb-voyager/src/importdata/conflictDetectionCache.go
+++ b/yb-voyager/src/importdata/conflictDetectionCache.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/conflictDetectionCache_test.go
+++ b/yb-voyager/src/importdata/conflictDetectionCache_test.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"os"

--- a/yb-voyager/src/importdata/conflictDetectionCache_test.go
+++ b/yb-voyager/src/importdata/conflictDetectionCache_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
@@ -61,18 +62,18 @@ func newConflictCacheForTest(indexes [][]string) *ConflictDetectionCache {
 // (allowing per-index NULLS NOT DISTINCT configuration).
 func newConflictCacheForTestWithIndexes(indexes ...tgtdb.UniqueIndex) *ConflictDetectionCache {
 	tableToIndexes := utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]()
-	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
+	oname := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", "users")
 	table := sqlname.NameTuple{CurrentName: oname, TargetName: oname}
 	tableToIndexes.Put(table, indexes)
 	// Default the test table to PARTITION_BY_PK so the partition-key exclusion behaves
 	// like the previous same-PK exclusion (routing by primary key).
-	tablePartitionKeyMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-	tablePartitionKeyMap.Put(table, cdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
-	return NewConflictDetectionCache(tableToIndexes, []chan *tgtdb.Event{make(chan *tgtdb.Event, 1)}, POSTGRESQL, tablePartitionKeyMap)
+	tablePartitionKeyMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+	tablePartitionKeyMap.Put(table, CdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
+	return NewConflictDetectionCache(tableToIndexes, []chan *tgtdb.Event{make(chan *tgtdb.Event, 1)}, constants.POSTGRESQL, tablePartitionKeyMap, "")
 }
 
 func testTableTuple() sqlname.NameTuple {
-	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
+	oname := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", "users")
 	return sqlname.NameTuple{CurrentName: oname, TargetName: oname}
 }
 
@@ -142,7 +143,7 @@ func TestEventsConfict_TwoCompositeIndexes(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2"), "c": strPtr("3"), "d": strPtr("4")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
@@ -152,7 +153,7 @@ func TestEventsConfict_TwoCompositeIndexes(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("9"), "c": strPtr("3"), "d": strPtr("4")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 1)
@@ -167,7 +168,7 @@ func TestEventsConfict_MissingColumnInEvent(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
@@ -177,7 +178,7 @@ func TestEventsConfict_MissingColumnInEvent(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	_, err = cache.findConflictLocked(incoming)
 	require.Error(t, err)
@@ -193,7 +194,7 @@ func TestEventsConfict_SamePKNoConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
@@ -203,7 +204,7 @@ func TestEventsConfict_SamePKNoConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	conflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, conflicts, 0)
@@ -477,7 +478,7 @@ func TestEventsConfict_BeforeBeforeConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"check_id": strPtr("10")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	err := cache.Put(cached)
 	require.NoError(t, err)
@@ -488,7 +489,7 @@ func TestEventsConfict_BeforeBeforeConflict(t *testing.T) {
 		Key:          map[string]*string{"id": strPtr("2")},
 		BeforeFields: map[string]*string{"check_id": strPtr("10")},
 		Fields:       map[string]*string{"check_id": strPtr("20")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	foundConflicts := findConflictForTest(t, cache, incoming)
 	require.Len(t, foundConflicts, 1)
@@ -496,7 +497,7 @@ func TestEventsConfict_BeforeBeforeConflict(t *testing.T) {
 }
 
 func TestRecordUniqueKeyConflictCount_DedupesEventPair(t *testing.T) {
-	exportDir = t.TempDir()
+	exportDir := t.TempDir()
 	ukConflictStats = UniqueKeyConflictStats{}
 	ukConflictSeen = nil
 
@@ -504,9 +505,9 @@ func TestRecordUniqueKeyConflictCount_DedupesEventPair(t *testing.T) {
 	cached := withAfterFields(&tgtdb.Event{Vsn: 10, TableNameTup: table})
 	incoming := withAfterFields(&tgtdb.Event{Vsn: 20, TableNameTup: table})
 
-	recordUniqueKeyConflictCount(cached, incoming)
-	recordUniqueKeyConflictCount(cached, incoming)
-	recordUniqueKeyConflictCount(incoming, cached)
+	recordUniqueKeyConflictCount(exportDir, cached, incoming)
+	recordUniqueKeyConflictCount(exportDir, cached, incoming)
+	recordUniqueKeyConflictCount(exportDir, incoming, cached)
 
 	require.Equal(t, 1, ukConflictStats.Total)
 	require.Equal(t, 1, ukConflictStats.ByTable[table.ForKey()])
@@ -518,7 +519,7 @@ func TestRecordUniqueKeyConflictCount_DedupesEventPair(t *testing.T) {
 }
 
 func TestUniqueKeyConflictPairKey_OrdersVsns(t *testing.T) {
-	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
+	oname := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", "users")
 	table := sqlname.NameTuple{CurrentName: oname, TargetName: oname}.ForKey()
 	require.Equal(t, uniqueKeyConflictPairKey(table, 20, 10), uniqueKeyConflictPairKey(table, 10, 20))
 }
@@ -555,7 +556,7 @@ func TestConflictLookup_FindsBeforeAfterConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	cache.Put(cached)
 
@@ -565,7 +566,7 @@ func TestConflictLookup_FindsBeforeAfterConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	got := findConflictForTest(t, cache, incoming)
 	require.Len(t, got, 1)
@@ -581,7 +582,7 @@ func TestConflictLookup_FindsCompositeConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	cache.Put(cached)
 
@@ -591,7 +592,7 @@ func TestConflictLookup_FindsCompositeConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"a": strPtr("1"), "b": strPtr("2")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	got := findConflictForTest(t, cache, incoming)
 	require.Len(t, got, 1)
@@ -608,7 +609,7 @@ func TestConflictLookup_FindsBeforeBeforeConflict_NullsNotDistinct(t *testing.T)
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("10")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	cache.Put(cached)
 
@@ -619,7 +620,7 @@ func TestConflictLookup_FindsBeforeBeforeConflict_NullsNotDistinct(t *testing.T)
 		Key:          map[string]*string{"id": strPtr("2")},
 		BeforeFields: map[string]*string{"check_id": nil},
 		Fields:       map[string]*string{"check_id": strPtr("20")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	got := findConflictForTest(t, cache, incoming)
 	require.Len(t, got, 1)
@@ -635,7 +636,7 @@ func TestConflictLookup_NullsDistinctNotIndexed(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": nil},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	cache.Put(cached)
 	assert.Empty(t, cache.ukLookup, "NULL value under NULLS DISTINCT must not be indexed")
@@ -646,7 +647,7 @@ func TestConflictLookup_NullsDistinctNotIndexed(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": nil},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 }
@@ -661,7 +662,7 @@ func TestConflictLookup_SamePKNoConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	cache.Put(cached)
 
@@ -671,7 +672,7 @@ func TestConflictLookup_SamePKNoConflict(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          key,
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 }
@@ -685,7 +686,7 @@ func TestConflictLookup_NoConflictDoesNotBlock(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	cache.Put(cached)
 
@@ -695,7 +696,7 @@ func TestConflictLookup_NoConflictDoesNotBlock(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": strPtr("b@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 
@@ -720,7 +721,7 @@ func TestConflictLookup_RemoveDeindexes(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("1")},
 		BeforeFields: map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	cache.Put(cached)
 	require.NotEmpty(t, cache.ukLookup)
@@ -737,7 +738,7 @@ func TestConflictLookup_RemoveDeindexes(t *testing.T) {
 		TableNameTup: testTableTuple(),
 		Key:          map[string]*string{"id": strPtr("2")},
 		Fields:       map[string]*string{"email": strPtr("a@example.com")},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	})
 	assert.Empty(t, findConflictForTest(t, cache, incoming))
 }
@@ -746,18 +747,18 @@ func TestConflictLookup_RemoveDeindexes(t *testing.T) {
 // split of characters between adjacent columns.
 func TestComputeConflictBucketKey_NoAmbiguity(t *testing.T) {
 	idx := uidx("a", "b")
-	k1, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("ab"), "b": strPtr("")}, idx)
+	k1, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", constants.POSTGRESQL), map[string]*string{"a": strPtr("ab"), "b": strPtr("")}, idx)
 	if err != nil {
 		t.Fatalf("error computing conflict bucket key: %v", err)
 	}
-	k2, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a"), "b": strPtr("b")}, idx)
+	k2, err := computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", constants.POSTGRESQL), map[string]*string{"a": strPtr("a"), "b": strPtr("b")}, idx)
 	if err != nil {
 		t.Fatalf("error computing conflict bucket key: %v", err)
 	}
 	assert.NotEqual(t, k1, k2)
 
 	// missing column is not indexable and is reported as an error
-	_, err = computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", POSTGRESQL), map[string]*string{"a": strPtr("a")}, idx)
+	_, err = computeConflictBucketKey(testutils.CreateNameTupleWithTargetName("public.users", "", constants.POSTGRESQL), map[string]*string{"a": strPtr("a")}, idx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "column b is missing from fields")
 }

--- a/yb-voyager/src/importdata/eventQueue.go
+++ b/yb-voyager/src/importdata/eventQueue.go
@@ -29,6 +29,7 @@ import (
 	"github.com/goccy/go-json"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
@@ -40,15 +41,25 @@ const (
 	QUEUE_SEGMENT_FILE_EXTENSION = "ndjson"
 )
 
+// EventQueueConfig holds the values the event queue reads. They used to be cmd
+// package-level variables; the importer copies them in.
+type EventQueueConfig struct {
+	ExportDir    string
+	ImporterRole string
+	MetaDB       *metadb.MetaDB
+}
+
 type EventQueue struct {
+	cfg                EventQueueConfig
 	QueueDirPath       string
 	SegmentNumToStream int64
 	EndOfQueue         bool
 }
 
-func NewEventQueue(exportDir string) *EventQueue {
+func NewEventQueue(cfg EventQueueConfig) *EventQueue {
 	return &EventQueue{
-		QueueDirPath:       filepath.Join(exportDir, "data", QUEUE_DIR_NAME),
+		cfg:                cfg,
+		QueueDirPath:       filepath.Join(cfg.ExportDir, "data", QUEUE_DIR_NAME),
 		SegmentNumToStream: -1,
 		EndOfQueue:         false,
 	}
@@ -73,7 +84,7 @@ func (eq *EventQueue) GetNextSegment() (*EventQueueSegment, error) {
 		return nil, fmt.Errorf("failed to get next segment file path: %w", err)
 	}
 
-	segment := NewEventQueueSegment(segmentFilePath, eq.SegmentNumToStream)
+	segment := NewEventQueueSegment(segmentFilePath, eq.SegmentNumToStream, eq.cfg.MetaDB)
 	eq.SegmentNumToStream++
 	return segment, nil
 }
@@ -81,14 +92,14 @@ func (eq *EventQueue) GetNextSegment() (*EventQueueSegment, error) {
 func (eq *EventQueue) resolveSegmentToResumeFrom() error {
 	var err error
 	segmentsExporterRole := ""
-	if importerRole == SOURCE_DB_IMPORTER_ROLE {
+	if eq.cfg.ImporterRole == constants.SOURCE_DB_IMPORTER_ROLE {
 		// in case of fall-back import, restrict to only segments exported from target db.
-		segmentsExporterRole = TARGET_DB_EXPORTER_FB_ROLE
+		segmentsExporterRole = constants.TARGET_DB_EXPORTER_FB_ROLE
 
 	}
 
 	for {
-		eq.SegmentNumToStream, err = metaDB.GetMinSegmentExportedByAndNotImportedBy(importerRole, segmentsExporterRole)
+		eq.SegmentNumToStream, err = eq.cfg.MetaDB.GetMinSegmentExportedByAndNotImportedBy(eq.cfg.ImporterRole, segmentsExporterRole)
 		if err == nil {
 			break
 		} else if errors.Is(err, metadb.ErrNoQueueSegmentsFound) {
@@ -107,6 +118,7 @@ func (eq *EventQueue) resolveSegmentToResumeFrom() error {
 }
 
 type EventQueueSegment struct {
+	metaDB     *metadb.MetaDB
 	FilePath   string
 	SegmentNum int64 // 0-based
 	processed  bool
@@ -116,8 +128,9 @@ type EventQueueSegment struct {
 
 var EOFMarker = []byte(`\.`)
 
-func NewEventQueueSegment(filePath string, segmentNum int64) *EventQueueSegment {
+func NewEventQueueSegment(filePath string, segmentNum int64, metaDB *metadb.MetaDB) *EventQueueSegment {
 	return &EventQueueSegment{
+		metaDB:     metaDB,
 		FilePath:   filePath,
 		SegmentNum: segmentNum,
 		processed:  false,
@@ -132,9 +145,9 @@ func (eqs *EventQueueSegment) Open() error {
 	eqs.file = file
 
 	fn := func() (int64, error) {
-		return metaDB.GetLastValidOffsetInSegmentFile(eqs.SegmentNum)
+		return eqs.metaDB.GetLastValidOffsetInSegmentFile(eqs.SegmentNum)
 	}
-	eqs.reader = bufio.NewReaderSize(utils.NewTailReader(file, fn), 100*MB)
+	eqs.reader = bufio.NewReaderSize(utils.NewTailReader(file, fn), 100*constants.MB)
 	return nil
 }
 

--- a/yb-voyager/src/importdata/eventQueue.go
+++ b/yb-voyager/src/importdata/eventQueue.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package importdata
 
 import (
 	"bufio"

--- a/yb-voyager/src/importdata/failpoints.go
+++ b/yb-voyager/src/importdata/failpoints.go
@@ -16,11 +16,18 @@ limitations under the License.
 package importdata
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	goerrors "github.com/go-errors/errors"
+	"github.com/jackc/pgconn"
 	"github.com/pingcap/failpoint"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
 )
 
 func injectImportSnapshotTransformError() error {
@@ -35,4 +42,128 @@ func injectImportSnapshotTransformError() error {
 		}
 	})
 	return fpErr
+}
+
+// injectImportCDCTransformFailure simulates a failure during CDC event
+// transformation on the import side. Used by tests to verify resumability
+// and idempotency of the CDC apply path.
+func injectImportCDCTransformFailure(exportDir string) error {
+	var fpErr error
+	failpoint.Inject("importCDCTransformFailure", func(val failpoint.Value) {
+		if val != nil {
+			_ = os.MkdirAll(filepath.Join(exportDir, "failpoints"), 0755)
+			_ = os.WriteFile(filepath.Join(exportDir, "failpoints", "failpoint-import-cdc-transform.log"), []byte("hit\n"), 0644)
+			fpErr = goerrors.Errorf("failpoint: import CDC transform failure")
+		}
+	})
+	return fpErr
+}
+
+// injectImportCDCNonRetryableBatchDBError simulates a non-retryable DB error after a
+// successful CDC batch execution. Tests can use a hit-counter expression
+// (e.g. 100*off->return(true)) to crash after N successful batches.
+func injectImportCDCNonRetryableBatchDBError(exportDir string) error {
+	var fpErr error
+	failpoint.Inject("importCDCNonRetryableBatchDBError", func(val failpoint.Value) {
+		if val != nil {
+			_ = os.MkdirAll(filepath.Join(exportDir, "failpoints"), 0755)
+			_ = os.WriteFile(
+				filepath.Join(exportDir, "failpoints", "failpoint-import-cdc-non-retryable-batch-db-error.log"),
+				[]byte("hit\n"),
+				0644,
+			)
+			fpErr = &pgconn.PgError{
+				Code:    "23505",
+				Message: "failpoint: duplicate key value violates unique constraint",
+			}
+		}
+	})
+	return fpErr
+}
+
+// injectUniqueKeyConflictDetected supports two test modes via GO_FAILPOINTS:
+//   - return(true): crash on first conflict (false-positive validation)
+//   - return("count"): deduped conflict counting in unique-key-conflict-stats.json
+func injectUniqueKeyConflictDetectedFailpoint(exportDir string, cachedEvent, incomingEvent *tgtdb.Event) {
+	failpoint.Inject("uniqueKeyConflictDetected", func(val failpoint.Value) {
+		if val == nil {
+			return
+		}
+		if mode, ok := val.(string); ok && mode == "count" {
+			recordUniqueKeyConflictCount(exportDir, cachedEvent, incomingEvent)
+			return
+		}
+		writeFailpointMarker(exportDir, "failpoint-unique-key-conflict-detected.log")
+		utils.ErrExit("failpoint: unexpected unique key conflict detected")
+	})
+}
+
+const uniqueKeyConflictStatsFileName = "unique-key-conflict-stats.json"
+
+// UniqueKeyConflictStats is written to <exportDir>/failpoints/unique-key-conflict-stats.json.
+type UniqueKeyConflictStats struct {
+	Total   int            `json:"total"`
+	ByTable map[string]int `json:"by_table"`
+}
+
+var (
+	ukConflictStatsMu sync.Mutex
+	ukConflictStats   UniqueKeyConflictStats
+	ukConflictSeen    map[string]struct{}
+)
+
+func initUniqueKeyConflictStatsLocked() {
+	if ukConflictSeen == nil {
+		ukConflictSeen = make(map[string]struct{})
+	}
+	if ukConflictStats.ByTable == nil {
+		ukConflictStats.ByTable = make(map[string]int)
+	}
+}
+
+func uniqueKeyConflictPairKey(table string, cachedVsn, incomingVsn int64) string {
+	vsn1, vsn2 := cachedVsn, incomingVsn
+	if vsn1 > vsn2 {
+		vsn1, vsn2 = vsn2, vsn1
+	}
+	return fmt.Sprintf("%s:%d:%d", table, vsn1, vsn2)
+}
+
+func recordUniqueKeyConflictCount(exportDir string, cachedEvent, incomingEvent *tgtdb.Event) {
+	table := cachedEvent.TableNameTup.ForKey()
+	pairKey := uniqueKeyConflictPairKey(table, cachedEvent.Vsn, incomingEvent.Vsn)
+
+	ukConflictStatsMu.Lock()
+	defer ukConflictStatsMu.Unlock()
+
+	initUniqueKeyConflictStatsLocked()
+	if _, seen := ukConflictSeen[pairKey]; seen {
+		return
+	}
+	ukConflictSeen[pairKey] = struct{}{}
+	ukConflictStats.Total++
+	ukConflictStats.ByTable[table]++
+	_ = writeUniqueKeyConflictStatsLocked(exportDir)
+}
+
+func writeUniqueKeyConflictStatsLocked(exportDir string) error {
+	if exportDir == "" {
+		return nil
+	}
+	failpointsDir := filepath.Join(exportDir, "failpoints")
+	if err := os.MkdirAll(failpointsDir, 0755); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(ukConflictStats, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(failpointsDir, uniqueKeyConflictStatsFileName), payload, 0644)
+}
+
+// writeFailpointMarker mirrors cmd's helper of the same name for the injectors that
+// moved here; the marker files live under <exportDir>/failpoints as before.
+func writeFailpointMarker(exportDir string, filename string) {
+	_ = os.MkdirAll(filepath.Join(exportDir, "failpoints"), 0755)
+	_ = os.WriteFile(filepath.Join(exportDir, "failpoints", filename), []byte("hit\n"), 0644)
 }

--- a/yb-voyager/src/importdata/importData.go
+++ b/yb-voyager/src/importdata/importData.go
@@ -1,0 +1,1665 @@
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package importdata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	goerrors "github.com/go-errors/errors"
+	"github.com/google/uuid"
+	"github.com/gosuri/uitable"
+	"github.com/samber/lo"
+	log "github.com/sirupsen/logrus"
+	"github.com/sourcegraph/conc/pool"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/adaptiveparallelism"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/cp"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/datafile"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/datastore"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/monitor"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
+	reporter "github.com/yugabyte/yb-voyager/yb-voyager/src/reporter/stats"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/srcdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/types"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
+)
+
+// Config holds every value the import engine reads that cmd used to keep in
+// package-level variables. cmd fills it from its flags and command-level setup
+// and passes it by value to NewImporter; nothing in here is a callback.
+type Config struct {
+	ExportDir                string
+	MetaDB                   *metadb.MetaDB
+	MigrationUUID            uuid.UUID
+	ImporterRole             string
+	ImportType               string
+	IdentityColumnsMetaDBKey string
+	SourceDBType             string
+	Source                   srcdb.Source
+	Tconf                    tgtdb.TargetConf
+	Tdb                      tgtdb.TargetDB
+	ControlPlane             cp.ControlPlane
+
+	StartClean                     utils.BoolStr
+	TruncateTables                 utils.BoolStr
+	TruncateSplits                 utils.BoolStr
+	DisablePb                      utils.BoolStr
+	BatchSizeInNumRows             int64
+	ErrorPolicySnapshot            ErrorPolicy
+	EnableRandomBatchProduction    utils.BoolStr
+	MaxConcurrentBatchProductions  int
+	SkipReplicationChecks          utils.BoolStr
+	SkipNodeHealthChecks           utils.BoolStr
+	SkipDiskUsageHealthChecks      utils.BoolStr
+	CdcPartitionKey                string
+	CdcPartitionKeyOverrides       string                             // raw flag value: persisted to metadb and compared on resume
+	CdcPartitionKeyOverridesParsed map[string]CdcPartitionKeyOverride // the same value parsed once by cmd's flag validation
+	ImportUsePartitionRoot         utils.BoolStr
+	EventBatchMaxRetryCount        int
+	ReportProgressInBytes          bool
+
+	DataFileDescriptor       *datafile.Descriptor
+	DataStore                datastore.DataStore
+	ImportTableList          []sqlname.NameTuple
+	CallhomeMetricsCollector *callhome.ImportDataMetricsCollector
+	// SnapshotImportStartedEvent is the control-plane event ImportData emits for the
+	// target importer; cmd builds it from its own state (migration UUID, target conf).
+	SnapshotImportStartedEvent cp.SnapshotImportStartedEvent
+}
+
+// Importer is the import-data engine: the snapshot import plus the CDC streaming
+// phase for one importer role. Its fields are the former cmd package-level runtime
+// variables; cmd reads the few it needs through the accessors below.
+type Importer struct {
+	cfg Config
+
+	batchImportPool            *pool.Pool
+	colocatedBatchImportPool   *pool.Pool
+	colocatedBatchImportQueue  chan func()
+	progressReporter           *ImportDataProgressReporter
+	valueConverter             dbzm.SnapshotPhaseValueConverter
+	tableToColumnNames         *utils.StructMap[sqlname.NameTuple, []string] // map of table name to columnNames
+	tableToIdentityColumnNames *utils.StructMap[sqlname.NameTuple, []string] // map of table name to generated always as identity column's names
+	tableNameToSchema          *utils.StructMap[sqlname.NameTuple, map[string]map[string]string]
+	conflictDetectionCache     *ConflictDetectionCache
+	eventQueue                 *EventQueue
+	statsReporter              *reporter.StreamImportStatsReporter
+	importPhase                string
+	prevExporterRole           string // used to determine if cache reinitialization is needed
+
+	state        *ImportDataState
+	errorHandler ImportDataErrorHandler
+}
+
+func NewImporter(cfg Config) *Importer {
+	return &Importer{
+		cfg:                cfg,
+		tableToColumnNames: utils.NewStructMap[sqlname.NameTuple, []string](),
+		importPhase:        dbzm.MODE_SNAPSHOT,
+	}
+}
+
+// ImportPhase is the phase the engine is in (snapshot, streaming, or a cutover
+// phase name); cmd's callhome payloads report it.
+func (imp *Importer) ImportPhase() string { return imp.importPhase }
+
+// StatsReporter is the streaming-phase stats reporter, nil until streaming starts.
+func (imp *Importer) StatsReporter() *reporter.StreamImportStatsReporter { return imp.statsReporter }
+
+// State is the import state ImportData created; nil until ImportData runs.
+func (imp *Importer) State() *ImportDataState { return imp.state }
+
+// ErrorHandler is the error handler ImportData created; nil until ImportData runs.
+func (imp *Importer) ErrorHandler() ImportDataErrorHandler { return imp.errorHandler }
+
+// ShutdownProgressBars stops the mpb progress container so that its rendering
+// goroutine no longer writes to stdout.
+func (imp *Importer) ShutdownProgressBars() {
+	if imp.progressReporter != nil {
+		imp.progressReporter.Shutdown()
+	}
+}
+
+// Component configs derived from Config plus the runtime state the components read.
+func (imp *Importer) importDataStateConfig() ImportDataStateConfig {
+	return ImportDataStateConfig{
+		ExportDir:          imp.cfg.ExportDir,
+		ImporterRole:       imp.cfg.ImporterRole,
+		Tdb:                imp.cfg.Tdb,
+		Tconf:              imp.cfg.Tconf,
+		MigrationUUID:      imp.cfg.MigrationUUID,
+		TruncateSplits:     imp.cfg.TruncateSplits,
+		DataFileDescriptor: imp.cfg.DataFileDescriptor,
+	}
+}
+
+func (imp *Importer) sequentialFileBatchProducerConfig() SequentialFileBatchProducerConfig {
+	return SequentialFileBatchProducerConfig{
+		ImporterRole:       imp.cfg.ImporterRole,
+		Tdb:                imp.cfg.Tdb,
+		Tconf:              imp.cfg.Tconf,
+		DataFileDescriptor: imp.cfg.DataFileDescriptor,
+		DataStore:          imp.cfg.DataStore,
+		BatchSizeInNumRows: imp.cfg.BatchSizeInNumRows,
+		ValueConverter:     imp.valueConverter,
+		TableToColumnNames: imp.tableToColumnNames,
+	}
+}
+
+func (imp *Importer) fileTaskImporterConfig() FileTaskImporterConfig {
+	return FileTaskImporterConfig{
+		ImporterRole:          imp.cfg.ImporterRole,
+		Tdb:                   imp.cfg.Tdb,
+		Tconf:                 imp.cfg.Tconf,
+		ExportDir:             imp.cfg.ExportDir,
+		MigrationUUID:         imp.cfg.MigrationUUID,
+		DataFileDescriptor:    imp.cfg.DataFileDescriptor,
+		ReportProgressInBytes: imp.cfg.ReportProgressInBytes,
+		ControlPlane:          imp.cfg.ControlPlane,
+		TableToColumnNames:    imp.tableToColumnNames,
+		TableNameToSchema:     imp.tableNameToSchema,
+	}
+}
+
+func (imp *Importer) initialiseErrorHandler() (ImportDataErrorHandler, error) {
+	exportDirDataDir := filepath.Join(imp.cfg.ExportDir, "data")
+	errorHandler, err := GetImportDataErrorHandler(imp.cfg.ErrorPolicySnapshot, exportDirDataDir, imp.cfg.ImporterRole)
+	if err != nil {
+		return nil, goerrors.Errorf("Failed to initialize error handler: %w", err)
+	}
+	err = imp.updateErrorPolicyInMetaDB(imp.cfg.ErrorPolicySnapshot)
+	if err != nil {
+		return nil, goerrors.Errorf("Failed to update error policy in meta DB: %w", err)
+	}
+	return errorHandler, nil
+}
+
+func (imp *Importer) updateTargetConfInMigrationStatus() error {
+	err := imp.cfg.MetaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		switch imp.cfg.ImporterRole {
+		case constants.TARGET_DB_IMPORTER_ROLE, constants.IMPORT_FILE_ROLE:
+			record.TargetDBConf = imp.cfg.Tconf.Clone()
+			record.TargetDBConf.Password = ""
+			record.TargetDBConf.Uri = ""
+		case constants.SOURCE_REPLICA_DB_IMPORTER_ROLE:
+			record.SourceReplicaDBConf = imp.cfg.Tconf.Clone()
+			record.SourceReplicaDBConf.Password = ""
+			record.SourceReplicaDBConf.Uri = ""
+		case constants.SOURCE_DB_IMPORTER_ROLE:
+			record.SourceDBAsTargetConf = imp.cfg.Tconf.Clone()
+			record.SourceDBAsTargetConf.Password = ""
+			record.SourceDBAsTargetConf.Uri = ""
+		default:
+			panic(fmt.Sprintf("unsupported importer role: %s", imp.cfg.ImporterRole))
+		}
+	})
+	if err != nil {
+		return goerrors.Errorf("Failed to update target conf in migration status record: %w", err)
+	}
+	return nil
+}
+
+func (imp *Importer) prepareTargetDBForImport() error {
+	//init target db connection pool
+	err := imp.cfg.Tdb.InitConnPool()
+	if err != nil {
+		return goerrors.Errorf("Failed to initialize the target DB connection pool: %w", err)
+	}
+
+	//start adaptive parallelism
+	var adaptiveParallelismStarted bool
+	adaptiveParallelismStarted, err = imp.startAdaptiveParallelism(imp.cfg.Tconf.AdaptiveParallelismMode, imp.cfg.CallhomeMetricsCollector)
+	if err != nil {
+		return goerrors.Errorf("Failed to start adaptive parallelism: %w", err)
+	}
+	//start monitoring target YB health
+	err = imp.startMonitoringTargetYBHealth()
+	if err != nil {
+		return goerrors.Errorf("Failed to start monitoring health: %w", err)
+	}
+	if adaptiveParallelismStarted {
+		utils.PrintAndLogf("Using 1-%d parallel jobs (adaptive)", imp.cfg.Tconf.MaxParallelism)
+	} else {
+		utils.PrintAndLogf("Using %d parallel jobs.", imp.cfg.Tconf.Parallelism)
+	}
+
+	targetDBVersion := imp.cfg.Tdb.GetVersion()
+	fmt.Printf("%s version: %s\n", imp.cfg.Tconf.TargetDBType, targetDBVersion)
+
+	//create voyager metadata schema
+	err = imp.cfg.Tdb.CreateVoyagerSchema()
+	if err != nil {
+		return goerrors.Errorf("Failed to create voyager metadata schema on target DB: %w", err)
+	}
+	return nil
+}
+
+func (imp *Importer) handleStartCleanForSnapshot(state *ImportDataState, importFileTasks []*ImportFileTask, errorHandler ImportDataErrorHandler) error {
+	imp.cleanImportState(state, importFileTasks)
+	err := cleanStoredErrors(errorHandler, importFileTasks)
+	if err != nil {
+		return goerrors.Errorf("Failed to clean stored errors: %w", err)
+	}
+	return nil
+}
+
+func (imp *Importer) initialiseValueConverter(importTableList []sqlname.NameTuple, msr *metadb.MigrationStatusRecord) error {
+	var err error
+	if msr.IsSnapshotExportedViaDebezium() {
+		imp.valueConverter, err = dbzm.NewSnapshotPhaseValueConverter(imp.cfg.ExportDir, imp.cfg.Tdb, imp.cfg.Tconf, imp.cfg.ImporterRole, msr.SourceDBConf.DBType, importTableList)
+	} else {
+		imp.valueConverter, err = dbzm.NewSnapshotPhaseNoOpValueConverter()
+	}
+	if err != nil {
+		return goerrors.Errorf("Failed to create value converter: %w", err)
+	}
+
+	imp.tableNameToSchema, err = imp.valueConverter.GetTableNameToSchema()
+	if err != nil {
+		return goerrors.Errorf("Failed to get table name to schema: %w", err)
+	}
+	return nil
+}
+
+func (imp *Importer) handleIdentityColumns(importTableList []sqlname.NameTuple) error {
+	err := imp.fetchAndStoreGeneratedAlwaysIdentityColumnsInMetadb(importTableList)
+	if err != nil {
+		return goerrors.Errorf("Failed to fetch and store generated always identity columns: %w", err)
+	}
+	err = imp.disableGeneratedAlwaysAsIdentityColumns()
+	if err != nil {
+		return goerrors.Errorf("Failed to disable generated always identity columns: %w", err)
+	}
+	return nil
+}
+
+func (imp *Importer) importSnapshotData(msr *metadb.MigrationStatusRecord, errorHandler ImportDataErrorHandler,
+	state *ImportDataState, importFileTasks []*ImportFileTask, importTableList []sqlname.NameTuple) error {
+	var err error
+	var pendingTasks, completedTasks []*ImportFileTask
+
+	if imp.cfg.StartClean {
+		pendingTasks = importFileTasks
+	} else {
+		pendingTasks, completedTasks, err = classifyTasksForImport(state, importFileTasks)
+		if err != nil {
+			utils.ErrExit("Failed to classify tasks: %w", err)
+		}
+	}
+	log.Infof("pending tasks: %v", pendingTasks)
+	log.Infof("completed tasks: %v", completedTasks)
+
+	err = imp.runPKConflictModeGuardrails(state, importFileTasks)
+	if err != nil {
+		utils.ErrExit("Error checking PK conflict mode on fresh start: %w", err)
+	}
+
+	err = imp.initialiseValueConverter(importTableList, msr)
+	if err != nil {
+		utils.ErrExit("Failed to initialize value converter: %w", err)
+	}
+
+	utils.PrintAndLogf("Already imported tables: %v", ImportFileTasksToTableNames(completedTasks))
+	if len(pendingTasks) == 0 {
+		utils.PrintAndLogf("All the tables are already imported, nothing left to import\n")
+		return nil
+	}
+	utils.PrintAndLogf("Tables to import: %v", ImportFileTasksToTableNames(pendingTasks))
+	err = imp.prepareTableToColumns(pendingTasks) //prepare the tableToColumns map
+	if err != nil {
+		utils.ErrExit("failed to prepare table to columns: %w", err)
+	}
+	maxParallelConns, err := imp.getMaxParallelConnections()
+	if err != nil {
+		utils.ErrExit("Failed to get max parallel connections: %w", err)
+	}
+	if !imp.cfg.Tconf.AdaptiveParallelismMode.IsEnabled() {
+		// Adaptive parallelism emits this gauge itself once it starts polling;
+		// for a fixed --parallel-jobs run there's no such poller, so emit once here.
+		metrics.Get().SetImportParallelism(imp.cfg.ImporterRole, maxParallelConns)
+	}
+	importDataAllTableMetrics := imp.createInitialImportDataTableMetrics(importFileTasks, pendingTasks)
+	if imp.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE {
+		imp.cfg.ControlPlane.UpdateImportedRowCount(importDataAllTableMetrics)
+	}
+
+	useTaskPicker := utils.GetEnvAsBool("YBVOYAGER_USE_TASK_PICKER_FOR_IMPORT", true)
+	if useTaskPicker {
+		maxColocatedBatchesInProgress := utils.GetEnvAsInt("YBVOYAGER_MAX_COLOCATED_BATCHES_IN_PROGRESS", 3)
+		err := imp.importTasksViaTaskPicker(pendingTasks, state, imp.progressReporter,
+			maxParallelConns, maxParallelConns, maxColocatedBatchesInProgress, msr.IsSnapshotExportedViaDebezium(),
+			imp.cfg.MaxConcurrentBatchProductions, bool(imp.cfg.EnableRandomBatchProduction),
+			errorHandler, imp.cfg.CallhomeMetricsCollector)
+		if err != nil {
+			utils.ErrExit("Failed to import tasks via task picker. %w", err)
+		}
+	} else {
+		poolSize := maxParallelConns * 2
+		for _, task := range pendingTasks {
+			// The code can produce `poolSize` number of batches at a time. But, it can consume only
+			// `parallelism` number of batches at a time.
+			imp.batchImportPool = pool.New().WithMaxGoroutines(poolSize)
+			log.Infof("created batch import pool of size: %d", poolSize)
+
+			batchProducer, err := NewSequentialFileBatchProducer(imp.sequentialFileBatchProducerConfig(), task, state, msr.IsSnapshotExportedViaDebezium(), errorHandler, imp.progressReporter)
+			if err != nil {
+				utils.ErrExit("Failed to create batch producer: %w", err)
+			}
+
+			taskImporter, err := NewFileTaskImporter(imp.fileTaskImporterConfig(), task, state, batchProducer, imp.batchImportPool, imp.progressReporter, nil, false, errorHandler, imp.cfg.CallhomeMetricsCollector)
+			if err != nil {
+				utils.ErrExit("Failed to create file task importer: %w", err)
+			}
+
+			for !taskImporter.AllBatchesSubmitted() {
+				err := taskImporter.ProduceAndSubmitNextBatchToWorkerPool()
+				if err != nil {
+					utils.ErrExit("Failed to submit next batch: task:%v err: %w", task, err)
+				}
+			}
+
+			imp.batchImportPool.Wait() // wait for file import to finish
+			taskImporter.PostProcess()
+		}
+		time.Sleep(time.Second * 2)
+	}
+
+	return nil
+}
+
+func (imp *Importer) ImportData(importFileTasks []*ImportFileTask) {
+	errorHandler, err := imp.initialiseErrorHandler()
+	if err != nil {
+		utils.ErrExit("Failed to initialize error policy and error handler: %w", err)
+	}
+
+	if imp.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE {
+		importDataStartEvent := imp.cfg.SnapshotImportStartedEvent
+		imp.cfg.ControlPlane.SnapshotImportStarted(&importDataStartEvent)
+	}
+	err = imp.updateTargetConfInMigrationStatus()
+	if err != nil {
+		utils.ErrExit("Failed to update target conf in migration status record: %w", err)
+	}
+	msr, err := imp.cfg.MetaDB.GetMigrationStatusRecord()
+	if err != nil {
+		utils.ErrExit("Failed to get migration status record: %w", err)
+	}
+	//create progress reporter
+	imp.progressReporter = NewImportDataProgressReporter(bool(imp.cfg.DisablePb))
+
+	err = imp.prepareTargetDBForImport()
+	if err != nil {
+		utils.ErrExit("Failed to prepare target DB for import: %w", err)
+	}
+
+	state := NewImportDataState(imp.importDataStateConfig())
+	// kept on the importer so the caller's post-processing (sequence restore,
+	// cutover) can read import state and stashed errors
+	imp.state = state
+	imp.errorHandler = errorHandler
+
+	err = imp.clearMigrationStateForImportDataStartClean(state, importFileTasks, errorHandler)
+	if err != nil {
+		utils.ErrExit("Failed to clean MigrationStatusRecord for import data start clean: %w", err)
+	}
+
+	var tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]
+	if changeStreamingIsEnabled(imp.cfg.ImportType) {
+		tableToUniqueIndexes, err = imp.cfg.Tdb.GetTableToUniqueIndexesMap(imp.cfg.ImportTableList)
+		if err != nil {
+			utils.ErrExit("Failed to get table unique indexes map from target: %s", err)
+		}
+	}
+	// Validate/resolve cdc-partition-key (+ overrides) and persist the per-table map
+	// before snapshot so bad configs fail fast (not at streamChanges).
+	// Runs after start-clean so a cleared map is recomputed for the new run.
+	// Must run before updateImportDataStartedInMetaDB so a failed prepare does not
+	// lock change-guard / ImportDataStarted for a config that never took effect.
+	err = imp.prepareCdcPartitionKey(imp.cfg.ImportTableList, tableToUniqueIndexes)
+	if err != nil {
+		utils.ErrExit("Failed to prepare cdc-partition-key: %w", err)
+	}
+
+	// Fetch the primary-key columns of the import tables from the target (before snapshot) so
+	// they can be passed to streamChanges and the conflict-detection cache without re-querying
+	// during streaming. Also fails fast if a custom-partition-key table has no primary key.
+	importTableToPKColumns, err := imp.getPrimaryKeyColumnsForImportTables(imp.cfg.ImportTableList)
+	if err != nil {
+		utils.ErrExit("Failed to get primary key columns for import tables: %w", err)
+	}
+	//updating the metadb after the startclean clears any required metadb state
+	err = imp.updateImportDataStartedAndSomeConfigsInMetaDB()
+	if err != nil {
+		utils.ErrExit("Failed to update import data started in meta DB: %w", err)
+	}
+
+	if state.HasExistingState() {
+		utils.PrintAndLogf("\nResuming import of data in %q database", imp.cfg.Tconf.DBName)
+	} else {
+		utils.PrintAndLogf("\nimport of data in %q database started", imp.cfg.Tconf.DBName)
+	}
+
+	// Handle identity columns before snapshot import for Oracle targets (source-replica/source)
+	// Oracle requires GENERATED ALWAYS columns to be converted to GENERATED BY DEFAULT for COPY to work
+	if imp.identityColumnsNeedHandlingForSnapshotImport() {
+		err = imp.handleIdentityColumns(imp.cfg.ImportTableList)
+		if err != nil {
+			utils.ErrExit("Failed to handle identity columns: %w", err)
+		}
+	}
+
+	// Import snapshots
+	if ImportSnapshotRequired(imp.cfg.ImporterRole, imp.cfg.ImportType) {
+		err = imp.importSnapshotData(msr, errorHandler, state, importFileTasks, imp.cfg.ImportTableList)
+		if err != nil {
+			utils.ErrExit("failed to import snapshot data: %w", err)
+		}
+		utils.PrintAndLogf("snapshot data import complete\n\n")
+	}
+
+	if changeStreamingIsEnabled(imp.cfg.ImportType) {
+		// For non-Oracle targets (YugabyteDB/PostgreSQL), handle identity columns before streaming phase
+		// For Oracle targets, this was already done before snapshot import
+		if !imp.identityColumnsNeedHandlingForSnapshotImport() {
+			err = imp.handleIdentityColumns(imp.cfg.ImportTableList)
+			if err != nil {
+				utils.ErrExit("Failed to handle identity columns: %w", err)
+			}
+		}
+		if ImportSnapshotRequired(imp.cfg.ImporterRole, imp.cfg.ImportType) {
+			DisplayImportedRowCountSnapshot(imp.importDataStateConfig(), state, importFileTasks, errorHandler)
+		}
+		err = imp.streamChanges(state, imp.cfg.ImportTableList, importTableToPKColumns, tableToUniqueIndexes)
+		if err != nil {
+			utils.ErrExit("Failed to stream changes to %s: %w", imp.cfg.Tconf.TargetDBType, err)
+		}
+	}
+	// The post-processing that followed here (sequence restore, cutover
+	// processing, the snapshot import report) is run by the caller; see
+	// cmd's importDataPostProcessing.
+}
+
+/*
+getPrimaryKeyColumnsForImportTables fetches the primary-key columns of every import table
+from the target DB (in one batched query) so they can be threaded into the streaming
+conflict-detection cache.
+
+It is called once near the start of importData (for the target PG→YB live path only; other
+paths return an empty map since conflict detection does not run for them). Because importData
+runs in the same process before streamChanges on both the first run and resume, the map does
+not need to be persisted in metaDB.
+
+It also fails fast, before the snapshot import, if a table routed by a custom partition key
+has no primary key on the target: custom routing adds the PK as a synthetic unique index for
+conflict detection (a recycled PK across different custom keys must be serialized), so a
+custom-key table without a PK cannot be made correct. This is scoped to custom-key tables so
+that legitimately PK-less tables under pk/table routing (e.g. partitioned roots imported via
+--use-partition-root) are not blocked.
+*/
+func (imp *Importer) getPrimaryKeyColumnsForImportTables(tableNames []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, []string], error) {
+	tableToPKColumns := utils.NewStructMap[sqlname.NameTuple, []string]()
+
+	// Only the target PG→YB live streaming path runs conflict detection and needs primary keys.
+	if imp.cfg.ImporterRole != constants.TARGET_DB_IMPORTER_ROLE || !changeStreamingIsEnabled(imp.cfg.ImportType) || imp.cfg.SourceDBType != constants.POSTGRESQL {
+		return tableToPKColumns, nil
+	}
+
+	tableToPKColumns, err := imp.cfg.Tdb.GetPrimaryKeyColumnsForTables(tableNames)
+	if err != nil {
+		return nil, fmt.Errorf("error getting primary key columns for import tables: %w", err)
+	}
+
+	var tablesWithoutPK []sqlname.NameTuple
+	for _, t := range tableNames {
+		if pkColumns, _ := tableToPKColumns.Get(t); len(pkColumns) == 0 {
+			tablesWithoutPK = append(tablesWithoutPK, t)
+		}
+	}
+	if len(tablesWithoutPK) > 0 {
+		return nil, goerrors.Errorf("table(s) %v have no primary key on the target; live migration is not allowed for these tables", tablesWithoutPK)
+	}
+
+	return tableToPKColumns, nil
+}
+
+// For a fresh start but non empty tables in tableList && OnPrimaryKeyConflict is set to IGNORE -> notify user
+func (imp *Importer) runPKConflictModeGuardrails(state *ImportDataState, allTasks []*ImportFileTask) error {
+	// in case of ERROR mode, no need to check for non-empty tables
+	// but for IGNORE or UPDATE(in future), we need to prompt user
+	if imp.cfg.Tconf.OnPrimaryKeyConflictAction == constants.PRIMARY_KEY_CONFLICT_ACTION_ERROR_POLICY {
+		return nil
+	}
+
+	if !isTargetDBImporter(imp.cfg.ImporterRole) {
+		return nil
+	}
+
+	if !isFreshStart(state, allTasks) {
+		log.Info("Not a fresh start, skipping primary key conflict mode check.")
+		return nil
+	}
+
+	pendingTasks := getPendingTasks(state, allTasks)
+	pendingTablesList := ImportFileTasksToTableNameTuples(pendingTasks)
+	nonEmptyTables := imp.cfg.Tdb.GetNonEmptyTables(pendingTablesList)
+	if len(nonEmptyTables) == 0 {
+		log.Info("No non-empty tables found in the target DB, skipping primary key conflict mode check.")
+		return nil
+	}
+
+	tableToPKColumns, err := imp.cfg.Tdb.GetPrimaryKeyColumnsForTables(nonEmptyTables)
+	if err != nil {
+		return fmt.Errorf("failed to get primary key columns for tables: %w", err)
+	}
+	var nonEmptyTablesWithPK []sqlname.NameTuple
+	for _, table := range nonEmptyTables {
+		colList, _ := tableToPKColumns.Get(table)
+		if len(colList) > 0 { // table has PK
+			nonEmptyTablesWithPK = append(nonEmptyTablesWithPK, table)
+		}
+	}
+
+	// all nonEmptyTables have no primary key columns
+	if len(nonEmptyTablesWithPK) == 0 {
+		log.Infof("No non-empty tables with primary key found in %v, skipping primary key conflict mode check.",
+			sqlname.NameTupleListToStrings(nonEmptyTables))
+		return nil
+	}
+
+	utils.PrintAndLogf(
+		"\nTarget tables with pre-existing data: %v\n"+
+			"Note that because of the config on-primary-key-conflict as 'IGNORE', rows that have a primary key conflict "+
+			"with an existing row in the above set of tables will be silently ignored.\n",
+		sqlname.NameTupleListToStrings(nonEmptyTablesWithPK),
+	)
+	if !utils.AskPrompt("Please confirm whether to proceed") {
+		utils.ErrExit("Aborting import.")
+	}
+
+	return nil
+}
+
+// A fresh start is when all tasks are pending(non-zero), no started or completed tasks.
+func isFreshStart(state *ImportDataState, allTasks []*ImportFileTask) bool {
+	inProgressTasks := getInProgressTasks(state, allTasks)
+	notStartedTasks := getNotStartedTasks(state, allTasks)
+	completedTasks := getCompletedTasks(state, allTasks)
+
+	return len(inProgressTasks) == 0 && len(completedTasks) == 0 && len(notStartedTasks) == len(allTasks)
+}
+
+// restoreGeneratedIdentityColumns enables & restores generated identity columns
+// 1. GENERATED ALWAYS: Re-enables(also restores the values) 'GENERATED ALWAYS' identity columns previously disabled before import data
+// 2. GENERATED BY DEFAULT: Remaining columns were always 'generated by default'; just restore their values.
+func (imp *Importer) RestoreGeneratedIdentityColumns(importTableList []sqlname.NameTuple) error {
+	if importTableList == nil {
+		return nil
+	}
+
+	err := imp.enableGeneratedAlwaysAsIdentityColumns()
+	if err != nil {
+		return err
+	}
+
+	// TODO: these sequences of all identity columns are also covered as part of the RestoreSequences as well so we don't need this ALTER
+	// see if we should remove it.
+	err = imp.restoreGeneratedByDefaultAsIdentityColumns(importTableList)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (imp *Importer) getMaxParallelConnections() (int, error) {
+	maxParallelConns := imp.cfg.Tconf.Parallelism
+	if imp.cfg.Tconf.AdaptiveParallelismMode.IsEnabled() {
+		// in case of adaptive parallelism, we need to use maxParalllelism * 2
+		yb, ok := imp.cfg.Tdb.(*tgtdb.TargetYugabyteDB)
+		if !ok {
+			return 0, goerrors.Errorf("adaptive parallelism is only supported if target DB is YugabyteDB")
+		}
+		maxParallelConns = yb.GetNumMaxConnectionsInPool()
+	}
+	return maxParallelConns, nil
+}
+
+func waitIfNoBatchAvailableForAllTasks(taskPicker FileTaskPicker, taskImporters map[int]*FileTaskImporter) {
+	inProgressTasks := taskPicker.InProgressTasks()
+	if len(inProgressTasks) == 0 {
+		return
+	}
+
+	allTasksBatchNotAvailable := true
+
+	for _, task := range inProgressTasks {
+		importer, exists := taskImporters[task.ID]
+		if !exists {
+			// Importer not yet created for this task - the picker has picked a new task
+			// that the main loop hasn't processed yet. Don't wait, let the loop create it.
+			return
+		}
+
+		if importer.IsNextBatchAvailable() {
+			allTasksBatchNotAvailable = false
+			break
+		}
+	}
+
+	if allTasksBatchNotAvailable {
+		log.Infof("No batches available for all in-progress tasks. Waiting for batch production.")
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func waitIfAllBatchesSubmittedForAllTasks(taskPicker FileTaskPicker, taskImporters map[int]*FileTaskImporter) {
+	inProgressTasks := taskPicker.InProgressTasks()
+	if len(inProgressTasks) == 0 {
+		return
+	}
+
+	allTasksAllBatchesSubmitted := true
+
+	for _, task := range inProgressTasks {
+		importer, exists := taskImporters[task.ID]
+		if !exists {
+			// Importer not yet created for this task - the picker has picked a new task
+			// that the main loop hasn't processed yet. Don't wait, let the loop create it.
+			return
+		}
+		if !importer.AllBatchesSubmitted() {
+			allTasksAllBatchesSubmitted = false
+			break
+		}
+	}
+
+	if allTasksAllBatchesSubmitted {
+		log.Infof("All batches submitted for all in-progress tasks. Waiting for import completion.")
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+/*
+1. Initialize a worker pool. In case of TARGET_DB_IMPORTER_ROLE  or IMPORT_FILE_ROLE, also create a colocated batch import pool and a corresponding queue.
+2. Create a task picker which helps the importer choose which task to process in each iteration.
+3. Loop until all tasks are done:
+  - Pick a task from the task picker.
+  - If the task is not already being processed, create a new FileTaskImporter for the task.
+  - For the task that is picked, produce the next batch and submit it to the worker pool. Worker will asynchronously import the batch.
+  - If task is done, mark it as done in the task picker.
+*/
+func (imp *Importer) importTasksViaTaskPicker(pendingTasks []*ImportFileTask, state *ImportDataState, progressReporter *ImportDataProgressReporter,
+	maxParallelConns int, maxShardedTasksInProgress int, maxColocatedBatchesInProgress int,
+	isRowTransformationRequired bool, maxConcurrentBatchProductions int, enableRandomBatchProduction bool,
+	errorHandler ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) error {
+
+	var err error
+	imp.setupWorkerPoolAndQueue(maxParallelConns, maxColocatedBatchesInProgress)
+	taskImporters := map[int]*FileTaskImporter{}
+	tableTypes, err := GetTableTypes(imp.cfg.ImporterRole, imp.cfg.Tconf.TargetDBType, imp.cfg.Tdb, pendingTasks)
+	if err != nil {
+		return fmt.Errorf("get table types: %w", err)
+	}
+
+	// Initialize semaphore to limit concurrent batch productions
+	concurrentBatchProductionSem := semaphore.NewWeighted(int64(maxConcurrentBatchProductions))
+
+	var taskPicker FileTaskPicker
+	// The colocation-aware task picker only applies to a real YugabyteDB
+	// target. yb-amp (PostgreSQL-compatible, no colocation/tablets) and the
+	// PG fall-forward/back roles use the sequential picker instead.
+	if (imp.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE || imp.cfg.ImporterRole == constants.IMPORT_FILE_ROLE) && imp.cfg.Tconf.TargetDBType == constants.YUGABYTEDB {
+		yb, ok := imp.cfg.Tdb.(*tgtdb.TargetYugabyteDB)
+		if !ok {
+			return goerrors.Errorf("expected tdb to be of type TargetYugabyteDB, got: %T", imp.cfg.Tdb)
+		}
+		taskPicker, err = NewColocatedCappedRandomTaskPicker(maxShardedTasksInProgress, maxColocatedBatchesInProgress, pendingTasks, state, yb, imp.colocatedBatchImportQueue, tableTypes)
+		if err != nil {
+			return fmt.Errorf("create colocated aware randmo task picker: %w", err)
+		}
+	} else {
+		taskPicker, err = NewSequentialTaskPicker(pendingTasks, state)
+		if err != nil {
+			return fmt.Errorf("create sequential task picker: %w", err)
+		}
+	}
+
+	for taskPicker.HasMoreTasks() {
+		task, err := taskPicker.Pick()
+		if err != nil {
+			return fmt.Errorf("get next task: %w", err)
+		}
+		log.Debugf("Picked task for import: %s", task)
+		var taskImporter *FileTaskImporter
+		var ok bool
+		taskImporter, ok = taskImporters[task.ID]
+		if !ok {
+			taskImporter, err = imp.createFileTaskImporter(task, state, imp.batchImportPool, progressReporter, imp.colocatedBatchImportQueue, tableTypes, isRowTransformationRequired, enableRandomBatchProduction, concurrentBatchProductionSem, errorHandler, callhomeMetricsCollector)
+			if err != nil {
+				return fmt.Errorf("create file task importer: %w", err)
+			}
+			log.Infof("created file task importer for table: %s, task: %v", task.TableNameTup.ForOutput(), task)
+			taskImporters[task.ID] = taskImporter
+		}
+
+		if taskImporter.AllBatchesSubmitted() {
+			// All batches for this task have been submitted.
+			// task could have been completed (all batches imported) OR still in progress
+			// in case task is done, we should inform task picker so that we stop picking that task.
+			log.Debugf("All batches submitted for task: %s", task)
+			taskDone, err := state.AllBatchesImported(task.FilePath, task.TableNameTup)
+			if err != nil {
+				return fmt.Errorf("check if all batches are imported: task: %v err :%w", task, err)
+			}
+			if taskDone {
+				taskImporter.PostProcess()
+				err = taskPicker.MarkTaskAsDone(task)
+				if err != nil {
+					return fmt.Errorf("mark task as done: task: %v, err: %w", task, err)
+				}
+				state.UnregisterFileTaskImporter(taskImporter)
+				log.Infof("Import of task done: %s", task)
+				continue
+			}
+			// Batches still being imported by workers; continue with some other task.
+			waitIfAllBatchesSubmittedForAllTasks(taskPicker, taskImporters)
+			continue
+		}
+
+		if !taskImporter.IsNextBatchAvailable() {
+			// Picked task has no batch ready. Small sleep to prevent tight spinning
+			// in case picker keeps returning tasks without batches.
+			log.Debugf("No next batch available for table: %s", task.TableNameTup.ForOutput())
+			waitIfNoBatchAvailableForAllTasks(taskPicker, taskImporters)
+			continue
+		}
+
+		log.Infof("Producing and submitting next batch for task: %s", task)
+
+		err = taskImporter.ProduceAndSubmitNextBatchToWorkerPool()
+		if err != nil {
+			return goerrors.Errorf("submit next batch: task:%v err: %w", task, err)
+		}
+	}
+	return nil
+}
+
+func (imp *Importer) setupWorkerPoolAndQueue(maxParallelConns int, maxColocatedBatchesInProgress int) {
+	shardedPoolSize := maxParallelConns * 2
+	imp.batchImportPool = pool.New().WithMaxGoroutines(shardedPoolSize)
+	log.Infof("created batch import pool of size: %d", shardedPoolSize)
+
+	if imp.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE || imp.cfg.ImporterRole == constants.IMPORT_FILE_ROLE {
+		imp.colocatedBatchImportPool = pool.New().WithMaxGoroutines(maxColocatedBatchesInProgress)
+		log.Infof("created colocated batch import pool of size: %d", maxColocatedBatchesInProgress)
+
+		imp.colocatedBatchImportQueue = make(chan func(), maxColocatedBatchesInProgress*2)
+
+		colocatedBatchImportQueueConsumer := func() {
+			// just read from channel and submit to the worker pool.
+			// worker pool has a max size of maxColocatedBatchesInProgress, so it will block if all workers are busy.
+			for f := range imp.colocatedBatchImportQueue {
+				imp.colocatedBatchImportPool.Go(f)
+			}
+		}
+		go colocatedBatchImportQueueConsumer()
+	}
+}
+
+/*
+when TARGET_DB_IMPORTER_ROLE or IMPORT_FILE_ROLE, we pass on
+the batchImportPool and the colocatedBatchImportQueue to the FileTaskImporter
+so that it can submit sharded table batches to the batchImportPool,
+and colocated table batches to the colocatedBatchImportQueue.
+
+Otherwise, we simply pass the batchImportPool to the FileTaskImporter.
+*/
+func (imp *Importer) createFileTaskImporter(task *ImportFileTask, state *ImportDataState, batchImportPool *pool.Pool, progressReporter *ImportDataProgressReporter, colocatedBatchImportQueue chan func(),
+	tableTypes *utils.StructMap[sqlname.NameTuple, string], isRowTransformationRequired bool, enableRandomBatchProduction bool, concurrentBatchProductionSem *semaphore.Weighted, errorHandler ImportDataErrorHandler, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (*FileTaskImporter, error) {
+	var taskImporter *FileTaskImporter
+	var err error
+	var batchProducer FileBatchProducer
+
+	// tableTypes (the colocation map) is only populated for a real YugabyteDB
+	// target. For yb-amp (PostgreSQL-compatible, no colocation) and the PG
+	// fall-forward/back roles it is nil, so they take the plain sequential
+	// importer path below.
+	// The colocation-aware importer applies only to a real YugabyteDB target;
+	// tableTypes is populated (non-nil) exactly for that case (see getTableTypes).
+	// Non-YB targets (yb-amp, etc.) take the plain sequential importer below.
+	if (imp.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE || imp.cfg.ImporterRole == constants.IMPORT_FILE_ROLE) && imp.cfg.Tconf.TargetDBType == constants.YUGABYTEDB {
+		tableType, ok := tableTypes.Get(task.TableNameTup)
+		if !ok {
+			return nil, goerrors.Errorf("table type not found for table: %s", task.TableNameTup.ForOutput())
+		}
+
+		if enableRandomBatchProduction {
+			batchProducer, err = NewRandomFileBatchProducer(imp.sequentialFileBatchProducerConfig(), task, state, isRowTransformationRequired, errorHandler, progressReporter, concurrentBatchProductionSem)
+			if err != nil {
+				return nil, fmt.Errorf("creating random batch producer: %w", err)
+			}
+		} else {
+			batchProducer, err = NewSequentialFileBatchProducer(imp.sequentialFileBatchProducerConfig(), task, state, isRowTransformationRequired, errorHandler, progressReporter)
+			if err != nil {
+				return nil, fmt.Errorf("creating sequential batch producer: %w", err)
+			}
+		}
+		taskImporter, err = NewFileTaskImporter(imp.fileTaskImporterConfig(), task, state, batchProducer, batchImportPool, progressReporter, colocatedBatchImportQueue, tableType == COLOCATED, errorHandler, callhomeMetricsCollector)
+
+		if err != nil {
+			return nil, fmt.Errorf("create file task importer: %w", err)
+		}
+	} else {
+		batchProducer, err = NewSequentialFileBatchProducer(imp.sequentialFileBatchProducerConfig(), task, state, isRowTransformationRequired, errorHandler, progressReporter)
+		if err != nil {
+			return nil, fmt.Errorf("creating sequential batch producer: %w", err)
+		}
+
+		taskImporter, err = NewFileTaskImporter(imp.fileTaskImporterConfig(), task, state, batchProducer, batchImportPool, progressReporter, nil, false, errorHandler, callhomeMetricsCollector)
+		if err != nil {
+			return nil, fmt.Errorf("create file task importer: %w", err)
+		}
+	}
+	return taskImporter, nil
+}
+
+func (imp *Importer) startMonitoringTargetYBHealth() error {
+	if !slices.Contains([]string{constants.TARGET_DB_IMPORTER_ROLE, constants.IMPORT_FILE_ROLE}, imp.cfg.ImporterRole) {
+		return nil
+	}
+	// Target health monitoring (node / disk-usage / replication metrics) is a
+	// YugabyteDB-cluster concept. Non-YB targets (yb-amp's stateless PG17 compute,
+	// etc.) expose no such API, so it does not apply.
+	if imp.cfg.Tconf.TargetDBType != constants.YUGABYTEDB {
+		return nil
+	}
+	if imp.cfg.SkipNodeHealthChecks && imp.cfg.SkipDiskUsageHealthChecks && imp.cfg.SkipReplicationChecks {
+		return nil
+	}
+	yb, ok := imp.cfg.Tdb.(*tgtdb.TargetYugabyteDB)
+	if !ok {
+		return goerrors.Errorf("monitoring health is only supported if target DB is YugabyteDB")
+	}
+
+	go func() {
+		//for now not sending any other parameters as not required for monitor usage
+		ybClient := dbzm.NewYugabyteDBCDCClient(imp.cfg.ExportDir, "", imp.cfg.Tconf.SSLRootCert, imp.cfg.Tconf.DBName, "", nil)
+		err := ybClient.Init()
+		if err != nil {
+			log.Errorf("error intialising the yb client : %v", err)
+		}
+		monitorTDBHealth := monitor.NewMonitorTargetYBHealth(yb, bool(imp.cfg.SkipDiskUsageHealthChecks), bool(imp.cfg.SkipReplicationChecks), bool(imp.cfg.SkipNodeHealthChecks), ybClient, func(info string) {
+			imp.displayMonitoringInformationOnTheConsole(info)
+		})
+
+		err = monitorTDBHealth.StartMonitoring()
+		//lint:ignore SA4023 StartMonitoring currently only returns on error; keep the conventional check
+		if err != nil {
+			log.Errorf("error monitoring the target health: %v", err)
+		}
+	}()
+	return nil
+}
+
+func (imp *Importer) displayMonitoringInformationOnTheConsole(info string) {
+	if info == "" {
+		return
+	}
+	if imp.cfg.DisablePb {
+		utils.PrintAndLog(info)
+	} else {
+		log.Warnf("monitoring: %v", info)
+		if imp.importPhase == dbzm.MODE_SNAPSHOT || imp.cfg.ImporterRole == constants.IMPORT_FILE_ROLE {
+			imp.progressReporter.DisplayInformation(info)
+		} else {
+			imp.statsReporter.DisplayInformation(info)
+
+		}
+	}
+}
+
+func (imp *Importer) startAdaptiveParallelism(mode types.AdaptiveParallelismMode, callhomeMetricsCollector *callhome.ImportDataMetricsCollector) (bool, error) {
+	if !mode.IsEnabled() {
+		return false, nil
+	}
+	yb, ok := imp.cfg.Tdb.(*tgtdb.TargetYugabyteDB)
+	if !ok {
+		return false, goerrors.Errorf("adaptive parallelism is only supported if target DB is YugabyteDB")
+	}
+
+	if !yb.IsAdaptiveParallelismSupported() {
+		utils.PrintAndLog(color.YellowString("Note: Continuing without adaptive parallelism as it is not supported in this version of YugabyteDB."))
+		return false, nil
+	}
+
+	go func() {
+		err := adaptiveparallelism.AdaptParallelism(yb, mode, callhomeMetricsCollector)
+		if err != nil {
+			log.Errorf("adaptive parallelism error: %v", err)
+		}
+	}()
+	return true, nil
+}
+
+func (imp *Importer) waitForDebeziumStartIfRequired() error {
+	msr, err := imp.cfg.MetaDB.GetMigrationStatusRecord()
+	if err != nil {
+		return fmt.Errorf("failed to get migration status record: %w", err)
+	}
+	if msr.SnapshotMechanism == "debezium" {
+		// we already wait for snapshot to have completed by debezium
+		// so no need to wait again here.
+		return nil
+	}
+
+	// in case pg_dump was used to export snapshot data,
+	// we need to wait for export-data to have started debezium in cdc phase
+	// in order to avoid any race conditions.
+	fmt.Println("Initializing streaming phase...")
+	log.Infof("waiting for export-data to have started debezium in cdc phase")
+	for {
+		msr, err = imp.cfg.MetaDB.GetMigrationStatusRecord()
+		if err != nil {
+			return fmt.Errorf("failed to get migration status record: %w", err)
+		}
+		if lo.Contains([]string{constants.TARGET_DB_IMPORTER_ROLE, constants.SOURCE_REPLICA_DB_IMPORTER_ROLE}, imp.cfg.ImporterRole) &&
+			msr.ExportDataSourceDebeziumStarted {
+			break
+		}
+		if imp.cfg.ImporterRole == constants.SOURCE_DB_IMPORTER_ROLE && msr.ExportDataTargetDebeziumStarted {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	return nil
+}
+
+// Handling identity columns for resumable import data
+// Background: A previous incomplete import run may have disabled "GENERATED ALWAYS AS IDENTITY" columns.
+// Two scenarios:
+//  1. Columns are disabled: Restore TableToIdentityColumnNames map from metaDB
+//  2. Columns are enabled: Fetch identity columns from database and persist to metaDB for import data resumability
+func (imp *Importer) fetchAndStoreGeneratedAlwaysIdentityColumnsInMetadb(tables []sqlname.NameTuple) error {
+	tableKeyToIdentityColumnNames := make(map[string][]string)
+
+	// Fetch the table to identity columns information from metadb if present
+	found, err := imp.cfg.MetaDB.GetJsonObject(nil, imp.cfg.IdentityColumnsMetaDBKey, &tableKeyToIdentityColumnNames)
+	if err != nil {
+		return goerrors.Errorf("failed to get identity columns from meta db: %w", err)
+	}
+	if found {
+		// Using retrieved identity columns from metaDB to populate TableToIdentityColumns
+		imp.tableToIdentityColumnNames = utils.NewStructMap[sqlname.NameTuple, []string]()
+		for key, columns := range tableKeyToIdentityColumnNames {
+			nameTuple, err := namereg.NameReg.LookupTableName(key)
+			if err != nil {
+				return goerrors.Errorf("lookup for table name in name reg: %v with: %w", key, err)
+			}
+			imp.tableToIdentityColumnNames.Put(nameTuple, columns)
+		}
+		return nil
+	}
+
+	// If not found, fetch it from target db and populate TableToIdentityColumnNames and persist it to metaDB
+	imp.tableToIdentityColumnNames, err = imp.cfg.Tdb.GetIdentityColumnNamesForTables(tables, constants.IDENTITY_GENERATION_ALWAYS)
+	if err != nil {
+		return fmt.Errorf("failed to get identity(%s) columns for tables: %w", constants.IDENTITY_GENERATION_ALWAYS, err)
+	}
+
+	err = imp.tableToIdentityColumnNames.IterKV(func(key sqlname.NameTuple, value []string) (bool, error) {
+		tableKeyToIdentityColumnNames[key.ForKey()] = value
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to iterate identity column names: %w", err)
+	}
+	err = imp.cfg.MetaDB.InsertJsonObject(nil, imp.cfg.IdentityColumnsMetaDBKey, tableKeyToIdentityColumnNames)
+	if err != nil {
+		return goerrors.Errorf("failed to insert into the key '%s': %w", imp.cfg.IdentityColumnsMetaDBKey, err)
+	}
+	return nil
+}
+func (imp *Importer) disableGeneratedAlwaysAsIdentityColumns() error {
+	err := imp.cfg.Tdb.DisableGeneratedAlwaysAsIdentityColumns(imp.tableToIdentityColumnNames)
+	if err != nil {
+		return goerrors.Errorf("failed to disable generated always as identity columns: %w", err)
+	}
+	return nil
+}
+
+// identityColumnsNeedHandlingForSnapshotImport checks if identity columns need to be handled
+// (disabled before snapshot import) for Oracle targets in live migration.
+// This is required because Oracle's SQL*Loader/COPY fails for GENERATED ALWAYS columns,
+// so we need to temporarily convert them to GENERATED BY DEFAULT for snapshot import.
+// The restoration is handled in postCutoverProcessing() for live migrations.
+// For PostgreSQL/YugabyteDB targets, COPY works with GENERATED ALWAYS columns, so no handling is needed.
+// Note: SOURCE_DB_IMPORTER_ROLE (fallback) doesn't import snapshots, so not included here.
+func (imp *Importer) identityColumnsNeedHandlingForSnapshotImport() bool {
+	// Only source-replica import has Oracle as target and requires snapshot import
+	return imp.cfg.Tconf.TargetDBType == constants.ORACLE && imp.cfg.ImporterRole == constants.SOURCE_REPLICA_DB_IMPORTER_ROLE
+}
+
+func (imp *Importer) enableGeneratedAlwaysAsIdentityColumns() error {
+	err := imp.cfg.Tdb.EnableGeneratedAlwaysAsIdentityColumns(imp.tableToIdentityColumnNames)
+	if err != nil {
+		return goerrors.Errorf("failed to enable generated always as identity columns: %w", err)
+	}
+	return nil
+}
+
+func (imp *Importer) restoreGeneratedByDefaultAsIdentityColumns(tables []sqlname.NameTuple) error {
+	log.Infof("restoring generated by default as identity columns for tables: %v", tables)
+	tablesToIdentityColumnNames, err := imp.cfg.Tdb.GetIdentityColumnNamesForTables(tables, constants.IDENTITY_GENERATION_BY_DEFAULT)
+	if err != nil {
+		return fmt.Errorf("failed to get identity(%s) columns for tables: %w", constants.IDENTITY_GENERATION_BY_DEFAULT, err)
+	}
+	err = imp.cfg.Tdb.EnableGeneratedByDefaultAsIdentityColumns(tablesToIdentityColumnNames)
+	if err != nil {
+		return fmt.Errorf("failed to enable generated by default as identity columns: %w", err)
+	}
+	return nil
+}
+
+func ImportFileTasksToTableNames(tasks []*ImportFileTask) []string {
+	tableNames := []string{}
+	for _, t := range tasks {
+		tableNames = append(tableNames, t.TableNameTup.ForKey())
+	}
+	return lo.Uniq(tableNames)
+}
+
+func ImportFileTasksToTableNameTuples(tasks []*ImportFileTask) []sqlname.NameTuple {
+	tableNames := []sqlname.NameTuple{}
+	for _, t := range tasks {
+		tableNames = append(tableNames, t.TableNameTup)
+	}
+	return lo.UniqBy(tableNames, func(t sqlname.NameTuple) string {
+		return t.ForKey()
+	})
+}
+
+func classifyTasksForImport(state *ImportDataState, tasks []*ImportFileTask) (pendingTasks, completedTasks []*ImportFileTask, err error) {
+	inProgressTasks := []*ImportFileTask{}
+	notStartedTasks := []*ImportFileTask{}
+	for _, task := range tasks {
+		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get table import state: %w", err)
+		}
+		switch fileImportState {
+		case FILE_IMPORT_COMPLETED, FILE_IMPORT_COMPLETED_WITH_ERRORS:
+			completedTasks = append(completedTasks, task)
+		case FILE_IMPORT_IN_PROGRESS:
+			inProgressTasks = append(inProgressTasks, task)
+		case FILE_IMPORT_NOT_STARTED:
+			notStartedTasks = append(notStartedTasks, task)
+		default:
+			return nil, nil, goerrors.Errorf("invalid table import state: %s", fileImportState)
+		}
+	}
+	// Start with in-progress tasks, followed by not-started tasks.
+	return append(inProgressTasks, notStartedTasks...), completedTasks, nil
+}
+
+func getNotStartedTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
+	notStartedTasks := []*ImportFileTask{}
+	for _, task := range tasks {
+		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
+		if err != nil {
+			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
+		}
+		if fileImportState == FILE_IMPORT_NOT_STARTED {
+			notStartedTasks = append(notStartedTasks, task)
+		}
+	}
+	return notStartedTasks
+}
+
+func getInProgressTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
+	inProgressTasks := []*ImportFileTask{}
+	for _, task := range tasks {
+		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
+		if err != nil {
+			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
+		}
+		if fileImportState == FILE_IMPORT_IN_PROGRESS {
+			inProgressTasks = append(inProgressTasks, task)
+		}
+	}
+	return inProgressTasks
+}
+
+func getPendingTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
+	return append(getInProgressTasks(state, tasks), getNotStartedTasks(state, tasks)...)
+}
+
+func getCompletedTasks(state *ImportDataState, tasks []*ImportFileTask) []*ImportFileTask {
+	completedTasks := []*ImportFileTask{}
+	for _, task := range tasks {
+		fileImportState, err := state.GetFileImportState(task.FilePath, task.TableNameTup)
+		if err != nil {
+			utils.ErrExit("get table import state: %s: %w", task.TableNameTup, err)
+		}
+		if fileImportState == FILE_IMPORT_COMPLETED || fileImportState == FILE_IMPORT_COMPLETED_WITH_ERRORS {
+			completedTasks = append(completedTasks, task)
+		}
+	}
+	return completedTasks
+}
+
+func (imp *Importer) cleanImportState(state *ImportDataState, tasks []*ImportFileTask) {
+	tableNames := ImportFileTasksToTableNameTuples(tasks)
+	nonEmptyNts := imp.cfg.Tdb.GetNonEmptyTables(tableNames)
+	if len(nonEmptyNts) > 0 {
+		nonEmptyTableNames := lo.Map(nonEmptyNts, func(nt sqlname.NameTuple, _ int) string {
+			return nt.ForOutput()
+		})
+		if imp.cfg.TruncateTables {
+			// truncate tables only supported for import-data-to-target.
+			utils.PrintAndLogf("Non-empty tables on DB: %v", nonEmptyTableNames)
+			utils.PrintAndLogf("Truncating all tables in import scope on DB to keep FK-dependents consistent")
+			err := imp.cfg.Tdb.TruncateTables(tableNames)
+			if err != nil {
+				utils.ErrExit("failed to truncate tables: %w", err)
+			}
+		} else {
+			utils.PrintAndLogf("Non-Empty tables: [%s]", strings.Join(nonEmptyTableNames, ", "))
+			utils.PrintAndLogf("The above list of tables on DB are not empty.")
+			utils.PrintAndLogf("If you wish to truncate them, re-run the import command with --truncate-tables true")
+			yes := utils.AskPrompt("Do you want to start afresh without truncating tables")
+			if !yes {
+				utils.ErrExit("Aborting import.")
+			}
+		}
+
+	}
+
+	for _, task := range tasks {
+		err := state.Clean(task.FilePath, task.TableNameTup)
+		if err != nil {
+			utils.ErrExit("failed to clean import data state for table: %q: %w", task.TableNameTup, err)
+		}
+	}
+
+	sqlldrDir := filepath.Join(imp.cfg.ExportDir, "sqlldr")
+	if utils.FileOrFolderExists(sqlldrDir) {
+		err := os.RemoveAll(sqlldrDir)
+		if err != nil {
+			utils.ErrExit("failed to remove sqlldr directory: %q: %w", sqlldrDir, err)
+		}
+	}
+}
+
+func (imp *Importer) prepareTableToColumns(tasks []*ImportFileTask) error {
+	for _, task := range tasks {
+		var columns []string
+		dfdTableToExportedColumns, err := getDfdTableNameToExportedColumns(tasks, imp.cfg.DataFileDescriptor)
+		if err != nil {
+			return goerrors.Errorf("failed to get dfd table to exported columns: %w", err)
+		}
+		if dfdTableToExportedColumns != nil {
+			columns, _ = dfdTableToExportedColumns.Get(task.TableNameTup)
+		} else if imp.cfg.DataFileDescriptor.HasHeader {
+			// File is either exported from debezium OR this is `import data file` case.
+			reader, err := imp.cfg.DataStore.Open(task.FilePath)
+			if err != nil {
+				return goerrors.Errorf("datastore.Open: %q: %w", task.FilePath, err)
+			}
+			df, err := datafile.NewDataFile(task.FilePath, reader, imp.cfg.DataFileDescriptor, 0)
+			if err != nil {
+				return goerrors.Errorf("opening datafile: %q: %w", task.FilePath, err)
+			}
+			header := df.GetHeader()
+			columns = strings.Split(header, imp.cfg.DataFileDescriptor.Delimiter)
+			log.Infof("read header from file %q: %s", task.FilePath, header)
+			log.Infof("header row split using delimiter %q: %v\n", imp.cfg.DataFileDescriptor.Delimiter, columns)
+			df.Close()
+		}
+		imp.tableToColumnNames.Put(task.TableNameTup, columns)
+	}
+	return nil
+}
+
+func getDfdTableNameToExportedColumns(tasks []*ImportFileTask, dataFileDescriptor *datafile.Descriptor) (*utils.StructMap[sqlname.NameTuple, []string], error) {
+	if dataFileDescriptor.TableNameToExportedColumns == nil {
+		return nil, nil
+	}
+	tableTupleToexportedColumns := utils.NewStructMap[sqlname.NameTuple, []string]()
+	for tableName, columnList := range dataFileDescriptor.TableNameToExportedColumns {
+		//Using lookup with ignoring if target not found as we are creating tuple for tables in datafile descriptor which are tables exported
+		tuple, err := namereg.NameReg.LookupTableNameAndIgnoreIfTargetNotFoundBasedOnRole(tableName)
+		if err != nil {
+			return nil, goerrors.Errorf("failed to lookup table name: %w", err)
+		}
+		tableTupleToexportedColumns.Put(tuple, columnList)
+	}
+
+	result := utils.NewStructMap[sqlname.NameTuple, []string]()
+	// checking columns for all tables in the datafile descriptor by using the file tasks
+	//as this is used only for import batch which is snapshot
+	for _, task := range tasks {
+		columnList, ok := tableTupleToexportedColumns.Get(task.TableNameTup)
+		if ok {
+			result.Put(task.TableNameTup, columnList)
+		} else {
+			return nil, goerrors.Errorf("table %q not found in data file descriptor", task.TableNameTup.ForKey())
+		}
+	}
+	return result, nil
+}
+
+// createInitialImportDataTableMetrics sets table-scope metrics (totals, expected
+// rows, pre-registered per-table series) from allTasks so they stay accurate on
+// resume, when pendingTasks alone would under-report tables already completed in
+// a prior run. The control-plane event list is still built from pendingTasks only
+// (unchanged behaviour: the control plane only expects updates for tables being
+// worked on in this run).
+func (imp *Importer) createInitialImportDataTableMetrics(allTasks, pendingTasks []*ImportFileTask) []*cp.UpdateImportedRowCountEvent {
+	metrics.Get().SetImportSnapshotTablesTotal(imp.cfg.ImporterRole, len(allTasks))
+	for _, task := range allTasks {
+		metrics.Get().SetImportSnapshotTableExpectedRows(imp.cfg.ImporterRole, task.TableNameTup, task.RowCount)
+		metrics.Get().InitImportSnapshotTable(imp.cfg.ImporterRole, task.TableNameTup)
+	}
+
+	result := []*cp.UpdateImportedRowCountEvent{}
+	for _, task := range pendingTasks {
+		schemaName, tableName := task.TableNameTup.ForKeyTableSchema()
+		tableMetrics := cp.UpdateImportedRowCountEvent{
+			BaseUpdateRowCountEvent: cp.BaseUpdateRowCountEvent{
+				BaseEvent: cp.BaseEvent{
+					EventType:     "IMPORT DATA",
+					MigrationUUID: imp.cfg.MigrationUUID,
+					SchemaNames:   []string{schemaName},
+				},
+				TableName:         tableName,
+				Status:            cp.EXPORT_OR_IMPORT_DATA_STATUS_INT_TO_STR[constants.ROW_UPDATE_STATUS_NOT_STARTED],
+				TotalRowCount:     GetTotalProgressAmount(task, imp.cfg.ReportProgressInBytes),
+				CompletedRowCount: 0,
+			},
+		}
+		result = append(result, &tableMetrics)
+	}
+
+	return result
+}
+
+func (imp *Importer) clearMigrationStateForImportDataStartClean(state *ImportDataState, importFileTasks []*ImportFileTask, errorHandler ImportDataErrorHandler) error {
+	if !imp.cfg.StartClean {
+		log.Infof("skipping cleaning migration status record for import data command start clean")
+		return nil
+	}
+
+	if imp.cfg.ImportType == utils.CHANGES_ONLY {
+		utils.ErrExit("start-clean flag is not supported for changes-only import type")
+	}
+
+	msr, err := imp.cfg.MetaDB.GetMigrationStatusRecord()
+	if err != nil {
+		return goerrors.Errorf("failed to get migration status record: %w", err)
+	}
+
+	if msr == nil {
+		return goerrors.Errorf("migration status record not found.")
+	}
+
+	// Guardrail: for change-streaming imports, start-clean resets the per-importer
+	// imported_by flags and re-streams the queue from the earliest segment. If that
+	// segment has already been archived/deleted by `archive changes`, the queue can
+	// no longer be re-streamed from the beginning. Detect this and fail before
+	// mutating any metaDB state.
+	if changeStreamingIsEnabled(imp.cfg.ImportType) {
+		resumeSegmentDeleted, err := imp.cfg.MetaDB.AnySegmentsDeletedOrArchived()
+		if err != nil {
+			return goerrors.Errorf("failed to check for archived/deleted queue segments: %w", err)
+		}
+		if resumeSegmentDeleted {
+			return goerrors.Errorf("cannot perform import data with --start-clean: some queue segments have already been archived/deleted by 'archive changes'. The change-event queue can no longer be re-streamed from the beginning, so a clean restart is not possible.")
+		}
+	}
+
+	err = imp.cfg.MetaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+		record.OnPrimaryKeyConflictAction = ""
+	})
+	if err != nil {
+		return goerrors.Errorf("failed to update migration status record: %w", err)
+	}
+	err = imp.cfg.MetaDB.UpdateImportDataStatusRecord(func(record *metadb.ImportDataStatusRecord) {
+		record.TableToCDCPartitionKey = nil
+	})
+	if err != nil {
+		return goerrors.Errorf("failed to update import data status record: %w", err)
+	}
+
+	err = imp.handleStartCleanForSnapshot(state, importFileTasks, errorHandler)
+	if err != nil {
+		utils.ErrExit("Failed to handle fresh start: %w", err)
+	}
+
+	if changeStreamingIsEnabled(imp.cfg.ImportType) {
+		// clearing state from metaDB based on importerRole
+		err := imp.cfg.MetaDB.ResetQueueSegmentMeta(imp.cfg.ImporterRole)
+		if err != nil {
+			utils.ErrExit("failed to reset queue segment meta: %w", err)
+		}
+		err = imp.cfg.MetaDB.DeleteJsonObject(imp.cfg.IdentityColumnsMetaDBKey)
+		if err != nil {
+			utils.ErrExit("failed to reset identity columns meta: %w", err)
+		}
+	}
+	return nil
+}
+
+func cleanStoredErrors(errorHandler ImportDataErrorHandler, tasks []*ImportFileTask) error {
+	// clean stored errors for all tasks
+	for _, task := range tasks {
+		err := errorHandler.CleanUpStoredErrors(task.TableNameTup, task.FilePath)
+		if err != nil {
+			return fmt.Errorf("failed to clean up stored errors for task %s: %w", task.TableNameTup.ForOutput(), err)
+		}
+	}
+	return nil
+}
+
+func isTargetDBImporter(importerRole string) bool {
+	return importerRole == constants.TARGET_DB_IMPORTER_ROLE || importerRole == constants.IMPORT_FILE_ROLE
+}
+
+func (imp *Importer) updateErrorPolicyInMetaDB(errorPolicy ErrorPolicy) error {
+
+	switch imp.cfg.ImporterRole {
+	case constants.IMPORT_FILE_ROLE:
+		err := imp.cfg.MetaDB.UpdateImportDataFileStatusRecord(func(record *metadb.ImportDataFileStatusRecord) {
+			record.ErrorPolicy = errorPolicy.String()
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update error policy in import data file status record: %w", err)
+		}
+	case constants.TARGET_DB_IMPORTER_ROLE:
+		err := imp.cfg.MetaDB.UpdateImportDataStatusRecord(func(record *metadb.ImportDataStatusRecord) {
+			record.ErrorPolicySnapshot = errorPolicy.String()
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update error policy in import data status record: %w", err)
+		}
+		// Not applicable for other roles
+	}
+	return nil
+}
+
+func (imp *Importer) updateImportDataStartedAndSomeConfigsInMetaDB() error {
+	switch imp.cfg.ImporterRole {
+	case constants.TARGET_DB_IMPORTER_ROLE:
+		log.Infof("updating import data started in meta db with cdc-partition-key: %s, overrides: %q", imp.cfg.CdcPartitionKey, imp.cfg.CdcPartitionKeyOverrides)
+		err := imp.cfg.MetaDB.UpdateImportDataStatusRecord(func(record *metadb.ImportDataStatusRecord) {
+			record.ImportDataStarted = true
+			record.CdcPartitioningStrategyConfig = imp.cfg.CdcPartitionKey
+			record.CdcPartitionKeyOverridesConfig = imp.cfg.CdcPartitionKeyOverrides
+		})
+		if err != nil {
+			return goerrors.Errorf("Failed to update import data status record: %w", err)
+		}
+		err = imp.cfg.MetaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+			record.ImportDataToTargetStarted = true
+		})
+		if err != nil {
+			return goerrors.Errorf("failed to update migration status record: %w", err)
+		}
+
+	case constants.IMPORT_FILE_ROLE:
+		err := imp.cfg.MetaDB.UpdateImportDataFileStatusRecord(func(record *metadb.ImportDataFileStatusRecord) {
+			record.ImportDataStarted = true
+		})
+		if err != nil {
+			return goerrors.Errorf("Failed to update import data file status record: %w", err)
+		}
+	case constants.SOURCE_DB_IMPORTER_ROLE:
+		err := imp.cfg.MetaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+			record.ImportDataToSourceStarted = true
+		})
+		if err != nil {
+			return goerrors.Errorf("failed to update migration status record: %w", err)
+		}
+	}
+	return nil
+}
+
+func ImportSnapshotRequired(importerRole string, importType string) bool {
+	switch importerRole {
+	case constants.SOURCE_REPLICA_DB_IMPORTER_ROLE:
+		return true
+	case constants.IMPORT_FILE_ROLE:
+		return true
+	case constants.SOURCE_DB_IMPORTER_ROLE:
+		return false
+	case constants.TARGET_DB_IMPORTER_ROLE:
+		return importType == utils.SNAPSHOT_ONLY || importType == utils.SNAPSHOT_AND_CHANGES
+	default:
+		panic(fmt.Sprintf("invalid importer role: %s", importerRole))
+	}
+}
+
+// RowCountPair holds imported and errored row counts for a table.
+type RowCountPair struct {
+	Imported int64
+	Errored  int64
+}
+
+// DisplayImportedRowCountSnapshot prints the snapshot import report. stateCfg carries the
+// role, export dir, target conf and data-file descriptor it used to read from cmd globals.
+func DisplayImportedRowCountSnapshot(stateCfg ImportDataStateConfig, state *ImportDataState, tasks []*ImportFileTask, errorHandler ImportDataErrorHandler) {
+	importerRole := stateCfg.ImporterRole
+	if importerRole == constants.IMPORT_FILE_ROLE {
+		fmt.Printf("import report\n")
+	} else {
+		fmt.Printf("snapshot import report\n")
+	}
+	tableList := ImportFileTasksToTableNameTuples(tasks)
+	uitable := uitable.New()
+
+	// TODO: refactor this; we don't need to pass the dbType as a parameter,
+	// we can just pass the importerRole directly.
+	var dbType string
+	switch importerRole {
+	case constants.IMPORT_FILE_ROLE:
+		dbType = "target-file"
+	case constants.SOURCE_REPLICA_DB_IMPORTER_ROLE:
+		dbType = "source-replica"
+	case constants.TARGET_DB_IMPORTER_ROLE:
+		dbType = "target"
+	}
+
+	snapshotRowCount, err := GetImportedSnapshotRowsMap(dbType, tableList, errorHandler, stateCfg)
+	if err != nil {
+		utils.ErrExit("failed to get imported snapshot rows map: %w", err)
+	}
+
+	keys := make([]sqlname.NameTuple, 0, len(snapshotRowCount.Keys()))
+	// the callback never returns an error
+	_ = snapshotRowCount.IterKV(func(k sqlname.NameTuple, v RowCountPair) (bool, error) {
+		keys = append(keys, k)
+		return true, nil
+	})
+
+	sort.Slice(keys, func(i, j int) bool {
+		val1, _ := snapshotRowCount.Get(keys[i])
+		val2, _ := snapshotRowCount.Get(keys[j])
+		return val1.Imported > val2.Imported
+	})
+
+	hasErrors := false
+	for _, tableName := range keys {
+		rowCountPair, _ := snapshotRowCount.Get(tableName)
+		if rowCountPair.Errored > 0 {
+			hasErrors = true
+			break
+		}
+	}
+
+	for i, tableName := range keys {
+		if i == 0 {
+			if hasErrors {
+				addHeader(uitable, "SCHEMA", "TABLE", "IMPORTED ROW COUNT", "ERRORED ROW COUNT")
+			} else {
+				addHeader(uitable, "SCHEMA", "TABLE", "IMPORTED ROW COUNT")
+			}
+		}
+		s, t := tableName.ForCatalogQuery()
+		rowCountPair, _ := snapshotRowCount.Get(tableName)
+		if hasErrors {
+			uitable.AddRow(s, t, rowCountPair.Imported, rowCountPair.Errored)
+		} else {
+			uitable.AddRow(s, t, rowCountPair.Imported)
+		}
+	}
+	if len(tableList) > 0 {
+		fmt.Printf("\n")
+		fmt.Println(uitable)
+		fmt.Printf("\n")
+	}
+	if hasErrors {
+		// in case there are errored rows, and we are in on-pk-conflict ignore mode,
+		// it is possible that the batches which errored out were partially ingested.
+		if stateCfg.Tconf.OnPrimaryKeyConflictAction == constants.PRIMARY_KEY_CONFLICT_ACTION_IGNORE {
+			utils.PrintAndLog(color.YellowString("Note: It is possible that the table row count on the target DB may not match the IMPORTED ROW COUNT as some batches may have been partially ingested."))
+		}
+		utils.PrintAndLog(color.RedString("Errored snapshot rows are stashed in %q", errorHandler.GetErrorsLocation()))
+	}
+}
+
+// GetImportedSnapshotRowsMap returns imported/errored snapshot row counts per table for the
+// importer identified by dbType ("target", "target-file", "source-replica"). stateCfg supplies
+// the export dir, target conf and data-file descriptor; its ImporterRole is overridden by
+// dbType exactly as the cmd package-level importerRole used to be.
+func GetImportedSnapshotRowsMap(dbType string, tableList []sqlname.NameTuple, errorHandler ImportDataErrorHandler, stateCfg ImportDataStateConfig) (*utils.StructMap[sqlname.NameTuple, RowCountPair], error) {
+
+	var err error
+	cfg := stateCfg
+	switch dbType {
+	case "target":
+		cfg.ImporterRole = constants.TARGET_DB_IMPORTER_ROLE
+	case "target-file":
+		cfg.ImporterRole = constants.IMPORT_FILE_ROLE
+	case "source-replica":
+		cfg.ImporterRole = constants.SOURCE_REPLICA_DB_IMPORTER_ROLE
+	}
+	importerRole := cfg.ImporterRole
+	exportDir := cfg.ExportDir
+	dataFileDescriptor := cfg.DataFileDescriptor
+	state := NewImportDataState(cfg)
+	var snapshotDataFileDescriptor *datafile.Descriptor
+
+	if dataFileDescriptor != nil {
+		// in case of import-data and import-data-file, import-data-to-source-replica,
+		// the data file descriptor is already loaded in memory
+		snapshotDataFileDescriptor = dataFileDescriptor
+	} else {
+		// get data-migration-report use-case where
+		// we need to read the data file descriptor from export-dir
+		dataFileDescriptorPath := filepath.Join(exportDir, datafile.DESCRIPTOR_PATH)
+		if utils.FileOrFolderExists(dataFileDescriptorPath) {
+			snapshotDataFileDescriptor = datafile.OpenDescriptor(exportDir)
+		}
+	}
+	snapshotRowsMap := utils.NewStructMap[sqlname.NameTuple, RowCountPair]()
+	nameTupleTodataFileEntry := utils.NewStructMap[sqlname.NameTuple, []*datafile.FileEntry]()
+	nameTupleTodataFilesMap := utils.NewStructMap[sqlname.NameTuple, []string]()
+	if snapshotDataFileDescriptor != nil {
+		for _, fileEntry := range snapshotDataFileDescriptor.DataFileList {
+			//ignoring target as the dataFileDescriptor can contain tables that exported but not present in target
+			nt, err := namereg.NameReg.LookupTableNameAndIgnoreIfTargetNotFoundBasedOnRole(fileEntry.TableName)
+			if err != nil {
+				return nil, goerrors.Errorf("lookup table name from data file descriptor %s : %w", fileEntry.TableName, err)
+			}
+			fileEntries, ok := nameTupleTodataFileEntry.Get(nt)
+			if !ok {
+				fileEntries = []*datafile.FileEntry{}
+			}
+			fileEntries = append(fileEntries, fileEntry)
+			nameTupleTodataFileEntry.Put(nt, fileEntries)
+		}
+		for _, table := range tableList {
+			fileEntries, ok := nameTupleTodataFileEntry.Get(table)
+			if !ok {
+				//We can't error out here as this is possible in case there are empty tables in live migraton scenario and
+				//In get data-migration-report, table list can consist that table name but it won't be present in dataFileDescriptor
+				log.Warnf("table %s not found in data file descriptor", table.ForKey())
+				continue
+			}
+			list := lo.Map(fileEntries, func(fileEntry *datafile.FileEntry, _ int) string {
+				return fileEntry.FilePath
+			})
+			nameTupleTodataFilesMap.Put(table, list)
+		}
+	}
+
+	err = nameTupleTodataFilesMap.IterKV(func(nt sqlname.NameTuple, dataFilePaths []string) (bool, error) {
+		for _, dataFilePath := range dataFilePaths {
+			importedRowCount, err := state.GetImportedRowCount(dataFilePath, nt)
+			if err != nil {
+				return false, fmt.Errorf("could not fetch imported row count for table %q: %w", nt, err)
+			}
+			erroredRowCount, err := state.GetErroredRowCount(dataFilePath, nt)
+			if err != nil {
+				return false, fmt.Errorf("could not fetch errored row count for table %q: %w", nt, err)
+			}
+			existingRowCountPair, _ := snapshotRowsMap.Get(nt)
+			existingRowCountPair.Imported += importedRowCount
+			existingRowCountPair.Errored += erroredRowCount
+
+			if isTargetDBImporter(importerRole) && errorHandler != nil {
+				// error handler will be nil if import-data/import-data-file was not run yet
+				processingErrorRowCount, _, err := errorHandler.GetProcessingErrorCountSize(nt, dataFilePath)
+				if err != nil {
+					return false, fmt.Errorf("get processing error count size: %w", err)
+				}
+				existingRowCountPair.Errored += processingErrorRowCount
+			}
+			snapshotRowsMap.Put(nt, existingRowCountPair)
+
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, goerrors.Errorf("error getting row count of tables: %w", err)
+	}
+	return snapshotRowsMap, nil
+}
+
+// addHeader mirrors cmd's uitable header helper of the same name.
+func addHeader(table *uitable.Table, cols ...string) {
+	headerfmt := color.New(color.FgGreen, color.Underline).SprintFunc()
+	columns := lo.Map(cols, func(col string, _ int) interface{} {
+		return headerfmt(col)
+	})
+	table.AddRow(columns...)
+}

--- a/yb-voyager/src/importdata/importDataTestUtils.go
+++ b/yb-voyager/src/importdata/importDataTestUtils.go
@@ -1,4 +1,4 @@
-//go:build unit || integration
+//go:build unit || integration || cdc_benchmark
 
 /*
 Copyright (c) YugabyteDB, Inc.
@@ -55,6 +55,20 @@ var (
 	testImporterCfg FileTaskImporterConfig
 )
 
+// testImporter stands in for the cmd package-level variables the streaming and
+// cdc-partition-key tests used to set directly (importerRole, tdb, cdcPartitionKey,
+// ...). Like those globals it lives for the whole test binary; tests set what they
+// need and restore it in cleanups, as before.
+var testImporter = NewImporter(Config{})
+
+// setTestCdcPartitionKeyOverrides sets the raw --cdc-partition-key-overrides value
+// together with its parsed form (in production cmd parses the flag once and passes
+// both in Config).
+func setTestCdcPartitionKeyOverrides(raw string, parsed map[string]CdcPartitionKeyOverride) {
+	testImporter.cfg.CdcPartitionKeyOverrides = raw
+	testImporter.cfg.CdcPartitionKeyOverridesParsed = parsed
+}
+
 func testDataFileDescriptor(lexportDir string) *datafile.Descriptor {
 	return &datafile.Descriptor{
 		FileFormat: "csv",
@@ -70,7 +84,7 @@ func testDataFileDescriptor(lexportDir string) *datafile.Descriptor {
 // initTestMetaDB creates the export-dir skeleton and metadata DB the way cmd's
 // CreateMigrationProjectIfNotExists + initMetaDB do for these tests (minus the
 // schema object dirs and the anonymizer, which no component here reads).
-func initTestMetaDB(exportDir string) error {
+func initTestMetaDB(exportDir string) (*metadb.MetaDB, error) {
 	for _, subdir := range []string{
 		"schema", "data", "reports",
 		"assessment", "assessment/metadata", "assessment/dbs", "assessment/metadata/schema", "assessment/reports",
@@ -78,26 +92,26 @@ func initTestMetaDB(exportDir string) error {
 		"temp", "temp/ora2pg_temp_dir", "temp/schema",
 	} {
 		if err := os.MkdirAll(filepath.Join(exportDir, subdir), 0755); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	if err := metadb.CreateAndInitMetaDBIfRequired(exportDir); err != nil {
-		return err
+		return nil, err
 	}
 	m, err := metadb.NewMetaDB(exportDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := m.InitMigrationStatusRecord(""); err != nil {
-		return err
+		return nil, err
 	}
 	if err := m.InitImportDataStatusRecord(); err != nil {
-		return err
+		return nil, err
 	}
 	if err := m.InitImportDataFileStatusRecord(); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return m, nil
 }
 
 func setupExportDirAndImportDependencies(batchSizeRows int64, batchSizeBytes int64) (string, string, *ImportDataState, ImportDataErrorHandler, *ImportDataProgressReporter, error) {
@@ -111,7 +125,7 @@ func setupExportDirAndImportDependencies(batchSizeRows int64, batchSizeBytes int
 		return "", "", nil, nil, nil, err
 	}
 
-	err = initTestMetaDB(lexportDir)
+	_, err = initTestMetaDB(lexportDir)
 	if err != nil {
 		return "", "", nil, nil, nil, err
 	}

--- a/yb-voyager/src/importdata/importData_metrics_test.go
+++ b/yb-voyager/src/importdata/importData_metrics_test.go
@@ -3,12 +3,12 @@
 package importdata
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metrics"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/utils/sqlname"
 )
@@ -24,16 +24,10 @@ func TestCreateInitialImportDataTableMetrics_SetsTotalRows(t *testing.T) {
 	defer metrics.SetRecorder(prev)
 	metrics.SetRecorder(rec)
 
-	prevRole := importerRole
-	defer func() { importerRole = prevRole }()
-	importerRole = TARGET_DB_IMPORTER_ROLE
-
-	prevReportInBytes := reportProgressInBytes
-	defer func() { reportProgressInBytes = prevReportInBytes }()
-	reportProgressInBytes = false
+	imp := &Importer{cfg: Config{ImporterRole: constants.TARGET_DB_IMPORTER_ROLE, ReportProgressInBytes: false}}
 
 	tup := newImportMetricsTestTuple("public", "orders")
-	tasks := []*importdata.ImportFileTask{
+	tasks := []*ImportFileTask{
 		{
 			ID:           1,
 			FilePath:     "orders_data.sql",
@@ -43,9 +37,46 @@ func TestCreateInitialImportDataTableMetrics_SetsTotalRows(t *testing.T) {
 		},
 	}
 
-	createInitialImportDataTableMetrics(tasks, tasks)
+	imp.createInitialImportDataTableMetrics(tasks, tasks)
 
 	assert.Equal(t, int64(1000), rec.ImportTableExpectedRows["public.orders"])
-	assert.Equal(t, int64(1), rec.ImportSnapshotTablesTotal[TARGET_DB_IMPORTER_ROLE])
+	assert.Equal(t, int64(1), rec.ImportSnapshotTablesTotal[constants.TARGET_DB_IMPORTER_ROLE])
 	assert.Equal(t, 1, rec.ImportSnapshotTableInit["public.orders"])
+}
+
+func makeTasksForTest(n int) []*ImportFileTask {
+	tasks := make([]*ImportFileTask, n)
+	for i := 0; i < n; i++ {
+		obj := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", fmt.Sprintf("table_%d", i))
+		tup := sqlname.NameTuple{CurrentName: obj, SourceName: obj, TargetName: obj}
+		tasks[i] = &ImportFileTask{
+			ID:           i,
+			FilePath:     fmt.Sprintf("/tmp/table_%d.sql", i),
+			TableNameTup: tup,
+			RowCount:     100,
+		}
+	}
+	return tasks
+}
+
+// TestInitialImportMetricsUsesAllTasks guards against createInitialImportDataTableMetrics
+// under-reporting yb_voyager_import_data_snapshot_tables_total on resume, when only the
+// not-yet-imported (pending) tasks would otherwise be counted instead of all tasks.
+
+func TestInitialImportMetricsUsesAllTasks(t *testing.T) {
+	imp := &Importer{cfg: Config{ImporterRole: constants.TARGET_DB_IMPORTER_ROLE}}
+
+	prev := metrics.Get()
+	rec := metrics.NewRecordingRecorder()
+	metrics.SetRecorder(rec)
+	defer metrics.SetRecorder(prev)
+
+	all := makeTasksForTest(3)
+	pending := all[2:] // 2 tables already completed in a prior run, 1 pending
+
+	result := imp.createInitialImportDataTableMetrics(all, pending)
+
+	assert.Equal(t, int64(3), rec.ImportSnapshotTablesTotal[constants.TARGET_DB_IMPORTER_ROLE])
+	assert.Len(t, rec.ImportSnapshotTableInit, 3)
+	assert.Len(t, result, 1, "control-plane event list must still cover pending tasks only")
 }

--- a/yb-voyager/src/importdata/importData_metrics_test.go
+++ b/yb-voyager/src/importdata/importData_metrics_test.go
@@ -1,6 +1,6 @@
 //go:build unit
 
-package cmd
+package importdata
 
 import (
 	"testing"

--- a/yb-voyager/src/importdata/live_migration.go
+++ b/yb-voyager/src/importdata/live_migration.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"context"

--- a/yb-voyager/src/importdata/live_migration.go
+++ b/yb-voyager/src/importdata/live_migration.go
@@ -33,8 +33,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/callhome"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/dbzm"
-	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	reporter "github.com/yugabyte/yb-voyager/yb-voyager/src/reporter/stats"
@@ -74,8 +74,6 @@ var MAX_EVENTS_PER_BATCH int
 var MAX_INTERVAL_BETWEEN_BATCHES int //ms
 var END_OF_QUEUE_SEGMENT_EVENT = &tgtdb.Event{Op: "end_of_source_queue_segment"}
 var FLUSH_BATCH_EVENT = &tgtdb.Event{Op: "flush_batch"}
-var eventQueue *EventQueue
-var statsReporter *reporter.StreamImportStatsReporter
 
 const (
 	PARTITION_BY_PK     = "pk"
@@ -92,34 +90,34 @@ func init() {
 	MAX_INTERVAL_BETWEEN_BATCHES = utils.GetEnvAsInt("MAX_INTERVAL_BETWEEN_BATCHES", 2000)
 }
 
-func cutoverInitiatedAndCutoverEventProcessed() (bool, error) {
-	msr, err := metaDB.GetMigrationStatusRecord()
+func (imp *Importer) cutoverInitiatedAndCutoverEventProcessed() (bool, error) {
+	msr, err := imp.cfg.MetaDB.GetMigrationStatusRecord()
 	if err != nil {
 		return false, goerrors.Errorf("getting migration status record: %w", err)
 	}
-	switch importerRole {
-	case TARGET_DB_IMPORTER_ROLE:
+	switch imp.cfg.ImporterRole {
+	case constants.TARGET_DB_IMPORTER_ROLE:
 		return msr.CutoverToTargetRequested && msr.CutoverDetectedByTargetImporter, nil
-	case SOURCE_REPLICA_DB_IMPORTER_ROLE:
+	case constants.SOURCE_REPLICA_DB_IMPORTER_ROLE:
 		return msr.CutoverToSourceReplicaRequested && msr.CutoverDetectedBySourceReplicaImporter, nil
-	case SOURCE_DB_IMPORTER_ROLE:
+	case constants.SOURCE_DB_IMPORTER_ROLE:
 		return msr.CutoverToSourceRequested && msr.CutoverDetectedBySourceImporter, nil
 	}
 
 	return false, nil
 }
 
-func streamChanges(state *importdata.ImportDataState, tableNames []sqlname.NameTuple, tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string], tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
-	if err := waitForDebeziumStartIfRequired(); err != nil {
+func (imp *Importer) streamChanges(state *ImportDataState, tableNames []sqlname.NameTuple, tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string], tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
+	if err := imp.waitForDebeziumStartIfRequired(); err != nil {
 		return fmt.Errorf("waiting for debezium to start: %w", err)
 	}
-	importPhase = dbzm.MODE_STREAMING
-	utils.PrintAndLogfInfo("streaming changes to %s...", tconf.TargetDBType)
-	streamingPhaseValueConverter, err := dbzm.NewStreamingPhaseDebeziumValueConverter(tableNames, exportDir, tconf, importerRole, sourceDBType)
+	imp.importPhase = dbzm.MODE_STREAMING
+	utils.PrintAndLogfInfo("streaming changes to %s...", imp.cfg.Tconf.TargetDBType)
+	streamingPhaseValueConverter, err := dbzm.NewStreamingPhaseDebeziumValueConverter(tableNames, imp.cfg.ExportDir, imp.cfg.Tconf, imp.cfg.ImporterRole, imp.cfg.SourceDBType)
 	if err != nil {
 		return goerrors.Errorf("Failed to create streaming phase value converter: %w", err)
 	}
-	ok, err := cutoverInitiatedAndCutoverEventProcessed()
+	ok, err := imp.cutoverInitiatedAndCutoverEventProcessed()
 	if err != nil {
 		return err
 	}
@@ -134,36 +132,36 @@ func streamChanges(state *importdata.ImportDataState, tableNames []sqlname.NameT
 	if err != nil {
 		return goerrors.Errorf("init name registry again: %w", err)
 	}
-	tdb.PrepareForStreaming()
-	err = state.InitLiveMigrationState(migrationUUID, NUM_EVENT_CHANNELS, bool(startClean), tableNames)
+	imp.cfg.Tdb.PrepareForStreaming()
+	err = state.InitLiveMigrationState(imp.cfg.MigrationUUID, NUM_EVENT_CHANNELS, bool(imp.cfg.StartClean), tableNames)
 	if err != nil {
 		utils.ErrExit("Failed to init event channels metadata table on target DB: %w", err)
 	}
-	eventChannelsMetaInfo, err := state.GetEventChannelsMetaInfo(migrationUUID)
+	eventChannelsMetaInfo, err := state.GetEventChannelsMetaInfo(imp.cfg.MigrationUUID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch event channel meta info from target : %w", err)
 	}
-	numInserts, numUpdates, numDeletes, err := state.GetTotalNumOfEventsImportedByType(migrationUUID)
+	numInserts, numUpdates, numDeletes, err := state.GetTotalNumOfEventsImportedByType(imp.cfg.MigrationUUID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch import stats meta by type: %w", err)
 	}
-	statsReporter = reporter.NewStreamImportStatsReporter(importerRole)
-	err = statsReporter.Init(migrationUUID, metaDB, numInserts, numUpdates, numDeletes)
+	imp.statsReporter = reporter.NewStreamImportStatsReporter(imp.cfg.ImporterRole)
+	err = imp.statsReporter.Init(imp.cfg.MigrationUUID, imp.cfg.MetaDB, numInserts, numUpdates, numDeletes)
 	if err != nil {
 		return fmt.Errorf("failed to initialize stats reporter: %w", err)
 	}
 
-	tablePartitionKeyMap, err := getCdcPartitioningStrategyPerTable(tableNames)
+	tablePartitionKeyMap, err := imp.getCdcPartitioningStrategyPerTable(tableNames)
 	if err != nil {
 		return fmt.Errorf("error handling cdc partitioning strategy: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go statsReporter.ReportStats(ctx, !bool(disablePb))
-	defer statsReporter.Finalize()
+	go imp.statsReporter.ReportStats(ctx, !bool(imp.cfg.DisablePb))
+	defer imp.statsReporter.Finalize()
 
-	eventQueue = NewEventQueue(exportDir)
+	imp.eventQueue = NewEventQueue(EventQueueConfig{ExportDir: imp.cfg.ExportDir, ImporterRole: imp.cfg.ImporterRole, MetaDB: imp.cfg.MetaDB})
 	// setup target event channels
 	var evChans []chan *tgtdb.Event
 	var processingDoneChans []chan bool
@@ -172,9 +170,9 @@ func streamChanges(state *importdata.ImportDataState, tableNames []sqlname.NameT
 		processingDoneChans = append(processingDoneChans, make(chan bool, 1))
 	}
 
-	log.Infof("streaming changes from %s", eventQueue.QueueDirPath)
-	for !eventQueue.EndOfQueue { // continuously get next segments to stream
-		segment, err := eventQueue.GetNextSegment()
+	log.Infof("streaming changes from %s", imp.eventQueue.QueueDirPath)
+	for !imp.eventQueue.EndOfQueue { // continuously get next segments to stream
+		segment, err := imp.eventQueue.GetNextSegment()
 		if err != nil {
 			if segment == nil && (errors.Is(err, os.ErrNotExist) || errors.Is(err, sql.ErrNoRows)) {
 				time.Sleep(2 * time.Second)
@@ -184,7 +182,7 @@ func streamChanges(state *importdata.ImportDataState, tableNames []sqlname.NameT
 		}
 		log.Infof("got next segment to stream: %v", segment)
 
-		err = streamChangesFromSegment(segment, evChans, processingDoneChans, eventChannelsMetaInfo, statsReporter, state, streamingPhaseValueConverter, tablePartitionKeyMap, tableToPKColumns, tableNames, tableToUniqueIndexes)
+		err = imp.streamChangesFromSegment(segment, evChans, processingDoneChans, eventChannelsMetaInfo, imp.statsReporter, state, streamingPhaseValueConverter, tablePartitionKeyMap, tableToPKColumns, tableNames, tableToUniqueIndexes)
 		if err != nil {
 			return goerrors.Errorf("error streaming changes for segment %s: %w", segment.FilePath, err)
 		}
@@ -192,18 +190,15 @@ func streamChanges(state *importdata.ImportDataState, tableNames []sqlname.NameT
 	return nil
 }
 
-// used to determine if cache reinitialization is needed
-var prevExporterRole = ""
-
-func streamChangesFromSegment(
+func (imp *Importer) streamChangesFromSegment(
 	segment *EventQueueSegment,
 	evChans []chan *tgtdb.Event,
 	processingDoneChans []chan bool,
-	eventChannelsMetaInfo map[int]importdata.EventChannelMetaInfo,
+	eventChannelsMetaInfo map[int]EventChannelMetaInfo,
 	statsReporter *reporter.StreamImportStatsReporter,
-	state *importdata.ImportDataState,
+	state *ImportDataState,
 	streamingPhaseValueConverter dbzm.StreamingPhaseValueConverter,
-	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride],
+	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride],
 	tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string],
 	importTableList []sqlname.NameTuple,
 	tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
@@ -223,7 +218,7 @@ func streamChangesFromSegment(
 		} else {
 			return goerrors.Errorf("unable to find channel meta info for channel - %v", i)
 		}
-		go processEvents(i, evChans[i], chanLastAppliedVsn, processingDoneChans[i], statsReporter, state)
+		go imp.processEvents(i, evChans[i], chanLastAppliedVsn, processingDoneChans[i], statsReporter, state)
 	}
 
 	log.Infof("streaming changes for segment %s", segment.FilePath)
@@ -238,33 +233,33 @@ func streamChangesFromSegment(
 		}
 
 		// segment switch and cutover(for example: source changed from PG to YB)
-		if event != nil && prevExporterRole != event.ExporterRole {
+		if event != nil && imp.prevExporterRole != event.ExporterRole {
 			/*
 				Note: `sourceDBType` is a global variable, which always represent the initial source db type
 				which does not change even after cutover to target but for conflict detection cache,
 				we need to use the actual source db type at the moment.
 			*/
-			sourceDBTypeForConflictCache := lo.Ternary(isTargetDBExporter(event.ExporterRole), YUGABYTEDB, sourceDBType)
-			err = initializeConflictDetectionCache(evChans, sourceDBTypeForConflictCache, importTableList, tablePartitionKeyMap, tableToPKColumns, tableToUniqueIndexes)
+			sourceDBTypeForConflictCache := lo.Ternary(isTargetDBExporter(event.ExporterRole), constants.YUGABYTEDB, imp.cfg.SourceDBType)
+			err = imp.initializeConflictDetectionCache(evChans, sourceDBTypeForConflictCache, importTableList, tablePartitionKeyMap, tableToPKColumns, tableToUniqueIndexes)
 			if err != nil {
 				return goerrors.Errorf("error initializing conflict detection cache: %w", err)
 			}
-			prevExporterRole = event.ExporterRole
+			imp.prevExporterRole = event.ExporterRole
 		}
 
-		if event.IsCutoverToTarget() && importerRole == TARGET_DB_IMPORTER_ROLE ||
-			event.IsCutoverToSourceReplica() && importerRole == SOURCE_REPLICA_DB_IMPORTER_ROLE ||
-			event.IsCutoverToSource() && importerRole == SOURCE_DB_IMPORTER_ROLE { // cutover or fall-forward command
+		if event.IsCutoverToTarget() && imp.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE ||
+			event.IsCutoverToSourceReplica() && imp.cfg.ImporterRole == constants.SOURCE_REPLICA_DB_IMPORTER_ROLE ||
+			event.IsCutoverToSource() && imp.cfg.ImporterRole == constants.SOURCE_DB_IMPORTER_ROLE { // cutover or fall-forward command
 
-			err := metaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
-				switch importerRole {
-				case TARGET_DB_IMPORTER_ROLE:
+			err := imp.cfg.MetaDB.UpdateMigrationStatusRecord(func(record *metadb.MigrationStatusRecord) {
+				switch imp.cfg.ImporterRole {
+				case constants.TARGET_DB_IMPORTER_ROLE:
 					record.CutoverDetectedByTargetImporter = true
 					record.CutoverTimings.DetectedByTargetImporterAt = utils.GetCurrentTimestamp()
-				case SOURCE_REPLICA_DB_IMPORTER_ROLE:
+				case constants.SOURCE_REPLICA_DB_IMPORTER_ROLE:
 					record.CutoverDetectedBySourceReplicaImporter = true
 					record.CutoverTimings.DetectedBySourceReplicaImporterAt = utils.GetCurrentTimestamp()
-				case SOURCE_DB_IMPORTER_ROLE:
+				case constants.SOURCE_DB_IMPORTER_ROLE:
 					record.CutoverDetectedBySourceImporter = true
 					record.CutoverTimings.DetectedBySourceImporterAt = utils.GetCurrentTimestamp()
 				}
@@ -272,14 +267,14 @@ func streamChangesFromSegment(
 			if err != nil {
 				return goerrors.Errorf("error updating the migration status record for cutover detected case: %w", err)
 			}
-			updateCallhomeImportPhase(event)
+			imp.updateCallhomeImportPhase(event)
 
-			eventQueue.EndOfQueue = true
+			imp.eventQueue.EndOfQueue = true
 			segment.MarkProcessed()
 			break
 		}
 
-		err = handleEvent(event, evChans, streamingPhaseValueConverter, tablePartitionKeyMap)
+		err = imp.handleEvent(event, evChans, streamingPhaseValueConverter, tablePartitionKeyMap)
 		if err != nil {
 			return goerrors.Errorf("error handling event: %w", err)
 		}
@@ -293,7 +288,7 @@ func streamChangesFromSegment(
 		<-processingDoneChans[i]
 	}
 
-	err = metaDB.MarkEventQueueSegmentAsProcessed(segment.SegmentNum, importerRole)
+	err = imp.cfg.MetaDB.MarkEventQueueSegmentAsProcessed(segment.SegmentNum, imp.cfg.ImporterRole)
 	if err != nil {
 		return goerrors.Errorf("error marking segment %s as processed: %w", segment.FilePath, err)
 	}
@@ -301,32 +296,32 @@ func streamChangesFromSegment(
 	return nil
 }
 
-func updateCallhomeImportPhase(event *tgtdb.Event) {
+func (imp *Importer) updateCallhomeImportPhase(event *tgtdb.Event) {
 	if !callhome.SendDiagnostics {
 		return
 	}
 	switch true {
-	case event.IsCutoverToTarget() && importerRole == TARGET_DB_IMPORTER_ROLE:
-		importPhase = CUTOVER_TO_TARGET
-	case event.IsCutoverToSourceReplica() && importerRole == SOURCE_REPLICA_DB_IMPORTER_ROLE:
-		importPhase = CUTOVER_TO_SOURCE_REPLICA
-	case event.IsCutoverToSource() && importerRole == SOURCE_DB_IMPORTER_ROLE:
-		importPhase = CUTOVER_TO_SOURCE
+	case event.IsCutoverToTarget() && imp.cfg.ImporterRole == constants.TARGET_DB_IMPORTER_ROLE:
+		imp.importPhase = constants.CUTOVER_TO_TARGET
+	case event.IsCutoverToSourceReplica() && imp.cfg.ImporterRole == constants.SOURCE_REPLICA_DB_IMPORTER_ROLE:
+		imp.importPhase = constants.CUTOVER_TO_SOURCE_REPLICA
+	case event.IsCutoverToSource() && imp.cfg.ImporterRole == constants.SOURCE_DB_IMPORTER_ROLE:
+		imp.importPhase = constants.CUTOVER_TO_SOURCE
 	}
 
 }
 
-func shouldFormatValues(event *tgtdb.Event) bool {
-	switch tconf.TargetDBType {
-	case YUGABYTEDB, YUGABYTEDB_AMP, POSTGRESQL:
+func (imp *Importer) shouldFormatValues(event *tgtdb.Event) bool {
+	switch imp.cfg.Tconf.TargetDBType {
+	case constants.YUGABYTEDB, constants.YUGABYTEDB_AMP, constants.POSTGRESQL:
 		return event.Op == "u"
-	case ORACLE:
+	case constants.ORACLE:
 		return true
 	}
 	return false
 }
 
-func shouldHandleConflicts(event *tgtdb.Event, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex], tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) (bool, error) {
+func shouldHandleConflicts(event *tgtdb.Event, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex], tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]) (bool, error) {
 	if tableToUniqueIndexes == nil {
 		return false, goerrors.Errorf("table to unique indexes is not initialized")
 	}
@@ -348,10 +343,10 @@ func shouldHandleConflicts(event *tgtdb.Event, tableToUniqueIndexes *utils.Struc
 	return true, nil
 }
 
-func handleEvent(event *tgtdb.Event,
+func (imp *Importer) handleEvent(event *tgtdb.Event,
 	evChans []chan *tgtdb.Event,
 	streamingPhaseValueConverter dbzm.StreamingPhaseValueConverter,
-	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) error {
+	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]) error {
 	if event.IsCutoverEvent() {
 		// nil in case of cutover or fall_forward events for unconcerned importer
 		return nil
@@ -371,18 +366,18 @@ func handleEvent(event *tgtdb.Event,
 		Checking for all possible conflicts among events
 		For more details about ConflictDetectionCache see the related comment in [conflictDetectionCache.go](../conflictDetectionCache.go)
 	*/
-	ok, err := shouldHandleConflicts(event, conflictDetectionCache.tableToUniqueIndexes, tablePartitionKeyMap)
+	ok, err := shouldHandleConflicts(event, imp.conflictDetectionCache.tableToUniqueIndexes, tablePartitionKeyMap)
 	if err != nil {
 		return goerrors.Errorf("error checking if should handle conflicts: %w", err)
 	}
 	if ok {
 		if event.Op == "d" {
-			err = conflictDetectionCache.Put(event)
+			err = imp.conflictDetectionCache.Put(event)
 			if err != nil {
 				return goerrors.Errorf("error putting event into conflict detection cache: %w", err)
 			}
 		} else { // "i" or "u"
-			err = conflictDetectionCache.WaitUntilNoConflict(event)
+			err = imp.conflictDetectionCache.WaitUntilNoConflict(event)
 			if err != nil {
 				return goerrors.Errorf("error waiting for conflicts to clear for event vsn(%d): %w", event.Vsn, err)
 			}
@@ -390,7 +385,7 @@ func handleEvent(event *tgtdb.Event,
 				// Adding all the update events to the conflict detection cache since we need to check detect the conflicts in cases where
 				// unique key column is not changed in addition to unique key column is actually changed
 				// since the unique key is removed the index even if the column is actually changed because of partial predicate
-				err = conflictDetectionCache.Put(event)
+				err = imp.conflictDetectionCache.Put(event)
 				if err != nil {
 					return goerrors.Errorf("error putting event into conflict detection cache: %w", err)
 				}
@@ -399,12 +394,12 @@ func handleEvent(event *tgtdb.Event,
 	}
 
 	// preparing value converters for the streaming mode
-	err = streamingPhaseValueConverter.ConvertEvent(event, event.TableNameTup, shouldFormatValues(event))
+	err = streamingPhaseValueConverter.ConvertEvent(event, event.TableNameTup, imp.shouldFormatValues(event))
 	if err != nil {
 		return goerrors.Errorf("error transforming event key fields: %w", err)
 	}
 
-	if err := injectImportCDCTransformFailure(); err != nil {
+	if err := injectImportCDCTransformFailure(imp.cfg.ExportDir); err != nil {
 		return err
 	}
 
@@ -436,7 +431,7 @@ const customKeyNullSentinel = "\x00NULL\x00"
 // identical to the previous hashEvent implementation so channel assignment - which is
 // baked into per-channel resumption state - does not change across upgrades for existing
 // pk/table migrations.
-func GetEventPartitionKey(e *tgtdb.Event, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) (string, error) {
+func GetEventPartitionKey(e *tgtdb.Event, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]) (string, error) {
 	if tablePartitionKeyMap == nil {
 		return "", goerrors.Errorf("table partition key map is not initialized")
 	}
@@ -493,7 +488,7 @@ func GetEventPartitionKey(e *tgtdb.Event, tablePartitionKeyMap *utils.StructMap[
 }
 
 // Returns a hash value between 0..NUM_EVENT_CHANNELS
-func hashEvent(e *tgtdb.Event, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) (int, error) {
+func hashEvent(e *tgtdb.Event, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]) (int, error) {
 	partitionKey, err := GetEventPartitionKey(e, tablePartitionKeyMap)
 	if err != nil {
 		return 0, err
@@ -536,7 +531,7 @@ func customPartitionKeyColumnValue(e *tgtdb.Event, col string) (*string, bool, e
 	}
 	return nil, false, nil
 }
-func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, done chan bool, statsReporter *reporter.StreamImportStatsReporter, state *importdata.ImportDataState) {
+func (imp *Importer) processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, done chan bool, statsReporter *reporter.StreamImportStatsReporter, state *ImportDataState) {
 	endOfProcessing := false
 	for !endOfProcessing {
 		batch := []*tgtdb.Event{}
@@ -555,12 +550,12 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 				}
 				if event.Vsn <= lastAppliedVsn {
 					log.Tracef("ignoring event %v because event vsn <= %v", event, lastAppliedVsn)
-					conflictDetectionCache.RemoveEvents(event)
+					imp.conflictDetectionCache.RemoveEvents(event)
 					continue
 				}
-				if importerRole == SOURCE_DB_IMPORTER_ROLE && event.ExporterRole != TARGET_DB_EXPORTER_FB_ROLE {
+				if imp.cfg.ImporterRole == constants.SOURCE_DB_IMPORTER_ROLE && event.ExporterRole != constants.TARGET_DB_EXPORTER_FB_ROLE {
 					log.Tracef("ignoring event %v because importer role is FB_DB_IMPORTER_ROLE and event exporter role is not TARGET_DB_EXPORTER_FB_ROLE.", event)
-					conflictDetectionCache.RemoveEvents(event)
+					imp.conflictDetectionCache.RemoveEvents(event)
 					continue
 				}
 				batch = append(batch, event)
@@ -581,22 +576,22 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 		eventBatch := tgtdb.NewEventBatch(batch, chanNo)
 		var err error
 		sleepIntervalSec := 0
-		for attempt := 0; attempt < EVENT_BATCH_MAX_RETRY_COUNT; attempt++ {
-			err = tdb.ExecuteBatch(migrationUUID, eventBatch)
+		for attempt := 0; attempt < imp.cfg.EventBatchMaxRetryCount; attempt++ {
+			err = imp.cfg.Tdb.ExecuteBatch(imp.cfg.MigrationUUID, eventBatch)
 			if err == nil {
-				if fpErr := injectImportCDCNonRetryableBatchDBError(); fpErr != nil {
+				if fpErr := injectImportCDCNonRetryableBatchDBError(imp.cfg.ExportDir); fpErr != nil {
 					err = fpErr
 				}
 			}
 			if err == nil {
 				break
-			} else if tdb.IsNonRetryableCopyError(err) {
+			} else if imp.cfg.Tdb.IsNonRetryableCopyError(err) {
 				break
 			}
 			log.Warnf("retriable error executing batch(%s) on channel %v (last VSN: %d): %v", eventBatch.ID(), chanNo, eventBatch.GetLastVsn(), err)
 			sleepIntervalSec += 10
-			if sleepIntervalSec > importdata.MAX_SLEEP_SECOND {
-				sleepIntervalSec = importdata.MAX_SLEEP_SECOND
+			if sleepIntervalSec > MAX_SLEEP_SECOND {
+				sleepIntervalSec = MAX_SLEEP_SECOND
 			}
 			log.Infof("sleep for %d seconds before retrying the batch on channel %v (attempt %d)",
 				sleepIntervalSec, chanNo, attempt)
@@ -608,7 +603,7 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 			// - It can fail with some duplicate / unique key constraint errors
 			// - Stats will double count the events.
 			// Therefore, we check if batch has already been imported before retrying.
-			alreadyImported, aerr := checkifEventBatchAlreadyImported(state, eventBatch, migrationUUID)
+			alreadyImported, aerr := imp.checkifEventBatchAlreadyImported(state, eventBatch, imp.cfg.MigrationUUID)
 			if aerr != nil {
 				utils.ErrExit("error checking if event batch channel %d (last VSN: %d) already imported: %w", chanNo, eventBatch.GetLastVsn(), aerr)
 			}
@@ -621,7 +616,7 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 		if err != nil {
 			utils.ErrExit("error executing batch on channel %v: %w", chanNo, err)
 		}
-		conflictDetectionCache.RemoveEvents(eventBatch.Events...)
+		imp.conflictDetectionCache.RemoveEvents(eventBatch.Events...)
 		statsReporter.BatchImported(eventBatch.EventCounts.NumInserts, eventBatch.EventCounts.NumUpdates, eventBatch.EventCounts.NumDeletes)
 		log.Debugf("processEvents from channel %v: Executed Batch of size - %d successfully in time %s",
 			chanNo, len(batch), time.Since(start).String())
@@ -637,7 +632,7 @@ func processEvents(chanNo int, evChan chan *tgtdb.Event, lastAppliedVsn int64, d
 // Attribute name registry is not required here as for the PG->YB migrations the attribute name is same in both the places - event's fields coming from source and unique-index-column mapping coming from target and
 // And this path is only for PG->YB migrations as of now.
 // This path assumes that the column name remains same in PG->YB migrations.
-func initializeConflictDetectionCache(evChans []chan *tgtdb.Event, sourceDBTypeForConflictCache string, importTableList []sqlname.NameTuple, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string], tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
+func (imp *Importer) initializeConflictDetectionCache(evChans []chan *tgtdb.Event, sourceDBTypeForConflictCache string, importTableList []sqlname.NameTuple, tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string], tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
 
 	// For custom-key tables the primary key must join the unique indexes to be able to detect PK-recycle races.
 	// GetTableToUniqueIndexesMap deliberately excludes the primary key (filters out contype='p'): under default pk routing,
@@ -654,7 +649,7 @@ func initializeConflictDetectionCache(evChans []chan *tgtdb.Event, sourceDBTypeF
 	}
 
 	log.Infof("initializing conflict detection cache")
-	conflictDetectionCache = NewConflictDetectionCache(tableToUniqueIndexes, evChans, sourceDBTypeForConflictCache, tablePartitionKeyMap)
+	imp.conflictDetectionCache = NewConflictDetectionCache(tableToUniqueIndexes, evChans, sourceDBTypeForConflictCache, tablePartitionKeyMap, imp.cfg.ExportDir)
 	return nil
 }
 
@@ -667,7 +662,7 @@ func initializeConflictDetectionCache(evChans []chan *tgtdb.Event, sourceDBTypeF
 func addPrimaryKeyToConflictSetForCustomTables(
 	tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex],
 	importTableList []sqlname.NameTuple,
-	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride],
+	tablePartitionKeyMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride],
 	tableToPKColumns *utils.StructMap[sqlname.NameTuple, []string],
 ) error {
 	var customTables []sqlname.NameTuple
@@ -738,24 +733,35 @@ func uniqueIndexWithSameColumnsExists(indexes []tgtdb.UniqueIndex, columns []str
 	return false
 }
 
-func checkifEventBatchAlreadyImported(state *importdata.ImportDataState, eventBatch *tgtdb.EventBatch, migrationUUID uuid.UUID) (bool, error) {
+func (imp *Importer) checkifEventBatchAlreadyImported(state *ImportDataState, eventBatch *tgtdb.EventBatch, migrationUUID uuid.UUID) (bool, error) {
 	var res bool
 	var err error
 	sleepIntervalSec := 0
-	for attempt := 0; attempt < EVENT_BATCH_MAX_RETRY_COUNT; attempt++ {
+	for attempt := 0; attempt < imp.cfg.EventBatchMaxRetryCount; attempt++ {
 		res, err = state.IsEventBatchAlreadyImported(eventBatch, migrationUUID)
 		if err == nil {
 			break
-		} else if tdb.IsNonRetryableCopyError(err) {
+		} else if imp.cfg.Tdb.IsNonRetryableCopyError(err) {
 			break
 		}
 		sleepIntervalSec += 10
-		if sleepIntervalSec > importdata.MAX_SLEEP_SECOND {
-			sleepIntervalSec = importdata.MAX_SLEEP_SECOND
+		if sleepIntervalSec > MAX_SLEEP_SECOND {
+			sleepIntervalSec = MAX_SLEEP_SECOND
 		}
 		log.Infof("sleep for %d seconds before retrying to check if event batch (last vsn: %d) already imported (attempt %d)",
 			sleepIntervalSec, eventBatch.GetLastVsn(), attempt)
 		time.Sleep(time.Duration(sleepIntervalSec) * time.Second)
 	}
 	return res, err
+}
+
+// changeStreamingIsEnabled and isTargetDBExporter mirror the cmd helpers of the same
+// name (cmd/exportData.go, cmd/exportDataDebezium.go) so the engine does not depend on
+// cmd or on the export package.
+func changeStreamingIsEnabled(importType string) bool {
+	return importType == utils.CHANGES_ONLY || importType == utils.SNAPSHOT_AND_CHANGES
+}
+
+func isTargetDBExporter(exporterRole string) bool {
+	return exporterRole == constants.TARGET_DB_EXPORTER_FF_ROLE || exporterRole == constants.TARGET_DB_EXPORTER_FB_ROLE
 }

--- a/yb-voyager/src/importdata/live_migration_cdc_partition_strategy.go
+++ b/yb-voyager/src/importdata/live_migration_cdc_partition_strategy.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"fmt"

--- a/yb-voyager/src/importdata/live_migration_cdc_partition_strategy.go
+++ b/yb-voyager/src/importdata/live_migration_cdc_partition_strategy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/tgtdb"
@@ -40,12 +41,12 @@ auto/expr-UK/generated-stored-column rules), and persists TableToCDCPartitionKey
 It is intentionally called before snapshot import so bad configs fail fast.
 On resume (map already in metaDB) this is a no-op.
 */
-func prepareCdcPartitionKey(tableNames []sqlname.NameTuple, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
-	if importerRole != TARGET_DB_IMPORTER_ROLE || !changeStreamingIsEnabled(importType) || sourceDBType != POSTGRESQL {
+func (imp *Importer) prepareCdcPartitionKey(tableNames []sqlname.NameTuple, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
+	if imp.cfg.ImporterRole != constants.TARGET_DB_IMPORTER_ROLE || !changeStreamingIsEnabled(imp.cfg.ImportType) || imp.cfg.SourceDBType != constants.POSTGRESQL {
 		return nil
 	}
 
-	importDataStatus, err := metaDB.GetImportDataStatusRecord()
+	importDataStatus, err := imp.cfg.MetaDB.GetImportDataStatusRecord()
 	if err != nil {
 		return fmt.Errorf("error getting import data status record for cdc-partition-key: %w", err)
 	}
@@ -60,14 +61,14 @@ func prepareCdcPartitionKey(tableNames []sqlname.NameTuple, tableToUniqueIndexes
 		// captured on the first run so no target-DB re-query is needed — and reject if it
 		// differs from what was persisted. This catches semantically-different overrides
 		// that a plain string compare would miss (ordering, spelling/quoting, whitespace).
-		if err := validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, tableToUniqueIndexes); err != nil {
+		if err := imp.validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, tableToUniqueIndexes); err != nil {
 			return err
 		}
 		log.Infof("cdc partition key already prepared in metadb and unchanged; skipping recompute")
 		return nil
 	}
 
-	_, err = computeAndPersistCdcPartitioningStrategyPerTable(tableNames, importDataStatus, tableToUniqueIndexes)
+	_, err = imp.computeAndPersistCdcPartitioningStrategyPerTable(tableNames, importDataStatus, tableToUniqueIndexes)
 	return err
 }
 
@@ -79,18 +80,18 @@ Non-target and Oracle source paths force PARTITION_BY_TABLE in-memory (not persi
 
 TODO: handle upgrade scenario for PG/Oracle pk->table change
 */
-func getCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], error) {
-	tablePartitionKeyMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
+func (imp *Importer) getCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], error) {
+	tablePartitionKeyMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
 
-	if shouldForceTablePartitioning(importerRole, sourceDBType, tconf.TargetDBType) {
+	if shouldForceTablePartitioning(imp.cfg.ImporterRole, imp.cfg.SourceDBType, imp.cfg.Tconf.TargetDBType) {
 		//TODO: remove this and just handle this in auto resolveEffectiveCdcPartitionKeys
 		for _, t := range tableNames {
-			tablePartitionKeyMap.Put(t, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+			tablePartitionKeyMap.Put(t, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
 		}
 		return tablePartitionKeyMap, nil
 	}
 
-	importDataStatus, err := metaDB.GetImportDataStatusRecord()
+	importDataStatus, err := imp.cfg.MetaDB.GetImportDataStatusRecord()
 	if err != nil {
 		return nil, fmt.Errorf("error getting cdc partitioning strategy: %w", err)
 	}
@@ -107,7 +108,7 @@ func getCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple) (*utils.
 		if err != nil {
 			return nil, fmt.Errorf("error looking up table name: %w", err)
 		}
-		tablePartitionKeyMap.Put(tuple, cdcPartitionKeyOverride{Strategy: partitionKey.Strategy, Columns: partitionKey.Columns})
+		tablePartitionKeyMap.Put(tuple, CdcPartitionKeyOverride{Strategy: partitionKey.Strategy, Columns: partitionKey.Columns})
 	}
 	for _, t := range tableNames {
 		partitionKey, ok := tablePartitionKeyMap.Get(t)
@@ -122,23 +123,23 @@ func getCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple) (*utils.
 }
 
 func shouldForceTablePartitioning(importerRole string, sourceDBType string, targetDBType string) bool {
-	if importerRole != TARGET_DB_IMPORTER_ROLE {
+	if importerRole != constants.TARGET_DB_IMPORTER_ROLE {
 		//For PG/ORacle source/source-replica, using partitioning by table since there won't be any huge difference in
 		// performance between the two strategies for single node databases like PG/Oracle
 		//and Parititon by table is better from data correctness perspective
 		return true
 	}
-	if sourceDBType != POSTGRESQL {
+	if sourceDBType != constants.POSTGRESQL {
 		//For Oracle source and target db impoorter, using partitioning by table since we don't have complete support for the conflict detection
 		//and Parititon by table is better from data correctness perspective
 		return true
 	}
-	if targetDBType == YUGABYTEDB_AMP {
+	if targetDBType == constants.YUGABYTEDB_AMP {
 		// yb-amp is a single-node PostgreSQL-compatible compute (no YB
 		// tablets / colocation), so — exactly like the PG/Oracle
 		// source/source-replica case — PARTITION_BY_TABLE has no real
 		// throughput downside and is safer for correctness. It also sidesteps
-		// getExpressionUniqueIndexTables(), which is implemented only on the
+		// imp.getExpressionUniqueIndexTables(), which is implemented only on the
 		// TargetYugabyteDB driver.
 		return true
 	}
@@ -146,17 +147,17 @@ func shouldForceTablePartitioning(importerRole string, sourceDBType string, targ
 }
 
 // resolveEffectiveCdcPartitionKeys applies global strategy, then per-table overlays,
-func resolveEffectiveCdcPartitionKeys(
+func (imp *Importer) resolveEffectiveCdcPartitionKeys(
 	tableNames []sqlname.NameTuple,
 	globalKey string,
-	overrides *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride],
+	overrides *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride],
 	exprUKSet *utils.StructMap[sqlname.NameTuple, bool],
 	generatedStoredCols *utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn],
 	targetDBType string,
-) (*utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], error) {
-	result := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
+) (*utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], error) {
+	result := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
 	if overrides == nil {
-		overrides = utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
+		overrides = utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
 	}
 	if exprUKSet == nil {
 		exprUKSet = utils.NewStructMap[sqlname.NameTuple, bool]()
@@ -167,25 +168,25 @@ func resolveEffectiveCdcPartitionKeys(
 
 	switch globalKey {
 	case "auto":
-		if shouldForceTablePartitioning(importerRole, sourceDBType, targetDBType) {
+		if shouldForceTablePartitioning(imp.cfg.ImporterRole, imp.cfg.SourceDBType, targetDBType) {
 			for _, t := range tableNames {
-				result.Put(t, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+				result.Put(t, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
 			}
 		} else {
 			for _, t := range tableNames {
 				if ok, _, _ := shouldForceTablePartitioningForTable(t, exprUKSet, generatedStoredCols); ok {
-					result.Put(t, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+					result.Put(t, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
 				} else {
-					result.Put(t, cdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
+					result.Put(t, CdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
 				}
 			}
 		}
 	default:
 		for _, t := range tableNames {
-			result.Put(t, cdcPartitionKeyOverride{Strategy: globalKey})
+			result.Put(t, CdcPartitionKeyOverride{Strategy: globalKey})
 		}
 	}
-	err := overrides.IterKV(func(t sqlname.NameTuple, override cdcPartitionKeyOverride) (bool, error) {
+	err := overrides.IterKV(func(t sqlname.NameTuple, override CdcPartitionKeyOverride) (bool, error) {
 		result.Put(t, override)
 		return true, nil
 	})
@@ -227,8 +228,8 @@ func tableHasGeneratedColumn(generatedStoredCols *utils.StructMap[sqlname.NameTu
 
 // resolveCdcPartitionKeyOverrides looks up override table names in namereg and
 // validates each is present in importTableList. Returns a map keyed by NameTuple.
-func resolveCdcPartitionKeyOverrides(rawOverrides map[string]cdcPartitionKeyOverride, importTableList []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], error) {
-	resolved := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
+func resolveCdcPartitionKeyOverrides(rawOverrides map[string]CdcPartitionKeyOverride, importTableList []sqlname.NameTuple) (*utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], error) {
+	resolved := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
 	if len(rawOverrides) == 0 {
 		return resolved, nil
 	}
@@ -257,14 +258,14 @@ func resolveCdcPartitionKeyOverrides(rawOverrides map[string]cdcPartitionKeyOver
 	return resolved, nil
 }
 
-func needsNonTablePartitionKeyChecks(cdcPartitionKey string, overrides *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) (bool, error) {
+func needsNonTablePartitionKeyChecks(cdcPartitionKey string, overrides *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]) (bool, error) {
 	// Collect expression-UK / generated-stored-column tables whenever we need them for
 	// auto resolution or pk/custom validation.
 	if cdcPartitionKey != PARTITION_BY_TABLE {
 		return true, nil
 	}
 	var validationsNeeded bool
-	err := overrides.IterKV(func(_ sqlname.NameTuple, override cdcPartitionKeyOverride) (bool, error) {
+	err := overrides.IterKV(func(_ sqlname.NameTuple, override CdcPartitionKeyOverride) (bool, error) {
 		if override.Strategy != PARTITION_BY_TABLE {
 			validationsNeeded = true
 			return false, nil
@@ -289,15 +290,15 @@ func shouldForceTablePartitioningForTable(table sqlname.NameTuple, exprUKSet *ut
 
 // computeAndPersistCdcPartitioningStrategyPerTable resolves global + overrides +
 // auto/expr-UK/generated-stored-column rules and writes TableToCDCPartitionKey to metaDB.
-func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], error) {
-	tableToPartitionKeyOverrideMap, exprUKKeysForStorage, err := computeCdcPartitioningStrategyPerTable(tableNames, true, importDataStatus, tableToUniqueIndexes)
+func (imp *Importer) computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], error) {
+	tableToPartitionKeyOverrideMap, exprUKKeysForStorage, err := imp.computeCdcPartitioningStrategyPerTable(tableNames, true, importDataStatus, tableToUniqueIndexes)
 	if err != nil {
 		return nil, fmt.Errorf("error computing cdc partitioning strategy per table: %w", err)
 	}
 
 	// Combine strategy + custom key columns into the single persisted per-table map.
 	metadbMap := make(map[string]metadb.CDCPartitionKey)
-	err = tableToPartitionKeyOverrideMap.IterKV(func(key sqlname.NameTuple, override cdcPartitionKeyOverride) (bool, error) {
+	err = tableToPartitionKeyOverrideMap.IterKV(func(key sqlname.NameTuple, override CdcPartitionKeyOverride) (bool, error) {
 		metadbMap[key.ForKey()] = metadb.CDCPartitionKey{Strategy: override.Strategy, Columns: override.Columns}
 		return true, nil
 	})
@@ -305,7 +306,7 @@ func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameT
 		return nil, fmt.Errorf("error building cdc partition key map: %w", err)
 	}
 
-	err = metaDB.UpdateImportDataStatusRecord(func(obj *metadb.ImportDataStatusRecord) {
+	err = imp.cfg.MetaDB.UpdateImportDataStatusRecord(func(obj *metadb.ImportDataStatusRecord) {
 		obj.TableToCDCPartitionKey = metadbMap
 		obj.CdcExpressionUniqueIndexTables = exprUKKeysForStorage
 	})
@@ -316,33 +317,32 @@ func computeAndPersistCdcPartitioningStrategyPerTable(tableNames []sqlname.NameT
 	return tableToPartitionKeyOverrideMap, nil
 }
 
-func computeCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple, isFirstRun bool, importDataStatus *metadb.ImportDataStatusRecord, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], []string, error) {
-	rawOverrides, err := parseCdcPartitionKeyOverrides(cdcPartitionKeyOverrides)
-	if err != nil {
-		return nil, nil, err
-	}
+func (imp *Importer) computeCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple, isFirstRun bool, importDataStatus *metadb.ImportDataStatusRecord, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], []string, error) {
+	// the raw --cdc-partition-key-overrides string is parsed once by cmd during flag
+	// validation; cmd passes the result in Config.
+	rawOverrides := imp.cfg.CdcPartitionKeyOverridesParsed
 	overrides, err := resolveCdcPartitionKeyOverrides(rawOverrides, tableNames)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	exprUKSet, err := getExpressionUniqueIndexTablesIfRequired(tableNames, overrides, cdcPartitionKey, isFirstRun, importDataStatus)
+	exprUKSet, err := imp.getExpressionUniqueIndexTablesIfRequired(tableNames, overrides, imp.cfg.CdcPartitionKey, isFirstRun, importDataStatus)
 	if err != nil {
 		return nil, nil, err
 	}
 	// Generated stored columns are recomputed from the source-captured metaDB record on every
 	// run (not persisted in the import status record), so this is independent of isFirstRun.
-	generatedStoredCols, err := getGeneratedStoredColumnsIfRequired(tableNames, overrides, cdcPartitionKey, tableToUniqueIndexes)
+	generatedStoredCols, err := imp.getGeneratedStoredColumnsIfRequired(tableNames, overrides, imp.cfg.CdcPartitionKey, tableToUniqueIndexes)
 	if err != nil {
 		return nil, nil, err
 	}
-	tableToPartitionKeyOverrideMap, err := resolveEffectiveCdcPartitionKeys(tableNames, cdcPartitionKey, overrides, exprUKSet, generatedStoredCols, tconf.TargetDBType)
+	tableToPartitionKeyOverrideMap, err := imp.resolveEffectiveCdcPartitionKeys(tableNames, imp.cfg.CdcPartitionKey, overrides, exprUKSet, generatedStoredCols, imp.cfg.Tconf.TargetDBType)
 
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = validateAndFinalizeCDCPartitionKeysPerTable(tableToPartitionKeyOverrideMap, tableNames, exprUKSet, generatedStoredCols)
+	err = imp.validateAndFinalizeCDCPartitionKeysPerTable(tableToPartitionKeyOverrideMap, tableNames, exprUKSet, generatedStoredCols)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -352,7 +352,7 @@ func computeCdcPartitioningStrategyPerTable(tableNames []sqlname.NameTuple, isFi
 	return tableToPartitionKeyOverrideMap, exprUKKeysForStorage, nil
 }
 
-func getExpressionUniqueIndexTablesIfRequired(tableNames []sqlname.NameTuple, overrides *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], cdcPartitionKey string, isFirstRun bool, importDataStatus *metadb.ImportDataStatusRecord) (*utils.StructMap[sqlname.NameTuple, bool], error) {
+func (imp *Importer) getExpressionUniqueIndexTablesIfRequired(tableNames []sqlname.NameTuple, overrides *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], cdcPartitionKey string, isFirstRun bool, importDataStatus *metadb.ImportDataStatusRecord) (*utils.StructMap[sqlname.NameTuple, bool], error) {
 	// Always return a non-nil map: callers call exprUKSet.Keys()/pass it to
 	// resolveEffectiveCdcPartitionKeys, and a nil *StructMap panics on Keys().
 	exprUKSet := utils.NewStructMap[sqlname.NameTuple, bool]()
@@ -368,7 +368,7 @@ func getExpressionUniqueIndexTablesIfRequired(tableNames []sqlname.NameTuple, ov
 	var expressionUniqueIndexTables []sqlname.NameTuple
 	if isFirstRun {
 		// First run: query the target DB for the authoritative set of expression-UK tables.
-		expressionUniqueIndexTables, err = getExpressionUniqueIndexTables(tableNames)
+		expressionUniqueIndexTables, err = imp.getExpressionUniqueIndexTables(tableNames)
 		if err != nil {
 			return nil, fmt.Errorf("error getting expression unique index tables: %w", err)
 		}
@@ -400,7 +400,7 @@ func getExpressionUniqueIndexTablesIfRequired(tableNames []sqlname.NameTuple, ov
 // for the CDC partitioning decision. It is intentionally NOT persisted in the import status
 // record: it is recomputed from the source-captured metaDB record (+ target UK/PK) on every
 // run (first run and resume alike) via getGeneratedStoredColumnsHybrid.
-func getGeneratedStoredColumnsIfRequired(tableNames []sqlname.NameTuple, overrides *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], cdcPartitionKey string, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn], error) {
+func (imp *Importer) getGeneratedStoredColumnsIfRequired(tableNames []sqlname.NameTuple, overrides *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], cdcPartitionKey string, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn], error) {
 	needsCheck, err := needsNonTablePartitionKeyChecks(cdcPartitionKey, overrides)
 	if err != nil {
 		return nil, err
@@ -408,7 +408,7 @@ func getGeneratedStoredColumnsIfRequired(tableNames []sqlname.NameTuple, overrid
 	if !needsCheck {
 		return utils.NewStructMap[sqlname.NameTuple, []GeneratedStoredColumn](), nil
 	}
-	return getGeneratedStoredColumnsHybrid(tableNames, tableToUniqueIndexes)
+	return imp.getGeneratedStoredColumnsHybrid(tableNames, tableToUniqueIndexes)
 }
 
 // validateCdcPartitioningStrategyUnchanged re-resolves the effective per-table CDC
@@ -417,15 +417,15 @@ func getGeneratedStoredColumnsIfRequired(tableNames []sqlname.NameTuple, overrid
 // tables captured on the first run (treating a missing generated-stored set as empty for
 // older records) so resume never silently applies a changed cdc-partition-key /
 // cdc-partition-key-overrides.
-func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
+func (imp *Importer) validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, importDataStatus *metadb.ImportDataStatusRecord, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) error {
 
 	cdcPartitionKeyOverridesStored := importDataStatus.CdcPartitionKeyOverridesConfig
-	if cdcPartitionKeyOverridesStored == cdcPartitionKeyOverrides {
+	if cdcPartitionKeyOverridesStored == imp.cfg.CdcPartitionKeyOverrides {
 		//No changes in the overrides so we can continue
 		return nil
 	}
 
-	resolvedTableToPartitionKeyOverrideMap, _, err := computeCdcPartitioningStrategyPerTable(tableNames, false, importDataStatus, tableToUniqueIndexes)
+	resolvedTableToPartitionKeyOverrideMap, _, err := imp.computeCdcPartitioningStrategyPerTable(tableNames, false, importDataStatus, tableToUniqueIndexes)
 	if err != nil {
 		return fmt.Errorf("error computing cdc partitioning strategy per table: %w", err)
 	}
@@ -442,12 +442,12 @@ func validateCdcPartitioningStrategyUnchanged(tableNames []sqlname.NameTuple, im
 // reordering is treated as a change. resolvedCustomColumns are the resolved custom key
 // columns; stored is the persisted per-table CDC partition key (strategy + columns).
 func diffCdcPartitioningStrategy(
-	resolved *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride],
+	resolved *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride],
 	stored map[string]metadb.CDCPartitionKey,
 ) error {
 	var changed []string
 	var missingInStored []string
-	err := resolved.IterKV(func(t sqlname.NameTuple, override cdcPartitionKeyOverride) (bool, error) {
+	err := resolved.IterKV(func(t sqlname.NameTuple, override CdcPartitionKeyOverride) (bool, error) {
 		storedPartitionKey, ok := stored[t.ForKey()]
 		if !ok {
 			missingInStored = append(missingInStored, t.ForKey())
@@ -502,11 +502,11 @@ func diffCdcPartitioningStrategy(
 	return nil
 }
 
-func getExpressionUniqueIndexTables(tableNames []sqlname.NameTuple) ([]sqlname.NameTuple, error) {
-	if tconf.TargetDBType != YUGABYTEDB {
+func (imp *Importer) getExpressionUniqueIndexTables(tableNames []sqlname.NameTuple) ([]sqlname.NameTuple, error) {
+	if imp.cfg.Tconf.TargetDBType != constants.YUGABYTEDB {
 		return nil, nil
 	}
-	yb, ok := tdb.(*tgtdb.TargetYugabyteDB)
+	yb, ok := imp.cfg.Tdb.(*tgtdb.TargetYugabyteDB)
 	if !ok {
 		return nil, goerrors.Errorf("target db is not a YugabyteDB")
 	}
@@ -539,10 +539,10 @@ func getExpressionUniqueIndexTables(tableNames []sqlname.NameTuple) ([]sqlname.N
 //
 // If the source capture is absent (export written by an older voyager, or capture not yet
 // persisted).
-func getGeneratedStoredColumnsHybrid(tableNames []sqlname.NameTuple, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn], error) {
+func (imp *Importer) getGeneratedStoredColumnsHybrid(tableNames []sqlname.NameTuple, tableToUniqueIndexes *utils.StructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]) (*utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn], error) {
 	result := utils.NewStructMap[sqlname.NameTuple, []GeneratedStoredColumn]()
 
-	exportStatus, err := metaDB.GetExportDataSourceDBExporterStatusRecord()
+	exportStatus, err := imp.cfg.MetaDB.GetExportDataSourceDBExporterStatusRecord()
 	if err != nil {
 		return nil, fmt.Errorf("error getting export data source db exporter status record: %w", err)
 	}
@@ -617,9 +617,9 @@ type GeneratedStoredColumn struct {
 // table list once in importData.)
 // rejects the PK/Custom strategy on the tables having expression-based unique index or a unique index on a stored generated column
 // custom key columns can't be a stored generated column
-func validateAndFinalizeCDCPartitionKeysPerTable(tableToPartitionKeyOverrideMap *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], tableNames []sqlname.NameTuple, exprUKSet *utils.StructMap[sqlname.NameTuple, bool], generatedStoredCols *utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn]) error {
+func (imp *Importer) validateAndFinalizeCDCPartitionKeysPerTable(tableToPartitionKeyOverrideMap *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], tableNames []sqlname.NameTuple, exprUKSet *utils.StructMap[sqlname.NameTuple, bool], generatedStoredCols *utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn]) error {
 	var customTables []sqlname.NameTuple
-	err := tableToPartitionKeyOverrideMap.IterKV(func(t sqlname.NameTuple, override cdcPartitionKeyOverride) (bool, error) {
+	err := tableToPartitionKeyOverrideMap.IterKV(func(t sqlname.NameTuple, override CdcPartitionKeyOverride) (bool, error) {
 		if override.Strategy == PARTITION_BY_CUSTOM {
 			customTables = append(customTables, t)
 		}
@@ -634,7 +634,7 @@ func validateAndFinalizeCDCPartitionKeysPerTable(tableToPartitionKeyOverrideMap 
 	tableToColumns := make(map[string][]string)
 	for _, t := range customTables {
 		override, _ := tableToPartitionKeyOverrideMap.Get(t)
-		tableColumns, err := tdb.GetListOfTableAttributes(t)
+		tableColumns, err := imp.cfg.Tdb.GetListOfTableAttributes(t)
 		if err != nil {
 			return fmt.Errorf("error getting columns of table %s for custom cdc-partition-key validation: %w", t.ForOutput(), err)
 		}
@@ -642,7 +642,7 @@ func validateAndFinalizeCDCPartitionKeysPerTable(tableToPartitionKeyOverrideMap 
 		var missing []string
 		var ambiguous []string
 		for _, c := range override.Columns {
-			bestMatchingColumnName, err := tdb.FindBestMatchingTargetColumnName(c, tableColumns)
+			bestMatchingColumnName, err := imp.cfg.Tdb.FindBestMatchingTargetColumnName(c, tableColumns)
 			if err != nil {
 				if _, ok := err.(*tgtdb.ErrAmbiguousColumnName); ok {
 					ambiguous = append(ambiguous, c)
@@ -714,4 +714,13 @@ func validateAndFinalizeCDCPartitionKeysPerTable(tableToPartitionKeyOverrideMap 
 
 	}
 	return nil
+}
+
+// CdcPartitionKeyOverride is a single parsed per-table override from
+// --cdc-partition-key-overrides. Strategy is one of PARTITION_BY_PK,
+// PARTITION_BY_TABLE or PARTITION_BY_CUSTOM. Columns is set (non-empty, in the
+// user-specified order) only when Strategy == PARTITION_BY_CUSTOM.
+type CdcPartitionKeyOverride struct {
+	Strategy string
+	Columns  []string
 }

--- a/yb-voyager/src/importdata/live_migration_test.go
+++ b/yb-voyager/src/importdata/live_migration_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/constants"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/namereg"
 	reporter "github.com/yugabyte/yb-voyager/yb-voyager/src/reporter/stats"
@@ -64,11 +64,11 @@ func TestProcessEventsBasic(t *testing.T) {
 	lastAppliedVsn := int64(0)
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
-	tdb = &mockYugabyteDB{}
-	state := newImportDataStateFromGlobals()
-	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]())
+	testImporter.cfg.Tdb = &mockYugabyteDB{}
+	state := NewImportDataState(testImporter.importDataStateConfig())
+	testImporter.conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, constants.POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride](), testImporter.cfg.ExportDir)
 
-	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
+	oname := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", "users")
 	evChan <- &tgtdb.Event{
 		Vsn: 1,
 		Op:  "i",
@@ -76,10 +76,10 @@ func TestProcessEventsBasic(t *testing.T) {
 			CurrentName: oname,
 			TargetName:  oname,
 		},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	}
 	evChan <- END_OF_QUEUE_SEGMENT_EVENT
-	processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
+	testImporter.processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
 }
 
 // Test that the event is removed from the conflict detection cache after it is processed
@@ -91,11 +91,11 @@ func TestProcessEventsRemovesEventFromConflicDetectionCache(t *testing.T) {
 	lastAppliedVsn := int64(0)
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
-	tdb = &mockYugabyteDB{}
-	state := newImportDataStateFromGlobals()
-	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]())
+	testImporter.cfg.Tdb = &mockYugabyteDB{}
+	state := NewImportDataState(testImporter.importDataStateConfig())
+	testImporter.conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, constants.POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride](), testImporter.cfg.ExportDir)
 
-	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
+	oname := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", "users")
 	e := &tgtdb.Event{
 		Vsn: 1,
 		Op:  "i",
@@ -103,16 +103,16 @@ func TestProcessEventsRemovesEventFromConflicDetectionCache(t *testing.T) {
 			CurrentName: oname,
 			TargetName:  oname,
 		},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE,
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE,
 	}
 
-	conflictDetectionCache.Put(e)
+	testImporter.conflictDetectionCache.Put(e)
 	evChan <- e
 	evChan <- END_OF_QUEUE_SEGMENT_EVENT
-	processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
+	testImporter.processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
 
 	// Check that the event was removed from the cache
-	if _, ok := conflictDetectionCache.m[e.Vsn]; ok {
+	if _, ok := testImporter.conflictDetectionCache.m[e.Vsn]; ok {
 		t.Errorf("Event not removed from conflict detection cache")
 	}
 }
@@ -123,16 +123,16 @@ func TestProcessEventsRemovesEventFromConflicDetectionCache(t *testing.T) {
 func TestProcessEventsRemovesIgnoredEventFromConflicDetectionCache(t *testing.T) {
 	// to simulate the case where source db importer ignores
 	// all events that are not from the target db exporter.
-	importerRole = SOURCE_DB_IMPORTER_ROLE
+	testImporter.cfg.ImporterRole = constants.SOURCE_DB_IMPORTER_ROLE
 	evChan := make(chan *tgtdb.Event, EVENT_CHANNEL_SIZE)
 	lastAppliedVsn := int64(100) // so that event with vsn 1 is ignored.
 	doneChan := make(chan bool, 1)
 	statsReporter := &reporter.StreamImportStatsReporter{}
-	tdb = &mockYugabyteDB{}
-	state := newImportDataStateFromGlobals()
-	conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]())
+	testImporter.cfg.Tdb = &mockYugabyteDB{}
+	state := NewImportDataState(testImporter.importDataStateConfig())
+	testImporter.conflictDetectionCache = NewConflictDetectionCache(utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex](), []chan *tgtdb.Event{evChan}, constants.POSTGRESQL, utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride](), testImporter.cfg.ExportDir)
 
-	oname := sqlname.NewObjectName(YUGABYTEDB, "public", "public", "users")
+	oname := sqlname.NewObjectName(constants.YUGABYTEDB, "public", "public", "users")
 	e1 := &tgtdb.Event{
 		Vsn: 1, // so that it is less than lastAppliedVsn and ignored.
 		Op:  "i",
@@ -140,7 +140,7 @@ func TestProcessEventsRemovesIgnoredEventFromConflicDetectionCache(t *testing.T)
 			CurrentName: oname,
 			TargetName:  oname,
 		},
-		ExporterRole: TARGET_DB_EXPORTER_FB_ROLE, // so that it is not ignored because importerRole is SOURCE_DB_IMPORTER_ROLE
+		ExporterRole: constants.TARGET_DB_EXPORTER_FB_ROLE, // so that it is not ignored because importerRole is SOURCE_DB_IMPORTER_ROLE
 	}
 
 	e2 := &tgtdb.Event{
@@ -150,221 +150,27 @@ func TestProcessEventsRemovesIgnoredEventFromConflicDetectionCache(t *testing.T)
 			CurrentName: oname,
 			TargetName:  oname,
 		},
-		ExporterRole: SOURCE_DB_EXPORTER_ROLE, // not TARGET_DB_EXPORTER_FB_ROLE so that it is ignored.
+		ExporterRole: constants.SOURCE_DB_EXPORTER_ROLE, // not TARGET_DB_EXPORTER_FB_ROLE so that it is ignored.
 	}
 
-	conflictDetectionCache.Put(e1)
-	conflictDetectionCache.Put(e2)
+	testImporter.conflictDetectionCache.Put(e1)
+	testImporter.conflictDetectionCache.Put(e2)
 	evChan <- e1
 	evChan <- e2
 	evChan <- END_OF_QUEUE_SEGMENT_EVENT
-	processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
+	testImporter.processEvents(1, evChan, lastAppliedVsn, doneChan, statsReporter, state)
 
 	// Check that the event was removed from the cache
-	if _, ok := conflictDetectionCache.m[e1.Vsn]; ok {
+	if _, ok := testImporter.conflictDetectionCache.m[e1.Vsn]; ok {
 		t.Errorf("Event %v not removed from conflict detection cache", e1)
 	}
-	if _, ok := conflictDetectionCache.m[e2.Vsn]; ok {
+	if _, ok := testImporter.conflictDetectionCache.m[e2.Vsn]; ok {
 		t.Errorf("Event %v not removed from conflict detection cache", e2)
 	}
 }
 
-func TestIsCDCSavepointFixedInTargetDBVersion(t *testing.T) {
-	tests := []struct {
-		name               string
-		dbVersionStr       string
-		expectedFixed      bool
-		expectedFixVersion string
-	}{
-		{name: "empty version string", dbVersionStr: "", expectedFixed: false, expectedFixVersion: ""},
-		{name: "malformed version string", dbVersionStr: "not-a-version", expectedFixed: false, expectedFixVersion: ""},
-
-		{name: "2024.2 series below fix", dbVersionStr: "11.2-YB-2024.2.7.0-b1", expectedFixed: false, expectedFixVersion: "2024.2.8.0"},
-		{name: "2024.2 series exactly at fix", dbVersionStr: "11.2-YB-2024.2.8.0-b85", expectedFixed: true, expectedFixVersion: "2024.2.8.0"},
-		{name: "2024.2 series above fix", dbVersionStr: "11.2-YB-2024.2.9.0-b1", expectedFixed: true, expectedFixVersion: "2024.2.8.0"},
-
-		{name: "2025.1 series below fix", dbVersionStr: "11.2-YB-2025.1.3.0-b1", expectedFixed: false, expectedFixVersion: "2025.1.4.0"},
-		{name: "2025.1 series exactly at fix", dbVersionStr: "11.2-YB-2025.1.4.0-b42", expectedFixed: true, expectedFixVersion: "2025.1.4.0"},
-		{name: "2025.1 series above fix", dbVersionStr: "11.2-YB-2025.1.5.0-b1", expectedFixed: true, expectedFixVersion: "2025.1.4.0"},
-
-		{name: "2025.2 series below fix", dbVersionStr: "11.2-YB-2025.2.1.0-b1", expectedFixed: false, expectedFixVersion: "2025.2.2.0"},
-		{name: "2025.2 series exactly at fix", dbVersionStr: "11.2-YB-2025.2.2.0-b10", expectedFixed: true, expectedFixVersion: "2025.2.2.0"},
-		{name: "2025.2 series above fix", dbVersionStr: "11.2-YB-2025.2.3.0-b1", expectedFixed: true, expectedFixVersion: "2025.2.2.0"},
-
-		{name: "2024.1 series has no fix entry", dbVersionStr: "11.2-YB-2024.1.5.0-b1", expectedFixed: false, expectedFixVersion: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fixed, fixVersion := isCDCSavepointFixedInTargetDBVersion(tt.dbVersionStr)
-			assert.Equal(t, tt.expectedFixed, fixed)
-			assert.Equal(t, tt.expectedFixVersion, fixVersion)
-		})
-	}
-}
-
-func TestShouldWarnServerSeriesNewerThanConnector(t *testing.T) {
-	tests := []struct {
-		name             string
-		connectorVersion string
-		serverYBVersion  string
-		expectedWarn     bool
-		wantErr          bool
-	}{
-		{"same release, server higher maintenance is NOT newer", "2025.2.3", "2025.2.9.0", false, false},
-		{"same release, server higher connector-counter-equivalent is NOT newer", "2025.2.3", "2025.2.4.0", false, false},
-		{"same release exact", "2025.2.3", "2025.2.0.0", false, false},
-		{"server on newer release warns", "2024.2.5", "2025.1.0.0", true, false},
-		{"server on older release does not warn", "2025.2.3", "2024.2.8.0", false, false},
-		{"server on unrecognized (newer) release warns", "2025.2.3", "2026.1.0.0", true, false},
-		{"connector 2-segment release tag, same release", "2025.2", "2025.2.9.0", false, false},
-		{"preview server warns (connector not built for preview)", "2025.2.3", "2.25.1.0", true, false},
-		{"stable-old server does not warn (connector is newer and backward-compatible)", "2025.2.3", "2.20.1.0", false, false},
-		{"unparseable server version returns error", "2025.2.3", "not-a-version", false, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			warn, _, err := shouldWarnServerSeriesNewerThanConnector(tt.connectorVersion, tt.serverYBVersion)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedWarn, warn)
-		})
-	}
-}
-
-func TestParseCdcPartitionKeyOverrides(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    map[string]cdcPartitionKeyOverride
-		wantErr string
-	}{
-		{
-			name:  "empty",
-			input: "",
-			want:  map[string]cdcPartitionKeyOverride{},
-		},
-		{
-			name:  "whitespace only",
-			input: "   ",
-			want:  map[string]cdcPartitionKeyOverride{},
-		},
-		{
-			name:  "single pk override",
-			input: "public.orders:pk",
-			want:  map[string]cdcPartitionKeyOverride{"public.orders": {Strategy: PARTITION_BY_PK}},
-		},
-		{
-			name:  "multiple overrides with semicolon",
-			input: "public.orders:table;sales.events:pk",
-			want: map[string]cdcPartitionKeyOverride{
-				"public.orders": {Strategy: PARTITION_BY_TABLE},
-				"sales.events":  {Strategy: PARTITION_BY_PK},
-			},
-		},
-		{
-			name:  "trims whitespace around entries",
-			input: " public.orders : table ; sales.events : pk ",
-			want: map[string]cdcPartitionKeyOverride{
-				"public.orders": {Strategy: PARTITION_BY_TABLE},
-				"sales.events":  {Strategy: PARTITION_BY_PK},
-			},
-		},
-		{
-			name:  "trailing semicolon ignored",
-			input: "public.orders:pk;",
-			want:  map[string]cdcPartitionKeyOverride{"public.orders": {Strategy: PARTITION_BY_PK}},
-		},
-		{
-			name:  "single custom column",
-			input: "public.orders:(customer_id)",
-			want: map[string]cdcPartitionKeyOverride{
-				"public.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}},
-			},
-		},
-		{
-			name:  "multi custom columns",
-			input: "public.orders:(customer_id,region)",
-			want: map[string]cdcPartitionKeyOverride{
-				"public.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id", "region"}},
-			},
-		},
-		{
-			name:  "custom columns trim inner whitespace and preserve order",
-			input: "public.orders:( region , customer_id )",
-			want: map[string]cdcPartitionKeyOverride{
-				"public.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"region", "customer_id"}},
-			},
-		},
-		{
-			name:  "custom mixed with pk override",
-			input: "public.orders:(customer_id);sales.events:pk",
-			want: map[string]cdcPartitionKeyOverride{
-				"public.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}},
-				"sales.events":  {Strategy: PARTITION_BY_PK},
-			},
-		},
-		{
-			name:    "rejects missing colon",
-			input:   "public.orders",
-			wantErr: "expected format",
-		},
-		{
-			name:    "rejects empty strategy",
-			input:   "public.orders:",
-			wantErr: "non-empty",
-		},
-		{
-			name:    "rejects custom column list without parentheses",
-			input:   "public.orders:customer_id",
-			wantErr: "parenthesized custom key column list",
-		},
-		{
-			name:    "rejects empty parenthesized custom key",
-			input:   "public.orders:()",
-			wantErr: "custom key column list is empty",
-		},
-		{
-			name:    "rejects empty column in custom key",
-			input:   "public.orders:(customer_id,,region)",
-			wantErr: "empty column name",
-		},
-		{
-			name:    "rejects duplicate column in custom key",
-			input:   "public.orders:(customer_id,customer_id)",
-			wantErr: "duplicate column",
-		},
-		{
-			name:    "rejects duplicate table with conflicting values",
-			input:   "public.orders:pk;public.orders:table",
-			wantErr: "duplicate table",
-		},
-		{
-			name:    "rejects duplicate table even with same value",
-			input:   "public.orders:(customer_id);public.orders:(customer_id)",
-			wantErr: "duplicate table",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseCdcPartitionKeyOverrides(tc.input)
-			if tc.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
 func testCdcPartitionNameTuple(schema, table string) sqlname.NameTuple {
-	oname := sqlname.NewObjectName(POSTGRESQL, "public", schema, table)
+	oname := sqlname.NewObjectName(constants.POSTGRESQL, "public", schema, table)
 	return sqlname.NameTuple{
 		CurrentName: oname,
 		SourceName:  oname,
@@ -372,9 +178,9 @@ func testCdcPartitionNameTuple(schema, table string) sqlname.NameTuple {
 	}
 }
 
-func strategiesByTableName(m *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) map[string]string {
+func strategiesByTableName(m *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]) map[string]string {
 	out := make(map[string]string)
-	_ = m.IterKV(func(k sqlname.NameTuple, v cdcPartitionKeyOverride) (bool, error) {
+	_ = m.IterKV(func(k sqlname.NameTuple, v CdcPartitionKeyOverride) (bool, error) {
 		_, table := k.ForCatalogQuery()
 		out[table] = v.Strategy
 		return true, nil
@@ -382,9 +188,9 @@ func strategiesByTableName(m *utils.StructMap[sqlname.NameTuple, cdcPartitionKey
 	return out
 }
 
-func overrideSpecsByTableName(m *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride]) map[string]cdcPartitionKeyOverride {
-	out := make(map[string]cdcPartitionKeyOverride)
-	_ = m.IterKV(func(k sqlname.NameTuple, v cdcPartitionKeyOverride) (bool, error) {
+func overrideSpecsByTableName(m *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride]) map[string]CdcPartitionKeyOverride {
+	out := make(map[string]CdcPartitionKeyOverride)
+	_ = m.IterKV(func(k sqlname.NameTuple, v CdcPartitionKeyOverride) (bool, error) {
 		_, table := k.ForCatalogQuery()
 		out[table] = v
 		return true, nil
@@ -397,17 +203,17 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	events := testCdcPartitionNameTuple("test_schema", "events")
 	audit := testCdcPartitionNameTuple("test_schema", "audit")
 	tables := []sqlname.NameTuple{orders, events, audit}
-	oldImporterRole := importerRole
-	oldSourceDBType := sourceDBType
+	oldImporterRole := testImporter.cfg.ImporterRole
+	oldSourceDBType := testImporter.cfg.SourceDBType
 	defer func() {
-		importerRole = oldImporterRole
-		sourceDBType = oldSourceDBType
+		testImporter.cfg.ImporterRole = oldImporterRole
+		testImporter.cfg.SourceDBType = oldSourceDBType
 	}()
-	importerRole = TARGET_DB_IMPORTER_ROLE
-	sourceDBType = POSTGRESQL
+	testImporter.cfg.ImporterRole = constants.TARGET_DB_IMPORTER_ROLE
+	testImporter.cfg.SourceDBType = constants.POSTGRESQL
 
 	t.Run("global pk applies to all", func(t *testing.T) {
-		got, err := resolveEffectiveCdcPartitionKeys(tables, PARTITION_BY_PK, nil, nil, nil, YUGABYTEDB)
+		got, err := testImporter.resolveEffectiveCdcPartitionKeys(tables, PARTITION_BY_PK, nil, nil, nil, constants.YUGABYTEDB)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
 			"orders": PARTITION_BY_PK,
@@ -417,7 +223,7 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	})
 
 	t.Run("global table applies to all", func(t *testing.T) {
-		got, err := resolveEffectiveCdcPartitionKeys(tables, PARTITION_BY_TABLE, nil, nil, nil, YUGABYTEDB)
+		got, err := testImporter.resolveEffectiveCdcPartitionKeys(tables, PARTITION_BY_TABLE, nil, nil, nil, constants.YUGABYTEDB)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
 			"orders": PARTITION_BY_TABLE,
@@ -429,7 +235,7 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	t.Run("auto uses pk except expression-UK tables", func(t *testing.T) {
 		exprUK := utils.NewStructMap[sqlname.NameTuple, bool]()
 		exprUK.Put(audit, true)
-		got, err := resolveEffectiveCdcPartitionKeys(tables, "auto", nil, exprUK, nil, YUGABYTEDB)
+		got, err := testImporter.resolveEffectiveCdcPartitionKeys(tables, "auto", nil, exprUK, nil, constants.YUGABYTEDB)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
 			"orders": PARTITION_BY_PK,
@@ -439,7 +245,7 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	})
 
 	t.Run("auto on AMP forces table for all", func(t *testing.T) {
-		got, err := resolveEffectiveCdcPartitionKeys(tables, "auto", nil, nil, nil, YUGABYTEDB_AMP)
+		got, err := testImporter.resolveEffectiveCdcPartitionKeys(tables, "auto", nil, nil, nil, constants.YUGABYTEDB_AMP)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
 			"orders": PARTITION_BY_TABLE,
@@ -449,9 +255,9 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	})
 
 	t.Run("overlay changes only listed tables", func(t *testing.T) {
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
-		got, err := resolveEffectiveCdcPartitionKeys(tables, PARTITION_BY_PK, overrides, nil, nil, YUGABYTEDB)
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+		got, err := testImporter.resolveEffectiveCdcPartitionKeys(tables, PARTITION_BY_PK, overrides, nil, nil, constants.YUGABYTEDB)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
 			"orders": PARTITION_BY_TABLE,
@@ -461,10 +267,10 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	})
 
 	t.Run("auto plus override pk on normal table", func(t *testing.T) {
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(events, cdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
-		overrides.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
-		got, err := resolveEffectiveCdcPartitionKeys(tables, "auto", overrides, nil, nil, YUGABYTEDB)
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(events, CdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
+		overrides.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+		got, err := testImporter.resolveEffectiveCdcPartitionKeys(tables, "auto", overrides, nil, nil, constants.YUGABYTEDB)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
 			"orders": PARTITION_BY_TABLE,
@@ -485,8 +291,8 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	t.Run("rejects override pk on expression-UK table", func(t *testing.T) {
 		exprUK := utils.NewStructMap[sqlname.NameTuple, bool]()
 		exprUK.Put(audit, true)
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
 		_, err := resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_TABLE, overrides, exprUK, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expression-based unique index")
@@ -495,8 +301,8 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	t.Run("rejects override custom on expression-UK table", func(t *testing.T) {
 		exprUK := utils.NewStructMap[sqlname.NameTuple, bool]()
 		exprUK.Put(audit, true)
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"col1"}})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"col1"}})
 		_, err := resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_TABLE, overrides, exprUK, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expression-based unique index")
@@ -506,8 +312,8 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	t.Run("override table on expression-UK table is allowed", func(t *testing.T) {
 		exprUK := utils.NewStructMap[sqlname.NameTuple, bool]()
 		exprUK.Put(audit, true)
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
 		got, err := resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_PK, overrides, exprUK, nil)
 		require.NoError(t, err)
 		assert.Equal(t, PARTITION_BY_TABLE, strategiesByTableName(got)["audit"])
@@ -517,8 +323,8 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	t.Run("rejects override custom (id column) on expression-UK table", func(t *testing.T) {
 		exprUK := utils.NewStructMap[sqlname.NameTuple, bool]()
 		exprUK.Put(audit, true)
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"id"}})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"id"}})
 		_, err := resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_TABLE, overrides, exprUK, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expression-based unique index")
@@ -556,15 +362,15 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 		assert.Contains(t, err.Error(), "has a unique index on a stored generated column")
 		assert.Contains(t, err.Error(), "audit")
 
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"id"}})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"id"}})
 		_, err = resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_TABLE, overrides, nil, generated)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "has a unique index on a stored generated column")
 		assert.Contains(t, err.Error(), "audit")
 
-		overrides = utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+		overrides = utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
 		got, err = resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_PK, overrides, nil, generated)
 		require.NoError(t, err)
 		assert.Equal(t, PARTITION_BY_TABLE, strategiesByTableName(got)["audit"])
@@ -573,8 +379,8 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 
 	t.Run("custom key is a generated column without UK: custom rejected; pk allowed", func(t *testing.T) {
 		generated := generatedStoredColMap(audit, GeneratedStoredColumn{Name: "amount", InUniqueIndex: false})
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"amount"}})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"amount"}})
 		_, err := resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_PK, overrides, nil, generated)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "custom key column(s) - [amount] are a stored generated column(s)")
@@ -587,8 +393,8 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 
 	t.Run("custom key is a regular column and generated column unused by UK: custom allowed", func(t *testing.T) {
 		generated := generatedStoredColMap(audit, GeneratedStoredColumn{Name: "amount", InUniqueIndex: false})
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"id"}})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"id"}})
 		got, err := resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_PK, overrides, nil, generated)
 		require.NoError(t, err)
 		assert.Equal(t, PARTITION_BY_CUSTOM, strategiesByTableName(got)["audit"])
@@ -596,8 +402,8 @@ func TestResolveEffectiveCdcPartitionKeys(t *testing.T) {
 	})
 
 	t.Run("custom key column missing on table is rejected", func(t *testing.T) {
-		overrides := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		overrides.Put(audit, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"no_such_col"}})
+		overrides := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		overrides.Put(audit, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"no_such_col"}})
 		_, err := resolveAndValidateCdcPartitionKeysForTest(t, tables, PARTITION_BY_TABLE, overrides, nil, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "do not exist on table")
@@ -638,16 +444,16 @@ func resolveAndValidateCdcPartitionKeysForTest(
 	t *testing.T,
 	tables []sqlname.NameTuple,
 	globalKey string,
-	overrides *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride],
+	overrides *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride],
 	exprUK *utils.StructMap[sqlname.NameTuple, bool],
 	generated *utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn],
-) (*utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride], error) {
+) (*utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride], error) {
 	t.Helper()
-	origTdb := tdb
-	tdb = &mockTargetDBForCdcPartitionKeyValidation{tableColumns: []string{"id", "col1", "amount", "customer_id", "region"}}
-	t.Cleanup(func() { tdb = origTdb })
+	origTdb := testImporter.cfg.Tdb
+	testImporter.cfg.Tdb = &mockTargetDBForCdcPartitionKeyValidation{tableColumns: []string{"id", "col1", "amount", "customer_id", "region"}}
+	t.Cleanup(func() { testImporter.cfg.Tdb = origTdb })
 
-	resolved, err := resolveEffectiveCdcPartitionKeys(tables, globalKey, overrides, exprUK, generated, YUGABYTEDB)
+	resolved, err := testImporter.resolveEffectiveCdcPartitionKeys(tables, globalKey, overrides, exprUK, generated, constants.YUGABYTEDB)
 	require.NoError(t, err, "resolveEffectiveCdcPartitionKeys should not reject; rejections live in validateAndFinalizeCDCPartitionKeysPerTable")
 
 	// validateAndFinalizeCDCPartitionKeysPerTable does not nil-guard its map arguments (production
@@ -658,7 +464,7 @@ func resolveAndValidateCdcPartitionKeysForTest(
 	if generated == nil {
 		generated = utils.NewStructMap[sqlname.NameTuple, []GeneratedStoredColumn]()
 	}
-	return resolved, validateAndFinalizeCDCPartitionKeysPerTable(resolved, tables, exprUK, generated)
+	return resolved, testImporter.validateAndFinalizeCDCPartitionKeysPerTable(resolved, tables, exprUK, generated)
 }
 
 func generatedStoredColMap(t sqlname.NameTuple, cols ...GeneratedStoredColumn) *utils.StructMap[sqlname.NameTuple, []GeneratedStoredColumn] {
@@ -678,7 +484,7 @@ func setupCdcOverridesNameRegistry(t *testing.T) {
 		namereg.NameReg = origNameReg
 		sqlname.SourceDBType = origSourceDBType
 	})
-	sqlname.SourceDBType = POSTGRESQL
+	sqlname.SourceDBType = constants.POSTGRESQL
 
 	dir, err := os.MkdirTemp("", "cdcpk-namereg-*")
 	require.NoError(t, err)
@@ -715,41 +521,41 @@ func TestResolveCdcPartitionKeyOverrides(t *testing.T) {
 
 	t.Run("valid override resolves", func(t *testing.T) {
 		got, err := resolveCdcPartitionKeyOverrides(
-			map[string]cdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_TABLE}}, importList)
+			map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_TABLE}}, importList)
 		require.NoError(t, err)
-		assert.Equal(t, map[string]cdcPartitionKeyOverride{"orders": {Strategy: PARTITION_BY_TABLE}}, overrideSpecsByTableName(got))
+		assert.Equal(t, map[string]CdcPartitionKeyOverride{"orders": {Strategy: PARTITION_BY_TABLE}}, overrideSpecsByTableName(got))
 	})
 
 	t.Run("custom override resolves with columns", func(t *testing.T) {
 		got, err := resolveCdcPartitionKeyOverrides(
-			map[string]cdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}}}, importList)
+			map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}}}, importList)
 		require.NoError(t, err)
-		assert.Equal(t, map[string]cdcPartitionKeyOverride{"orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}}}, overrideSpecsByTableName(got))
+		assert.Equal(t, map[string]CdcPartitionKeyOverride{"orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}}}, overrideSpecsByTableName(got))
 	})
 
 	t.Run("empty overrides returns empty", func(t *testing.T) {
-		got, err := resolveCdcPartitionKeyOverrides(map[string]cdcPartitionKeyOverride{}, importList)
+		got, err := resolveCdcPartitionKeyOverrides(map[string]CdcPartitionKeyOverride{}, importList)
 		require.NoError(t, err)
 		assert.Empty(t, overrideSpecsByTableName(got))
 	})
 
 	t.Run("rejects table not found in name registry", func(t *testing.T) {
 		_, err := resolveCdcPartitionKeyOverrides(
-			map[string]cdcPartitionKeyOverride{"test_schema.missing": {Strategy: PARTITION_BY_PK}}, importList)
+			map[string]CdcPartitionKeyOverride{"test_schema.missing": {Strategy: PARTITION_BY_PK}}, importList)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in name registry")
 	})
 
 	t.Run("rejects table not in import table list", func(t *testing.T) {
 		_, err := resolveCdcPartitionKeyOverrides(
-			map[string]cdcPartitionKeyOverride{"test_schema.events": {Strategy: PARTITION_BY_PK}},
+			map[string]CdcPartitionKeyOverride{"test_schema.events": {Strategy: PARTITION_BY_PK}},
 			[]sqlname.NameTuple{orders}) // events excluded from import list
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "is not in the import table list")
 	})
 
 	t.Run("rejects conflicting values across different spellings", func(t *testing.T) {
-		_, err := resolveCdcPartitionKeyOverrides(map[string]cdcPartitionKeyOverride{
+		_, err := resolveCdcPartitionKeyOverrides(map[string]CdcPartitionKeyOverride{
 			"test_schema.orders":     {Strategy: PARTITION_BY_PK},
 			`"test_schema"."orders"`: {Strategy: PARTITION_BY_TABLE},
 		}, importList)
@@ -758,7 +564,7 @@ func TestResolveCdcPartitionKeyOverrides(t *testing.T) {
 	})
 
 	t.Run("dedups same value across different spellings", func(t *testing.T) {
-		_, err := resolveCdcPartitionKeyOverrides(map[string]cdcPartitionKeyOverride{
+		_, err := resolveCdcPartitionKeyOverrides(map[string]CdcPartitionKeyOverride{
 			"test_schema.orders": {Strategy: PARTITION_BY_PK},
 			"orders":             {Strategy: PARTITION_BY_PK}, // unqualified resolves to default schema
 		}, importList)
@@ -781,10 +587,12 @@ func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
 	metaExportDir, err := os.MkdirTemp("", "cdcpk-metadb-*")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(metaExportDir) })
-	origMetaDB := metaDB
-	metaDB = initMetaDB(metaExportDir)
-	t.Cleanup(func() { metaDB = origMetaDB })
-	require.NoError(t, metaDB.UpdateExportDataSourceDBExporterStatusRecord(func(r *metadb.ExportDataSourceDBExporterStatusRecord) {
+	origMetaDB := testImporter.cfg.MetaDB
+	testMetaDB, err := initTestMetaDB(metaExportDir)
+	require.NoError(t, err)
+	testImporter.cfg.MetaDB = testMetaDB
+	t.Cleanup(func() { testImporter.cfg.MetaDB = origMetaDB })
+	require.NoError(t, testImporter.cfg.MetaDB.UpdateExportDataSourceDBExporterStatusRecord(func(r *metadb.ExportDataSourceDBExporterStatusRecord) {
 		r.TableToGeneratedStoredColumns = map[string][]string{}
 	}))
 
@@ -792,17 +600,18 @@ func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
 	// columns, so an empty map is sufficient for the resume-recompute in this test.
 	emptyUK := utils.NewStructMap[sqlname.NameTuple, []tgtdb.UniqueIndex]()
 
-	origKey := cdcPartitionKey
-	origOverrides := cdcPartitionKeyOverrides
-	origTargetDBType := tconf.TargetDBType
-	origTdb := tdb
+	origKey := testImporter.cfg.CdcPartitionKey
+	origOverrides := testImporter.cfg.CdcPartitionKeyOverrides
+	origOverridesParsed := testImporter.cfg.CdcPartitionKeyOverridesParsed
+	origTargetDBType := testImporter.cfg.Tconf.TargetDBType
+	origTdb := testImporter.cfg.Tdb
 	t.Cleanup(func() {
-		cdcPartitionKey = origKey
-		cdcPartitionKeyOverrides = origOverrides
-		tconf.TargetDBType = origTargetDBType
-		tdb = origTdb
+		testImporter.cfg.CdcPartitionKey = origKey
+		setTestCdcPartitionKeyOverrides(origOverrides, origOverridesParsed)
+		testImporter.cfg.Tconf.TargetDBType = origTargetDBType
+		testImporter.cfg.Tdb = origTdb
 	})
-	tconf.TargetDBType = YUGABYTEDB
+	testImporter.cfg.Tconf.TargetDBType = constants.YUGABYTEDB
 
 	lookup := func(name string) sqlname.NameTuple {
 		nt, err := namereg.NameReg.LookupTableName(name)
@@ -816,7 +625,7 @@ func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
 	// validateCustomPartitionKeyTables (invoked on both first-run and resume) resolves custom
 	// key columns against the target table's attributes, so stub them for the custom-key
 	// resume-guard subtests below. Only "orders" is ever routed by a custom key here.
-	tdb = &mockYugabyteDB{
+	testImporter.cfg.Tdb = &mockYugabyteDB{
 		tableAttrs: map[string][]string{
 			orders.ForKey(): {"id", "customer_id", "region"},
 		},
@@ -824,14 +633,14 @@ func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
 
 	// First-run config: global pk with an override putting orders on table. No
 	// expression-UK tables (captured as a non-nil empty slice on the first run).
-	firstRun, err := resolveEffectiveCdcPartitionKeys(
+	firstRun, err := testImporter.resolveEffectiveCdcPartitionKeys(
 		tableNames, PARTITION_BY_PK,
-		mustResolveOverrides(t, "test_schema.orders:table", tableNames),
-		utils.NewStructMap[sqlname.NameTuple, bool](), nil, YUGABYTEDB)
+		mustResolveOverrides(t, map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_TABLE}}, tableNames),
+		utils.NewStructMap[sqlname.NameTuple, bool](), nil, constants.YUGABYTEDB)
 	require.NoError(t, err)
 
 	storedMap := make(map[string]metadb.CDCPartitionKey)
-	require.NoError(t, firstRun.IterKV(func(k sqlname.NameTuple, v cdcPartitionKeyOverride) (bool, error) {
+	require.NoError(t, firstRun.IterKV(func(k sqlname.NameTuple, v CdcPartitionKeyOverride) (bool, error) {
 		storedMap[k.ForKey()] = metadb.CDCPartitionKey{Strategy: v.Strategy, Columns: v.Columns}
 		return true, nil
 	}))
@@ -844,36 +653,36 @@ func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
 	}
 
 	t.Run("same config passes", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "test_schema.orders:table"
-		require.NoError(t, validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK))
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides("test_schema.orders:table", map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_TABLE}})
+		require.NoError(t, testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK))
 	})
 
 	t.Run("semantically-equivalent overrides (quoting) pass", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = `"test_schema"."orders":table`
-		require.NoError(t, validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK))
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides(`"test_schema"."orders":table`, map[string]CdcPartitionKeyOverride{`"test_schema"."orders"`: {Strategy: PARTITION_BY_TABLE}})
+		require.NoError(t, testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK))
 	})
 
 	t.Run("semantically-equivalent overrides (whitespace) pass", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "  test_schema.orders:table ; "
-		require.NoError(t, validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK))
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides("  test_schema.orders:table ; ", map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_TABLE}})
+		require.NoError(t, testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK))
 	})
 
 	t.Run("changed override target table is rejected", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "test_schema.events:table"
-		err := validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK)
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides("test_schema.events:table", map[string]CdcPartitionKeyOverride{"test_schema.events": {Strategy: PARTITION_BY_TABLE}})
+		err := testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "changing cdc-partition-key")
 		assert.Contains(t, err.Error(), "events")
 	})
 
 	t.Run("removed override is rejected", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = ""
-		err := validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK)
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides("", map[string]CdcPartitionKeyOverride{})
+		err := testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, importDataStatus, emptyUK)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "changing cdc-partition-key")
 		assert.Contains(t, err.Error(), "orders")
@@ -895,15 +704,15 @@ func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
 	}
 
 	t.Run("custom key: same columns (equivalent spelling) pass", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = `"test_schema"."orders":(customer_id)`
-		require.NoError(t, validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id"), emptyUK))
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides(`"test_schema"."orders":(customer_id)`, map[string]CdcPartitionKeyOverride{`"test_schema"."orders"`: {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}}})
+		require.NoError(t, testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id"), emptyUK))
 	})
 
 	t.Run("custom key: changed column is rejected", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "test_schema.orders:(region)"
-		err := validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id"), emptyUK)
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides("test_schema.orders:(region)", map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"region"}}})
+		err := testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id"), emptyUK)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "changing cdc-partition-key")
 		assert.Contains(t, err.Error(), "custom key columns")
@@ -911,209 +720,27 @@ func TestValidateCdcPartitioningStrategyUnchanged(t *testing.T) {
 	})
 
 	t.Run("custom key: reordered multi-columns are rejected (order is significant)", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "test_schema.orders:(region,customer_id)"
-		err := validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id", "region"), emptyUK)
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides("test_schema.orders:(region,customer_id)", map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"region", "customer_id"}}})
+		err := testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id", "region"), emptyUK)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "custom key columns")
 	})
 
 	t.Run("custom key: added column is rejected", func(t *testing.T) {
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "test_schema.orders:(customer_id,region)"
-		err := validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id"), emptyUK)
+		testImporter.cfg.CdcPartitionKey = PARTITION_BY_PK
+		setTestCdcPartitionKeyOverrides("test_schema.orders:(customer_id,region)", map[string]CdcPartitionKeyOverride{"test_schema.orders": {Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id", "region"}}})
+		err := testImporter.validateCdcPartitioningStrategyUnchanged(tableNames, customStatus("customer_id"), emptyUK)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "custom key columns")
 	})
 }
 
-func mustResolveOverrides(t *testing.T, raw string, tableNames []sqlname.NameTuple) *utils.StructMap[sqlname.NameTuple, cdcPartitionKeyOverride] {
+func mustResolveOverrides(t *testing.T, parsed map[string]CdcPartitionKeyOverride, tableNames []sqlname.NameTuple) *utils.StructMap[sqlname.NameTuple, CdcPartitionKeyOverride] {
 	t.Helper()
-	parsed, err := parseCdcPartitionKeyOverrides(raw)
-	require.NoError(t, err)
 	resolved, err := resolveCdcPartitionKeyOverrides(parsed, tableNames)
 	require.NoError(t, err)
 	return resolved
-}
-
-// TestValidateCdcPartitionKeyFlags covers the flag-level guardrails in
-// validateCdcPartitionKeyFlags: context restrictions (target/YB/PG/streaming),
-// value validation, and the resume change-guards (including the positive
-// same-config and start-clean bypass paths).
-func TestValidateCdcPartitionKeyFlags(t *testing.T) {
-	origImporterRole := importerRole
-	origTargetDBType := tconf.TargetDBType
-	origSourceDBType := sourceDBType
-	origImportType := importType
-	origKey := cdcPartitionKey
-	origOverrides := cdcPartitionKeyOverrides
-	origStartClean := startClean
-	origMetaDB := metaDB
-	t.Cleanup(func() {
-		importerRole = origImporterRole
-		tconf.TargetDBType = origTargetDBType
-		sourceDBType = origSourceDBType
-		importType = origImportType
-		cdcPartitionKey = origKey
-		cdcPartitionKeyOverrides = origOverrides
-		startClean = origStartClean
-		metaDB = origMetaDB
-	})
-
-	// newCmd registers the two flags bound to the package globals. StringVar resets
-	// the globals to their defaults, so callers must set globals AFTER calling this.
-	newCmd := func() *cobra.Command {
-		c := &cobra.Command{Use: "import-data-test"}
-		c.Flags().StringVar(&cdcPartitionKey, "cdc-partition-key", "auto", "")
-		c.Flags().StringVar(&cdcPartitionKeyOverrides, "cdc-partition-key-overrides", "", "")
-		return c
-	}
-	setValidContext := func() {
-		importerRole = TARGET_DB_IMPORTER_ROLE
-		tconf.TargetDBType = YUGABYTEDB
-		sourceDBType = POSTGRESQL
-		importType = SNAPSHOT_AND_CHANGES
-		startClean = false
-	}
-	seedMetaDB := func(t *testing.T, mutate func(*metadb.ImportDataStatusRecord)) {
-		dir, err := os.MkdirTemp("", "cdcpk-metadb-*")
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = os.RemoveAll(dir) })
-		metaDB = CreateMigrationProjectIfNotExists(POSTGRESQL, dir)
-		if mutate != nil {
-			require.NoError(t, metaDB.UpdateImportDataStatusRecord(mutate))
-		}
-	}
-
-	t.Run("rejected for non-target importer role", func(t *testing.T) {
-		setValidContext()
-		importerRole = SOURCE_REPLICA_DB_IMPORTER_ROLE
-		cmd := newCmd()
-		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "only supported for import data to target")
-	})
-
-	t.Run("rejected for non-yugabytedb target", func(t *testing.T) {
-		setValidContext()
-		tconf.TargetDBType = POSTGRESQL
-		cmd := newCmd()
-		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "only supported for import data to target")
-	})
-
-	t.Run("allowed (no-op) for non-target when no flags passed", func(t *testing.T) {
-		setValidContext()
-		importerRole = SOURCE_REPLICA_DB_IMPORTER_ROLE
-		cmd := newCmd() // no flags Set -> not passed
-		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
-	})
-
-	t.Run("rejected for offline migration", func(t *testing.T) {
-		setValidContext()
-		importType = SNAPSHOT_ONLY
-		cmd := newCmd()
-		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not supported for offline migration")
-	})
-
-	t.Run("rejected for non-postgres source", func(t *testing.T) {
-		setValidContext()
-		sourceDBType = ORACLE
-		cmd := newCmd()
-		require.NoError(t, cmd.Flags().Set("cdc-partition-key", "pk"))
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "only supported for PostgreSQL source")
-	})
-
-	t.Run("rejects empty cdc-partition-key", func(t *testing.T) {
-		setValidContext()
-		seedMetaDB(t, nil)
-		cmd := newCmd()
-		cdcPartitionKey = ""
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cdc-partition-key is required")
-	})
-
-	t.Run("rejects invalid cdc-partition-key value", func(t *testing.T) {
-		setValidContext()
-		seedMetaDB(t, nil)
-		cmd := newCmd()
-		cdcPartitionKey = "foo"
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid cdc-partition-key")
-	})
-
-	t.Run("valid fresh start passes", func(t *testing.T) {
-		setValidContext()
-		seedMetaDB(t, nil) // no import started yet
-		cmd := newCmd()
-		cdcPartitionKey = "pk"
-		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
-	})
-
-	t.Run("resume with same config passes", func(t *testing.T) {
-		setValidContext()
-		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
-			r.ImportDataStarted = true
-			r.CdcPartitioningStrategyConfig = PARTITION_BY_PK
-			r.CdcPartitionKeyOverridesConfig = "test_schema.orders:table"
-		})
-		cmd := newCmd()
-		cdcPartitionKey = PARTITION_BY_PK
-		cdcPartitionKeyOverrides = "test_schema.orders:table"
-		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
-	})
-
-	t.Run("resume rejects changed global key", func(t *testing.T) {
-		setValidContext()
-		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
-			r.ImportDataStarted = true
-			r.CdcPartitioningStrategyConfig = "auto"
-		})
-		cmd := newCmd()
-		cdcPartitionKey = PARTITION_BY_PK
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "changing cdc-partition-key is not allowed")
-	})
-
-	// NOTE: changed cdc-partition-key-overrides is no longer rejected here by a raw string
-	// compare; the semantic per-table comparison is covered by
-	// TestValidateCdcPartitioningStrategyUnchanged.
-
-	t.Run("resume from older version without stored strategy is rejected", func(t *testing.T) {
-		setValidContext()
-		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
-			r.ImportDataStarted = true
-			r.CdcPartitioningStrategyConfig = ""
-		})
-		cmd := newCmd()
-		cdcPartitionKey = PARTITION_BY_PK
-		err := validateCdcPartitionKeyFlags(cmd)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "Resuming from an earlier version")
-	})
-
-	t.Run("start-clean bypasses resume change-guards", func(t *testing.T) {
-		setValidContext()
-		startClean = true
-		seedMetaDB(t, func(r *metadb.ImportDataStatusRecord) {
-			r.ImportDataStarted = true
-			r.CdcPartitioningStrategyConfig = "auto"
-		})
-		cmd := newCmd()
-		cdcPartitionKey = PARTITION_BY_PK
-		require.NoError(t, validateCdcPartitionKeyFlags(cmd))
-	})
 }
 
 // TestHashEventCustomKey covers PARTITION_BY_CUSTOM routing in hashEvent: events of the
@@ -1124,8 +751,8 @@ func TestHashEventCustomKey(t *testing.T) {
 	sp := func(s string) *string { return &s }
 
 	orders := testCdcPartitionNameTuple("test_schema", "orders")
-	singleColMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-	singleColMap.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}})
+	singleColMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+	singleColMap.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}})
 
 	// insert: key value in Fields (BeforeFields nil)
 	insertEvent := &tgtdb.Event{
@@ -1161,8 +788,8 @@ func TestHashEventCustomKey(t *testing.T) {
 	assert.Less(t, insertHash, NUM_EVENT_CHANNELS)
 
 	t.Run("multi-column order is respected", func(t *testing.T) {
-		multiColMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		multiColMap.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id", "region"}})
+		multiColMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		multiColMap.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id", "region"}})
 
 		ev := &tgtdb.Event{
 			Vsn: 10, Op: "c", TableNameTup: orders,
@@ -1176,8 +803,8 @@ func TestHashEventCustomKey(t *testing.T) {
 		assert.Equal(t, h1, h2)
 
 		// reversed column order is a different key ordering; usually a different channel.
-		reversedColMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		reversedColMap.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"region", "customer_id"}})
+		reversedColMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		reversedColMap.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"region", "customer_id"}})
 		hRev, err := hashEvent(ev, reversedColMap)
 		require.NoError(t, err)
 		_ = hRev // no strict inequality assertion to avoid rare hash collisions
@@ -1206,8 +833,8 @@ func TestHashEventCustomKey(t *testing.T) {
 	})
 
 	t.Run("missing custom columns map entry errors", func(t *testing.T) {
-		emptyColMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-		emptyColMap.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM})
+		emptyColMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+		emptyColMap.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM})
 		_, err := hashEvent(insertEvent, emptyColMap)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "custom partition key columns not found")
@@ -1218,12 +845,12 @@ func TestGetEventPartitionKey(t *testing.T) {
 	sp := func(s string) *string { return &s }
 	orders := testCdcPartitionNameTuple("test_schema", "orders")
 
-	pkMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-	pkMap.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
-	tableMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-	tableMap.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
-	customMap := utils.NewStructMap[sqlname.NameTuple, cdcPartitionKeyOverride]()
-	customMap.Put(orders, cdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}})
+	pkMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+	pkMap.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_PK})
+	tableMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+	tableMap.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_TABLE})
+	customMap := utils.NewStructMap[sqlname.NameTuple, CdcPartitionKeyOverride]()
+	customMap.Put(orders, CdcPartitionKeyOverride{Strategy: PARTITION_BY_CUSTOM, Columns: []string{"customer_id"}})
 
 	t.Run("pk: same PK -> same key, different PK -> different key", func(t *testing.T) {
 		e1 := &tgtdb.Event{Vsn: 1, Op: "u", TableNameTup: orders, Key: map[string]*string{"id": sp("1")}}

--- a/yb-voyager/src/importdata/live_migration_test.go
+++ b/yb-voyager/src/importdata/live_migration_test.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package importdata
 
 import (
 	"os"

--- a/yb-voyager/src/testlivemigration/import_data_cdc_failures_test.go
+++ b/yb-voyager/src/testlivemigration/import_data_cdc_failures_test.go
@@ -116,7 +116,7 @@ func TestImportCDCTransformFailureAndResume(t *testing.T) {
 		// Skip the first 250 transform calls (let them succeed), then trigger a
 		// transform failure on the 251st call. 250 is chosen to be large enough
 		// that meaningful CDC progress is observable before the crash.
-		"github.com/yugabyte/yb-voyager/yb-voyager/cmd/importCDCTransformFailure=250*off->return()",
+		"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/importCDCTransformFailure=250*off->return()",
 	)
 	err = lm.StartImportDataWithEnv(true, nil, []string{
 		failpointEnv,
@@ -252,7 +252,7 @@ func TestImportCDCDbErrorAndResume(t *testing.T) {
 		// Skip the first 100 batch-commit calls (let them succeed), then inject a
 		// DB error on the 101st. 100 is chosen so `last_applied_vsn > 0` is
 		// observable and we can prove resume work is meaningful.
-		"github.com/yugabyte/yb-voyager/yb-voyager/cmd/importCDCNonRetryableBatchDBError=100*off->return(true)",
+		"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/importCDCNonRetryableBatchDBError=100*off->return(true)",
 	)
 	err = lm.StartImportDataWithEnv(true, map[string]string{
 		"--max-retries-streaming": "1",
@@ -760,7 +760,7 @@ func TestImportCDCMultiChannelBatchFailureAndResume(t *testing.T) {
 		// Skip the first 100 batch-commit calls across all channels (let them
 		// succeed), then inject a DB error on the 101st. 100 is large enough that
 		// multiple channels make meaningful progress before the crash.
-		"github.com/yugabyte/yb-voyager/yb-voyager/cmd/importCDCNonRetryableBatchDBError=100*off->return(true)",
+		"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/importCDCNonRetryableBatchDBError=100*off->return(true)",
 	)
 	err = lm.StartImportDataWithEnv(true, map[string]string{
 		"--max-retries-streaming": "1",
@@ -912,7 +912,6 @@ func TestImportCDCMultiChannelBatchFailureAndResume(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
-
 
 // getReportCDCCounts extracts the total imported and exported CDC event counts for a
 // table from a DataMigrationReport. The tableName must be in the quoted format

--- a/yb-voyager/src/testlivemigration/live_migration_integration_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_integration_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/yugabyte/yb-voyager/yb-voyager/cmd"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
 
@@ -1080,10 +1080,10 @@ FROM generate_series(1, 10);`,
 	for i := 0; i < 5; i++ {
 		importDataStatus, err = testMetaDB.GetImportDataStatusRecord()
 		testutils.FatalIfError(t, err, "Failed to get import data status record")
-		if importDataStatus.CdcPartitioningStrategyConfig == cmd.PARTITION_BY_PK {
+		if importDataStatus.CdcPartitioningStrategyConfig == importdata.PARTITION_BY_PK {
 			break
 		} else if i == 4 {
-			t.Fatalf("failed to validate cdc partitioning strategy: got: %s, expected: %s", importDataStatus.CdcPartitioningStrategyConfig, cmd.PARTITION_BY_PK)
+			t.Fatalf("failed to validate cdc partitioning strategy: got: %s, expected: %s", importDataStatus.CdcPartitioningStrategyConfig, importdata.PARTITION_BY_PK)
 		}
 		time.Sleep(5 * time.Second)
 	}

--- a/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
+++ b/yb-voyager/src/testlivemigration/live_migration_uk_conflict_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/yugabyte/yb-voyager/yb-voyager/cmd"
+	"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata"
 	"github.com/yugabyte/yb-voyager/yb-voyager/src/metadb"
 	testutils "github.com/yugabyte/yb-voyager/yb-voyager/test/utils"
 )
@@ -269,10 +269,10 @@ func TestLiveMigrationWithMultiColumnUniqueIndexConflictDetectionCases(t *testin
 	testutils.FatalIfError(t, err, "failed to start export data")
 
 	uniqueKeyConflictFailpointEnv := testutils.GetFailpointEnvVar(
-		"github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return(true)",
+		"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return(true)",
 	)
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictFailpointMarker := filepath.Join(
 		liveMigrationTest.GetCurrentExportDir(), "failpoints", "failpoint-unique-key-conflict-detected.log")
@@ -512,7 +512,7 @@ func TestLiveMigrationWithUniqueKeyValuesWithPartialPredicateConflictDetectionCa
 	testutils.FatalIfError(t, err, "failed to start export data")
 
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -572,7 +572,7 @@ func TestLiveMigrationWithUniqueKeyConflictWithTablePartitioning(t *testing.T) {
 	testutils.FatalIfError(t, err, "failed to start export data")
 
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 
 	uniqueKeyConflictStatsPath := filepath.Join(
@@ -727,7 +727,7 @@ FROM generate_series(1, 20) as i;`,
 	testutils.FatalIfError(t, err, "failed to start export data")
 
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -886,7 +886,7 @@ FROM generate_series(1, 20) as i;`,
 	testutils.FatalIfError(t, err, "failed to start export data")
 
 	uniqueKeyConflictFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("true")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("true")`,
 	)
 
 	uniqueKeyConflictFailpointMarker := filepath.Join(
@@ -1045,7 +1045,7 @@ FROM generate_series(1, 20) as i;`,
 	testutils.FatalIfError(t, err, "failed to start export data")
 
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		liveMigrationTest.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -1183,13 +1183,13 @@ func TestLiveMigrationWithUniqueKeyConflictsOnCaseSensitiveColumns(t *testing.T)
 	table := `"test_schema"."test_unique_key_on_case_sensitive_columns"`
 
 	uniqueKeyConflictFailpointEnv := testutils.GetFailpointEnvVar(
-		"github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return(true)",
+		"github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return(true)",
 	)
 	uniqueKeyConflictFailpointMarker := filepath.Join(
 		liveMigrationTest.GetCurrentExportDir(), "failpoints", "failpoint-unique-key-conflict-detected.log")
 
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		liveMigrationTest.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -1364,8 +1364,8 @@ func TestLiveMigrationCdcPartitionKeyConfigs(t *testing.T) {
 
 	assert.Equal(t, "pk", importDataStatus.CdcPartitioningStrategyConfig)
 	assert.Equal(t, "", importDataStatus.CdcPartitionKeyOverridesConfig)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", cmd.PARTITION_BY_PK)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", cmd.PARTITION_BY_PK)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", importdata.PARTITION_BY_PK)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", importdata.PARTITION_BY_PK)
 
 	err = lm.StopImportData()
 	testutils.FatalIfError(t, err, "failed to stop import data")
@@ -1405,8 +1405,8 @@ func TestLiveMigrationCdcPartitionKeyConfigs(t *testing.T) {
 	testutils.FatalIfError(t, err, "failed to get import data status record")
 	assert.Equal(t, "pk", importDataStatus.CdcPartitioningStrategyConfig)
 	assert.Equal(t, mixedOverrides, importDataStatus.CdcPartitionKeyOverridesConfig)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", cmd.PARTITION_BY_TABLE)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", cmd.PARTITION_BY_PK)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", importdata.PARTITION_BY_TABLE)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", importdata.PARTITION_BY_PK)
 
 	err = lm.ValidateDataConsistency([]string{`"test_schema"."orders"`, `"test_schema"."events"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate snapshot data consistency")
@@ -1516,8 +1516,8 @@ func TestLiveMigrationCdcPartitionKeyOverridesEquivalentOnResume(t *testing.T) {
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
 	assert.Equal(t, "pk", importDataStatus.CdcPartitioningStrategyConfig)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", cmd.PARTITION_BY_TABLE)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", cmd.PARTITION_BY_PK)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", importdata.PARTITION_BY_TABLE)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", importdata.PARTITION_BY_PK)
 	// Expression-UK tables are captured on the first run (none here, but non-nil) so the
 	// resume comparison needs no target-DB re-query.
 	require.NotNil(t, importDataStatus.CdcExpressionUniqueIndexTables,
@@ -1561,8 +1561,8 @@ func TestLiveMigrationCdcPartitionKeyOverridesEquivalentOnResume(t *testing.T) {
 	importDataStatus, err = lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record after resume")
 	assert.Equal(t, "pk", importDataStatus.CdcPartitioningStrategyConfig)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", cmd.PARTITION_BY_TABLE)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", cmd.PARTITION_BY_PK)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "orders", importdata.PARTITION_BY_TABLE)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "events", importdata.PARTITION_BY_PK)
 
 	err = lm.ValidateDataConsistency([]string{`"test_schema"."orders"`, `"test_schema"."events"`}, "id")
 	testutils.FatalIfError(t, err, "failed to validate snapshot data consistency after resume")
@@ -1675,7 +1675,7 @@ func TestLiveMigrationCdcPartitionKeyRejectsPkOnExpressionUniqueIndex(t *testing
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
 	require.Equal(t, "auto", importDataStatus.CdcPartitioningStrategyConfig)
-	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "users", cmd.PARTITION_BY_TABLE)
+	assertStrategyInMap(t, importDataStatus.TableToCDCPartitionKey, "users", importdata.PARTITION_BY_TABLE)
 
 	// Resume WITHOUT start-clean trying to switch the expression-UK table from table to pk
 	// must be rejected: pk-partitioning cannot detect unique-key conflicts on an expression
@@ -1774,7 +1774,7 @@ func TestLiveMigrationWithCoveringUniqueKeyIndex(t *testing.T) {
 	defer lm.Cleanup()
 
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -1938,9 +1938,9 @@ func TestLiveMigrationWithCustomCdcPartitionKey(t *testing.T) {
 	importDataStatus, err := testMetaDB.GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
 
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."orders"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."orders"`].Strategy,
 		"orders should use the custom partition strategy")
-	assert.Equal(t, cmd.PARTITION_BY_PK, importDataStatus.TableToCDCPartitionKey[`"test_schema"."events"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_PK, importDataStatus.TableToCDCPartitionKey[`"test_schema"."events"`].Strategy,
 		"events should resolve to pk under auto")
 	assert.Equal(t, []string{"customer_id"}, importDataStatus.TableToCDCPartitionKey[`"test_schema"."orders"`].Columns,
 		"orders custom key columns should be persisted")
@@ -2053,7 +2053,7 @@ func TestLiveMigrationCustomCdcPartitionKeyNoConflict(t *testing.T) {
 
 	// count-only failpoint: any detected UK conflict is recorded in the stats file.
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -2074,7 +2074,7 @@ func TestLiveMigrationCustomCdcPartitionKeyNoConflict(t *testing.T) {
 	testutils.FatalIfError(t, err, "failed to initialize meta db")
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
 		"test_live should use the custom partition strategy")
 	assert.Equal(t, []string{"custom_key"}, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Columns,
 		"test_live custom key columns should be persisted")
@@ -2236,7 +2236,7 @@ func TestLiveMigrationCustomCaseSensitiveCdcPartitionKeyNoConflict(t *testing.T)
 
 	// count-only failpoint: any detected UK conflict is recorded in the stats file.
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -2260,11 +2260,11 @@ func TestLiveMigrationCustomCaseSensitiveCdcPartitionKeyNoConflict(t *testing.T)
 	testutils.FatalIfError(t, err, "failed to initialize meta db")
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
 		"test_live should use the custom partition strategy")
 	assert.Equal(t, []string{"CustomKey"}, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Columns,
 		"test_live custom key columns should be persisted")
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live_multi_case"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live_multi_case"`].Strategy,
 		"test_live_multi_case should use the custom partition strategy")
 	assert.Equal(t, []string{"customKey", "customKey1"}, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live_multi_case"`].Columns,
 		"test_live_multi_case custom key columns should be persisted")
@@ -2589,7 +2589,7 @@ func TestLiveMigrationWithSubsetOFPartialUNiqueIndexColumnsBeingChangedInUpdate(
 	testutils.FatalIfError(t, err, "failed to start export data")
 
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		liveMigrationTest.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -2724,7 +2724,7 @@ func TestLiveMigrationCustomCdcPartitionKeyPKRecycleConflict(t *testing.T) {
 
 	// count-only failpoint: any detected UK conflict is recorded in the stats file.
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -2745,7 +2745,7 @@ func TestLiveMigrationCustomCdcPartitionKeyPKRecycleConflict(t *testing.T) {
 	testutils.FatalIfError(t, err, "failed to initialize meta db")
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
 		"test_live should use the custom partition strategy")
 	assert.Equal(t, []string{"region"}, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Columns,
 		"test_live custom key columns should be persisted")
@@ -2885,7 +2885,7 @@ func TestLiveMigrationPartitionedTableWithCustomCdcPartitionKeyNoConflict(t *tes
 
 	// count-only failpoint: any detected UK conflict is recorded in the stats file.
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -2907,7 +2907,7 @@ func TestLiveMigrationPartitionedTableWithCustomCdcPartitionKeyNoConflict(t *tes
 	testutils.FatalIfError(t, err, "failed to initialize meta db")
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
 		"test_live should use the custom partition strategy")
 	assert.Equal(t, []string{"custom_key"}, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Columns,
 		"test_live custom key columns should be persisted")
@@ -3032,7 +3032,7 @@ func TestLiveMigrationPartitionedTableWithCustomCdcPartitionKeyPKRecycleConflict
 
 	// count-only failpoint: any detected UK conflict is recorded in the stats file.
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -3053,7 +3053,7 @@ func TestLiveMigrationPartitionedTableWithCustomCdcPartitionKeyPKRecycleConflict
 	testutils.FatalIfError(t, err, "failed to initialize meta db")
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Strategy,
 		"test_live should use the custom partition strategy")
 	assert.Equal(t, []string{"custom_key"}, importDataStatus.TableToCDCPartitionKey[`"test_schema"."test_live"`].Columns,
 		"test_live custom key columns should be persisted")
@@ -3177,7 +3177,7 @@ func TestLiveMigrationPartitionedTableChildPKWithCustomCdcPartitionKeyPKRecycleC
 
 	// count-only failpoint: any detected UK conflict is recorded in the stats file.
 	uniqueKeyConflictCountFailpointEnv := testutils.GetFailpointEnvVar(
-		`github.com/yugabyte/yb-voyager/yb-voyager/cmd/uniqueKeyConflictDetected=return("count")`,
+		`github.com/yugabyte/yb-voyager/yb-voyager/src/importdata/uniqueKeyConflictDetected=return("count")`,
 	)
 	uniqueKeyConflictStatsPath := filepath.Join(
 		lm.GetCurrentExportDir(), "failpoints", "unique-key-conflict-stats.json")
@@ -3205,7 +3205,7 @@ func TestLiveMigrationPartitionedTableChildPKWithCustomCdcPartitionKeyPKRecycleC
 	testutils.FatalIfError(t, err, "failed to initialize meta db")
 	importDataStatus, err := lm.GetMetaDB().GetImportDataStatusRecord()
 	testutils.FatalIfError(t, err, "failed to get import data status record")
-	assert.Equal(t, cmd.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"public"."orders"`].Strategy,
+	assert.Equal(t, importdata.PARTITION_BY_CUSTOM, importDataStatus.TableToCDCPartitionKey[`"public"."orders"`].Strategy,
 		"orders should use the custom partition strategy")
 	assert.Equal(t, []string{"custom_key"}, importDataStatus.TableToCDCPartitionKey[`"public"."orders"`].Columns,
 		"orders custom key columns should be persisted")

--- a/yb-voyager/test/cdcbench/README.md
+++ b/yb-voyager/test/cdcbench/README.md
@@ -19,15 +19,15 @@ debezium-server (generation only — cached artifacts replay with neither).
 cd yb-voyager
 
 # full suite, 5 runs each (benchstat-ready)
-go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./cmd/
+go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./src/importdata/
 
 # a single workload
-go test -tags cdc_benchmark -run '^$' -bench 'CDCIngest/edge-all-updates' -benchtime 1x ./cmd/
+go test -tags cdc_benchmark -run '^$' -bench 'CDCIngest/edge-all-updates' -benchtime 1x ./src/importdata/
 
 # compare two checkouts
-go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./cmd/ > before.txt
+go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./src/importdata/ > before.txt
 # ...switch branches / apply change...
-go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./cmd/ > after.txt
+go test -tags cdc_benchmark -run '^$' -bench CDCIngest -benchtime 1x -count 5 ./src/importdata/ > after.txt
 benchstat before.txt after.txt
 ```
 
@@ -91,8 +91,8 @@ before-image (see `conflict-update-pairs/dml.sql`).
 
 ## Architecture
 
-`test/cdcbench` knows nothing about the `cmd` package. The three pieces that need cmd
-internals are injected as closures (`Hooks`) by the shim `cmd/cdc_ingest_bench_test.go`
+`test/cdcbench` knows nothing about the `importdata` package. The three pieces that need
+importdata internals are injected as closures (`Hooks`) by the shim `src/importdata/cdc_ingest_bench_test.go`
 (build tag `cdc_benchmark`): `Bootstrap` (prepare metaDB/name registry/table list for
 an artifact copy and install the mock), `StreamAll` (calls the real `streamChanges` —
 the timed region), and `CacheDepth` (conflict-cache occupancy for the sampler).


### PR DESCRIPTION
### Describe the changes in this pull request

Moves the import-data engine and the CDC streaming phase from `cmd/` to `src/importdata/` (PR C of 3, stacked on #3789). No behavior change. After this, cmd keeps the cobra commands, flag validation, process succession, cutover choreography and callhome payloads. Everything that moves data lives in `importdata`.

Review tip: two commits. The first is a pure `git mv` of `live_migration.go`, the cdc-partition-key strategy, `eventQueue.go`, `conflictDetectionCache.go` and their tests. The second, "adapt", is the real diff. The one place rename detection is imperfect is the split of `cmd/importData.go`: its engine half becomes `src/importdata/importData.go`. The function-level stay/move list is in the plan.

- **`importdata.Config`** — every value the engine reads that cmd kept in globals, copied in by value from `buildImportDataConfig`. No callbacks.
- **`importdata.Importer`** — carries the former import-only runtime globals (pools, progress reporter, value converter, column/identity/schema maps, conflict cache, event queue, stats reporter, import phase). Engine functions become its methods. Body edits are prefix-only (`tdb` → `imp.cfg.Tdb`). Field names mirror the old globals; renames come later.
- **Seam** — `ImportData()` ends after the snapshot import or after `streamChanges`. The tail (sequence restore, cutover processing, snapshot report, final print) runs from cmd's `importDataPostProcessing` in the same order. Sequence restoration stays in cmd for now because it needs the analyze-schema SQL parser.
- **cmd handle** — one `importer` variable. Payload builders read phase and CDC stats through `currentImportPhase()` / `currentStatsReporter()`, which return the command-level values until the engine exists.
- **Snapshot report** — `GetImportedSnapshotRowsMap`, `DisplayImportedRowCountSnapshot`, `RowCountPair` move from `common.go` and take the state config explicitly.
- **Failpoints** — the CDC and unique-key injectors move with the engine and take the export dir as a parameter. `src/testlivemigration` failpoint paths follow.
- **Flag parsing stays in cmd** — only the `CdcPartitionKeyOverride` type moves. cmd passes the parsed map in Config, so the engine never re-parses the flag at runtime.
- **Private one-liners in importdata** — `changeStreamingIsEnabled`, `isTargetDBExporter`, `addHeader`, so the package depends on neither cmd nor `src/export`.

**Deliberate deviations from a pure move, the only non-prefix edits:**
1. `displayImportedRowCountSnapshot` drops its `retrieveMigrationUUID()` call. It is a no-op once the UUID is set, which every import command does in PreRun.
2. `getImportedSnapshotRowsMap` no longer assigns the cmd global `importerRole` as a side effect. The two `get data-migration-report` call sites assign it explicitly before the call.
3. `source = *msr.SourceDBConf` moves from inside `importData()` to the cmd conductor right before `ImportData()`, from the same MSR read. Nothing in between reads `source`.

Plan and decision record: https://claude.ai/code/artifact/bb4ab0a1-ad28-4e45-a556-4a6b483db845

### Describe if there are any user-facing changes

No user-facing changes.

### How was this pull request tested?

Existing tests, moved with their code: `go test -tags unit ./src/importdata/ ./cmd/`, `go test -tags integration ./src/importdata/`, every `integration_voyager_command` test matching `Import` against a branch binary, and with `failpoint-ctl enable`: `TestImportCDCTransformFailureAndResume`, `TestImportCDCDbErrorAndResume`, `TestLiveMigrationWithUniqueKeyConflictWithTablePartitioning`. Vet under all tags including the live-migration suite tags, staticcheck, gofmt.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No. Payload shape and values are unchanged.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No.
