### PR TITLE
Correct sequence restoration when the exported value lags the data

### DIFF
--- a/migtests/scripts/live-migration-resumption/helpers.py
+++ b/migtests/scripts/live-migration-resumption/helpers.py
@@ -42,6 +42,8 @@ class Context:
         self.stop_event = threading.Event()
         self.process_lock = threading.Lock()
         self.active_resumers: Dict[str, "Resumer"] = {}
+        # roles cut over to whose sequences still need the post-cutover check
+        self.pending_sequence_checks: set[str] = set()
         self.loop_iteration: int = 0
         self.conflict_generators: Dict[str, "ConflictGenerator"] = {}
         self.export_dir_base: str = os.path.abspath(cfg.get("export_dir") or "")
@@ -1368,6 +1370,20 @@ def create_cutover_table(ctx, target: str = "source") -> None:
     user_override = admin_cfg["user"]
     password_override = admin_cfg.get("password")
     run_psql(ctx, target, "-c", sql, user_override=user_override, password_override=password_override)
+
+
+def verify_sequence_restored(ctx, role: str) -> None:
+    """Insert into cutover_table letting the SERIAL default supply the id.
+
+    Every other sequence-backed table is populated by the event generator with
+    random ids and retry-on-conflict, which hides a sequence that was restored
+    behind the data. cutover_table is only ever written by these honest inserts,
+    so its ids stay dense and a stale sequence collides immediately.
+
+    Must run after the row count/hash validations: it adds a row on one side only.
+    """
+    sql = "INSERT INTO public.cutover_table(status) VALUES (\'verify sequence restored after cutover\');"
+    run_psql(ctx, role, "-c", sql)
 
 
 def reset_database_for_role(role: str, ctx) -> None:

--- a/migtests/scripts/live-migration-resumption/orchestrator.py
+++ b/migtests/scripts/live-migration-resumption/orchestrator.py
@@ -254,17 +254,20 @@ def wait_for_action(stage: Dict[str, Any], ctx: Any) -> None:
 @action("cutover_to_target")
 def cutover_to_target_action(_stage, ctx: Any) -> None:
     H.initiate_cutover(ctx.cfg, ctx.env, "target")
+    ctx.pending_sequence_checks.add("target")
 
 
 @action("cutover_to_source")
 def cutover_to_source_action(_stage, ctx: Any) -> None:
     H.initiate_cutover(ctx.cfg, ctx.env, "source")
+    ctx.pending_sequence_checks.add("source")
 
 
 @action("cutover_to_source_replica")
 def cutover_to_source_replica_action(_stage, ctx: Any) -> None:
     """Initiate cutover back to the source-replica database."""
     H.initiate_cutover(ctx.cfg, ctx.env, "source-replica")
+    ctx.pending_sequence_checks.add("source_replica")
 
 
 @action("row_count_validations")
@@ -287,6 +290,13 @@ def row_hash_validations_action(stage: Dict[str, Any], ctx: Any) -> None:
         H.run_sql_file(ctx, sql_path, target=role, use_admin=False)
 
     H.run_segment_hash_validations(ctx, left_role, right_role)
+
+    # A cutover restores sequences; confirm an insert relying on a sequence default
+    # still works. Done here rather than in the cutover action because it adds a row
+    # on one side only, which would fail the hash above.
+    for role in sorted(ctx.pending_sequence_checks):
+        H.verify_sequence_restored(ctx, role)
+    ctx.pending_sequence_checks.clear()
 
 
 def _conflict_log_table_markers(table: str | None) -> list[str] | None:

--- a/yb-voyager/cmd/importDataSequenceRestoration.go
+++ b/yb-voyager/cmd/importDataSequenceRestoration.go
@@ -109,6 +109,11 @@ func restoreSequencesInOfflineMigration(msr *metadb.MigrationStatusRecord, impor
 		}
 	}
 
+	err = correctSequenceLastValuesAgainstTableMax(sequenceNameTupleToLastValueMap)
+	if err != nil {
+		return fmt.Errorf("failed to correct sequence last values: %w", err)
+	}
+
 	//restore the sequence last value
 	err = tdb.RestoreSequences(sequenceNameTupleToLastValueMap)
 	if err != nil {
@@ -131,11 +136,169 @@ func restoreSequencesInLiveMigration(sequenceLastValue map[string]int64) error {
 		}
 		sequenceNameTupleToLastValueMap.Put(sequenceTuple, lastValue)
 	}
