### PR TITLE
Validate row counts and hashes after cutover to target in all resumption tests

### DIFF
--- a/migtests/tests/resumption/live-migration/fall-forward-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fall-forward-resumption-test/scenario.yaml.template
@@ -192,6 +192,15 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  # Forward-leg validation, before the fall-forward leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
+
   # Phase 2: explicit fallback leg (target -> source replica) with resumptions
 
   - name: start_fallback_exporter_from_target

--- a/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-resumption-test/scenario.yaml.template
@@ -172,6 +172,15 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  # Forward-leg validation, before the fall-back leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
+
   - name: start_fallback_exporter_from_target
     action: voyager_export_from_target_start
 

--- a/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallback-unique-conflict-test/scenario.yaml.template
@@ -234,6 +234,15 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  # Forward-leg validation, before the fall-back leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
+
   - name: start_fallback_exporter_from_target
     action: voyager_export_from_target_start
 

--- a/migtests/tests/resumption/live-migration/fallf-index-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallf-index-resumption-test/scenario.yaml.template
@@ -196,6 +196,15 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  # Forward-leg validation, before the fall-forward leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
+
   # Phase 2: explicit fallback leg (target -> source replica) with resumptions
 
   - name: start_fallback_exporter_from_target

--- a/migtests/tests/resumption/live-migration/fallf-large-num-tables-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallf-large-num-tables-test/scenario.yaml.template
@@ -192,6 +192,15 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  # Forward-leg validation, before the fall-forward leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
+
   # Phase 2: explicit fallback leg (target -> source replica) with resumptions
 
   - name: start_fallback_exporter_from_target

--- a/migtests/tests/resumption/live-migration/fallf-large-row-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallf-large-row-resumption-test/scenario.yaml.template
@@ -202,6 +202,15 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  # Forward-leg validation, before the fall-forward leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
+
   # Phase 2: explicit fallback leg (target -> source replica) with resumptions
 
   - name: start_fallback_exporter_from_target

--- a/migtests/tests/resumption/live-migration/fallf-large-schema-resumption-test/scenario.yaml.template
+++ b/migtests/tests/resumption/live-migration/fallf-large-schema-resumption-test/scenario.yaml.template
@@ -192,6 +192,15 @@ stages:
     command: import_data
     graceful_timeout_sec: 60
 
+  # Forward-leg validation, before the fall-forward leg starts writing to either
+  # side. Source and target must already agree here, so a divergence is pinned
+  # to the forward leg instead of surfacing only in the final validations.
+  - name: row_count_validations_after_cutover_to_target
+    action: row_count_validations
+
+  - name: row_hash_validations_after_cutover_to_target
+    action: row_hash_validations
+
   # Phase 2: explicit fallback leg (target -> source replica) with resumptions
 
   - name: start_fallback_exporter_from_target


### PR DESCRIPTION
### Describe the changes in this pull request

Fixes #3698.

Two-leg resumption tests compared source and target only at the very end, after the fall-back or fall-forward leg. A divergence could not be attributed to a leg without reconstructing the event ledger offline.

- Adds `row_count_validations` and `row_hash_validations` right after cutover to target in the five fall-forward tests and the two fall-back ones.
- The new stages sit between stopping the forward processes and starting the next leg's. Neither side is being written there, so the two must already agree.
- No existing stage is changed. iteration-test, partition-iteration-test and custom-cdc-partition-key-test already had this pass, and forward-migration is single-leg and already validates in the right place.

Motivating case: live-migration-resumption build 1285 ended with source one row ahead of target on one table. Attributing that to the forward leg needed an offline reconciliation of exported-event stats against both final row counts.

### Describe if there are any user-facing changes
No user-facing changes.

### How was this pull request tested?
The same two-phase structure already runs in iteration-test and partition-iteration-test, and in custom-cdc-partition-key-test where it passed a full local run before #3770 merged. Verified here that all 11 resumption scenarios parse and that the new stages land between the forward stop stages and the next leg's start stages. Not yet run end to end on Jenkins.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?
No.

### Does your PR have changes to on-disk structures that can cause upgrade issues?
No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