-	err := tdb.RestoreSequences(sequenceNameTupleToLastValueMap)
+	err := correctSequenceLastValuesAgainstTableMax(sequenceNameTupleToLastValueMap)
+	if err != nil {
+		return fmt.Errorf("failed to correct sequence last values: %w", err)
+	}
+	err = tdb.RestoreSequences(sequenceNameTupleToLastValueMap)
 	if err != nil {
 		return fmt.Errorf("failed to restore sequences: %w", err)
 	}
 	return nil
+}
+
+// StrictSequenceRestoreEnvVar, when enabled, turns the "exported sequence value lagged
+// behind the data" correction below into a hard failure instead of a warning. Tests
+// enable it so that a regression in the exported sequence max is caught loudly instead
+// of being silently absorbed by the correction.
+const StrictSequenceRestoreEnvVar = "YB_VOYAGER_STRICT_SEQUENCE_RESTORE"
+
+// sequenceOwnerColumn identifies one column whose default draws from a sequence.
+type sequenceOwnerColumn struct {
+	table  sqlname.NameTuple
+	column string
+}
+
+/*
+correctSequenceLastValuesAgainstTableMax raises each sequence's restore value to the
+maximum value actually present in the column(s) that sequence feeds, whenever the
+exported value lags behind the data.
+
+The exported value is a running maximum of the values observed in the change stream. If
+the last events before cutover are not folded into it before it is read, setval() leaves
+the sequence at or below a value already present in the table, and the next insert that
+relies on the sequence default fails with a duplicate key error. Using
+GREATEST(exported, table max) makes restoration correct regardless of why the exported
+value lagged behind.
+
+The correction is never silent: it is reported as a warning by default and as a hard
+error when StrictSequenceRestoreEnvVar is enabled, so that the underlying lag stays
+detectable instead of being hidden.
+
+Sequences whose exported value is 0 are left untouched, matching the existing convention
+that such values can be legitimate (for example cyclic sequences).
+*/
+func correctSequenceLastValuesAgainstTableMax(sequenceNameTupleToLastValueMap *utils.StructMap[sqlname.NameTuple, int64]) error {
+	msr, err := metaDB.GetMigrationStatusRecord()
+	if err != nil {
+		return fmt.Errorf("get migration status record: %w", err)
+	}
+	sequenceToColumns, err := fetchSequenceToColumnListMap(msr)
+	if err != nil {
+		return fmt.Errorf("failed to fetch sequence to column list map: %w", err)
+	}
+
+	strict := utils.GetEnvAsBool(StrictSequenceRestoreEnvVar, false)
+	var laggedSequences []string
+
+	err = sequenceNameTupleToLastValueMap.IterKV(func(sequenceTuple sqlname.NameTuple, lastValue int64) (bool, error) {
+		if lastValue == 0 {
+			return true, nil
+		}
+		ownerColumns, ok := sequenceToColumns.Get(sequenceTuple)
+		if !ok {
+			// Sequence is not attached to any column, so there is no data to compare against.
+			return true, nil
+		}
+		tableMax, err := maxValueAcrossSequenceColumns(sequenceTuple, ownerColumns)
+		if err != nil {
+			return false, err
+		}
+		if tableMax <= lastValue {
+			return true, nil
+		}
+		laggedSequences = append(laggedSequences,
+			fmt.Sprintf("%s (exported=%d, data max=%d)", sequenceTuple.ForKey(), lastValue, tableMax))
+		utils.PrintAndLogfWarning("sequence %s: exported last value %d is behind the maximum value %d already present in the data; "+
+			"restoring it to %d instead. This means the exported sequence value lagged behind the migrated data.",
+			sequenceTuple.ForKey(), lastValue, tableMax, tableMax)
+		sequenceNameTupleToLastValueMap.Put(sequenceTuple, tableMax)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to compare sequence values against the data: %w", err)
+	}
+
+	if strict && len(laggedSequences) > 0 {
+		return goerrors.Errorf("exported sequence values lagged behind the migrated data for %d sequence(s): %s (%s is enabled)",
+			len(laggedSequences), strings.Join(laggedSequences, ", "), StrictSequenceRestoreEnvVar)
+	}
+	return nil
+}
+
+// maxValueAcrossSequenceColumns returns the largest value present across all columns fed
+// by the given sequence. Columns that do not hold numeric values are skipped, mirroring
+// the export side which only tracks sequence maximums for integer columns.
+func maxValueAcrossSequenceColumns(sequenceTuple sqlname.NameTuple, ownerColumns []sequenceOwnerColumn) (int64, error) {
+	var maxValue int64
+	for _, ownerColumn := range ownerColumns {
+		if !ownerColumn.table.TargetTableAvailable() {
+			continue
+		}
+		query := fmt.Sprintf(`SELECT COALESCE(MAX(%s), 0) FROM %s`,
+			quoteIdentifierIfUnquoted(ownerColumn.column), ownerColumn.table.ForUserQuery())
+		var columnMax int64
+		if err := tdb.QueryRow(query).Scan(&columnMax); err != nil {
+			// A non-numeric column fed by a sequence (for example a text column whose
+			// default embeds nextval) cannot be compared; skip it rather than failing
+			// the whole restoration.
+			log.Warnf("skipping max value check for column %s of sequence %s: %v",
+				ownerColumn.column, sequenceTuple.ForKey(), err)
+			continue
+		}
+		if columnMax > maxValue {
+			maxValue = columnMax
+		}
+	}
+	return maxValue, nil
+}
+
+// fetchSequenceToColumnListMap maps each sequence to the columns it feeds, using the
+// column-to-sequence mapping recorded for the database being imported into.
+func fetchSequenceToColumnListMap(msr *metadb.MigrationStatusRecord) (*utils.StructMap[sqlname.NameTuple, []sequenceOwnerColumn], error) {
+	columnToSequenceMapping := msr.SourceColumnToSequenceMapping
+	if importerRole == TARGET_DB_IMPORTER_ROLE && len(msr.TargetColumnToSequenceMapping) > 0 {
+		columnToSequenceMapping = msr.TargetColumnToSequenceMapping
+	}
+	if len(columnToSequenceMapping) == 0 {
+		columnToSequenceMapping = msr.TargetColumnToSequenceMapping
+	}
+
+	sequenceToColumns := utils.NewStructMap[sqlname.NameTuple, []sequenceOwnerColumn]()
+	for column, sequenceName := range columnToSequenceMapping {
+		parts := strings.Split(column, ".") //column is qualified schema.tablename.colname
+		if len(parts) != 3 {
+			// Do not guess at the table/column split; a wrong guess would query the wrong
+			// relation. Skipping only means we fall back to the exported value.
+			log.Warnf("skipping max value check for unexpected qualified column name %q", column)
+			continue
+		}
+		tableName := fmt.Sprintf("%s.%s", parts[0], parts[1])
+		// A name that cannot be resolved only costs us the max value check for that
+		// column, so skip it. This runs for every migration, and failing here would turn
+		// a migration that works today into a cutover failure.
+		tableNameTuple, err := namereg.NameReg.LookupTableNameAndIgnoreIfTargetNotFoundBasedOnRole(tableName)
+		if err != nil {
+			log.Warnf("skipping max value check for table %q: %v", tableName, err)
+			continue
+		}
+		sequenceTuple, err := namereg.NameReg.LookupTableNameAndIgnoreIfTargetNotFoundBasedOnRole(sequenceName)
+		if err != nil {
+			log.Warnf("skipping max value check for sequence %q: %v", sequenceName, err)
+			continue
+		}
+		ownerColumn := sequenceOwnerColumn{table: tableNameTuple, column: parts[2]}
+		ownerColumns, _ := sequenceToColumns.Get(sequenceTuple)
+		sequenceToColumns.Put(sequenceTuple, append(ownerColumns, ownerColumn))
+	}
+	return sequenceToColumns, nil
+}
+
+func quoteIdentifierIfUnquoted(identifier string) string {
+	if strings.HasPrefix(identifier, `"`) && strings.HasSuffix(identifier, `"`) {
+		return identifier
+	}
+	return fmt.Sprintf(`"%s"`, identifier)
 }
 
 func shouldFilterSequences(sourceType string) bool {

--- a/yb-voyager/cmd/importDataSequenceRestoration_test.go
+++ b/yb-voyager/cmd/importDataSequenceRestoration_test.go
@@ -1,0 +1,54 @@
+//go:build unit
+
+/*
+Copyright (c) YugabyteDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuoteIdentifierIfUnquoted(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   string
+	}{
+		{
+			name:       "unquoted lower case column is quoted",
+			identifier: "id",
+			expected:   `"id"`,
+		},
+		{
+			name:       "unquoted mixed case column keeps its case once quoted",
+			identifier: "Id",
+			expected:   `"Id"`,
+		},
+		{
+			name:       "already quoted column is left as is",
+			identifier: `"Id"`,
+			expected:   `"Id"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, quoteIdentifierIfUnquoted(test.identifier))
+		})
+	}
+}


### PR DESCRIPTION
### Describe the changes in this pull request

At cutover, sequences are restored by calling `setval()` with a value read from `export_status.json`. That value is a running maximum of the values seen in the change stream, maintained by the exporter. It can lag the data that was actually migrated — if the last events before cutover are not folded into it before it is read, `setval()` leaves the sequence at or below a value already present in the table. The next insert that relies on the sequence default then fails with a duplicate key error.

**Fix:** restore to `GREATEST(exported, max value present in the column(s) the sequence feeds)` instead of blindly trusting the exported value, so restoration is correct regardless of *why* the exported value lagged. Applies to both the live and offline restore paths, and therefore to all target types, with no `tgtdb` changes.

The correction is never silent:
- it logs a warning naming the sequence, the exported value and the real max;
- `YB_VOYAGER_STRICT_SEQUENCE_RESTORE` turns it into a hard failure, so a lag can be caught in tests rather than absorbed.

The lookups this needs are **best-effort** — an unresolvable name, a non-numeric column or an unavailable table only costs the max-value check for that column and falls back to the exported value. This runs for every migration, so failing there would turn a working migration into a cutover failure.

**Test coverage** is added in the resumption framework rather than per scenario: each cutover records the role it switched to, and `row_hash_validations` drains those roles once the hashes are compared, inserting into `cutover_table` and letting the `SERIAL` default supply the id. Every other sequence-backed table is populated by the event generator with random ids and retry-on-conflict, which hides a sequence restored behind the data; `cutover_table` only ever receives these honest inserts, so its ids stay dense and a stale sequence collides immediately. Draining *after* the hashes matters — the insert adds a row on one side only. No scenario files change, so every resumption test (forward, fall-back and fall-forward) picks this up automatically.

### Describe if there are any user-facing changes

- **New opt-in env var `YB_VOYAGER_STRICT_SEQUENCE_RESTORE`** (default off). When enabled, a lagging exported sequence value fails the import instead of being corrected with a warning. Intended for tests/CI.
- **New warning** during sequence restoration when a correction is applied, naming the sequence and both values. Previously this situation produced no diagnostic at all — it surfaced later as an unexplained duplicate key error.
- No command line, configuration, installation or report changes.

### How was this pull request tested?

**Unit** — added `importDataSequenceRestoration_test.go` covering identifier quoting. `go build`, `go vet -tags unit` and `gofmt` are clean.

**Deterministic before/after (offline migration, lag forced by editing `postdata.sql` from the true `10` down to `3`, 10 rows imported):**

| | with fix | without fix |
| --- | --- | --- |
| warning | `exported last value 3 is behind the maximum value 10 … restoring it to 10 instead` | *(none)* |
| sequence after restore | **10** | **3** |
| insert relying on the default | **id=11**, succeeds | `ERROR: duplicate key value violates unique constraint "probe_tbl_pkey"` |

**End-to-end** — `partition-iteration-test` (live migration with fall-back, resumptions enabled) passed: 52 stages OK, 0 failed. Both framework probes fired and succeeded, on the target after cutover-to-target and on the source after cutover-to-source:

```
  1 | Last event before cutover
  2 | verify sequence restored after cutover   <- target probe
102 | Last event before cutover
103 | verify sequence restored after cutover   <- source probe
```

No `skipping max value check` warnings appeared, confirming every sequence's name resolved and every `MAX(col)` query ran — i.e. the correction path executes rather than silently degrading.

**Not reproduced:** the natural race was not reproduced on demand. The exported value was accurate in the end-to-end runs, so the correction did not need to engage there. The original failure is documented in `aa37d091` ("Fix duplicate key in cutover_table during fallback marker insert"), whose workaround — truncating `cutover_table` before the fallback marker insert — was removed in `f2b19fb4` on review, leaving the underlying behaviour unguarded. The fix stands on its own merit regardless: trusting a value that can lag the data is incorrect even if the window is narrow.

### Does your PR have changes in callhome/yugabyted payloads? If so, is the payload version incremented?

No changes to callhome or yugabyted payloads.

### Does your PR have changes to on-disk structures that can cause upgrade issues?

No. `export_status.json` is read, not written, and its shape is unchanged. No changes to MetaDB, the name registry, or any other on-disk structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
